### PR TITLE
feat(worker-manager): env-based config loading + SSH readiness wait

### DIFF
--- a/worker-manager/README.md
+++ b/worker-manager/README.md
@@ -63,22 +63,25 @@ The manager accepts injected adapters or falls back to concrete defaults:
 ## Configuration
 
 All configuration is read from environment variables with the `WM_` prefix.
+Values are loaded from `~/.config/tanren/tanren.env` (or `$XDG_CONFIG_HOME/tanren/tanren.env`)
+at startup; environment variables override file values. All required keys must be
+explicitly set — there are no built-in defaults.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `WM_IPC_DIR` | *(required)* | IPC directory path for the coordinator group |
-| `WM_GITHUB_DIR` | `~/github` | Root directory containing git repositories |
-| `WM_COMMANDS_DIR` | `.claude/commands/tanren` | Relative path to tanren commands within a project |
-| `WM_POLL_INTERVAL` | `5.0` | Seconds between dispatch directory polls |
-| `WM_HEARTBEAT_INTERVAL` | `30.0` | Seconds between heartbeat file updates |
-| `WM_OPENCODE_PATH` | `opencode` | Path to opencode CLI binary |
-| `WM_CODEX_PATH` | `codex` | Path to codex CLI binary |
-| `WM_CLAUDE_PATH` | `claude` | Path to Claude Code CLI binary |
-| `WM_DATA_DIR` | `~/.local/share/tanren-worker` | Directory for worker manager runtime state |
-| `WM_WORKTREE_REGISTRY_PATH` | `{data_dir}/worktrees.json` | Path to the worktree registry file |
-| `WM_MAX_OPENCODE` | `1` | Max concurrent implementation (opencode/claude) processes |
-| `WM_MAX_CODEX` | `1` | Max concurrent audit (codex) processes |
-| `WM_MAX_GATE` | `3` | Max concurrent gate (bash) processes |
+| `WM_GITHUB_DIR` | *(required)* | Root directory containing git repositories |
+| `WM_DATA_DIR` | *(required)* | Directory for worker manager runtime state |
+| `WM_COMMANDS_DIR` | *(required)* | Relative path to tanren commands within a project |
+| `WM_POLL_INTERVAL` | *(required)* | Seconds between dispatch directory polls |
+| `WM_HEARTBEAT_INTERVAL` | *(required)* | Seconds between heartbeat file updates |
+| `WM_OPENCODE_PATH` | *(required)* | Path to opencode CLI binary |
+| `WM_CODEX_PATH` | *(required)* | Path to codex CLI binary |
+| `WM_CLAUDE_PATH` | *(required)* | Path to Claude Code CLI binary |
+| `WM_MAX_OPENCODE` | *(required)* | Max concurrent implementation (opencode/claude) processes |
+| `WM_MAX_CODEX` | *(required)* | Max concurrent audit (codex) processes |
+| `WM_MAX_GATE` | *(required)* | Max concurrent gate (bash) processes |
+| `WM_WORKTREE_REGISTRY_PATH` | *(required)* | Path to the worktree registry file |
 | `WM_EVENTS_DB` | *(none)* | SQLite events DB path; enables event emission when set |
 | `WM_ROLES_CONFIG_PATH` | *(none)* | Path to roles YAML config file |
 | `WM_REMOTE_CONFIG` | *(none)* | Path to `remote.yml`; enables remote VM execution when set |

--- a/worker-manager/src/worker_manager/__main__.py
+++ b/worker-manager/src/worker_manager/__main__.py
@@ -1,9 +1,11 @@
 import asyncio
 
+from worker_manager.config import load_config_env
 from worker_manager.manager import WorkerManager
 
 
 def main() -> None:
+    load_config_env()
     manager = WorkerManager()
     asyncio.run(manager.run())
 

--- a/worker-manager/src/worker_manager/adapters/hetzner_vm.py
+++ b/worker-manager/src/worker_manager/adapters/hetzner_vm.py
@@ -160,9 +160,7 @@ class HetznerVMProvisioner:
 
     async def list_active(self) -> list[VMHandle]:
         """List active tanren-managed Hetzner VMs."""
-        selector = (
-            f"{self._settings.managed_by_label_key}={self._settings.managed_by_label_value}"
-        )
+        selector = f"{self._settings.managed_by_label_key}={self._settings.managed_by_label_value}"
 
         servers: list[object]
         try:
@@ -302,7 +300,7 @@ class HetznerVMProvisioner:
                 return None
             try:
                 return float(value)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 return None
 
         price_hourly = getattr(price, "price_hourly", None)

--- a/worker-manager/src/worker_manager/adapters/ssh.py
+++ b/worker-manager/src/worker_manager/adapters/ssh.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 from pathlib import Path
+from typing import Literal
 
 import paramiko
 from pydantic import BaseModel, ConfigDict, Field
@@ -25,6 +26,7 @@ class SSHConfig(BaseModel):
     key_path: str = Field(default="~/.ssh/tanren_vm")
     port: int = Field(default=22, ge=1, le=65535)
     connect_timeout: int = Field(default=10, ge=1)
+    host_key_policy: Literal["auto_add", "warn", "reject"] = Field(default="auto_add")
 
 
 class SSHConnection:
@@ -51,7 +53,14 @@ class SSHConnection:
             self._close_sync()
 
         client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.load_system_host_keys()
+
+        if self._config.host_key_policy == "reject":
+            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+        elif self._config.host_key_policy == "warn":
+            client.set_missing_host_key_policy(paramiko.WarningPolicy())
+        else:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         key_path = str(Path(self._config.key_path).expanduser())
         try:

--- a/worker-manager/src/worker_manager/adapters/ssh_environment.py
+++ b/worker-manager/src/worker_manager/adapters/ssh_environment.py
@@ -118,6 +118,7 @@ class SSHExecutionEnvironment:
                 key_path=self._ssh_defaults.key_path,
                 port=self._ssh_defaults.port,
                 connect_timeout=self._ssh_defaults.connect_timeout,
+                host_key_policy=self._ssh_defaults.host_key_policy,
             )
             conn = SSHConnection(ssh_config)
 

--- a/worker-manager/src/worker_manager/adapters/ssh_environment.py
+++ b/worker-manager/src/worker_manager/adapters/ssh_environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shlex
 import time
@@ -46,6 +47,9 @@ from worker_manager.signals import map_outcome, parse_signal_token
 logger = logging.getLogger(__name__)
 
 _PUSH_PHASES = frozenset({Phase.DO_TASK, Phase.AUDIT_TASK, Phase.RUN_DEMO, Phase.AUDIT_SPEC})
+
+_SSH_READY_TIMEOUT_SECS = 120
+_SSH_READY_POLL_SECS = 3
 
 
 class SSHExecutionEnvironment:
@@ -112,6 +116,9 @@ class SSHExecutionEnvironment:
                 connect_timeout=self._ssh_defaults.connect_timeout,
             )
             conn = SSHConnection(ssh_config)
+
+            # 4b. Wait for SSH to accept connections (sshd lags behind API status)
+            await self._await_ssh_ready(conn)
 
             # 5. Bootstrap VM (idempotent)
             bootstrap_result = await self._bootstrapper.bootstrap(conn)
@@ -259,8 +266,6 @@ class SSHExecutionEnvironment:
                 )
                 if error_class == ErrorClass.TRANSIENT and transient_retries < 3:
                     transient_retries += 1
-                    import asyncio
-
                     backoff = TRANSIENT_BACKOFF[transient_retries - 1]
                     logger.warning(
                         "Transient error (attempt %d/3), retrying in %ds",
@@ -271,8 +276,6 @@ class SSHExecutionEnvironment:
                     continue
                 if error_class == ErrorClass.AMBIGUOUS and transient_retries < 1:
                     transient_retries += 1
-                    import asyncio
-
                     logger.warning("Ambiguous error, retrying once in 10s")
                     await asyncio.sleep(10)
                     continue
@@ -384,6 +387,25 @@ class SSHExecutionEnvironment:
                             estimated_cost=cost,
                         )
                     )
+
+    async def _await_ssh_ready(
+        self, conn: SSHConnection, *, timeout: int = _SSH_READY_TIMEOUT_SECS
+    ) -> None:
+        """Poll SSH until the host accepts connections or deadline expires."""
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while time.monotonic() < deadline:
+            attempt += 1
+            if await conn.check_connection():
+                logger.info("SSH ready after %d attempt(s)", attempt)
+                return
+            logger.debug(
+                "SSH not ready (attempt %d), retrying in %ds",
+                attempt,
+                _SSH_READY_POLL_SECS,
+            )
+            await asyncio.sleep(_SSH_READY_POLL_SECS)
+        raise TimeoutError(f"SSH not reachable within {timeout}s on {conn.get_host_identifier()}")
 
     def _resolve_profile(self, dispatch: Dispatch, config: Config):
         """Read tanren.yml locally and resolve environment profile."""

--- a/worker-manager/src/worker_manager/adapters/ssh_environment.py
+++ b/worker-manager/src/worker_manager/adapters/ssh_environment.py
@@ -88,6 +88,10 @@ class SSHExecutionEnvironment:
         """Return default SSH settings used for remote connections."""
         return self._ssh_defaults
 
+    async def close(self) -> None:
+        """Release resources held by the environment (DB connections)."""
+        await self._state_store.close()
+
     async def provision(self, dispatch: Dispatch, config: Config) -> EnvironmentHandle:
         """Acquire VM, bootstrap, setup workspace, inject secrets."""
         # 1. Read tanren.yml LOCALLY to get environment profile

--- a/worker-manager/src/worker_manager/cli.py
+++ b/worker-manager/src/worker_manager/cli.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from worker_manager.config import load_config_env
 from worker_manager.env.cli import env_app, secret_app
 from worker_manager.run_cli import run_app
 from worker_manager.vm_cli import vm_app
@@ -14,4 +15,5 @@ tanren.add_typer(run_app, name="run")
 
 
 def main() -> None:
+    load_config_env()
     tanren()

--- a/worker-manager/src/worker_manager/config.py
+++ b/worker-manager/src/worker_manager/config.py
@@ -16,6 +16,10 @@ def _expand(path: str) -> str:
     return str(Path(path).expanduser())
 
 
+def _expand_optional(path: str | None) -> str | None:
+    return _expand(path) if path is not None else None
+
+
 @runtime_checkable
 class ConfigSource(Protocol):
     """Provide WM_* configuration values from an external source.
@@ -171,7 +175,7 @@ class Config(BaseModel):
                 resolved[key] = env_val
 
         # 3. Validate — all required keys must be present
-        missing = [k for k in _REQUIRED_KEYS if k not in resolved]
+        missing = [k for k in _REQUIRED_KEYS if not resolved.get(k, "").strip()]
         if missing:
             raise ValueError(
                 f"Missing required config: {', '.join(missing)}. "
@@ -188,11 +192,11 @@ class Config(BaseModel):
             opencode_path=resolved["WM_OPENCODE_PATH"],
             codex_path=resolved["WM_CODEX_PATH"],
             claude_path=resolved["WM_CLAUDE_PATH"],
-            roles_config_path=resolved.get("WM_ROLES_CONFIG_PATH"),
-            worktree_registry_path=resolved["WM_WORKTREE_REGISTRY_PATH"],
+            roles_config_path=_expand_optional(resolved.get("WM_ROLES_CONFIG_PATH")),
+            worktree_registry_path=_expand(resolved["WM_WORKTREE_REGISTRY_PATH"]),
             max_opencode=int(resolved["WM_MAX_OPENCODE"]),
             max_codex=int(resolved["WM_MAX_CODEX"]),
             max_gate=int(resolved["WM_MAX_GATE"]),
-            events_db=resolved.get("WM_EVENTS_DB"),
-            remote_config_path=resolved.get("WM_REMOTE_CONFIG"),
+            events_db=_expand_optional(resolved.get("WM_EVENTS_DB")),
+            remote_config_path=_expand_optional(resolved.get("WM_REMOTE_CONFIG")),
         )

--- a/worker-manager/src/worker_manager/config.py
+++ b/worker-manager/src/worker_manager/config.py
@@ -1,13 +1,89 @@
 """Worker manager configuration from environment variables with WM_ prefix."""
 
+import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
+from dotenv import dotenv_values
 from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
 
 
 def _expand(path: str) -> str:
     return str(Path(path).expanduser())
+
+
+@runtime_checkable
+class ConfigSource(Protocol):
+    """Provide WM_* configuration values from an external source.
+
+    Implementations load configuration from different backends
+    (dotenv files, Vault, SSM). Resolution in Config.from_env():
+    sources provide base values, os.environ overrides.
+    All required fields must be present — no built-in defaults.
+
+    Default implementation: DotenvConfigSource.
+    """
+
+    def load(self) -> dict[str, str]: ...
+
+
+class DotenvConfigSource:
+    """Load config from a dotenv file.
+
+    Default: $XDG_CONFIG_HOME/tanren/tanren.env (~/.config/tanren/tanren.env).
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            xdg = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+            path = Path(xdg) / "tanren" / "tanren.env"
+        self._path = path
+
+    def load(self) -> dict[str, str]:
+        if not self._path.exists():
+            logger.debug("No config file at %s — skipping", self._path)
+            return {}
+        values = dotenv_values(self._path)
+        loaded = {k: v for k, v in values.items() if v is not None}
+        logger.debug("Loaded %d config values from %s", len(loaded), self._path)
+        return loaded
+
+
+def load_config_env(source: ConfigSource | None = None) -> None:
+    """Load config into os.environ from the given source (default: tanren.env).
+
+    Only sets variables not already present in os.environ (env wins).
+    Convenience for entry points — ensures vm_cli.py and other code
+    reading os.environ.get("WM_*") directly picks up values.
+    """
+    src = source or DotenvConfigSource()
+    values = src.load()
+    for key, value in values.items():
+        if key not in os.environ:
+            os.environ[key] = value
+
+
+_REQUIRED_KEYS = (
+    "WM_IPC_DIR",
+    "WM_GITHUB_DIR",
+    "WM_DATA_DIR",
+    "WM_COMMANDS_DIR",
+    "WM_POLL_INTERVAL",
+    "WM_HEARTBEAT_INTERVAL",
+    "WM_OPENCODE_PATH",
+    "WM_CODEX_PATH",
+    "WM_CLAUDE_PATH",
+    "WM_MAX_OPENCODE",
+    "WM_MAX_CODEX",
+    "WM_MAX_GATE",
+    "WM_WORKTREE_REGISTRY_PATH",
+)
+
+_OPTIONAL_KEYS = ("WM_ROLES_CONFIG_PATH", "WM_EVENTS_DB", "WM_REMOTE_CONFIG")
 
 
 class Config(BaseModel):
@@ -77,33 +153,46 @@ class Config(BaseModel):
     )
 
     @classmethod
-    def from_env(cls) -> Config:
-        """Load configuration from WM_ prefixed environment variables."""
-        ipc_dir_raw = os.environ.get("WM_IPC_DIR")
-        if not ipc_dir_raw:
-            raise ValueError("WM_IPC_DIR environment variable is required")
-        ipc_dir = _expand(ipc_dir_raw)
-        github_dir = _expand(os.environ.get("WM_GITHUB_DIR", "~/github"))
-        data_dir = _expand(os.environ.get("WM_DATA_DIR", "~/.local/share/tanren-worker"))
+    def from_env(cls, sources: Sequence[ConfigSource] = ()) -> Config:
+        """Load configuration from sources and environment variables.
+
+        Sources provide base values. Environment variables override.
+        All required WM_* fields must be present — no built-in defaults.
+        """
+        # 1. Collect values from sources
+        resolved: dict[str, str] = {}
+        for source in sources:
+            resolved.update(source.load())
+
+        # 2. Environment variables override source values
+        for key in (*_REQUIRED_KEYS, *_OPTIONAL_KEYS):
+            env_val = os.environ.get(key)
+            if env_val is not None:
+                resolved[key] = env_val
+
+        # 3. Validate — all required keys must be present
+        missing = [k for k in _REQUIRED_KEYS if k not in resolved]
+        if missing:
+            raise ValueError(
+                f"Missing required config: {', '.join(missing)}. "
+                "Set them in tanren.env or as environment variables."
+            )
 
         return cls(
-            ipc_dir=ipc_dir,
-            github_dir=github_dir,
-            commands_dir=os.environ.get("WM_COMMANDS_DIR", ".claude/commands/tanren"),
-            poll_interval=float(os.environ.get("WM_POLL_INTERVAL", "5.0")),
-            heartbeat_interval=float(os.environ.get("WM_HEARTBEAT_INTERVAL", "30.0")),
-            opencode_path=os.environ.get("WM_OPENCODE_PATH", "opencode"),
-            codex_path=os.environ.get("WM_CODEX_PATH", "codex"),
-            claude_path=os.environ.get("WM_CLAUDE_PATH", "claude"),
-            roles_config_path=os.environ.get("WM_ROLES_CONFIG_PATH"),
-            data_dir=data_dir,
-            worktree_registry_path=os.environ.get(
-                "WM_WORKTREE_REGISTRY_PATH",
-                str(Path(data_dir) / "worktrees.json"),
-            ),
-            max_opencode=int(os.environ.get("WM_MAX_OPENCODE", "1")),
-            max_codex=int(os.environ.get("WM_MAX_CODEX", "1")),
-            max_gate=int(os.environ.get("WM_MAX_GATE", "3")),
-            events_db=os.environ.get("WM_EVENTS_DB"),
-            remote_config_path=os.environ.get("WM_REMOTE_CONFIG"),
+            ipc_dir=_expand(resolved["WM_IPC_DIR"]),
+            github_dir=_expand(resolved["WM_GITHUB_DIR"]),
+            data_dir=_expand(resolved["WM_DATA_DIR"]),
+            commands_dir=resolved["WM_COMMANDS_DIR"],
+            poll_interval=float(resolved["WM_POLL_INTERVAL"]),
+            heartbeat_interval=float(resolved["WM_HEARTBEAT_INTERVAL"]),
+            opencode_path=resolved["WM_OPENCODE_PATH"],
+            codex_path=resolved["WM_CODEX_PATH"],
+            claude_path=resolved["WM_CLAUDE_PATH"],
+            roles_config_path=resolved.get("WM_ROLES_CONFIG_PATH"),
+            worktree_registry_path=resolved["WM_WORKTREE_REGISTRY_PATH"],
+            max_opencode=int(resolved["WM_MAX_OPENCODE"]),
+            max_codex=int(resolved["WM_MAX_CODEX"]),
+            max_gate=int(resolved["WM_MAX_GATE"]),
+            events_db=resolved.get("WM_EVENTS_DB"),
+            remote_config_path=resolved.get("WM_REMOTE_CONFIG"),
         )

--- a/worker-manager/src/worker_manager/config.py
+++ b/worker-manager/src/worker_manager/config.py
@@ -46,7 +46,7 @@ class DotenvConfigSource:
     def __init__(self, path: Path | None = None) -> None:
         if path is None:
             xdg = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
-            path = Path(xdg) / "tanren" / "tanren.env"
+            path = Path(xdg).expanduser() / "tanren" / "tanren.env"
         self._path = path
 
     def load(self) -> dict[str, str]:
@@ -57,20 +57,6 @@ class DotenvConfigSource:
         loaded = {k: v for k, v in values.items() if v is not None}
         logger.debug("Loaded %d config values from %s", len(loaded), self._path)
         return loaded
-
-
-def load_config_env(source: ConfigSource | None = None) -> None:
-    """Load config into os.environ from the given source (default: tanren.env).
-
-    Only sets variables not already present in os.environ (env wins).
-    Convenience for entry points — ensures vm_cli.py and other code
-    reading os.environ.get("WM_*") directly picks up values.
-    """
-    src = source or DotenvConfigSource()
-    values = src.load()
-    for key, value in values.items():
-        if key not in os.environ:
-            os.environ[key] = value
 
 
 _REQUIRED_KEYS = (
@@ -90,6 +76,22 @@ _REQUIRED_KEYS = (
 )
 
 _OPTIONAL_KEYS = ("WM_ROLES_CONFIG_PATH", "WM_EVENTS_DB", "WM_REMOTE_CONFIG")
+
+_WM_KEYS = frozenset((*_REQUIRED_KEYS, *_OPTIONAL_KEYS))
+
+
+def load_config_env(source: ConfigSource | None = None) -> None:
+    """Load WM_* config into os.environ from the given source (default: tanren.env).
+
+    Only sets WM_* variables not already present in os.environ (env wins).
+    Non-WM keys from the source file are silently ignored to prevent
+    leaking credentials or path overrides into child processes.
+    """
+    src = source or DotenvConfigSource()
+    values = src.load()
+    for key, value in values.items():
+        if key in _WM_KEYS and key not in os.environ:
+            os.environ[key] = value
 
 
 class Config(BaseModel):

--- a/worker-manager/src/worker_manager/config.py
+++ b/worker-manager/src/worker_manager/config.py
@@ -17,7 +17,9 @@ def _expand(path: str) -> str:
 
 
 def _expand_optional(path: str | None) -> str | None:
-    return _expand(path) if path is not None else None
+    if not path or not path.strip():
+        return None
+    return _expand(path)
 
 
 @runtime_checkable

--- a/worker-manager/src/worker_manager/manager.py
+++ b/worker-manager/src/worker_manager/manager.py
@@ -316,6 +316,7 @@ class WorkerManager:
             key_path=remote_cfg.ssh.key_path,
             port=remote_cfg.ssh.port,
             connect_timeout=remote_cfg.ssh.connect_timeout,
+            host_key_policy=remote_cfg.ssh.host_key_policy,
         )
 
         state_store = SqliteVMStateStore(f"{self._config.data_dir}/vm-state.db")

--- a/worker-manager/src/worker_manager/remote_config.py
+++ b/worker-manager/src/worker_manager/remote_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
@@ -41,6 +41,7 @@ class RemoteSSHConfig(BaseModel):
     key_path: str = Field(default="~/.ssh/tanren_vm")
     port: int = Field(default=22, ge=1, le=65535)
     connect_timeout: int = Field(default=10, ge=1)
+    host_key_policy: Literal["auto_add", "warn", "reject"] = Field(default="auto_add")
 
 
 class RemoteGitConfig(BaseModel):

--- a/worker-manager/src/worker_manager/run_cli.py
+++ b/worker-manager/src/worker_manager/run_cli.py
@@ -127,6 +127,11 @@ def _load_handle(config: Config, identifier: str) -> tuple[PersistedRunHandle, P
             raise typer.Exit(code=1) from exc
         return parsed
 
+    # Accept file paths directly
+    file_path = Path(identifier)
+    if file_path.is_file():
+        return _parse(file_path), file_path
+
     direct = _handle_path(config, identifier)
     if direct.exists():
         return _parse(direct), direct
@@ -300,56 +305,63 @@ def run_provision(
         config = _load_config()
         _require_remote_config(config)
         env = _build_remote_execution_env(config)
+        try:
+            workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
+            dispatch = Dispatch(
+                workflow_id=workflow_id,
+                phase=Phase.DO_TASK,
+                project=project,
+                spec_folder=".",
+                branch=branch,
+                cli=Cli.CLAUDE,
+                model=None,
+                gate_cmd=None,
+                context=None,
+                timeout=1800,
+                environment_profile=environment_profile,
+            )
+            handle = await env.provision(dispatch, config)
+            runtime = cast(RemoteEnvironmentRuntime, handle.runtime)
+            vm = runtime.vm_handle
 
-        workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
-        dispatch = Dispatch(
-            workflow_id=workflow_id,
-            phase=Phase.DO_TASK,
-            project=project,
-            spec_folder=".",
-            branch=branch,
-            cli=Cli.CLAUDE,
-            model=None,
-            gate_cmd=None,
-            context=None,
-            timeout=1800,
-            environment_profile=environment_profile,
-        )
-        handle = await env.provision(dispatch, config)
-        runtime = cast(RemoteEnvironmentRuntime, handle.runtime)
-        vm = runtime.vm_handle
+            # Close the SSH connection from provision (not needed after handle save)
+            conn = cast(SSHConnection, runtime.connection)
+            await conn.close()
 
-        persisted = PersistedRunHandle(
-            env_id=handle.env_id,
-            vm_id=vm.vm_id,
-            project=project,
-            branch=branch,
-            workflow_id=workflow_id,
-            environment_profile=environment_profile,
-            local_worktree_path=str(Path(config.github_dir) / project),
-            workspace_path=runtime.workspace_path.path,
-            teardown_commands=runtime.teardown_commands,
-            provisioned_at_utc=_now_utc_iso(),
-            vm_handle=runtime.vm_handle,
-            ssh_defaults=PersistedSSHDefaults(
-                user=env.ssh_defaults.user,
-                key_path=env.ssh_defaults.key_path,
-                port=env.ssh_defaults.port,
-                connect_timeout=env.ssh_defaults.connect_timeout,
-            ),
-        )
-        path = _save_handle(config, persisted)
+            persisted = PersistedRunHandle(
+                env_id=handle.env_id,
+                vm_id=vm.vm_id,
+                project=project,
+                branch=branch,
+                workflow_id=workflow_id,
+                environment_profile=environment_profile,
+                local_worktree_path=str(Path(config.github_dir) / project),
+                workspace_path=runtime.workspace_path.path,
+                teardown_commands=runtime.teardown_commands,
+                provisioned_at_utc=_now_utc_iso(),
+                vm_handle=runtime.vm_handle,
+                ssh_defaults=PersistedSSHDefaults(
+                    user=env.ssh_defaults.user,
+                    key_path=env.ssh_defaults.key_path,
+                    port=env.ssh_defaults.port,
+                    connect_timeout=env.ssh_defaults.connect_timeout,
+                ),
+            )
+            path = _save_handle(config, persisted)
 
-        typer.echo(f"env_id: {persisted.env_id}")
-        typer.echo(f"vm_id: {persisted.vm_id}")
-        typer.echo(f"host: {vm.host}")
-        typer.echo(f"ssh: ssh {persisted.ssh_defaults.user}@{vm.host}")
-        typer.echo(
-            "vscode: "
-            f"code --remote ssh-remote+{persisted.ssh_defaults.user}@{vm.host} "
-            f"{runtime.workspace_path.path}"
-        )
-        typer.echo(f"handle_file: {path}")
+            typer.echo(f"env_id: {persisted.env_id}")
+            typer.echo(f"vm_id: {persisted.vm_id}")
+            typer.echo(f"host: {vm.host}")
+            typer.echo(f"ssh: ssh {persisted.ssh_defaults.user}@{vm.host}")
+            typer.echo(
+                "vscode: "
+                f"code --folder-uri vscode-remote://ssh-remote+"
+                f"{persisted.ssh_defaults.user}@{vm.host}"
+                f"{runtime.workspace_path.path}"
+            )
+            typer.echo(f"handle_file: {path}")
+        finally:
+            await env.close()
 
     asyncio.run(_run())
 
@@ -370,52 +382,54 @@ def run_execute(
         config = _load_config()
         _require_remote_config(config)
         env = _build_remote_execution_env(config)
-
-        persisted, _ = _load_handle(config, handle)
-        if persisted.project != project:
-            typer.echo(
-                f"Handle project mismatch: expected {persisted.project}, got {project}",
-                err=True,
-            )
-            raise typer.Exit(code=1)
-
-        tool = _resolve_agent_tool(config, phase)
-        resolved_gate_cmd = _resolve_gate_cmd(
-            config=config,
-            project=project,
-            environment_profile=persisted.environment_profile,
-            phase=phase,
-            gate_cmd=gate_cmd,
-        )
-        dispatch = _build_dispatch(
-            project=project,
-            phase=phase,
-            spec_path=spec_path,
-            branch=persisted.branch,
-            environment_profile=persisted.environment_profile,
-            workflow_id=persisted.workflow_id,
-            timeout=timeout,
-            context=context,
-            gate_cmd=resolved_gate_cmd,
-            tool=tool,
-        )
-        env_handle = _reconstruct_handle(persisted)
-        runtime = cast(RemoteEnvironmentRuntime, env_handle.runtime)
-        conn = cast(SSHConnection, runtime.connection)
-
         try:
-            result = await env.execute(env_handle, dispatch, config)
-        finally:
-            await conn.close()
+            persisted, _ = _load_handle(config, handle)
+            if persisted.project != project:
+                typer.echo(
+                    f"Handle project mismatch: expected {persisted.project}, got {project}",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
 
-        typer.echo(f"outcome: {result.outcome.value}")
-        typer.echo(f"signal: {result.signal}")
-        typer.echo(f"exit_code: {result.exit_code}")
-        typer.echo(f"duration_secs: {result.duration_secs}")
-        tail = _build_tail_output(result.stdout)
-        if tail:
-            typer.echo("stdout_tail:")
-            typer.echo(tail)
+            tool = _resolve_agent_tool(config, phase)
+            resolved_gate_cmd = _resolve_gate_cmd(
+                config=config,
+                project=project,
+                environment_profile=persisted.environment_profile,
+                phase=phase,
+                gate_cmd=gate_cmd,
+            )
+            dispatch = _build_dispatch(
+                project=project,
+                phase=phase,
+                spec_path=spec_path,
+                branch=persisted.branch,
+                environment_profile=persisted.environment_profile,
+                workflow_id=persisted.workflow_id,
+                timeout=timeout,
+                context=context,
+                gate_cmd=resolved_gate_cmd,
+                tool=tool,
+            )
+            env_handle = _reconstruct_handle(persisted)
+            runtime = cast(RemoteEnvironmentRuntime, env_handle.runtime)
+            conn = cast(SSHConnection, runtime.connection)
+
+            try:
+                result = await env.execute(env_handle, dispatch, config)
+            finally:
+                await conn.close()
+
+            typer.echo(f"outcome: {result.outcome.value}")
+            typer.echo(f"signal: {result.signal}")
+            typer.echo(f"exit_code: {result.exit_code}")
+            typer.echo(f"duration_secs: {result.duration_secs}")
+            tail = _build_tail_output(result.stdout)
+            if tail:
+                typer.echo("stdout_tail:")
+                typer.echo(tail)
+        finally:
+            await env.close()
 
     asyncio.run(_run())
 
@@ -430,23 +444,26 @@ def run_teardown(
         config = _load_config()
         _require_remote_config(config)
         env = _build_remote_execution_env(config)
-        persisted, handle_path = _load_handle(config, handle)
+        try:
+            persisted, handle_path = _load_handle(config, handle)
 
-        env_handle = _reconstruct_handle(persisted)
-        await env.teardown(env_handle)
+            env_handle = _reconstruct_handle(persisted)
+            await env.teardown(env_handle)
 
-        handle_path.unlink(missing_ok=True)
+            handle_path.unlink(missing_ok=True)
 
-        duration = _elapsed_seconds(persisted.provisioned_at_utc)
-        estimated_cost: float | None = None
-        vm_hourly_cost = persisted.vm_handle.hourly_cost
-        if vm_hourly_cost is not None:
-            estimated_cost = vm_hourly_cost * (duration / 3600.0)
+            duration = _elapsed_seconds(persisted.provisioned_at_utc)
+            estimated_cost: float | None = None
+            vm_hourly_cost = persisted.vm_handle.hourly_cost
+            if vm_hourly_cost is not None:
+                estimated_cost = vm_hourly_cost * (duration / 3600.0)
 
-        typer.echo(f"released_vm_id: {persisted.vm_id}")
-        typer.echo(f"removed_handle: {handle_path}")
-        if estimated_cost is not None:
-            typer.echo(f"estimated_cost: {estimated_cost:.4f}")
+            typer.echo(f"released_vm_id: {persisted.vm_id}")
+            typer.echo(f"removed_handle: {handle_path}")
+            if estimated_cost is not None:
+                typer.echo(f"estimated_cost: {estimated_cost:.4f}")
+        finally:
+            await env.close()
 
     asyncio.run(_run())
 
@@ -468,92 +485,94 @@ def run_full(
         config = _load_config()
         _require_remote_config(config)
         env = _build_remote_execution_env(config)
-
-        workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
-        provision_dispatch = Dispatch(
-            workflow_id=workflow_id,
-            phase=Phase.DO_TASK,
-            project=project,
-            spec_folder=spec_path,
-            branch=branch,
-            cli=Cli.CLAUDE,
-            model=None,
-            gate_cmd=None,
-            context=None,
-            timeout=timeout,
-            environment_profile=environment_profile,
-        )
-        handle = await env.provision(provision_dispatch, config)
-        runtime = cast(RemoteEnvironmentRuntime, handle.runtime)
-        vm = runtime.vm_handle
-
-        persisted = PersistedRunHandle(
-            env_id=handle.env_id,
-            vm_id=vm.vm_id,
-            project=project,
-            branch=branch,
-            workflow_id=workflow_id,
-            environment_profile=environment_profile,
-            local_worktree_path=str(Path(config.github_dir) / project),
-            workspace_path=runtime.workspace_path.path,
-            teardown_commands=runtime.teardown_commands,
-            provisioned_at_utc=_now_utc_iso(),
-            vm_handle=runtime.vm_handle,
-            ssh_defaults=PersistedSSHDefaults(
-                user=env.ssh_defaults.user,
-                key_path=env.ssh_defaults.key_path,
-                port=env.ssh_defaults.port,
-                connect_timeout=env.ssh_defaults.connect_timeout,
-            ),
-        )
-        handle_path: Path | None = None
-        execute_failed = False
         try:
-            handle_path = _save_handle(config, persisted)
-            tool = _resolve_agent_tool(config, phase)
-            resolved_gate_cmd = _resolve_gate_cmd(
-                config=config,
-                project=project,
-                environment_profile=environment_profile,
-                phase=phase,
-                gate_cmd=gate_cmd,
-            )
-            dispatch = _build_dispatch(
-                project=project,
-                phase=phase,
-                spec_path=spec_path,
-                branch=branch,
-                environment_profile=environment_profile,
+            workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
+            provision_dispatch = Dispatch(
                 workflow_id=workflow_id,
+                phase=Phase.DO_TASK,
+                project=project,
+                spec_folder=spec_path,
+                branch=branch,
+                cli=Cli.CLAUDE,
+                model=None,
+                gate_cmd=None,
+                context=None,
                 timeout=timeout,
-                context=context,
-                gate_cmd=resolved_gate_cmd,
-                tool=tool,
+                environment_profile=environment_profile,
             )
-            exec_handle = _reconstruct_handle(persisted)
-            exec_runtime = cast(RemoteEnvironmentRuntime, exec_handle.runtime)
-            exec_conn = cast(SSHConnection, exec_runtime.connection)
+            handle = await env.provision(provision_dispatch, config)
+            runtime = cast(RemoteEnvironmentRuntime, handle.runtime)
+            vm = runtime.vm_handle
+
+            persisted = PersistedRunHandle(
+                env_id=handle.env_id,
+                vm_id=vm.vm_id,
+                project=project,
+                branch=branch,
+                workflow_id=workflow_id,
+                environment_profile=environment_profile,
+                local_worktree_path=str(Path(config.github_dir) / project),
+                workspace_path=runtime.workspace_path.path,
+                teardown_commands=runtime.teardown_commands,
+                provisioned_at_utc=_now_utc_iso(),
+                vm_handle=runtime.vm_handle,
+                ssh_defaults=PersistedSSHDefaults(
+                    user=env.ssh_defaults.user,
+                    key_path=env.ssh_defaults.key_path,
+                    port=env.ssh_defaults.port,
+                    connect_timeout=env.ssh_defaults.connect_timeout,
+                ),
+            )
+            handle_path: Path | None = None
+            execute_failed = False
             try:
-                result = await env.execute(exec_handle, dispatch, config)
+                handle_path = _save_handle(config, persisted)
+                tool = _resolve_agent_tool(config, phase)
+                resolved_gate_cmd = _resolve_gate_cmd(
+                    config=config,
+                    project=project,
+                    environment_profile=environment_profile,
+                    phase=phase,
+                    gate_cmd=gate_cmd,
+                )
+                dispatch = _build_dispatch(
+                    project=project,
+                    phase=phase,
+                    spec_path=spec_path,
+                    branch=branch,
+                    environment_profile=environment_profile,
+                    workflow_id=workflow_id,
+                    timeout=timeout,
+                    context=context,
+                    gate_cmd=resolved_gate_cmd,
+                    tool=tool,
+                )
+                exec_handle = _reconstruct_handle(persisted)
+                exec_runtime = cast(RemoteEnvironmentRuntime, exec_handle.runtime)
+                exec_conn = cast(SSHConnection, exec_runtime.connection)
+                try:
+                    result = await env.execute(exec_handle, dispatch, config)
+                finally:
+                    await exec_conn.close()
+
+                typer.echo(f"outcome: {result.outcome.value}")
+                typer.echo(f"signal: {result.signal}")
+                typer.echo(f"exit_code: {result.exit_code}")
+                typer.echo(f"duration_secs: {result.duration_secs}")
+                if result.outcome != Outcome.SUCCESS:
+                    execute_failed = True
             finally:
-                await exec_conn.close()
+                teardown_handle = _reconstruct_handle(persisted)
+                await env.teardown(teardown_handle)
+                if handle_path is not None:
+                    handle_path.unlink(missing_ok=True)
 
-            typer.echo(f"outcome: {result.outcome.value}")
-            typer.echo(f"signal: {result.signal}")
-            typer.echo(f"exit_code: {result.exit_code}")
-            typer.echo(f"duration_secs: {result.duration_secs}")
-            if result.outcome != Outcome.SUCCESS:
-                execute_failed = True
+            typer.echo(f"provisioned_vm_id: {persisted.vm_id}")
+            typer.echo("teardown: completed")
+            if execute_failed:
+                raise typer.Exit(code=1)
         finally:
-            teardown_handle = _reconstruct_handle(persisted)
-            await env.teardown(teardown_handle)
-            if handle_path is not None:
-                handle_path.unlink(missing_ok=True)
-
-        typer.echo(f"provisioned_vm_id: {persisted.vm_id}")
-        typer.echo("teardown: completed")
-        if execute_failed:
-            raise typer.Exit(code=1)
+            await env.close()
 
     asyncio.run(_run())
 

--- a/worker-manager/src/worker_manager/run_cli.py
+++ b/worker-manager/src/worker_manager/run_cli.py
@@ -12,7 +12,7 @@ import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, cast
+from typing import Annotated, Literal, cast
 
 import typer
 import yaml
@@ -46,6 +46,7 @@ class PersistedSSHDefaults(BaseModel):
     key_path: str = Field(...)
     port: int = Field(...)
     connect_timeout: int = Field(...)
+    host_key_policy: str = Field(default="auto_add")
 
 
 class PersistedRunHandle(BaseModel):
@@ -109,6 +110,20 @@ def _save_handle(config: Config, persisted: PersistedRunHandle) -> Path:
     return path
 
 
+def _is_managed_handle(config: Config, handle_path: Path) -> bool:
+    """Return True if handle_path lives inside the managed run-handles directory."""
+    try:
+        handle_path.resolve().relative_to(_handle_dir(config).resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _is_explicit_path(identifier: str) -> bool:
+    """True if identifier contains a path separator, indicating an explicit file path."""
+    return "/" in identifier or "\\" in identifier
+
+
 def _load_handle(config: Config, identifier: str) -> tuple[PersistedRunHandle, Path]:
     def _parse(path: Path) -> PersistedRunHandle:
         try:
@@ -127,19 +142,22 @@ def _load_handle(config: Config, identifier: str) -> tuple[PersistedRunHandle, P
             raise typer.Exit(code=1) from exc
         return parsed
 
-    # Accept file paths directly
-    file_path = Path(identifier)
-    if file_path.is_file():
-        return _parse(file_path), file_path
-
+    # 1. Registry lookup by env_id
     direct = _handle_path(config, identifier)
     if direct.exists():
         return _parse(direct), direct
 
+    # 2. Registry lookup by vm_id
     for candidate in _handle_dir(config).glob("*.json"):
         loaded = _parse(candidate)
         if loaded.vm_id == identifier:
             return loaded, candidate
+
+    # 3. Explicit file path (only for path-like identifiers)
+    if _is_explicit_path(identifier):
+        file_path = Path(identifier)
+        if file_path.is_file():
+            return _parse(file_path), file_path
 
     typer.echo(f"No run handle found for identifier: {identifier}", err=True)
     raise typer.Exit(code=1)
@@ -193,6 +211,10 @@ def _reconstruct_handle(persisted: PersistedRunHandle) -> EnvironmentHandle:
         key_path=persisted.ssh_defaults.key_path,
         port=persisted.ssh_defaults.port,
         connect_timeout=persisted.ssh_defaults.connect_timeout,
+        host_key_policy=cast(
+            Literal["auto_add", "warn", "reject"],
+            persisted.ssh_defaults.host_key_policy,
+        ),
     )
     conn = SSHConnection(ssh_cfg)
 
@@ -345,6 +367,7 @@ def run_provision(
                     key_path=env.ssh_defaults.key_path,
                     port=env.ssh_defaults.port,
                     connect_timeout=env.ssh_defaults.connect_timeout,
+                    host_key_policy=env.ssh_defaults.host_key_policy,
                 ),
             )
             path = _save_handle(config, persisted)
@@ -450,8 +473,6 @@ def run_teardown(
             env_handle = _reconstruct_handle(persisted)
             await env.teardown(env_handle)
 
-            handle_path.unlink(missing_ok=True)
-
             duration = _elapsed_seconds(persisted.provisioned_at_utc)
             estimated_cost: float | None = None
             vm_hourly_cost = persisted.vm_handle.hourly_cost
@@ -459,7 +480,11 @@ def run_teardown(
                 estimated_cost = vm_hourly_cost * (duration / 3600.0)
 
             typer.echo(f"released_vm_id: {persisted.vm_id}")
-            typer.echo(f"removed_handle: {handle_path}")
+            if _is_managed_handle(config, handle_path):
+                handle_path.unlink(missing_ok=True)
+                typer.echo(f"removed_handle: {handle_path}")
+            else:
+                typer.echo(f"handle_retained: {handle_path} (external file)")
             if estimated_cost is not None:
                 typer.echo(f"estimated_cost: {estimated_cost:.4f}")
         finally:
@@ -521,6 +546,7 @@ def run_full(
                     key_path=env.ssh_defaults.key_path,
                     port=env.ssh_defaults.port,
                     connect_timeout=env.ssh_defaults.connect_timeout,
+                    host_key_policy=env.ssh_defaults.host_key_policy,
                 ),
             )
             handle_path: Path | None = None
@@ -564,7 +590,7 @@ def run_full(
             finally:
                 teardown_handle = _reconstruct_handle(persisted)
                 await env.teardown(teardown_handle)
-                if handle_path is not None:
+                if handle_path is not None and _is_managed_handle(config, handle_path):
                     handle_path.unlink(missing_ok=True)
 
             typer.echo(f"provisioned_vm_id: {persisted.vm_id}")

--- a/worker-manager/src/worker_manager/run_cli.py
+++ b/worker-manager/src/worker_manager/run_cli.py
@@ -46,7 +46,7 @@ class PersistedSSHDefaults(BaseModel):
     key_path: str = Field(...)
     port: int = Field(...)
     connect_timeout: int = Field(...)
-    host_key_policy: str = Field(default="auto_add")
+    host_key_policy: Literal["auto_add", "warn", "reject"] = Field(default="auto_add")
 
 
 class PersistedRunHandle(BaseModel):
@@ -211,10 +211,7 @@ def _reconstruct_handle(persisted: PersistedRunHandle) -> EnvironmentHandle:
         key_path=persisted.ssh_defaults.key_path,
         port=persisted.ssh_defaults.port,
         connect_timeout=persisted.ssh_defaults.connect_timeout,
-        host_key_policy=cast(
-            Literal["auto_add", "warn", "reject"],
-            persisted.ssh_defaults.host_key_policy,
-        ),
+        host_key_policy=persisted.ssh_defaults.host_key_policy,
     )
     conn = SSHConnection(ssh_cfg)
 
@@ -528,6 +525,10 @@ def run_full(
             handle = await env.provision(provision_dispatch, config)
             runtime = cast(RemoteEnvironmentRuntime, handle.runtime)
             vm = runtime.vm_handle
+
+            # Close the SSH connection from provision (not needed after handle save)
+            conn = cast(SSHConnection, runtime.connection)
+            await conn.close()
 
             persisted = PersistedRunHandle(
                 env_id=handle.env_id,

--- a/worker-manager/src/worker_manager/vm_cli.py
+++ b/worker-manager/src/worker_manager/vm_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 import typer
@@ -14,6 +13,7 @@ from worker_manager.adapters.hetzner_vm import HetznerProvisionerSettings
 from worker_manager.adapters.manual_vm import ManualProvisionerSettings
 from worker_manager.adapters.sqlite_vm_state import SqliteVMStateStore
 from worker_manager.adapters.ubuntu_bootstrap import UbuntuBootstrapper
+from worker_manager.config import Config
 from worker_manager.env.environment_schema import EnvironmentProfile, parse_environment_profiles
 from worker_manager.remote_config import ProvisionerType, load_remote_config
 from worker_manager.secrets import SecretConfig, SecretLoader
@@ -21,15 +21,19 @@ from worker_manager.secrets import SecretConfig, SecretLoader
 vm_app = typer.Typer(help="Manage remote VM assignments.")
 
 
-def _get_state_store() -> SqliteVMStateStore:
-    """Create a VMStateStore from WM_DATA_DIR config."""
-    data_dir = str(Path(os.environ.get("WM_DATA_DIR", "~/.local/share/tanren-worker")).expanduser())
-    db_path = f"{data_dir}/vm-state.db"
+def _load_config() -> Config:
+    """Load worker-manager Config, exiting on failure."""
+    try:
+        return Config.from_env()
+    except Exception as exc:
+        typer.echo(f"Failed to load config: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _get_state_store(config: Config) -> SqliteVMStateStore:
+    """Create a VMStateStore from Config.data_dir."""
+    db_path = f"{config.data_dir}/vm-state.db"
     return SqliteVMStateStore(db_path)
-
-
-def _github_dir() -> Path:
-    return Path(os.environ.get("WM_GITHUB_DIR", "~/github")).expanduser()
 
 
 @vm_app.command("list")
@@ -37,7 +41,8 @@ def vm_list() -> None:
     """Show active VM assignments."""
 
     async def _run() -> None:
-        store = _get_state_store()
+        config = _load_config()
+        store = _get_state_store(config)
         try:
             assignments = await store.get_active_assignments()
             if not assignments:
@@ -64,7 +69,8 @@ def vm_release(vm_id: str = typer.Argument(...)) -> None:
     """Manually release a stuck VM assignment."""
 
     async def _run() -> None:
-        store = _get_state_store()
+        config = _load_config()
+        store = _get_state_store(config)
         try:
             assignment = await store.get_assignment(vm_id)
             if assignment is None:
@@ -86,7 +92,8 @@ def vm_recover() -> None:
         from worker_manager.adapters.ssh import SSHConfig, SSHConnection
         from worker_manager.remote_config import RemoteSSHConfig
 
-        store = _get_state_store()
+        config = _load_config()
+        store = _get_state_store(config)
         try:
             assignments = await store.get_active_assignments()
             if not assignments:
@@ -95,14 +102,9 @@ def vm_recover() -> None:
 
             typer.echo(f"Checking {len(assignments)} active assignment(s)...")
 
-            remote_config_path = os.environ.get("WM_REMOTE_CONFIG")
-            if remote_config_path:
-                remote_config_path = str(Path(remote_config_path).expanduser())
             ssh_defaults: RemoteSSHConfig | None = None
-            if remote_config_path:
-                from worker_manager.remote_config import load_remote_config
-
-                ssh_defaults = load_remote_config(remote_config_path).ssh
+            if config.remote_config_path:
+                ssh_defaults = load_remote_config(config.remote_config_path).ssh
 
             for assignment in assignments:
                 if ssh_defaults is not None:
@@ -142,15 +144,14 @@ def vm_dry_run(
     environment_profile: str = typer.Option("default", "--environment-profile"),
 ) -> None:
     """Show what remote provision would do without creating resources."""
-    remote_config_path = os.environ.get("WM_REMOTE_CONFIG")
-    if not remote_config_path:
+    config = _load_config()
+    if not config.remote_config_path:
         typer.echo("WM_REMOTE_CONFIG is required for vm dry-run.", err=True)
         raise typer.Exit(code=1)
-    remote_config_path = str(Path(remote_config_path).expanduser())
 
-    remote_cfg = load_remote_config(remote_config_path)
+    remote_cfg = load_remote_config(config.remote_config_path)
 
-    tanren_yml = _github_dir() / project / "tanren.yml"
+    tanren_yml = Path(config.github_dir) / project / "tanren.yml"
     if tanren_yml.exists():
         raw = yaml.safe_load(tanren_yml.read_text()) or {}
         data = raw if isinstance(raw, dict) else {}
@@ -203,7 +204,7 @@ def vm_dry_run(
     else:
         typer.echo("  - <none>")
 
-    project_env_file = _github_dir() / project / ".env"
+    project_env_file = Path(config.github_dir) / project / ".env"
     project_secret_keys = []
     if project_env_file.exists():
         project_secret_keys = sorted(dotenv_values(project_env_file).keys())

--- a/worker-manager/src/worker_manager/vm_cli.py
+++ b/worker-manager/src/worker_manager/vm_cli.py
@@ -114,6 +114,7 @@ def vm_recover() -> None:
                         key_path=ssh_defaults.key_path,
                         port=ssh_defaults.port,
                         connect_timeout=ssh_defaults.connect_timeout,
+                        host_key_policy=ssh_defaults.host_key_policy,
                     )
                 else:
                     ssh_config = SSHConfig(host=assignment.host)

--- a/worker-manager/src/worker_manager/vm_cli.py
+++ b/worker-manager/src/worker_manager/vm_cli.py
@@ -96,6 +96,8 @@ def vm_recover() -> None:
             typer.echo(f"Checking {len(assignments)} active assignment(s)...")
 
             remote_config_path = os.environ.get("WM_REMOTE_CONFIG")
+            if remote_config_path:
+                remote_config_path = str(Path(remote_config_path).expanduser())
             ssh_defaults: RemoteSSHConfig | None = None
             if remote_config_path:
                 from worker_manager.remote_config import load_remote_config
@@ -144,6 +146,7 @@ def vm_dry_run(
     if not remote_config_path:
         typer.echo("WM_REMOTE_CONFIG is required for vm dry-run.", err=True)
         raise typer.Exit(code=1)
+    remote_config_path = str(Path(remote_config_path).expanduser())
 
     remote_cfg = load_remote_config(remote_config_path)
 

--- a/worker-manager/tests/unit/test_config.py
+++ b/worker-manager/tests/unit/test_config.py
@@ -77,6 +77,11 @@ class TestDotenvConfigSource:
         values = source.load()
         assert values == {"WM_IPC_DIR": "/xdg/ipc"}
 
+    def test_expands_tilde_in_xdg_config_home(self, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", "~/custom-config")
+        source = DotenvConfigSource()
+        assert "~" not in str(source._path)
+
 
 # ---------------------------------------------------------------------------
 # TestLoadConfigEnv
@@ -98,13 +103,15 @@ class TestLoadConfigEnv:
         load_config_env(source=source)
         assert os.environ["WM_IPC_DIR"] == "/from/env"
 
-    def test_accepts_custom_source(self, monkeypatch):
-        monkeypatch.delenv("_TEST_CUSTOM_KEY", raising=False)
-        source = _DictSource({"_TEST_CUSTOM_KEY": "custom-value"})
+    def test_ignores_non_wm_keys(self, monkeypatch):
+        """load_config_env only injects known WM_* keys, not arbitrary keys."""
+        monkeypatch.delenv("LEAKED_SECRET", raising=False)
+        monkeypatch.delenv("WM_IPC_DIR", raising=False)
+        source = _DictSource({"LEAKED_SECRET": "oops", "WM_IPC_DIR": "/from/source"})
         load_config_env(source=source)
-        assert os.environ["_TEST_CUSTOM_KEY"] == "custom-value"
-        # Clean up
-        monkeypatch.delenv("_TEST_CUSTOM_KEY")
+        assert os.environ.get("LEAKED_SECRET") is None
+        assert os.environ["WM_IPC_DIR"] == "/from/source"
+        monkeypatch.delenv("WM_IPC_DIR")
 
 
 # ---------------------------------------------------------------------------

--- a/worker-manager/tests/unit/test_config.py
+++ b/worker-manager/tests/unit/test_config.py
@@ -202,6 +202,34 @@ class TestConfig:
         config = Config.from_env()
         assert config.worktree_registry_path == "/tmp/data/worktrees.json"
 
+    def test_worktree_registry_path_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_WORKTREE_REGISTRY_PATH", "~/wt.json")
+        config = Config.from_env()
+        assert "~" not in config.worktree_registry_path
+
+    def test_optional_paths_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_ROLES_CONFIG_PATH", "~/roles.yml")
+        monkeypatch.setenv("WM_EVENTS_DB", "~/events.db")
+        monkeypatch.setenv("WM_REMOTE_CONFIG", "~/remote.yml")
+        config = Config.from_env()
+        assert "~" not in config.roles_config_path
+        assert "~" not in config.events_db
+        assert "~" not in config.remote_config_path
+
+    def test_raises_on_empty_required_value(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_IPC_DIR", "")
+        with pytest.raises(ValueError, match="WM_IPC_DIR"):
+            Config.from_env()
+
+    def test_raises_on_whitespace_only_value(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_IPC_DIR", "   ")
+        with pytest.raises(ValueError, match="WM_IPC_DIR"):
+            Config.from_env()
+
 
 # ---------------------------------------------------------------------------
 # ConfigSource protocol check

--- a/worker-manager/tests/unit/test_config.py
+++ b/worker-manager/tests/unit/test_config.py
@@ -230,6 +230,18 @@ class TestConfig:
         with pytest.raises(ValueError, match="WM_IPC_DIR"):
             Config.from_env()
 
+    def test_empty_optional_value_treated_as_none(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_REMOTE_CONFIG", "")
+        config = Config.from_env()
+        assert config.remote_config_path is None
+
+    def test_whitespace_optional_value_treated_as_none(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_EVENTS_DB", "   ")
+        config = Config.from_env()
+        assert config.events_db is None
+
 
 # ---------------------------------------------------------------------------
 # ConfigSource protocol check

--- a/worker-manager/tests/unit/test_config.py
+++ b/worker-manager/tests/unit/test_config.py
@@ -1,82 +1,216 @@
 """Tests for config module."""
 
 import os
+from pathlib import Path
 
 import pytest
 
-from worker_manager.config import Config
+from worker_manager.config import (
+    _REQUIRED_KEYS,
+    Config,
+    ConfigSource,
+    DotenvConfigSource,
+    load_config_env,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ALL_REQUIRED_ENV = {
+    "WM_IPC_DIR": "/tmp/test-ipc",
+    "WM_GITHUB_DIR": "/tmp/github",
+    "WM_DATA_DIR": "/tmp/data",
+    "WM_COMMANDS_DIR": ".claude/commands/tanren",
+    "WM_POLL_INTERVAL": "5.0",
+    "WM_HEARTBEAT_INTERVAL": "30.0",
+    "WM_OPENCODE_PATH": "opencode",
+    "WM_CODEX_PATH": "codex",
+    "WM_CLAUDE_PATH": "claude",
+    "WM_MAX_OPENCODE": "1",
+    "WM_MAX_CODEX": "1",
+    "WM_MAX_GATE": "3",
+    "WM_WORKTREE_REGISTRY_PATH": "/tmp/data/worktrees.json",
+}
+
+
+def _set_all_required(monkeypatch):
+    """Set all required WM_* env vars via monkeypatch."""
+    for key, value in _ALL_REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+class _DictSource:
+    """Trivial ConfigSource for testing."""
+
+    def __init__(self, values: dict[str, str]) -> None:
+        self._values = values
+
+    def load(self) -> dict[str, str]:
+        return dict(self._values)
+
+
+# ---------------------------------------------------------------------------
+# TestDotenvConfigSource
+# ---------------------------------------------------------------------------
+
+
+class TestDotenvConfigSource:
+    def test_loads_values_from_file(self, tmp_path: Path):
+        env_file = tmp_path / "tanren.env"
+        env_file.write_text("WM_IPC_DIR=/tmp/ipc\nWM_GITHUB_DIR=/tmp/gh\n")
+        source = DotenvConfigSource(path=env_file)
+        values = source.load()
+        assert values == {"WM_IPC_DIR": "/tmp/ipc", "WM_GITHUB_DIR": "/tmp/gh"}
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path):
+        source = DotenvConfigSource(path=tmp_path / "nonexistent.env")
+        assert source.load() == {}
+
+    def test_respects_xdg_config_home(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "tanren"
+        config_dir.mkdir()
+        env_file = config_dir / "tanren.env"
+        env_file.write_text("WM_IPC_DIR=/xdg/ipc\n")
+        source = DotenvConfigSource()
+        values = source.load()
+        assert values == {"WM_IPC_DIR": "/xdg/ipc"}
+
+
+# ---------------------------------------------------------------------------
+# TestLoadConfigEnv
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigEnv:
+    def test_populates_os_environ(self, monkeypatch):
+        monkeypatch.delenv("WM_IPC_DIR", raising=False)
+        source = _DictSource({"WM_IPC_DIR": "/from/source"})
+        load_config_env(source=source)
+        assert os.environ["WM_IPC_DIR"] == "/from/source"
+        # Clean up: load_config_env writes directly to os.environ
+        monkeypatch.delenv("WM_IPC_DIR")
+
+    def test_env_var_overrides_source(self, monkeypatch):
+        monkeypatch.setenv("WM_IPC_DIR", "/from/env")
+        source = _DictSource({"WM_IPC_DIR": "/from/source"})
+        load_config_env(source=source)
+        assert os.environ["WM_IPC_DIR"] == "/from/env"
+
+    def test_accepts_custom_source(self, monkeypatch):
+        monkeypatch.delenv("_TEST_CUSTOM_KEY", raising=False)
+        source = _DictSource({"_TEST_CUSTOM_KEY": "custom-value"})
+        load_config_env(source=source)
+        assert os.environ["_TEST_CUSTOM_KEY"] == "custom-value"
+        # Clean up
+        monkeypatch.delenv("_TEST_CUSTOM_KEY")
+
+
+# ---------------------------------------------------------------------------
+# TestConfigFromEnvWithSources
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFromEnvWithSources:
+    @pytest.fixture(autouse=True)
+    def _clear_wm_env(self, monkeypatch):
+        """Ensure no WM_* env vars leak into source-based tests."""
+        for key in (*_REQUIRED_KEYS, "WM_ROLES_CONFIG_PATH", "WM_EVENTS_DB", "WM_REMOTE_CONFIG"):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_resolves_all_required_from_source(self):
+        source = _DictSource(_ALL_REQUIRED_ENV)
+        config = Config.from_env(sources=[source])
+        assert config.ipc_dir == "/tmp/test-ipc"
+        assert config.github_dir == "/tmp/github"
+        assert config.poll_interval == 5.0
+        assert config.max_gate == 3
+
+    def test_env_overrides_source(self, monkeypatch):
+        source = _DictSource(_ALL_REQUIRED_ENV)
+        monkeypatch.setenv("WM_POLL_INTERVAL", "99.0")
+        config = Config.from_env(sources=[source])
+        assert config.poll_interval == 99.0
+
+    def test_raises_on_missing_required(self):
+        source = _DictSource({"WM_IPC_DIR": "/tmp/ipc"})
+        with pytest.raises(ValueError, match="Missing required config"):
+            Config.from_env(sources=[source])
+
+    def test_optional_keys_default_to_none(self):
+        source = _DictSource(_ALL_REQUIRED_ENV)
+        config = Config.from_env(sources=[source])
+        assert config.roles_config_path is None
+        assert config.events_db is None
+        assert config.remote_config_path is None
+
+
+# ---------------------------------------------------------------------------
+# TestConfig (existing — updated for zero-defaults)
+# ---------------------------------------------------------------------------
 
 
 class TestConfig:
-    def test_requires_ipc_dir(self, monkeypatch: object):
-        monkeypatch.delenv("WM_IPC_DIR", raising=False)
-        with pytest.raises(ValueError, match="WM_IPC_DIR"):
+    def test_raises_on_missing_required_keys(self, monkeypatch):
+        """from_env() with no sources and no env vars raises for all required keys."""
+        for key in _REQUIRED_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        with pytest.raises(ValueError, match="Missing required config"):
             Config.from_env()
 
-    def test_defaults_with_ipc_dir(self, monkeypatch: object):
-        monkeypatch.setenv("WM_IPC_DIR", "/tmp/test-ipc")
-        config = Config.from_env()
-        assert config.poll_interval == 5.0
-        assert config.heartbeat_interval == 30.0
-        assert config.max_opencode == 1
-        assert config.max_codex == 1
-        assert config.max_gate == 3
-        assert config.opencode_path == "opencode"
-        assert config.codex_path == "codex"
-        assert config.commands_dir == ".claude/commands/tanren"
-
-    def test_ipc_dir_expanded(self, monkeypatch: object):
+    def test_ipc_dir_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
         monkeypatch.setenv("WM_IPC_DIR", "~/test-ipc")
         config = Config.from_env()
         assert "~" not in config.ipc_dir
 
-    def test_data_dir_expanded(self, monkeypatch: object):
-        monkeypatch.setenv("WM_IPC_DIR", "/tmp/test-ipc")
+    def test_data_dir_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_DATA_DIR", "~/data")
         config = Config.from_env()
         assert "~" not in config.data_dir
 
-    def test_env_override(self, monkeypatch: object):
-        monkeypatch.setattr(
-            os,
-            "environ",
-            {
-                **os.environ,
-                "WM_IPC_DIR": "/tmp/test-ipc",
-                "WM_POLL_INTERVAL": "10.0",
-                "WM_MAX_GATE": "5",
-                "WM_OPENCODE_PATH": "/usr/local/bin/opencode",
-            },
-        )
+    def test_env_override(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_POLL_INTERVAL", "10.0")
+        monkeypatch.setenv("WM_MAX_GATE", "5")
+        monkeypatch.setenv("WM_OPENCODE_PATH", "/usr/local/bin/opencode")
         config = Config.from_env()
         assert config.poll_interval == 10.0
         assert config.max_gate == 5
         assert config.opencode_path == "/usr/local/bin/opencode"
 
-    def test_claude_path_default(self, monkeypatch: object):
-        monkeypatch.setenv("WM_IPC_DIR", "/tmp/test-ipc")
+    def test_claude_path(self, monkeypatch):
+        _set_all_required(monkeypatch)
         config = Config.from_env()
         assert config.claude_path == "claude"
 
-    def test_roles_config_path_default(self, monkeypatch: object):
-        monkeypatch.setenv("WM_IPC_DIR", "/tmp/test-ipc")
+    def test_roles_config_path_default(self, monkeypatch):
+        _set_all_required(monkeypatch)
         config = Config.from_env()
         assert config.roles_config_path is None
 
-    def test_roles_config_path_from_env(self, monkeypatch: object):
-        monkeypatch.setattr(
-            os,
-            "environ",
-            {
-                **os.environ,
-                "WM_IPC_DIR": "/tmp/test-ipc",
-                "WM_ROLES_CONFIG_PATH": "/etc/tanren/roles.yml",
-            },
-        )
+    def test_roles_config_path_from_env(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_ROLES_CONFIG_PATH", "/etc/tanren/roles.yml")
         config = Config.from_env()
         assert config.roles_config_path == "/etc/tanren/roles.yml"
 
-    def test_worktree_registry_in_data_dir(self, monkeypatch: object):
-        monkeypatch.setenv("WM_IPC_DIR", "/tmp/test-ipc")
+    def test_worktree_registry_path(self, monkeypatch):
+        _set_all_required(monkeypatch)
         config = Config.from_env()
-        assert config.worktree_registry_path.startswith(config.data_dir)
-        assert config.worktree_registry_path.endswith("worktrees.json")
+        assert config.worktree_registry_path == "/tmp/data/worktrees.json"
+
+
+# ---------------------------------------------------------------------------
+# ConfigSource protocol check
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSourceProtocol:
+    def test_dotenv_source_satisfies_protocol(self):
+        assert isinstance(DotenvConfigSource(), ConfigSource)
+
+    def test_dict_source_satisfies_protocol(self):
+        assert isinstance(_DictSource({}), ConfigSource)

--- a/worker-manager/tests/unit/test_entrypoints.py
+++ b/worker-manager/tests/unit/test_entrypoints.py
@@ -6,15 +6,20 @@ from __future__ import annotations
 def test_cli_main_invokes_typer_app(monkeypatch):
     from worker_manager import cli
 
-    called = {"tanren": False}
+    called = {"tanren": False, "load_config_env": False}
 
     def _fake_tanren() -> None:
         called["tanren"] = True
 
+    def _fake_load_config_env(*_a, **_kw) -> None:
+        called["load_config_env"] = True
+
     monkeypatch.setattr(cli, "tanren", _fake_tanren)
+    monkeypatch.setattr(cli, "load_config_env", _fake_load_config_env)
     cli.main()
 
     assert called["tanren"] is True
+    assert called["load_config_env"] is True
 
 
 def test_worker_main_builds_manager_and_runs(monkeypatch):
@@ -25,7 +30,14 @@ def test_worker_main_builds_manager_and_runs(monkeypatch):
             return "manager-run-coro"
 
     seen: dict[str, object] = {}
+    called = {"load_config_env": False}
+
     monkeypatch.setattr(main_mod, "WorkerManager", _FakeManager)
+
+    def _fake_load_config_env(*_a, **_kw) -> None:
+        called["load_config_env"] = True
+
+    monkeypatch.setattr(main_mod, "load_config_env", _fake_load_config_env)
 
     def _fake_asyncio_run(coro):
         seen["coro"] = coro
@@ -34,3 +46,4 @@ def test_worker_main_builds_manager_and_runs(monkeypatch):
     main_mod.main()
 
     assert seen["coro"] == "manager-run-coro"
+    assert called["load_config_env"] is True

--- a/worker-manager/tests/unit/test_hetzner_vm.py
+++ b/worker-manager/tests/unit/test_hetzner_vm.py
@@ -118,9 +118,7 @@ async def test_acquire_times_out_when_server_not_ready(monkeypatch):
         "worker_manager.adapters.hetzner_vm._build_hcloud_client",
         lambda token: client,
     )
-    settings = _settings().model_copy(
-        update={"readiness_timeout_secs": 1, "poll_interval_secs": 1}
-    )
+    settings = _settings().model_copy(update={"readiness_timeout_secs": 1, "poll_interval_secs": 1})
     provisioner = HetznerVMProvisioner(settings)
 
     with pytest.raises(TimeoutError):

--- a/worker-manager/tests/unit/test_run_cli.py
+++ b/worker-manager/tests/unit/test_run_cli.py
@@ -370,10 +370,7 @@ def test_run_execute_gate_uses_profile_gate_cmd_when_missing_flag(tmp_path: Path
     _persisted(config)
     _write_tanren_yml(
         config,
-        "environment:\n"
-        "  default:\n"
-        "    type: remote\n"
-        "    gate_cmd: make integration-check\n",
+        "environment:\n  default:\n    type: remote\n    gate_cmd: make integration-check\n",
     )
     env = AsyncMock()
     env.execute.return_value = PhaseResult(

--- a/worker-manager/tests/unit/test_run_cli.py
+++ b/worker-manager/tests/unit/test_run_cli.py
@@ -508,3 +508,99 @@ def test_run_full_teardown_runs_even_when_handle_save_fails(tmp_path: Path, monk
     assert result.exit_code == 1
     assert env.execute.await_count == 0
     assert env.teardown.await_count == 1
+
+
+def test_teardown_retains_external_handle_file(tmp_path: Path, monkeypatch):
+    """Handle files outside run-handles/ are not deleted on teardown."""
+    config = _config(tmp_path)
+    persisted = PersistedRunHandle(
+        env_id="env-ext",
+        vm_id="vm-ext",
+        project="proj",
+        branch="main",
+        workflow_id="run-proj-ext",
+        environment_profile="default",
+        local_worktree_path=str(Path(config.github_dir) / "proj"),
+        workspace_path="/workspace/proj",
+        teardown_commands=(),
+        provisioned_at_utc=datetime.now(UTC).isoformat(),
+        vm_handle=VMHandle(
+            vm_id="vm-ext",
+            host="203.0.113.10",
+            provider=VMProvider.HETZNER,
+            created_at="2026-01-01T00:00:00Z",
+            hourly_cost=0.5,
+        ),
+        ssh_defaults=PersistedSSHDefaults(
+            user="root",
+            key_path="~/.ssh/id_rsa",
+            port=22,
+            connect_timeout=10,
+        ),
+    )
+    external_file = tmp_path / "external-handle.json"
+    external_file.write_text(persisted.model_dump_json(indent=2))
+
+    env = AsyncMock()
+    monkeypatch.setattr("worker_manager.run_cli._load_config", lambda: config)
+    monkeypatch.setattr("worker_manager.run_cli._build_remote_execution_env", lambda cfg: env)
+
+    result = CliRunner().invoke(run, ["teardown", "--handle", str(external_file)])
+
+    assert result.exit_code == 0
+    assert external_file.exists(), "external handle file should NOT be deleted"
+    assert "handle_retained" in result.output
+
+
+def test_load_handle_registry_not_shadowed_by_cwd_file(tmp_path: Path, monkeypatch):
+    """A file named like an env_id in cwd must not shadow the registry."""
+    config = _config(tmp_path)
+    _persisted(config)  # creates env-123.json in registry
+
+    # Create a decoy file named "env-123" in cwd (not valid JSON)
+    monkeypatch.chdir(tmp_path)
+    decoy = tmp_path / "env-123"
+    decoy.write_text("not a handle")
+
+    loaded, loaded_path = _load_handle(config, "env-123")
+
+    assert loaded.env_id == "env-123"
+    # Must resolve from registry, not from cwd decoy
+    assert "run-handles" in str(loaded_path)
+
+
+def test_persisted_handle_roundtrips_host_key_policy(tmp_path: Path):
+    """host_key_policy survives save → load roundtrip."""
+    config = _config(tmp_path)
+    persisted = PersistedRunHandle(
+        env_id="env-hkp",
+        vm_id="vm-hkp",
+        project="proj",
+        branch="main",
+        workflow_id="run-proj-hkp",
+        environment_profile="default",
+        local_worktree_path=str(Path(config.github_dir) / "proj"),
+        workspace_path="/workspace/proj",
+        teardown_commands=(),
+        provisioned_at_utc=datetime.now(UTC).isoformat(),
+        vm_handle=VMHandle(
+            vm_id="vm-hkp",
+            host="203.0.113.10",
+            provider=VMProvider.HETZNER,
+            created_at="2026-01-01T00:00:00Z",
+            hourly_cost=0.5,
+        ),
+        ssh_defaults=PersistedSSHDefaults(
+            user="root",
+            key_path="~/.ssh/id_rsa",
+            port=22,
+            connect_timeout=10,
+            host_key_policy="reject",
+        ),
+    )
+    from worker_manager.run_cli import _save_handle
+
+    _save_handle(config, persisted)
+
+    loaded, _ = _load_handle(config, "env-hkp")
+    assert loaded.ssh_defaults.host_key_policy == "reject"

--- a/worker-manager/tests/unit/test_run_cli.py
+++ b/worker-manager/tests/unit/test_run_cli.py
@@ -18,6 +18,7 @@ from worker_manager.roles import AgentTool
 from worker_manager.run_cli import (
     PersistedRunHandle,
     PersistedSSHDefaults,
+    _load_handle,
     run,
 )
 from worker_manager.schemas import Cli, Outcome
@@ -435,6 +436,43 @@ def test_run_execute_gate_rejects_blank_gate_cmd(tmp_path: Path, monkeypatch):
     assert result.exit_code == 1
     assert "requires a non-empty gate command" in result.output
     env.execute.assert_not_called()
+
+
+def test_load_handle_accepts_file_path(tmp_path: Path):
+    config = _config(tmp_path)
+    persisted = PersistedRunHandle(
+        env_id="env-fp",
+        vm_id="vm-fp",
+        project="proj",
+        branch="main",
+        workflow_id="run-proj-fp",
+        environment_profile="default",
+        local_worktree_path=str(Path(config.github_dir) / "proj"),
+        workspace_path="/workspace/proj",
+        teardown_commands=(),
+        provisioned_at_utc=datetime.now(UTC).isoformat(),
+        vm_handle=VMHandle(
+            vm_id="vm-fp",
+            host="203.0.113.10",
+            provider=VMProvider.HETZNER,
+            created_at="2026-01-01T00:00:00Z",
+            hourly_cost=0.5,
+        ),
+        ssh_defaults=PersistedSSHDefaults(
+            user="root",
+            key_path="~/.ssh/id_rsa",
+            port=22,
+            connect_timeout=10,
+        ),
+    )
+    handle_file = tmp_path / "custom-handle.json"
+    handle_file.write_text(persisted.model_dump_json(indent=2))
+
+    loaded, loaded_path = _load_handle(config, str(handle_file))
+
+    assert loaded.env_id == "env-fp"
+    assert loaded.vm_id == "vm-fp"
+    assert loaded_path == handle_file
 
 
 def test_run_full_teardown_runs_even_when_handle_save_fails(tmp_path: Path, monkeypatch):

--- a/worker-manager/tests/unit/test_run_cli.py
+++ b/worker-manager/tests/unit/test_run_cli.py
@@ -220,6 +220,10 @@ def test_run_full_executes_in_order(tmp_path: Path, monkeypatch):
     assert env.execute.await_count == 1
     assert env.teardown.await_count == 1
 
+    # Provision-time SSH connection must be closed
+    runtime_conn = env.provision.return_value.runtime.connection
+    runtime_conn.close.assert_awaited_once()
+
 
 def test_run_full_teardown_runs_even_on_execute_failure(tmp_path: Path, monkeypatch):
     config = _config(tmp_path)
@@ -263,6 +267,10 @@ def test_run_full_teardown_runs_even_on_execute_failure(tmp_path: Path, monkeypa
     assert result.exit_code == 1
     assert env.teardown.await_count == 1
 
+    # Provision-time SSH connection must be closed
+    runtime_conn = env.provision.return_value.runtime.connection
+    runtime_conn.close.assert_awaited_once()
+
 
 def test_run_full_exits_nonzero_for_blocked(tmp_path: Path, monkeypatch):
     config = _config(tmp_path)
@@ -305,6 +313,10 @@ def test_run_full_exits_nonzero_for_blocked(tmp_path: Path, monkeypatch):
 
     assert result.exit_code == 1
     assert env.teardown.await_count == 1
+
+    # Provision-time SSH connection must be closed
+    runtime_conn = env.provision.return_value.runtime.connection
+    runtime_conn.close.assert_awaited_once()
 
 
 def test_run_execute_rejects_legacy_handle_schema(tmp_path: Path, monkeypatch):
@@ -604,3 +616,47 @@ def test_persisted_handle_roundtrips_host_key_policy(tmp_path: Path):
 
     loaded, _ = _load_handle(config, "env-hkp")
     assert loaded.ssh_defaults.host_key_policy == "reject"
+
+
+def test_persisted_handle_rejects_invalid_host_key_policy(tmp_path: Path, capsys):
+    """Invalid host_key_policy values are rejected at load time."""
+    import pytest
+    import typer
+
+    config = _config(tmp_path)
+    path = Path(config.data_dir) / "run-handles"
+    path.mkdir(parents=True, exist_ok=True)
+    handle_data = {
+        "env_id": "env-bad-hkp",
+        "vm_id": "vm-bad-hkp",
+        "project": "proj",
+        "branch": "main",
+        "workflow_id": "run-proj-bad-hkp",
+        "environment_profile": "default",
+        "local_worktree_path": str(Path(config.github_dir) / "proj"),
+        "workspace_path": "/workspace/proj",
+        "teardown_commands": [],
+        "provisioned_at_utc": datetime.now(UTC).isoformat(),
+        "vm_handle": {
+            "vm_id": "vm-bad-hkp",
+            "host": "203.0.113.10",
+            "provider": "hetzner",
+            "created_at": "2026-01-01T00:00:00Z",
+            "hourly_cost": 0.5,
+        },
+        "ssh_defaults": {
+            "user": "root",
+            "key_path": "~/.ssh/id_rsa",
+            "port": 22,
+            "connect_timeout": 10,
+            "host_key_policy": "bogus",
+        },
+    }
+    (path / "env-bad-hkp.json").write_text(json.dumps(handle_data))
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _load_handle(config, "env-bad-hkp")
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert "Run handle schema has changed" in captured.err

--- a/worker-manager/tests/unit/test_ssh.py
+++ b/worker-manager/tests/unit/test_ssh.py
@@ -23,6 +23,7 @@ class TestSSHConfig:
         assert cfg.key_path == "~/.ssh/tanren_vm"
         assert cfg.port == 22
         assert cfg.connect_timeout == 10
+        assert cfg.host_key_policy == "auto_add"
 
     def test_frozen(self):
         cfg = SSHConfig(host="10.0.0.1")
@@ -76,6 +77,7 @@ class TestEnsureConnected:
         result = conn._ensure_connected()
 
         assert result is mock_client
+        mock_client.load_system_host_keys.assert_called_once()
         mock_client.set_missing_host_key_policy.assert_called_once_with(
             mock_paramiko.AutoAddPolicy()
         )
@@ -85,6 +87,30 @@ class TestEnsureConnected:
         assert call_kwargs["port"] == 2222
         assert call_kwargs["username"] == "deploy"
         assert call_kwargs["timeout"] == 5
+
+    def test_warn_policy_sets_warning_policy(self, mock_paramiko):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+
+        conn = _make_conn(host_key_policy="warn")
+        conn._ensure_connected()
+
+        mock_client.load_system_host_keys.assert_called_once()
+        mock_client.set_missing_host_key_policy.assert_called_once_with(
+            mock_paramiko.WarningPolicy()
+        )
+
+    def test_reject_policy_sets_reject_policy(self, mock_paramiko):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+
+        conn = _make_conn(host_key_policy="reject")
+        conn._ensure_connected()
+
+        mock_client.load_system_host_keys.assert_called_once()
+        mock_client.set_missing_host_key_policy.assert_called_once_with(
+            mock_paramiko.RejectPolicy()
+        )
 
     def test_reuses_active_transport(self, mock_paramiko):
         mock_client = MagicMock()

--- a/worker-manager/tests/unit/test_ssh_environment.py
+++ b/worker-manager/tests/unit/test_ssh_environment.py
@@ -751,8 +751,13 @@ class TestAwaitSshReady:
         conn.check_connection.return_value = False
         conn.get_host_identifier = MagicMock(return_value="dev@10.0.0.42:22")
 
+        # Advance monotonic clock by 50s per call: 0, 50, 100, 150...
+        # With timeout=120, the loop runs ~2 iterations then exits
+        clock = iter(range(0, 1000, 50))
+
         with (
             patch(f"{_SSH_ENV}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{_SSH_ENV}.time.monotonic", side_effect=lambda: next(clock)),
             pytest.raises(TimeoutError, match="SSH not reachable"),
         ):
-            await env._await_ssh_ready(conn, timeout=1)
+            await env._await_ssh_ready(conn, timeout=120)

--- a/worker-manager/tests/unit/test_ssh_environment.py
+++ b/worker-manager/tests/unit/test_ssh_environment.py
@@ -719,6 +719,14 @@ class TestProvisionWorkflowId:
         assert handle.runtime.workflow_id == "wf-myproj-42-1000"
 
 
+class TestClose:
+    async def test_close_closes_state_store(self, env_kit):
+        """close() delegates to _state_store.close()."""
+        env = env_kit["env"]
+        await env.close()
+        env_kit["state_store"].close.assert_awaited_once()
+
+
 class TestAwaitSshReady:
     async def test_returns_immediately_when_ready(self, env_kit):
         """First check_connection() = True -> no sleep, immediate return."""

--- a/worker-manager/tests/unit/test_ssh_environment.py
+++ b/worker-manager/tests/unit/test_ssh_environment.py
@@ -214,6 +214,7 @@ class TestProvision:
         with (
             patch.object(env, "_resolve_profile", return_value=_make_profile()),
             patch.object(env, "_load_project_env", return_value={"KEY": "val"}),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock),
             patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
         ):
             mock_conn = AsyncMock()
@@ -260,6 +261,7 @@ class TestProvision:
 
         with (
             patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock),
             patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
         ):
             mock_conn = AsyncMock()
@@ -281,6 +283,7 @@ class TestProvision:
 
         with (
             patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock),
             patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
         ):
             MockSSH.return_value = AsyncMock()
@@ -290,6 +293,58 @@ class TestProvision:
 
         # VM must still be released
         env_kit["vm_provisioner"].release.assert_awaited_once()
+
+    async def test_waits_for_ssh_before_bootstrap(self, env_kit):
+        """provision() calls _await_ssh_ready between SSH creation and bootstrap."""
+        env = env_kit["env"]
+        dispatch = _make_dispatch()
+        config = env_kit["config"]
+        call_order: list[str] = []
+
+        async def _track_ssh_ready(conn):
+            call_order.append("ssh_ready")
+
+        async def _track_bootstrap(conn):
+            call_order.append("bootstrap")
+            return _make_bootstrap_result()
+
+        with (
+            patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(env, "_load_project_env", return_value={}),
+            patch.object(env, "_await_ssh_ready", side_effect=_track_ssh_ready),
+            patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
+        ):
+            MockSSH.return_value = AsyncMock()
+            env_kit["bootstrapper"].bootstrap.side_effect = _track_bootstrap
+            await env.provision(dispatch, config)
+
+        assert call_order == ["ssh_ready", "bootstrap"]
+
+    async def test_releases_vm_on_ssh_timeout(self, env_kit):
+        """provision() releases VM when SSH never becomes reachable."""
+        env = env_kit["env"]
+        dispatch = _make_dispatch()
+        config = env_kit["config"]
+
+        with (
+            patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(
+                env,
+                "_await_ssh_ready",
+                new_callable=AsyncMock,
+                side_effect=TimeoutError("SSH not reachable"),
+            ),
+            patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
+        ):
+            mock_conn = AsyncMock()
+            MockSSH.return_value = mock_conn
+
+            with pytest.raises(TimeoutError, match="SSH not reachable"):
+                await env.provision(dispatch, config)
+
+        # VM must be released on SSH timeout
+        env_kit["vm_provisioner"].release.assert_awaited_once_with(_make_vm_handle())
+        mock_conn.close.assert_awaited_once()
 
 
 class TestExecute:
@@ -381,7 +436,9 @@ class TestExecute:
         dispatch = _make_dispatch(phase=Phase.DO_TASK)
         config = env_kit["config"]
 
-        env_kit["workspace_mgr"].push_command.return_value = (
+        env_kit[
+            "workspace_mgr"
+        ].push_command.return_value = (
             "GIT_ASKPASS=/workspace/.git-askpass GIT_TERMINAL_PROMPT=0 git push origin feature-1"
         )
 
@@ -652,6 +709,7 @@ class TestProvisionWorkflowId:
         with (
             patch.object(env, "_resolve_profile", return_value=_make_profile()),
             patch.object(env, "_load_project_env", return_value={}),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock),
             patch("worker_manager.adapters.ssh_environment.SSHConnection") as MockSSH,
         ):
             MockSSH.return_value = AsyncMock()
@@ -659,3 +717,42 @@ class TestProvisionWorkflowId:
 
         assert handle.runtime.kind == "remote"
         assert handle.runtime.workflow_id == "wf-myproj-42-1000"
+
+
+class TestAwaitSshReady:
+    async def test_returns_immediately_when_ready(self, env_kit):
+        """First check_connection() = True -> no sleep, immediate return."""
+        env = env_kit["env"]
+        conn = AsyncMock()
+        conn.check_connection.return_value = True
+
+        with patch(f"{_SSH_ENV}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await env._await_ssh_ready(conn)
+
+        conn.check_connection.assert_awaited_once()
+        mock_sleep.assert_not_awaited()
+
+    async def test_polls_until_ready(self, env_kit):
+        """False x2 then True -> 2 sleeps, success."""
+        env = env_kit["env"]
+        conn = AsyncMock()
+        conn.check_connection.side_effect = [False, False, True]
+
+        with patch(f"{_SSH_ENV}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await env._await_ssh_ready(conn)
+
+        assert conn.check_connection.await_count == 3
+        assert mock_sleep.await_count == 2
+
+    async def test_raises_timeout_when_never_ready(self, env_kit):
+        """Always False -> TimeoutError raised."""
+        env = env_kit["env"]
+        conn = AsyncMock()
+        conn.check_connection.return_value = False
+        conn.get_host_identifier = MagicMock(return_value="dev@10.0.0.42:22")
+
+        with (
+            patch(f"{_SSH_ENV}.asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(TimeoutError, match="SSH not reachable"),
+        ):
+            await env._await_ssh_ready(conn, timeout=1)

--- a/worker-manager/tests/unit/test_vm_cli.py
+++ b/worker-manager/tests/unit/test_vm_cli.py
@@ -7,7 +7,18 @@ from unittest.mock import AsyncMock, patch
 from typer.testing import CliRunner
 
 from worker_manager.adapters.remote_types import VMAssignment
+from worker_manager.config import Config
 from worker_manager.vm_cli import vm
+
+
+def _mock_config(tmp_path=None) -> Config:
+    base = str(tmp_path) if tmp_path else "/tmp"
+    return Config(
+        ipc_dir=f"{base}/ipc",
+        github_dir=f"{base}/github",
+        data_dir=f"{base}/data",
+        worktree_registry_path=f"{base}/data/worktrees.json",
+    )
 
 
 def _make_assignment(**overrides) -> VMAssignment:
@@ -40,7 +51,10 @@ class TestVmList:
             _make_assignment(vm_id="vm-002", host="10.0.0.2"),
         ]
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
 
@@ -54,7 +68,10 @@ class TestVmList:
         store = _mock_store()
         store.get_active_assignments.return_value = []
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
 
@@ -65,7 +82,10 @@ class TestVmList:
         store = _mock_store()
         store.get_active_assignments.return_value = [_make_assignment()]
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
 
@@ -84,7 +104,10 @@ class TestVmRelease:
         assignment = _make_assignment()
         store.get_assignment.return_value = assignment
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["release", "vm-001"])
 
@@ -97,7 +120,10 @@ class TestVmRelease:
         store = _mock_store()
         store.get_assignment.return_value = None
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["release", "vm-unknown"])
 
@@ -110,7 +136,10 @@ class TestVmRecover:
         store = _mock_store()
         store.get_active_assignments.return_value = []
 
-        with patch("worker_manager.vm_cli._get_state_store", return_value=store):
+        with (
+            patch("worker_manager.vm_cli._load_config", return_value=_mock_config()),
+            patch("worker_manager.vm_cli._get_state_store", return_value=store),
+        ):
             runner = CliRunner()
             result = runner.invoke(vm, ["recover"])
 
@@ -119,7 +148,7 @@ class TestVmRecover:
 
 
 class TestVmDryRun:
-    def test_prints_dry_run_without_connecting(self, tmp_path, monkeypatch):
+    def test_prints_dry_run_without_connecting(self, tmp_path):
         github_dir = tmp_path / "github"
         project_dir = github_dir / "myproject"
         project_dir.mkdir(parents=True)
@@ -147,21 +176,26 @@ class TestVmDryRun:
             "  myproject: https://github.com/org/myproject.git\n"
         )
 
-        monkeypatch.setenv("WM_REMOTE_CONFIG", str(remote_cfg))
-        monkeypatch.setenv("WM_GITHUB_DIR", str(github_dir))
-
-        runner = CliRunner()
-        result = runner.invoke(
-            vm,
-            ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(github_dir),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            remote_config_path=str(remote_cfg),
         )
+        with patch("worker_manager.vm_cli._load_config", return_value=config):
+            runner = CliRunner()
+            result = runner.invoke(
+                vm,
+                ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+            )
 
         assert result.exit_code == 0
         assert "provisioner: manual" in result.output
         assert "repo_clone: https://github.com/org/myproject.git" in result.output
         assert "setup_commands:" in result.output
 
-    def test_uses_hetzner_server_type_override(self, tmp_path, monkeypatch):
+    def test_uses_hetzner_server_type_override(self, tmp_path):
         github_dir = tmp_path / "github"
         project_dir = github_dir / "myproject"
         project_dir.mkdir(parents=True)
@@ -185,14 +219,20 @@ class TestVmDryRun:
             "    image: ubuntu-24.04\n"
             "    ssh_key_name: tanren\n"
         )
-        monkeypatch.setenv("WM_REMOTE_CONFIG", str(remote_cfg))
-        monkeypatch.setenv("WM_GITHUB_DIR", str(github_dir))
 
-        runner = CliRunner()
-        result = runner.invoke(
-            vm,
-            ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(github_dir),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            remote_config_path=str(remote_cfg),
         )
+        with patch("worker_manager.vm_cli._load_config", return_value=config):
+            runner = CliRunner()
+            result = runner.invoke(
+                vm,
+                ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+            )
 
         assert result.exit_code == 0
         assert "provisioner: hetzner" in result.output
@@ -215,14 +255,20 @@ class TestVmDryRun:
             "secrets:\n"
             f"  developer_secrets_path: {secrets_file}\n"
         )
-        monkeypatch.setenv("WM_REMOTE_CONFIG", str(remote_cfg))
-        monkeypatch.setenv("WM_GITHUB_DIR", str(github_dir))
         monkeypatch.delenv("HCLOUD_TOKEN", raising=False)
 
-        result = CliRunner().invoke(
-            vm,
-            ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(github_dir),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            remote_config_path=str(remote_cfg),
         )
+        with patch("worker_manager.vm_cli._load_config", return_value=config):
+            result = CliRunner().invoke(
+                vm,
+                ["dry-run", "--project", "myproject", "--environment-profile", "default"],
+            )
 
         assert result.exit_code == 0
         import os


### PR DESCRIPTION
## Summary
- **Adapter-based config loading**: `ConfigSource` protocol + `DotenvConfigSource` reads `~/.config/tanren/tanren.env`, eliminating shell-exported `WM_*` variables. `load_config_env()` wired into both entry points (`cli.py`, `__main__.py`).
- **Zero defaults**: All 13 required `WM_*` fields must be explicitly set in a config source or environment. `from_env()` raises `ValueError` listing missing keys. Optional feature flags (`WM_ROLES_CONFIG_PATH`, `WM_EVENTS_DB`, `WM_REMOTE_CONFIG`) default to `None`.
- **SSH readiness wait**: `_await_ssh_ready()` polls `check_connection()` between VM API readiness and bootstrap in `SSHExecutionEnvironment.provision()`, preventing `NoValidConnectionsError` on fresh Hetzner VMs.

## Test plan
- [x] `make format` — clean
- [x] `make check` — docs-check, lint, typecheck, 613 unit tests pass, 83.67% coverage
- [x] `make integration` — 41 integration tests pass
- [ ] Manual smoke test: create `~/.config/tanren/tanren.env` with all required fields, verify `tanren run provision` works without exports
- [ ] Verify env var override: `WM_GITHUB_DIR=/tmp/override tanren env check`
- [ ] Verify missing field error: remove a key from tanren.env and confirm clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)