### PR TITLE
VM lifecycle endpoints and SSH reliability fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ unit:
 
 integration:
 	uv run pytest tests/integration -q --tb=short --timeout=30 \
-		-m "not ssh and not local_env" \
+		-m "not ssh and not local_env and not hetzner" \
 		--cov=packages --cov=services --cov-fail-under=75
 
 docs-check:

--- a/packages/tanren-core/src/tanren_core/adapters/hetzner_vm.py
+++ b/packages/tanren-core/src/tanren_core/adapters/hetzner_vm.py
@@ -49,6 +49,7 @@ class HetznerProvisionerSettings(BaseModel):
     default_server_type: str = Field(...)
     location: str = Field(...)
     image: str = Field(...)
+    architecture: str = Field(default="x86")
     ssh_key_name: str = Field(...)
     name_prefix: str = Field(default="tanren")
     labels: dict[str, str] = Field(default_factory=dict)
@@ -100,15 +101,16 @@ class HetznerVMProvisioner:
         if ssh_key is None:
             raise ValueError(f"Hetzner SSH key not found: {self._settings.ssh_key_name}")
 
-    async def acquire(self, requirements: VMRequirements) -> VMHandle:
-        """Create and wait for a Hetzner VM to become reachable.
+    def _create_server_sync(
+        self, requirements: VMRequirements
+    ) -> tuple[BoundServer, str, dict[str, str]]:
+        """Resolve resources and create server (sync — call via to_thread).
 
         Returns:
-            VMHandle for the provisioned VM.
+            Tuple of (server, server_type_name, labels).
 
         Raises:
-            ValueError: If the server type, location, or SSH key is not found.
-            TimeoutError: If the VM does not become ready within the timeout.
+            ValueError: If a required Hetzner resource is not found.
         """
         server_type_name = requirements.server_type or self._settings.default_server_type
         server_type = self._client.server_types.get_by_name(server_type_name)
@@ -123,7 +125,9 @@ class HetznerVMProvisioner:
         if ssh_key is None:
             raise ValueError(f"Hetzner SSH key not found: {self._settings.ssh_key_name}")
 
-        image = self._client.images.get_by_name(self._settings.image)
+        image = self._client.images.get_by_name_and_architecture(
+            self._settings.image, self._settings.architecture
+        )
         if image is None:
             raise ValueError(f"Hetzner image not found: {self._settings.image}")
 
@@ -143,17 +147,32 @@ class HetznerVMProvisioner:
             ssh_keys=[ssh_key],
             labels=labels,
         )
-        server = create.server
+        return create.server, server_type_name, labels
+
+    async def acquire(self, requirements: VMRequirements) -> VMHandle:
+        """Create and wait for a Hetzner VM to become reachable.
+
+        Returns:
+            VMHandle for the provisioned VM.
+
+        Raises:
+            TimeoutError: If the VM does not become ready within the timeout.
+        """
+        server, server_type_name, labels = await asyncio.to_thread(
+            self._create_server_sync, requirements
+        )
 
         try:
             deadline = time.monotonic() + self._settings.readiness_timeout_secs
             while time.monotonic() < deadline:
-                server.reload()
+                await asyncio.to_thread(server.reload)
                 if self._is_running(server):
                     host = self._extract_public_ipv4(server)
                     if host:
-                        hourly_cost = self._resolve_hourly_cost(
-                            server_type_name, self._settings.location
+                        hourly_cost = await asyncio.to_thread(
+                            self._resolve_hourly_cost,
+                            server_type_name,
+                            self._settings.location,
                         )
                         return VMHandle(
                             vm_id=str(server.id),
@@ -166,20 +185,22 @@ class HetznerVMProvisioner:
                 await asyncio.sleep(self._settings.poll_interval_secs)
 
             raise TimeoutError(
-                f"Hetzner server {server_name} did not become ready "
+                f"Hetzner server {server.id} did not become ready "
                 f"within {self._settings.readiness_timeout_secs}s"
             )
         except Exception:
-            self._delete_server_best_effort(server, context="acquire cleanup")
+            await asyncio.to_thread(
+                self._delete_server_best_effort, server, context="acquire cleanup"
+            )
             raise
 
     async def release(self, handle: VMHandle) -> None:
         """Delete the Hetzner server."""
-        server = self._get_server_for_handle(handle)
+        server = await asyncio.to_thread(self._get_server_for_handle, handle)
         if server is None:
             logger.warning("Hetzner release: server not found for %s", handle.vm_id)
             return
-        server.delete()
+        await asyncio.to_thread(server.delete)
 
     async def list_active(self) -> list[VMHandle]:
         """List active tanren-managed Hetzner VMs.
@@ -191,9 +212,9 @@ class HetznerVMProvisioner:
 
         servers: list[BoundServer]
         try:
-            servers = self._client.servers.get_all(label_selector=selector)
+            servers = await asyncio.to_thread(self._client.servers.get_all, label_selector=selector)
         except TypeError:
-            servers = self._client.servers.get_all()
+            servers = await asyncio.to_thread(self._client.servers.get_all)
 
         handles: list[VMHandle] = []
         for server in servers:
@@ -209,6 +230,11 @@ class HetznerVMProvisioner:
                 created_at = created_at_raw.isoformat()
             else:
                 created_at = str(created_at_raw or datetime.now(UTC).isoformat())
+            hourly_cost = await asyncio.to_thread(
+                self._resolve_hourly_cost,
+                self._server_type_name(server),
+                self._settings.location,
+            )
             handles.append(
                 VMHandle(
                     vm_id=str(server.id),
@@ -216,9 +242,7 @@ class HetznerVMProvisioner:
                     provider=VMProvider.HETZNER,
                     created_at=created_at,
                     labels=labels,
-                    hourly_cost=self._resolve_hourly_cost(
-                        self._server_type_name(server), self._settings.location
-                    ),
+                    hourly_cost=hourly_cost,
                 )
             )
         return handles

--- a/packages/tanren-core/src/tanren_core/adapters/ssh.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import socket
 import time
 from pathlib import Path
 from typing import Literal
@@ -62,13 +63,16 @@ class SSHConnection:
             self._close_sync()
 
         client = paramiko.SSHClient()
-        client.load_system_host_keys()
 
         if self._config.host_key_policy == "reject":
+            client.load_system_host_keys()
             client.set_missing_host_key_policy(paramiko.RejectPolicy())
         elif self._config.host_key_policy == "warn":
+            client.load_system_host_keys()
             client.set_missing_host_key_policy(paramiko.WarningPolicy())
         else:
+            # auto_add: skip system host keys — ephemeral VMs reuse IPs
+            # and stale entries cause BadHostKeyException
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         key_path = str(Path(self._config.key_path).expanduser())
@@ -85,6 +89,8 @@ class SSHConnection:
                 f"SSH auth failed for {self._config.user}@{self._config.host}: {e}"
             ) from e
         except paramiko.SSHException as e:
+            raise ConnectionError(f"SSH connection failed to {self._config.host}: {e}") from e
+        except OSError as e:
             raise ConnectionError(f"SSH connection failed to {self._config.host}: {e}") from e
 
         self._client = client
@@ -108,6 +114,9 @@ class SSHConnection:
                 self._sftp.stat(".")
                 return self._sftp
             except Exception:
+                logger.debug(
+                    "SFTP channel stale, recreating for %s", self._config.host, exc_info=True
+                )
                 self._sftp = None
 
         client = self._ensure_connected()
@@ -240,6 +249,42 @@ class SSHConnection:
         """
         return await asyncio.to_thread(self._download_sync, remote_path)
 
+    def _check_ssh_banner_sync(self) -> bool:
+        """Check if the remote SSH service sends a valid protocol banner.
+
+        Uses a raw TCP socket to avoid paramiko transport thread side-effects.
+
+        Returns:
+            True if the SSH banner was received.
+        """
+        try:
+            with socket.create_connection(
+                (self._config.host, self._config.port),
+                timeout=self._config.connect_timeout,
+            ) as sock:
+                data = sock.recv(256)
+                return data.startswith(b"SSH-")
+        except OSError as e:
+            logger.debug(
+                "SSH banner check failed for %s:%d: %s",
+                self._config.host,
+                self._config.port,
+                e,
+            )
+            return False
+
+    async def check_ssh_banner(self) -> bool:
+        """Check if the remote SSH service is ready by reading the protocol banner.
+
+        This is faster and more reliable than a full paramiko connection for
+        readiness polling — it avoids spawning transport threads that can
+        interfere with subsequent connection attempts.
+
+        Returns:
+            True if the SSH banner was received.
+        """
+        return await asyncio.to_thread(self._check_ssh_banner_sync)
+
     async def check_connection(self) -> bool:
         """Test connectivity with a simple echo command.
 
@@ -250,6 +295,7 @@ class SSHConnection:
             result = await self.run("echo tanren-ok", timeout=10)
             return result.exit_code == 0 and "tanren-ok" in result.stdout
         except Exception:
+            logger.debug("check_connection failed for %s", self._config.host, exc_info=True)
             return False
 
     def get_host_identifier(self) -> str:

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 _PUSH_PHASES = frozenset({Phase.DO_TASK, Phase.AUDIT_TASK, Phase.RUN_DEMO, Phase.AUDIT_SPEC})
 
-_SSH_READY_TIMEOUT_SECS = 120
+_SSH_READY_TIMEOUT_SECS = 300
 _SSH_READY_POLL_SECS = 3
 
 
@@ -77,6 +77,7 @@ class SSHExecutionEnvironment:
         ssh_config_defaults: SSHConfig,
         repo_urls: dict[str, str],
         provider: VMProvider = VMProvider.MANUAL,
+        ssh_ready_timeout_secs: int = _SSH_READY_TIMEOUT_SECS,
     ) -> None:
         """Initialize with remote execution adapters and configuration."""
         self._vm_provisioner = vm_provisioner
@@ -89,6 +90,7 @@ class SSHExecutionEnvironment:
         self._ssh_defaults = ssh_config_defaults
         self._repo_urls = repo_urls
         self._provider = provider
+        self._ssh_ready_timeout_secs = ssh_ready_timeout_secs
 
     @property
     def ssh_defaults(self) -> SSHConfig:
@@ -171,7 +173,7 @@ class SSHExecutionEnvironment:
             conn = SSHConnection(ssh_config)
 
             # 4b. Wait for SSH to accept connections (sshd lags behind API status)
-            await self._await_ssh_ready(conn)
+            await self._await_ssh_ready(conn, timeout=self._ssh_ready_timeout_secs)
 
             # 5. Bootstrap VM (idempotent)
             bootstrap_result = await self._bootstrapper.bootstrap(conn)
@@ -250,7 +252,7 @@ class SSHExecutionEnvironment:
                 try:
                     await conn.close()
                 except Exception:
-                    logger.warning("SSH close failed during provision cleanup")
+                    logger.warning("SSH close failed during provision cleanup", exc_info=True)
             try:
                 await self._vm_provisioner.release(vm_handle)
             except Exception:
@@ -437,17 +439,17 @@ class SSHExecutionEnvironment:
                         timeout=120,
                     )
                 except Exception:
-                    logger.warning("Teardown command failed: %s", cmd)
+                    logger.warning("Teardown command failed: %s", cmd, exc_info=True)
         finally:
             try:
                 await self._workspace_mgr.cleanup(conn, workspace)
             except Exception:
-                logger.warning("Workspace cleanup failed")
+                logger.warning("Workspace cleanup failed", exc_info=True)
             finally:
                 try:
                     await conn.close()
                 except Exception:
-                    logger.warning("SSH close failed")
+                    logger.warning("SSH close failed", exc_info=True)
                 finally:
                     # MUST happen — no orphaned VMs
                     try:

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -107,6 +107,7 @@ def build_ssh_execution_environment(
         ssh_config_defaults=ssh_defaults,
         repo_urls={binding.project: binding.repo_url for binding in remote_cfg.repos},
         provider=provider,
+        ssh_ready_timeout_secs=remote_cfg.ssh.ssh_ready_timeout_secs,
     )
 
     return env, state_store

--- a/packages/tanren-core/src/tanren_core/remote_config.py
+++ b/packages/tanren-core/src/tanren_core/remote_config.py
@@ -42,6 +42,7 @@ class RemoteSSHConfig(BaseModel):
     port: int = Field(default=22, ge=1, le=65535)
     connect_timeout: int = Field(default=10, ge=1)
     host_key_policy: Literal["auto_add", "warn", "reject"] = Field(default="auto_add")
+    ssh_ready_timeout_secs: int = Field(default=300, ge=30)
 
 
 class RemoteGitConfig(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ markers = [
     "ssh: requires real SSH connection",
     "local_env: requires real local environment",
     "api: API-specific tests",
+    "hetzner: requires Hetzner API token and provisions real VMs",
 ]
 
 # ===== COVERAGE =====

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -25,7 +26,7 @@ from tanren_api.state import APIStateStore
 from tanren_core.adapters.null_emitter import NullEventEmitter
 from tanren_core.adapters.sqlite_emitter import SqliteEventEmitter
 from tanren_core.builder import build_ssh_execution_environment
-from tanren_core.config import Config
+from tanren_core.config import Config, load_config_env
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.settings = settings
+        load_config_env()
         try:
             app.state.config = Config.from_env()
         except Exception:
@@ -61,11 +63,21 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
 
         if app.state.config and app.state.config.remote_config_path:
             try:
-                env, vm_store = build_ssh_execution_environment(app.state.config, app.state.emitter)
+                env, vm_store = await asyncio.to_thread(
+                    build_ssh_execution_environment, app.state.config, app.state.emitter
+                )
                 app.state.execution_env = env
                 app.state.vm_state_store = vm_store
             except Exception:
                 logger.warning("Failed to initialize remote execution environment", exc_info=True)
+            else:
+                if hasattr(env, "recover_stale_assignments"):
+                    try:
+                        recovered = await env.recover_stale_assignments()
+                        if recovered:
+                            logger.info("Recovered %d stale VM assignment(s) on startup", recovered)
+                    except Exception:
+                        logger.warning("Failed to recover stale VM assignments", exc_info=True)
 
         yield
 

--- a/services/tanren-api/src/tanren_api/models.py
+++ b/services/tanren-api/src/tanren_api/models.py
@@ -248,6 +248,28 @@ class VMReleaseConfirmed(BaseModel):
     status: VMStatus = Field(default=VMStatus.RELEASED, description="Release status")
 
 
+class VMProvisionAccepted(BaseModel):
+    """Accepted response for async VM provisioning."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    env_id: str = Field(..., description="Provisioning tracking identifier")
+    status: VMStatus = Field(default=VMStatus.PROVISIONING, description="Provisioning status")
+
+
+class VMProvisionStatus(BaseModel):
+    """Status of an in-progress or completed VM provisioning."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    env_id: str = Field(..., description="Provisioning tracking identifier")
+    status: VMStatus = Field(..., description="Current provisioning status")
+    vm_id: str | None = Field(default=None, description="VM identifier (set once provisioned)")
+    host: str | None = Field(default=None, description="VM hostname or IP (set once provisioned)")
+    provider: VMProvider | None = Field(default=None, description="VM provider")
+    created_at: str | None = Field(default=None, description="ISO 8601 creation timestamp")
+
+
 class VMDryRunResult(BaseModel):
     """Result of a VM dry-run provisioning check."""
 

--- a/services/tanren-api/src/tanren_api/models.py
+++ b/services/tanren-api/src/tanren_api/models.py
@@ -44,6 +44,7 @@ class VMStatus(StrEnum):
 
     ACTIVE = "active"
     PROVISIONING = "provisioning"
+    FAILED = "failed"
     RELEASING = "releasing"
     RELEASED = "released"
 
@@ -336,6 +337,8 @@ class RunStatus(BaseModel):
     outcome: Outcome | None = Field(default=None, description="Final outcome if completed")
     started_at: str | None = Field(default=None, description="ISO 8601 start timestamp")
     duration_secs: int | None = Field(default=None, ge=0, description="Elapsed seconds")
+    vm_id: str | None = Field(default=None, description="Backing VM identifier")
+    host: str | None = Field(default=None, description="VM hostname or IP")
 
 
 # ---------------------------------------------------------------------------

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -249,10 +249,10 @@ async def run_teardown(
     await store.cancel_environment_task(env_id)
 
     async def _teardown_background() -> None:
-        if record.handle is None:
+        if updated.handle is None:
             await store.remove_environment(env_id)
             return
-        inner = asyncio.ensure_future(execution_env.teardown(record.handle))
+        inner = asyncio.ensure_future(execution_env.teardown(updated.handle))
         try:
             await asyncio.shield(inner)
         except asyncio.CancelledError, Exception:
@@ -404,4 +404,6 @@ async def run_status(
         outcome=record.outcome,
         started_at=record.started_at,
         duration_secs=duration_secs,
+        vm_id=record.vm_id or None,
+        host=record.host or None,
     )

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -38,6 +38,7 @@ router = APIRouter(tags=["run"])
 
 _EXECUTE_FROM = frozenset({RunEnvironmentStatus.PROVISIONED, RunEnvironmentStatus.COMPLETED})
 _TEARDOWN_FROM = frozenset({
+    RunEnvironmentStatus.PROVISIONING,
     RunEnvironmentStatus.PROVISIONED,
     RunEnvironmentStatus.EXECUTING,
     RunEnvironmentStatus.COMPLETED,
@@ -59,9 +60,15 @@ async def run_provision(
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
 ) -> RunEnvironment:
-    """Provision a remote execution environment."""
+    """Provision a remote execution environment (non-blocking).
+
+    Returns immediately with status=provisioning. Poll GET /run/{env_id}/status
+    for progress.
+    """
     if execution_env is None:
         raise ServiceError("Remote execution environment not configured")
+
+    env_id = str(uuid.uuid4())
 
     dispatch = Dispatch(
         workflow_id=f"run-{uuid.uuid4().hex[:8]}",
@@ -74,30 +81,46 @@ async def run_provision(
         environment_profile=body.environment_profile,
     )
 
-    try:
-        handle = await execution_env.provision(dispatch, config)
-    except Exception as exc:
-        logger.exception("Provision failed for project %s", body.project)
-        raise ServiceError("Failed to provision environment") from exc
-    if not isinstance(handle.runtime, RemoteEnvironmentRuntime):
-        raise ServiceError("Provisioned environment is not a remote runtime")
-    vm_handle = handle.runtime.vm_handle
-
     record = EnvironmentRecord(
-        env_id=handle.env_id,
-        handle=handle,
-        status=RunEnvironmentStatus.PROVISIONED,
-        vm_id=vm_handle.vm_id,
-        host=vm_handle.host,
+        env_id=env_id,
+        handle=None,
+        status=RunEnvironmentStatus.PROVISIONING,
         started_at=_now(),
     )
     await store.add_environment(record)
 
+    async def _provision_background() -> None:
+        try:
+            handle = await execution_env.provision(dispatch, config)
+            runtime = handle.runtime
+            if not isinstance(runtime, RemoteEnvironmentRuntime):
+                raise ServiceError("Provisioned environment is not a remote runtime")
+            await store.update_environment(
+                env_id,
+                handle=handle,
+                vm_id=runtime.vm_handle.vm_id,
+                host=runtime.vm_handle.host,
+                status=RunEnvironmentStatus.PROVISIONED,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Provision failed for %s", env_id)
+            await store.update_environment(
+                env_id,
+                status=RunEnvironmentStatus.FAILED,
+                outcome=Outcome.ERROR,
+                completed_at=_now(),
+            )
+
+    task = asyncio.create_task(_provision_background())
+    await store.update_environment(env_id, task=task)
+
     return RunEnvironment(
-        env_id=handle.env_id,
-        vm_id=vm_handle.vm_id,
-        host=vm_handle.host,
-        status=RunEnvironmentStatus.PROVISIONED,
+        env_id=env_id,
+        vm_id="",
+        host="",
+        status=RunEnvironmentStatus.PROVISIONING,
     )
 
 
@@ -116,6 +139,9 @@ async def run_execute(
 
     if execution_env is None:
         raise ServiceError("Remote execution environment not configured")
+
+    if record.handle is None:
+        raise ConflictError(f"Environment {env_id} is still provisioning")
 
     if body.project != record.handle.project:
         raise ConflictError(
@@ -140,10 +166,12 @@ async def run_execute(
 
     gate = asyncio.Event()
 
+    handle = record.handle  # already guarded above; bind for type narrowing
+
     async def _execute_background() -> None:
         await gate.wait()
         try:
-            result = await execution_env.execute(record.handle, dispatch, config)
+            result = await execution_env.execute(handle, dispatch, config)
             env_status = (
                 RunEnvironmentStatus.COMPLETED
                 if result.outcome in _COMPLETED_ENV_OUTCOMES
@@ -221,6 +249,9 @@ async def run_teardown(
     await store.cancel_environment_task(env_id)
 
     async def _teardown_background() -> None:
+        if record.handle is None:
+            await store.remove_environment(env_id)
+            return
         inner = asyncio.ensure_future(execution_env.teardown(record.handle))
         try:
             await asyncio.shield(inner)

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -90,6 +90,7 @@ async def run_provision(
     await store.add_environment(record)
 
     async def _provision_background() -> None:
+        handle: EnvironmentHandle | None = None
         try:
             handle = await execution_env.provision(dispatch, config)
             runtime = handle.runtime
@@ -102,9 +103,11 @@ async def run_provision(
                 host=runtime.vm_handle.host,
                 status=RunEnvironmentStatus.PROVISIONED,
             )
+            handle = None  # Persisted — suppress finally cleanup
         except asyncio.CancelledError:
             raise
         except Exception:
+            handle = None  # Error handler owns cleanup
             logger.exception("Provision failed for %s", env_id)
             await store.update_environment(
                 env_id,
@@ -112,6 +115,15 @@ async def run_provision(
                 outcome=Outcome.ERROR,
                 completed_at=_now(),
             )
+        finally:
+            if handle is not None:
+                logger.warning("Cleaning up orphaned provision for %s", env_id)
+                inner = asyncio.ensure_future(execution_env.teardown(handle))
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError, Exception:
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await inner
 
     task = asyncio.create_task(_provision_background())
     await store.update_environment(env_id, task=task)
@@ -248,11 +260,27 @@ async def run_teardown(
     # Best-effort cancel of any stale execute task — we already own teardown.
     await store.cancel_environment_task(env_id)
 
+    # Capture the prior task before the teardown task overwrites it.
+    pre = await store.get_environment(env_id)
+    prior_task = pre.task if pre is not None else None
+
     async def _teardown_background() -> None:
-        if updated.handle is None:
+        # Wait for any in-flight provision to finish before inspecting
+        # the handle.  Without this, we can remove the record while
+        # provision is still running; provision then silently fails to
+        # persist its handle and skips its own finally cleanup,
+        # orphaning the VM.
+        if prior_task is not None and not prior_task.done():
+            logger.debug("Waiting for prior task to complete before teardown for %s", env_id)
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await prior_task
+
+        current = await store.get_environment(env_id)
+        handle = current.handle if current is not None else None
+        if handle is None:
             await store.remove_environment(env_id)
             return
-        inner = asyncio.ensure_future(execution_env.teardown(updated.handle))
+        inner = asyncio.ensure_future(execution_env.teardown(handle))
         try:
             await asyncio.shield(inner)
         except asyncio.CancelledError, Exception:

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -45,6 +45,8 @@ _TEARDOWN_FROM = frozenset({
     RunEnvironmentStatus.FAILED,
 })
 
+_PRIOR_TASK_TIMEOUT: float = 30.0
+
 _COMPLETED_DISPATCH_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
 _COMPLETED_ENV_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
 
@@ -96,22 +98,25 @@ async def run_provision(
             runtime = handle.runtime
             if not isinstance(runtime, RemoteEnvironmentRuntime):
                 raise ServiceError("Provisioned environment is not a remote runtime")
-            await store.update_environment(
+            updated = await store.try_transition_environment(
                 env_id,
+                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                to_status=RunEnvironmentStatus.PROVISIONED,
                 handle=handle,
                 vm_id=runtime.vm_handle.vm_id,
                 host=runtime.vm_handle.host,
-                status=RunEnvironmentStatus.PROVISIONED,
             )
-            handle = None  # Persisted — suppress finally cleanup
+            if updated is not None:
+                handle = None  # Persisted — suppress finally cleanup
         except asyncio.CancelledError:
             raise
         except Exception:
             handle = None  # Error handler owns cleanup
             logger.exception("Provision failed for %s", env_id)
-            await store.update_environment(
+            await store.try_transition_environment(
                 env_id,
-                status=RunEnvironmentStatus.FAILED,
+                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                to_status=RunEnvironmentStatus.FAILED,
                 outcome=Outcome.ERROR,
                 completed_at=_now(),
             )
@@ -272,8 +277,8 @@ async def run_teardown(
         # orphaning the VM.
         if prior_task is not None and not prior_task.done():
             logger.debug("Waiting for prior task to complete before teardown for %s", env_id)
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await prior_task
+            with contextlib.suppress(TimeoutError, asyncio.CancelledError, Exception):
+                await asyncio.wait_for(asyncio.shield(prior_task), timeout=_PRIOR_TASK_TIMEOUT)
 
         current = await store.get_environment(env_id)
         handle = current.handle if current is not None else None

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -167,11 +167,12 @@ async def get_provision_status(
         raise NotFoundError(f"Provision {env_id} not found")
 
     provider = _derive_provider(config)
-    vm_status = (
-        VMStatus.ACTIVE
-        if record.status == RunEnvironmentStatus.PROVISIONED
-        else VMStatus.PROVISIONING
-    )
+    if record.status == RunEnvironmentStatus.PROVISIONED:
+        vm_status = VMStatus.ACTIVE
+    elif record.status == RunEnvironmentStatus.FAILED:
+        vm_status = VMStatus.FAILED
+    else:
+        vm_status = VMStatus.PROVISIONING
 
     return VMProvisionStatus(
         env_id=env_id,

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -140,6 +140,7 @@ async def provision_vm(
                 handle=handle,
                 vm_id=vm_handle.vm_id,
                 host=vm_handle.host,
+                completed_at=_now(),
             )
             if updated is not None:
                 handle = None  # Persisted — suppress finally cleanup

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -3,28 +3,34 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path
 
-from tanren_api.dependencies import get_config, get_execution_env, get_vm_state_store
+from tanren_api.dependencies import get_api_store, get_config, get_execution_env, get_vm_state_store
 from tanren_api.errors import NotFoundError, ServiceError
 from tanren_api.models import (
     ProvisionRequest,
+    RunEnvironmentStatus,
     VMDryRunResult,
+    VMProvisionAccepted,
+    VMProvisionStatus,
     VMReleaseConfirmed,
     VMStatus,
     VMSummary,
 )
+from tanren_api.state import APIStateStore, EnvironmentRecord
 from tanren_core.adapters.protocols import ExecutionEnvironment
 from tanren_core.adapters.remote_types import VMHandle, VMProvider, VMRequirements
 from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
 from tanren_core.adapters.types import RemoteEnvironmentRuntime
 from tanren_core.config import Config
 from tanren_core.remote_config import ProvisionerType, load_remote_config
-from tanren_core.schemas import Cli, Dispatch, Phase
+from tanren_core.schemas import Cli, Dispatch, Outcome, Phase
 
 logger = logging.getLogger(__name__)
 
@@ -70,19 +76,25 @@ async def list_vms(
     ]
 
 
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
 @router.post("/vm/provision")
 async def provision_vm(
     body: ProvisionRequest,
+    store: Annotated[APIStateStore, Depends(get_api_store)],
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
-) -> VMHandle:
-    """Provision a new VM.
+) -> VMProvisionAccepted:
+    """Provision a new VM (non-blocking).
 
-    Returns:
-        VMHandle with vm_id, host, provider, created_at.
+    Returns immediately with env_id for polling via GET /vm/provision/{env_id}.
     """
     if execution_env is None:
         raise ServiceError("Remote execution environment not configured")
+
+    env_id = str(uuid.uuid4())
 
     dispatch = Dispatch(
         workflow_id=f"vm-provision-{body.project}-{uuid.uuid4().hex[:8]}",
@@ -94,23 +106,81 @@ async def provision_vm(
         timeout=1800,
         environment_profile=body.environment_profile,
     )
-    try:
-        handle = await execution_env.provision(dispatch, config)
-    except Exception as exc:
-        logger.exception("VM provision failed for %s", dispatch.workflow_id)
-        raise ServiceError("Failed to provision VM") from exc
-    runtime = handle.runtime
-    if not isinstance(runtime, RemoteEnvironmentRuntime):
-        raise ServiceError("Provisioned environment is not a remote runtime")
-    vm_handle = runtime.vm_handle
-    # Close the SSH connection to prevent leak (don't call full teardown — that releases the VM)
-    try:
-        close_fn = getattr(runtime.connection, "close", None)
-        if close_fn is not None:
-            await close_fn()
-    except Exception:
-        logger.debug("Failed to close provision-time SSH connection for %s", vm_handle.vm_id)
-    return vm_handle
+
+    record = EnvironmentRecord(
+        env_id=env_id,
+        handle=None,
+        status=RunEnvironmentStatus.PROVISIONING,
+        started_at=_now(),
+    )
+    await store.add_environment(record)
+
+    async def _provision_background() -> None:
+        try:
+            handle = await execution_env.provision(dispatch, config)
+            runtime = handle.runtime
+            if not isinstance(runtime, RemoteEnvironmentRuntime):
+                raise ServiceError("Provisioned environment is not a remote runtime")
+            vm_handle = runtime.vm_handle
+            # Close SSH connection to prevent leak (not full teardown — that releases the VM)
+            try:
+                close_fn = getattr(runtime.connection, "close", None)
+                if close_fn is not None:
+                    await close_fn()
+            except Exception:
+                logger.debug(
+                    "Failed to close provision-time SSH connection for %s", vm_handle.vm_id
+                )
+            await store.update_environment(
+                env_id,
+                handle=handle,
+                vm_id=vm_handle.vm_id,
+                host=vm_handle.host,
+                status=RunEnvironmentStatus.PROVISIONED,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("VM provision failed for %s", env_id)
+            await store.update_environment(
+                env_id,
+                status=RunEnvironmentStatus.FAILED,
+                outcome=Outcome.ERROR,
+                completed_at=_now(),
+            )
+
+    task = asyncio.create_task(_provision_background())
+    await store.update_environment(env_id, task=task)
+
+    return VMProvisionAccepted(env_id=env_id)
+
+
+@router.get("/vm/provision/{env_id}")
+async def get_provision_status(
+    env_id: Annotated[str, Path(description="Provisioning tracking identifier")],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
+    config: Annotated[Config, Depends(get_config)],
+) -> VMProvisionStatus:
+    """Poll status of an in-progress or completed VM provisioning."""
+    record = await store.get_environment(env_id)
+    if record is None:
+        raise NotFoundError(f"Provision {env_id} not found")
+
+    provider = _derive_provider(config)
+    vm_status = (
+        VMStatus.ACTIVE
+        if record.status == RunEnvironmentStatus.PROVISIONED
+        else VMStatus.PROVISIONING
+    )
+
+    return VMProvisionStatus(
+        env_id=env_id,
+        status=vm_status,
+        vm_id=record.vm_id or None,
+        host=record.host or None,
+        provider=provider if record.vm_id else None,
+        created_at=record.started_at,
+    )
 
 
 @router.delete("/vm/{vm_id}")

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -27,7 +28,7 @@ from tanren_api.state import APIStateStore, EnvironmentRecord
 from tanren_core.adapters.protocols import ExecutionEnvironment
 from tanren_core.adapters.remote_types import VMHandle, VMProvider, VMRequirements
 from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
-from tanren_core.adapters.types import RemoteEnvironmentRuntime
+from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
 from tanren_core.remote_config import ProvisionerType, load_remote_config
 from tanren_core.schemas import Cli, Dispatch, Outcome, Phase
@@ -116,6 +117,7 @@ async def provision_vm(
     await store.add_environment(record)
 
     async def _provision_background() -> None:
+        handle: EnvironmentHandle | None = None
         try:
             handle = await execution_env.provision(dispatch, config)
             runtime = handle.runtime
@@ -138,9 +140,11 @@ async def provision_vm(
                 host=vm_handle.host,
                 status=RunEnvironmentStatus.PROVISIONED,
             )
+            handle = None  # Persisted — suppress finally cleanup
         except asyncio.CancelledError:
             raise
         except Exception:
+            handle = None  # Error handler owns cleanup
             logger.exception("VM provision failed for %s", env_id)
             await store.update_environment(
                 env_id,
@@ -148,6 +152,15 @@ async def provision_vm(
                 outcome=Outcome.ERROR,
                 completed_at=_now(),
             )
+        finally:
+            if handle is not None:
+                logger.warning("Cleaning up orphaned VM provision for %s", env_id)
+                inner = asyncio.ensure_future(execution_env.teardown(handle))
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError, Exception:
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await inner
 
     task = asyncio.create_task(_provision_background())
     await store.update_environment(env_id, task=task)

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -133,22 +133,25 @@ async def provision_vm(
                 logger.debug(
                     "Failed to close provision-time SSH connection for %s", vm_handle.vm_id
                 )
-            await store.update_environment(
+            updated = await store.try_transition_environment(
                 env_id,
+                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                to_status=RunEnvironmentStatus.PROVISIONED,
                 handle=handle,
                 vm_id=vm_handle.vm_id,
                 host=vm_handle.host,
-                status=RunEnvironmentStatus.PROVISIONED,
             )
-            handle = None  # Persisted — suppress finally cleanup
+            if updated is not None:
+                handle = None  # Persisted — suppress finally cleanup
         except asyncio.CancelledError:
             raise
         except Exception:
             handle = None  # Error handler owns cleanup
             logger.exception("VM provision failed for %s", env_id)
-            await store.update_environment(
+            await store.try_transition_environment(
                 env_id,
-                status=RunEnvironmentStatus.FAILED,
+                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                to_status=RunEnvironmentStatus.FAILED,
                 outcome=Outcome.ERROR,
                 completed_at=_now(),
             )

--- a/services/tanren-api/src/tanren_api/state.py
+++ b/services/tanren-api/src/tanren_api/state.py
@@ -40,6 +40,11 @@ _TERMINAL_STATUSES = frozenset({
     DispatchRunStatus.FAILED,
     DispatchRunStatus.CANCELLED,
 })
+_TERMINAL_ENV_STATUSES = frozenset({
+    RunEnvironmentStatus.PROVISIONED,
+    RunEnvironmentStatus.COMPLETED,
+    RunEnvironmentStatus.FAILED,
+})
 
 
 @dataclass
@@ -192,7 +197,26 @@ class APIStateStore:
     async def add_environment(self, record: EnvironmentRecord) -> None:
         """Register a new environment."""
         async with self._lock:
+            self._reap_terminal_environments()
             self._environments[record.env_id] = record
+
+    def _reap_terminal_environments(self) -> None:
+        """Remove terminal environments older than retention window. Must hold _lock."""
+        cutoff = datetime.now(UTC) - timedelta(seconds=_MAX_TERMINAL_DISPATCH_AGE_SECS)
+        to_remove = []
+        for env_id, record in self._environments.items():
+            if record.status not in _TERMINAL_ENV_STATUSES:
+                continue
+            if record.completed_at is None:
+                continue
+            try:
+                completed = datetime.fromisoformat(record.completed_at)
+                if completed < cutoff:
+                    to_remove.append(env_id)
+            except ValueError, TypeError:
+                continue
+        for env_id in to_remove:
+            del self._environments[env_id]
 
     async def get_environment(self, env_id: str) -> EnvironmentRecord | None:
         """Look up an environment by ID. Returns a defensive copy.

--- a/services/tanren-api/src/tanren_api/state.py
+++ b/services/tanren-api/src/tanren_api/state.py
@@ -62,7 +62,7 @@ class EnvironmentRecord:
     """Tracks a provisioned execution environment."""
 
     env_id: str
-    handle: EnvironmentHandle
+    handle: EnvironmentHandle | None
     status: RunEnvironmentStatus
     phase: Phase | None = None
     outcome: Outcome | None = None
@@ -210,9 +210,12 @@ class APIStateStore:
         self,
         env_id: str,
         *,
+        handle: EnvironmentHandle | _UnsetType | None = _UNSET,
         status: RunEnvironmentStatus | _UnsetType = _UNSET,
         phase: Phase | _UnsetType | None = _UNSET,
         outcome: Outcome | _UnsetType | None = _UNSET,
+        vm_id: str | _UnsetType = _UNSET,
+        host: str | _UnsetType = _UNSET,
         dispatch_id: str | _UnsetType | None = _UNSET,
         started_at: str | _UnsetType | None = _UNSET,
         completed_at: str | _UnsetType | None = _UNSET,
@@ -223,12 +226,18 @@ class APIStateStore:
             record = self._environments.get(env_id)
             if record is None:
                 return
+            if not isinstance(handle, _UnsetType):
+                record.handle = handle
             if not isinstance(status, _UnsetType):
                 record.status = status
             if not isinstance(phase, _UnsetType):
                 record.phase = phase
             if not isinstance(outcome, _UnsetType):
                 record.outcome = outcome
+            if not isinstance(vm_id, _UnsetType):
+                record.vm_id = vm_id
+            if not isinstance(host, _UnsetType):
+                record.host = host
             if not isinstance(dispatch_id, _UnsetType):
                 record.dispatch_id = dispatch_id
             if not isinstance(started_at, _UnsetType):

--- a/services/tanren-api/src/tanren_api/state.py
+++ b/services/tanren-api/src/tanren_api/state.py
@@ -280,6 +280,9 @@ class APIStateStore:
         *,
         from_statuses: frozenset[RunEnvironmentStatus],
         to_status: RunEnvironmentStatus,
+        handle: EnvironmentHandle | _UnsetType | None = _UNSET,
+        vm_id: str | _UnsetType = _UNSET,
+        host: str | _UnsetType = _UNSET,
         phase: Phase | _UnsetType | None = _UNSET,
         outcome: Outcome | _UnsetType | None = _UNSET,
         dispatch_id: str | _UnsetType | None = _UNSET,
@@ -296,6 +299,12 @@ class APIStateStore:
             if record is None or record.status not in from_statuses:
                 return None
             record.status = to_status
+            if not isinstance(handle, _UnsetType):
+                record.handle = handle
+            if not isinstance(vm_id, _UnsetType):
+                record.vm_id = vm_id
+            if not isinstance(host, _UnsetType):
+                record.host = host
             if not isinstance(phase, _UnsetType):
                 record.phase = phase
             if not isinstance(outcome, _UnsetType):

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -600,6 +600,124 @@ async def test_run_teardown_uses_fresh_handle(client, auth_headers, app, mock_ex
 
 
 @pytest.mark.asyncio
+async def test_provision_then_immediate_teardown_no_orphan(
+    client, auth_headers, app, mock_execution_env, monkeypatch
+):
+    """Concurrent provision + immediate teardown → VM is cleaned up, no orphan.
+
+    Provision returns a handle but gets cancelled before persisting it.
+    The finally block in _provision_background cleans up the orphaned handle.
+    """
+    import contextlib  # noqa: PLC0415
+
+    store = app.state.api_store
+    original_handle = mock_execution_env.provision.return_value
+
+    # Block update_environment when it tries to persist the handle,
+    # simulating the window where provision completed but hasn't persisted yet.
+    persist_reached = asyncio.Event()
+    persist_release = asyncio.Event()
+    original_update = store.update_environment
+
+    async def _intercept_update(env_id, **kwargs):
+        if kwargs.get("handle") is not None:
+            persist_reached.set()
+            await persist_release.wait()
+        return await original_update(env_id, **kwargs)
+
+    monkeypatch.setattr(store, "update_environment", _intercept_update)
+
+    # Start provision
+    prov = await client.post(
+        "/api/v1/run/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    assert prov.status_code == 200
+    env_id = prov.json()["env_id"]
+
+    # Wait for provision to reach the persist step (handle obtained)
+    await persist_reached.wait()
+
+    # Cancel the provision task (simulating teardown cancelling it)
+    record = await store.get_environment(env_id)
+    assert record is not None
+    bg_task = record.task
+    assert bg_task is not None
+    bg_task.cancel()
+
+    # Unblock the intercepted update — cancellation propagates
+    persist_release.set()
+    with contextlib.suppress(asyncio.CancelledError):
+        await bg_task
+
+    # Finally block should have called teardown with the handle
+    mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+
+@pytest.mark.asyncio
+async def test_teardown_during_noncancellable_provision_no_orphan(
+    client, auth_headers, app, mock_execution_env, monkeypatch
+):
+    """End-to-end: provision blocks in a non-cancellable section, teardown
+    arrives, and the VM is still cleaned up (no orphan)."""
+    store = app.state.api_store
+    original_handle = mock_execution_env.provision.return_value
+
+    # Make provision block in a non-cancellable section
+    provision_entered = asyncio.Event()
+    provision_release = asyncio.Event()
+
+    async def _noncancellable_provision(*args, **kwargs):
+        provision_entered.set()
+        try:
+            await provision_release.wait()
+        except asyncio.CancelledError:
+            asyncio.current_task().uncancel()  # type: ignore[union-attr]
+            await provision_release.wait()
+        return original_handle
+
+    mock_execution_env.provision = AsyncMock(side_effect=_noncancellable_provision)
+
+    # Reduce cancel_environment_task timeout
+    original_cancel = store.cancel_environment_task
+
+    async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+        return await original_cancel(eid, wait_secs=wait_secs)
+
+    monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+    # Start provision
+    prov = await client.post(
+        "/api/v1/run/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    assert prov.status_code == 200
+    env_id = prov.json()["env_id"]
+    await provision_entered.wait()
+
+    # Teardown while provision is still running (non-cancellable)
+    resp = await client.post(
+        f"/api/v1/run/{env_id}/teardown",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+    # Unblock provision — it finishes and persists the handle
+    provision_release.set()
+
+    # Wait for teardown background task to complete
+    await asyncio.sleep(0.3)
+
+    # execution_env.teardown must have been called — no orphan
+    mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+    # Environment record should be removed
+    assert await store.get_environment(env_id) is None
+
+
+@pytest.mark.asyncio
 async def test_run_status_includes_vm_identity(client, auth_headers):
     """GET /run/{env_id}/status includes vm_id and host after provisioning."""
     prov = await client.post(

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -610,22 +610,25 @@ async def test_provision_then_immediate_teardown_no_orphan(
     """
     import contextlib  # noqa: PLC0415
 
+    from tanren_api.state import _UNSET  # noqa: PLC0415, PLC2701
+
     store = app.state.api_store
     original_handle = mock_execution_env.provision.return_value
 
-    # Block update_environment when it tries to persist the handle,
+    # Block try_transition_environment when it tries to persist the handle,
     # simulating the window where provision completed but hasn't persisted yet.
     persist_reached = asyncio.Event()
     persist_release = asyncio.Event()
-    original_update = store.update_environment
+    original_try = store.try_transition_environment
 
-    async def _intercept_update(env_id, **kwargs):
-        if kwargs.get("handle") is not None:
+    async def _intercept_try(env_id, **kwargs):
+        h = kwargs.get("handle", _UNSET)
+        if not isinstance(h, type(_UNSET)) and h is not None:
             persist_reached.set()
             await persist_release.wait()
-        return await original_update(env_id, **kwargs)
+        return await original_try(env_id, **kwargs)
 
-    monkeypatch.setattr(store, "update_environment", _intercept_update)
+    monkeypatch.setattr(store, "try_transition_environment", _intercept_try)
 
     # Start provision
     prov = await client.post(
@@ -714,6 +717,70 @@ async def test_teardown_during_noncancellable_provision_no_orphan(
     mock_execution_env.teardown.assert_awaited_once_with(original_handle)
 
     # Environment record should be removed
+    assert await store.get_environment(env_id) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_teardown_during_provision_preserves_tearing_down(
+    client, auth_headers, app, mock_execution_env, monkeypatch
+):
+    """End-to-end: provision blocks, teardown arrives, provision completes.
+
+    Provision's try_transition_environment sees TEARING_DOWN and refuses to
+    overwrite → provision's finally block cleans up the handle.  Teardown
+    background removes the record.
+    """
+    store = app.state.api_store
+    original_handle = mock_execution_env.provision.return_value
+
+    # Make provision block so we can interleave teardown
+    provision_entered = asyncio.Event()
+    provision_release = asyncio.Event()
+
+    async def _blocking_provision(*args, **kwargs):
+        provision_entered.set()
+        try:
+            await provision_release.wait()
+        except asyncio.CancelledError:
+            asyncio.current_task().uncancel()  # type: ignore[union-attr]
+            await provision_release.wait()
+        return original_handle
+
+    mock_execution_env.provision = AsyncMock(side_effect=_blocking_provision)
+
+    # Reduce cancel_environment_task timeout
+    original_cancel = store.cancel_environment_task
+
+    async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+        return await original_cancel(eid, wait_secs=wait_secs)
+
+    monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+    # Start provision
+    prov = await client.post(
+        "/api/v1/run/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    assert prov.status_code == 200
+    env_id = prov.json()["env_id"]
+    await provision_entered.wait()
+
+    # Teardown while provision is blocked
+    resp = await client.post(
+        f"/api/v1/run/{env_id}/teardown",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+    # Release provision
+    provision_release.set()
+    await asyncio.sleep(0.3)
+
+    # teardown called exactly once (by provision's finally block)
+    mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+    # Environment record removed
     assert await store.get_environment(env_id) is None
 
 

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -36,7 +36,7 @@ from tanren_core.adapters.types import (
     PhaseResult,
     RemoteEnvironmentRuntime,
 )
-from tanren_core.config import Config
+from tanren_core.config import Config, DotenvConfigSource, load_config_env
 from tanren_core.env.environment_schema import EnvironmentProfile
 from tanren_core.schemas import Outcome
 
@@ -332,7 +332,7 @@ async def test_vm_release_not_found(client, auth_headers):
 
 @pytest.mark.asyncio
 async def test_vm_provision(client, auth_headers):
-    """POST /api/v1/vm/provision returns VMHandle fields."""
+    """POST /api/v1/vm/provision returns accepted, then poll shows provisioned."""
     resp = await client.post(
         "/api/v1/vm/provision",
         headers=auth_headers,
@@ -340,9 +340,19 @@ async def test_vm_provision(client, auth_headers):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert "vm_id" in data
-    assert "host" in data
-    assert "provider" in data
+    assert "env_id" in data
+    assert data["status"] == "provisioning"
+
+    env_id = data["env_id"]
+    # Let the background provision task complete
+    await asyncio.sleep(0.05)
+
+    status_resp = await client.get(f"/api/v1/vm/provision/{env_id}", headers=auth_headers)
+    assert status_resp.status_code == 200
+    status_data = status_resp.json()
+    assert status_data["status"] == "active"
+    assert status_data["vm_id"] is not None
+    assert status_data["host"] is not None
 
 
 @pytest.mark.asyncio
@@ -355,6 +365,13 @@ async def test_vm_provision_no_exec_env(client, auth_headers, app):
         json={"project": "test", "branch": "main"},
     )
     assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_vm_provision_status_not_found(client, auth_headers):
+    """GET /api/v1/vm/provision/{env_id} returns 404 for unknown id."""
+    resp = await client.get("/api/v1/vm/provision/nonexistent", headers=auth_headers)
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -421,17 +438,31 @@ async def test_events_with_db(client, auth_headers, app, tmp_path):
 # ---------------------------------------------------------------------------
 
 
+async def _wait_provisioned(client, env_id, auth_headers, *, max_secs: float = 2.0):
+    """Poll until env reaches 'provisioned' status (helper)."""
+    deadline = asyncio.get_event_loop().time() + max_secs
+    while asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+        r = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
+        if r.json()["status"] == "provisioned":
+            return
+    raise AssertionError(f"Environment {env_id} did not reach 'provisioned' within {max_secs}s")
+
+
 @pytest.mark.asyncio
 async def test_run_provision_and_status(client, auth_headers):
-    """POST /api/v1/run/provision creates env, GET /status returns it."""
+    """POST /api/v1/run/provision returns provisioning, then transitions to provisioned."""
     resp = await client.post(
         "/api/v1/run/provision",
         headers=auth_headers,
         json={"project": "test", "branch": "main"},
     )
     assert resp.status_code == 200
-    env_id = resp.json()["env_id"]
+    data = resp.json()
+    env_id = data["env_id"]
+    assert data["status"] == "provisioning"
 
+    await _wait_provisioned(client, env_id, auth_headers)
     status_resp = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
     assert status_resp.status_code == 200
     assert status_resp.json()["status"] == "provisioned"
@@ -439,13 +470,14 @@ async def test_run_provision_and_status(client, auth_headers):
 
 @pytest.mark.asyncio
 async def test_run_execute_after_provision(client, auth_headers):
-    """POST /api/v1/run/{env_id}/execute returns accepted."""
+    """POST /api/v1/run/{env_id}/execute returns accepted after provision completes."""
     prov = await client.post(
         "/api/v1/run/provision",
         headers=auth_headers,
         json={"project": "test", "branch": "main"},
     )
     env_id = prov.json()["env_id"]
+    await _wait_provisioned(client, env_id, auth_headers)
 
     exec_resp = await client.post(
         f"/api/v1/run/{env_id}/execute",
@@ -461,6 +493,44 @@ async def test_run_execute_after_provision(client, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_run_execute_before_provision_complete(client, auth_headers, mock_execution_env):
+    """POST /run/{env_id}/execute returns 409 if env is still provisioning."""
+    # Make provision hang so we can try execute while still provisioning
+    provision_started = asyncio.Event()
+    provision_release = asyncio.Event()
+
+    async def _slow_provision(*args, **kwargs):
+        provision_started.set()
+        await provision_release.wait()
+        return mock_execution_env.provision.return_value
+
+    mock_execution_env.provision = AsyncMock(side_effect=_slow_provision)
+
+    prov = await client.post(
+        "/api/v1/run/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    env_id = prov.json()["env_id"]
+    await provision_started.wait()
+
+    exec_resp = await client.post(
+        f"/api/v1/run/{env_id}/execute",
+        headers=auth_headers,
+        json={
+            "project": "test",
+            "spec_path": "specs/test",
+            "phase": "do-task",
+        },
+    )
+    assert exec_resp.status_code == 409
+
+    # Clean up: let the provision complete
+    provision_release.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
 async def test_run_teardown(client, auth_headers):
     """POST /api/v1/run/{env_id}/teardown returns accepted."""
     prov = await client.post(
@@ -469,6 +539,7 @@ async def test_run_teardown(client, auth_headers):
         json={"project": "test", "branch": "main"},
     )
     env_id = prov.json()["env_id"]
+    await _wait_provisioned(client, env_id, auth_headers)
 
     resp = await client.post(f"/api/v1/run/{env_id}/teardown", headers=auth_headers)
     assert resp.status_code == 200
@@ -609,7 +680,7 @@ async def test_lifespan_config_from_env_failure_sets_none(tmp_path):
 
     # Clear all WM_* env vars so Config.from_env() raises ValueError
     cleaned = {k: v for k, v in os.environ.items() if not k.startswith("WM_")}
-    with patch.dict(os.environ, cleaned, clear=True):
+    with patch.dict(os.environ, cleaned, clear=True), patch("tanren_api.main.load_config_env"):
         async with application.router.lifespan_context(application):
             assert application.state.config is None
             assert isinstance(application.state.emitter, NullEventEmitter)
@@ -624,7 +695,7 @@ async def test_lifespan_with_events_db(tmp_path):
 
     # Config.from_env() will fail (no WM_ vars), but events_db from settings is used
     cleaned = {k: v for k, v in os.environ.items() if not k.startswith("WM_")}
-    with patch.dict(os.environ, cleaned, clear=True):
+    with patch.dict(os.environ, cleaned, clear=True), patch("tanren_api.main.load_config_env"):
         async with application.router.lifespan_context(application):
             assert application.state.config is None
             assert isinstance(application.state.emitter, SqliteEventEmitter)
@@ -671,6 +742,58 @@ async def test_lifespan_emitter_close_called(tmp_path):
             assert isinstance(emitter, NullEventEmitter)
         # After context exits, close() was called — NullEventEmitter.close() is a no-op
         # but we verify the lifespan completed without error
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_load_config_env():
+    """Lifespan calls load_config_env() before Config.from_env()."""
+    settings = APISettings(api_key=TEST_API_KEY, cors_origins=[])
+    application = create_app(settings)
+
+    cleaned = {k: v for k, v in os.environ.items() if not k.startswith("WM_")}
+    with (
+        patch.dict(os.environ, cleaned, clear=True),
+        patch("tanren_api.main.load_config_env") as mock_load,
+    ):
+        async with application.router.lifespan_context(application):
+            mock_load.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_config_loads_from_env_file(tmp_path):
+    """Lifespan loads config via load_config_env when WM_* vars are only in a file."""
+    env_file = tmp_path / "tanren.env"
+    env_file.write_text(
+        f"WM_IPC_DIR={tmp_path / 'ipc'}\n"
+        f"WM_GITHUB_DIR={tmp_path / 'github'}\n"
+        f"WM_DATA_DIR={tmp_path / 'data'}\n"
+        "WM_COMMANDS_DIR=.claude/commands/tanren\n"
+        "WM_POLL_INTERVAL=5.0\n"
+        "WM_HEARTBEAT_INTERVAL=30.0\n"
+        "WM_OPENCODE_PATH=opencode\n"
+        "WM_CODEX_PATH=codex\n"
+        "WM_CLAUDE_PATH=claude\n"
+        "WM_MAX_OPENCODE=1\n"
+        "WM_MAX_CODEX=1\n"
+        "WM_MAX_GATE=3\n"
+        f"WM_WORKTREE_REGISTRY_PATH={tmp_path / 'data' / 'worktrees.json'}\n"
+    )
+    settings = APISettings(api_key=TEST_API_KEY, cors_origins=[])
+    application = create_app(settings)
+
+    # Clear all WM_* vars — config is only in the file
+    cleaned = {k: v for k, v in os.environ.items() if not k.startswith("WM_")}
+    with (
+        patch.dict(os.environ, cleaned, clear=True),
+        patch(
+            "tanren_api.main.load_config_env",
+            side_effect=lambda source=None: load_config_env(DotenvConfigSource(env_file)),
+        ),
+    ):
+        async with application.router.lifespan_context(application):
+            assert application.state.config is not None
+            assert application.state.config.ipc_dir == str(tmp_path / "ipc")
+            assert application.state.config.github_dir == str(tmp_path / "github")
 
 
 # ---------------------------------------------------------------------------
@@ -934,6 +1057,91 @@ async def test_config_endpoint_remote_disabled_by_default(client, auth_headers):
     resp = await client.get("/api/v1/config", headers=auth_headers)
     body = resp.json()
     assert body["remote_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Lifespan — stale VM recovery (main.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_recover_stale_on_startup(tmp_path):
+    """Lifespan calls recover_stale_assignments() when execution env supports it."""
+    mock_env = AsyncMock()
+    mock_env.recover_stale_assignments = AsyncMock(return_value=2)
+    mock_env.close = AsyncMock()
+    mock_vm_store = AsyncMock()
+    mock_vm_store.close = AsyncMock()
+
+    env_vars = {
+        "WM_IPC_DIR": str(tmp_path / "ipc"),
+        "WM_GITHUB_DIR": str(tmp_path / "github"),
+        "WM_DATA_DIR": str(tmp_path / "data"),
+        "WM_COMMANDS_DIR": ".claude/commands/tanren",
+        "WM_POLL_INTERVAL": "5.0",
+        "WM_HEARTBEAT_INTERVAL": "30.0",
+        "WM_OPENCODE_PATH": "opencode",
+        "WM_CODEX_PATH": "codex",
+        "WM_CLAUDE_PATH": "claude",
+        "WM_MAX_OPENCODE": "1",
+        "WM_MAX_CODEX": "1",
+        "WM_MAX_GATE": "3",
+        "WM_WORKTREE_REGISTRY_PATH": str(tmp_path / "data" / "worktrees.json"),
+        "WM_REMOTE_CONFIG": str(tmp_path / "remote.toml"),
+    }
+    settings = APISettings(api_key=TEST_API_KEY, cors_origins=[])
+    application = create_app(settings)
+
+    with (
+        patch.dict(os.environ, env_vars, clear=False),
+        patch(
+            "tanren_api.main.build_ssh_execution_environment",
+            return_value=(mock_env, mock_vm_store),
+        ),
+    ):
+        async with application.router.lifespan_context(application):
+            assert application.state.execution_env is mock_env
+            mock_env.recover_stale_assignments.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_recover_stale_failure_does_not_block_startup(tmp_path):
+    """Startup completes even if recover_stale_assignments raises."""
+    mock_env = AsyncMock()
+    mock_env.recover_stale_assignments = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_env.close = AsyncMock()
+    mock_vm_store = AsyncMock()
+    mock_vm_store.close = AsyncMock()
+
+    env_vars = {
+        "WM_IPC_DIR": str(tmp_path / "ipc"),
+        "WM_GITHUB_DIR": str(tmp_path / "github"),
+        "WM_DATA_DIR": str(tmp_path / "data"),
+        "WM_COMMANDS_DIR": ".claude/commands/tanren",
+        "WM_POLL_INTERVAL": "5.0",
+        "WM_HEARTBEAT_INTERVAL": "30.0",
+        "WM_OPENCODE_PATH": "opencode",
+        "WM_CODEX_PATH": "codex",
+        "WM_CLAUDE_PATH": "claude",
+        "WM_MAX_OPENCODE": "1",
+        "WM_MAX_CODEX": "1",
+        "WM_MAX_GATE": "3",
+        "WM_WORKTREE_REGISTRY_PATH": str(tmp_path / "data" / "worktrees.json"),
+        "WM_REMOTE_CONFIG": str(tmp_path / "remote.toml"),
+    }
+    settings = APISettings(api_key=TEST_API_KEY, cors_origins=[])
+    application = create_app(settings)
+
+    with (
+        patch.dict(os.environ, env_vars, clear=False),
+        patch(
+            "tanren_api.main.build_ssh_execution_environment",
+            return_value=(mock_env, mock_vm_store),
+        ),
+    ):
+        async with application.router.lifespan_context(application):
+            # App started despite recovery failure
+            assert application.state.execution_env is mock_env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -572,6 +572,71 @@ async def test_run_status_not_found(client, auth_headers):
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_run_teardown_uses_fresh_handle(client, auth_headers, app, mock_execution_env):
+    """Teardown uses the transitioned record (not stale snapshot) so VM is released."""
+    from tanren_api.models import RunEnvironmentStatus  # noqa: PLC0415
+    from tanren_api.state import EnvironmentRecord  # noqa: PLC0415
+
+    store = app.state.api_store
+    handle = mock_execution_env.provision.return_value
+
+    # Add env with handle=None, then update with real handle to simulate race
+    env_id = "env-race-test"
+    record = EnvironmentRecord(
+        env_id=env_id,
+        handle=None,
+        status=RunEnvironmentStatus.PROVISIONED,
+        started_at="2026-01-01T00:00:00Z",
+    )
+    await store.add_environment(record)
+    await store.update_environment(env_id, handle=handle, vm_id="vm-int-1", host="10.0.0.1")
+
+    resp = await client.post(f"/api/v1/run/{env_id}/teardown", headers=auth_headers)
+    assert resp.status_code == 200
+
+    await asyncio.sleep(0.1)
+    mock_execution_env.teardown.assert_awaited_once_with(handle)
+
+
+@pytest.mark.asyncio
+async def test_run_status_includes_vm_identity(client, auth_headers):
+    """GET /run/{env_id}/status includes vm_id and host after provisioning."""
+    prov = await client.post(
+        "/api/v1/run/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    env_id = prov.json()["env_id"]
+    await _wait_provisioned(client, env_id, auth_headers)
+
+    status_resp = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
+    assert status_resp.status_code == 200
+    data = status_resp.json()
+    assert data["vm_id"] == "vm-int-1"
+    assert data["host"] == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_vm_provision_status_shows_failed(client, auth_headers, mock_execution_env):
+    """GET /vm/provision/{env_id} returns 'failed' when provisioning fails."""
+    mock_execution_env.provision = AsyncMock(side_effect=RuntimeError("boom"))
+
+    resp = await client.post(
+        "/api/v1/vm/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    assert resp.status_code == 200
+    env_id = resp.json()["env_id"]
+
+    await asyncio.sleep(0.05)
+
+    status_resp = await client.get(f"/api/v1/vm/provision/{env_id}", headers=auth_headers)
+    assert status_resp.status_code == 200
+    assert status_resp.json()["status"] == "failed"
+
+
 # ---------------------------------------------------------------------------
 # Error response format
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -1586,3 +1586,46 @@ async def test_vm_provision_orphan_cleanup_on_record_removal(
 
     # execution_env.teardown must have been called — no orphan
     mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+
+@pytest.mark.asyncio
+async def test_vm_provision_records_reaped_after_retention(client, auth_headers, app):
+    """Terminal environment records are removed after the retention window."""
+    store = app.state.api_store
+
+    # Provision two VMs
+    resp1 = await client.post(
+        "/api/v1/vm/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    env_id_1 = resp1.json()["env_id"]
+
+    resp2 = await client.post(
+        "/api/v1/vm/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    env_id_2 = resp2.json()["env_id"]
+
+    # Wait for both to complete
+    await asyncio.sleep(0.1)
+
+    # Patch the first record's completed_at to be old (beyond retention)
+    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
+
+    old_time = (datetime.now(UTC) - timedelta(seconds=3660)).isoformat()
+    await store.update_environment(env_id_1, completed_at=old_time)
+
+    # Provision a third — triggers reap
+    resp3 = await client.post(
+        "/api/v1/vm/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    env_id_3 = resp3.json()["env_id"]
+
+    # First record should be reaped, second and third remain
+    assert await store.get_environment(env_id_1) is None
+    assert await store.get_environment(env_id_2) is not None
+    assert await store.get_environment(env_id_3) is not None

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -1541,3 +1541,48 @@ async def test_middleware_websocket_scope_passthrough(app):
 
     await wrapped(scope, noop_receive, noop_send)
     assert calls == ["websocket"]
+
+
+@pytest.mark.asyncio
+async def test_vm_provision_orphan_cleanup_on_record_removal(
+    client, auth_headers, app, mock_execution_env, monkeypatch
+):
+    """End-to-end: VM provision blocks, teardown removes record, provision
+    completes → try_transition_environment returns None, finally block
+    cleans up the handle (no orphan)."""
+    store = app.state.api_store
+    original_handle = mock_execution_env.provision.return_value
+
+    # Make provision block so we can remove the record while it's in-flight
+    provision_entered = asyncio.Event()
+    provision_release = asyncio.Event()
+
+    async def _blocking_provision(*args, **kwargs):
+        provision_entered.set()
+        await provision_release.wait()
+        return original_handle
+
+    mock_execution_env.provision = AsyncMock(side_effect=_blocking_provision)
+
+    # Start provision
+    resp = await client.post(
+        "/api/v1/vm/provision",
+        headers=auth_headers,
+        json={"project": "test", "branch": "main"},
+    )
+    assert resp.status_code == 200
+    env_id = resp.json()["env_id"]
+
+    # Wait for provision to start
+    await provision_entered.wait()
+
+    # Simulate concurrent teardown removing the environment record
+    removed = await store.remove_environment(env_id)
+    assert removed is not None
+
+    # Release provision — it finishes but record is gone
+    provision_release.set()
+    await asyncio.sleep(0.1)
+
+    # execution_env.teardown must have been called — no orphan
+    mock_execution_env.teardown.assert_awaited_once_with(original_handle)

--- a/tests/integration/test_hetzner_provisioning.py
+++ b/tests/integration/test_hetzner_provisioning.py
@@ -1,0 +1,114 @@
+"""Integration tests for Hetzner VM provisioning.
+
+These tests provision real Hetzner VMs. Secrets are loaded from
+~/.config/tanren/secrets.env automatically. Skip when HETZNER_API_TOKEN
+is not available.
+
+Run with:
+    uv run pytest tests/integration/test_hetzner_provisioning.py -v --timeout=600
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import pytest
+
+from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
+from tanren_core.adapters.remote_types import VMProvider, VMRequirements
+from tanren_core.adapters.ssh import SSHConfig, SSHConnection
+from tanren_core.secrets import SecretLoader
+
+pytestmark = pytest.mark.hetzner
+
+
+def _load_token() -> str | None:
+    """Load HETZNER_API_TOKEN from the developer secrets file."""
+    loader = SecretLoader()
+    loader.autoload_into_env(override=False)
+    secrets = loader.load_developer()
+    return secrets.get("HETZNER_API_TOKEN")
+
+
+_TOKEN = _load_token()
+
+_skip_reason = "HETZNER_API_TOKEN not found in secrets.env"
+
+
+@pytest.fixture()
+def provisioner():
+    """Create a HetznerVMProvisioner using developer secrets and real config values."""
+    if not _TOKEN:
+        raise pytest.skip.Exception(_skip_reason)
+
+    os.environ.setdefault("HETZNER_API_TOKEN", _TOKEN)
+
+    settings = HetznerProvisionerSettings(
+        token_env="HETZNER_API_TOKEN",
+        default_server_type="cpx41",
+        location="hil",
+        image="ubuntu-24.04",
+        ssh_key_name="aegis-tanren",
+        name_prefix="tanren-test",
+        labels={"env": "test"},
+    )
+    return HetznerVMProvisioner(settings)
+
+
+@pytest.fixture()
+def requirements():
+    return VMRequirements(profile="test", cpu=2, memory_gb=4, gpu=False)
+
+
+class TestHetznerAcquireAndSSH:
+    @pytest.mark.timeout(600)
+    async def test_acquire_wait_ssh_release(self, provisioner, requirements):
+        """Acquire VM -> wait for SSH -> run command -> release."""
+        vm = await provisioner.acquire(requirements)
+        try:
+            assert vm.provider == VMProvider.HETZNER
+            assert vm.host
+
+            conn = SSHConnection(
+                SSHConfig(
+                    host=vm.host,
+                    user="root",
+                    key_path="~/.ssh/hetzner_tanren",
+                    connect_timeout=10,
+                )
+            )
+            try:
+                deadline = time.monotonic() + 300
+                while time.monotonic() < deadline:
+                    if await conn.check_connection():
+                        break
+                    await asyncio.sleep(3)
+                else:
+                    raise AssertionError(f"SSH not ready within 300s on {vm.host}")
+
+                result = await conn.run("echo tanren-ok")
+                assert result.exit_code == 0
+                assert "tanren-ok" in result.stdout
+            finally:
+                await conn.close()
+        finally:
+            await provisioner.release(vm)
+
+
+class TestHetznerProvisionLifecycle:
+    @pytest.mark.timeout(600)
+    async def test_provision_and_teardown(self, provisioner, requirements):
+        """Full acquire -> release lifecycle without SSH."""
+        vm = await provisioner.acquire(requirements)
+        try:
+            assert vm.vm_id
+            assert vm.host
+            assert vm.provider == VMProvider.HETZNER
+
+            active = await provisioner.list_active()
+            vm_ids = [h.vm_id for h in active]
+            assert vm.vm_id in vm_ids
+        finally:
+            await provisioner.release(vm)

--- a/tests/unit/api/test_models.py
+++ b/tests/unit/api/test_models.py
@@ -265,7 +265,8 @@ class TestModels:
     def test_vm_status_values(self):
         assert VMStatus.ACTIVE == "active"
         assert VMStatus.RELEASED == "released"
-        assert len(VMStatus) == 4
+        assert VMStatus.FAILED == "failed"
+        assert len(VMStatus) == 5
 
     def test_run_environment_status_values(self):
         assert RunEnvironmentStatus.PROVISIONING == "provisioning"

--- a/tests/unit/api/test_run.py
+++ b/tests/unit/api/test_run.py
@@ -11,6 +11,17 @@ import pytest
 from tanren_api.models import RunEnvironmentStatus
 
 
+async def _wait_provisioned(client, env_id, auth_headers, *, max_secs: float = 2.0):
+    """Poll until env reaches 'provisioned' status."""
+    deadline = asyncio.get_event_loop().time() + max_secs
+    while asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+        r = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
+        if r.json()["status"] == "provisioned":
+            return
+    raise AssertionError(f"Environment {env_id} did not reach 'provisioned' within {max_secs}s")
+
+
 @pytest.mark.api
 class TestRun:
     async def test_provision_returns_environment(self, client, auth_headers):
@@ -22,9 +33,12 @@ class TestRun:
         assert resp.status_code == 200
         data = resp.json()
         assert "env_id" in data
-        assert "vm_id" in data
-        assert "host" in data
-        assert data["status"] == "provisioned"
+        assert data["status"] == "provisioning"
+
+        # Wait for background provision to complete
+        await _wait_provisioned(client, data["env_id"], auth_headers)
+        status = await client.get(f"/api/v1/run/{data['env_id']}/status", headers=auth_headers)
+        assert status.json()["status"] == "provisioned"
 
     async def test_provision_no_execution_env(self, client, auth_headers, app):
         app.state.execution_env = None
@@ -43,6 +57,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         resp = await client.post(
             f"/api/v1/run/{env_id}/execute",
@@ -79,6 +94,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         resp = await client.post(
             f"/api/v1/run/{env_id}/teardown",
@@ -97,6 +113,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         resp = await client.get(
             f"/api/v1/run/{env_id}/status",
@@ -119,6 +136,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Now remove execution_env
         app.state.execution_env = None
@@ -142,6 +160,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         resp = await client.post(
             f"/api/v1/run/{env_id}/execute",
@@ -163,6 +182,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Execute
         await client.post(
@@ -194,6 +214,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Set status to TEARING_DOWN directly to avoid background removal race
         store = app.state.api_store
@@ -214,7 +235,7 @@ class TestRun:
     async def test_provision_wraps_provider_exception(
         self, client, auth_headers, mock_execution_env
     ):
-        """run_provision wraps provider exceptions in ServiceError (500)."""
+        """run_provision surfaces provider failure via status=failed."""
         mock_execution_env.provision = AsyncMock(side_effect=RuntimeError("boom"))
 
         resp = await client.post(
@@ -222,10 +243,15 @@ class TestRun:
             json={"project": "test", "branch": "main"},
             headers=auth_headers,
         )
-        assert resp.status_code == 500
-        data = resp.json()
-        assert data["error_code"] == "service_error"
-        assert "boom" not in data["detail"]
+        # Returns 200 immediately (non-blocking)
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for background task to fail
+        await asyncio.sleep(0.05)
+
+        status_resp = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
+        assert status_resp.json()["status"] == "failed"
 
     async def test_teardown_no_execution_env_returns_500(self, client, auth_headers, app):
         """Teardown without execution_env returns 500 and preserves environment record."""
@@ -236,6 +262,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Remove execution_env
         app.state.execution_env = None
@@ -263,6 +290,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Attach a task that resists one cancellation attempt
         async def _resist_one_cancel() -> None:
@@ -309,6 +337,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Make teardown block so first teardown task stays alive
         teardown_event = asyncio.Event()
@@ -361,6 +390,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Make teardown block on an event so we control when it finishes
         teardown_started = asyncio.Event()
@@ -419,6 +449,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Simulate a completed first execution
         store = app.state.api_store
@@ -554,6 +585,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Make execute block so we can inspect state while EXECUTING
         execute_event = asyncio.Event()
@@ -600,6 +632,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Simulate an in-progress teardown: set status to TEARING_DOWN and attach a task
         store = app.state.api_store
@@ -640,6 +673,7 @@ class TestRun:
             headers=auth_headers,
         )
         env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
 
         # Make execute block on an event
         execute_event = asyncio.Event()

--- a/tests/unit/api/test_run.py
+++ b/tests/unit/api/test_run.py
@@ -760,6 +760,123 @@ class TestRun:
         assert data["vm_id"] == "vm-test-1"
         assert data["host"] == "10.0.0.1"
 
+    async def test_provision_cancelled_after_handle_triggers_cleanup(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Provision cancelled after handle obtained → finally block calls teardown."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Block update_environment when it tries to persist the handle,
+        # giving us a window to cancel the task.
+        persist_reached = asyncio.Event()
+        persist_release = asyncio.Event()
+        original_update = store.update_environment
+
+        async def _intercept_update(env_id, **kwargs):
+            if kwargs.get("handle") is not None:
+                persist_reached.set()
+                await persist_release.wait()
+            return await original_update(env_id, **kwargs)
+
+        monkeypatch.setattr(store, "update_environment", _intercept_update)
+
+        resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for provision to reach the persist step
+        await persist_reached.wait()
+
+        # Cancel the task while it's blocked before persisting handle
+        record = await store.get_environment(env_id)
+        assert record is not None
+        bg_task = record.task
+        assert bg_task is not None
+        bg_task.cancel()
+
+        # Let the intercepted update proceed — task sees CancelledError
+        persist_release.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await bg_task
+
+        # Finally block should have called teardown with the handle
+        mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+    async def test_teardown_rereads_handle_from_store(
+        self, client, auth_headers, app, mock_execution_env
+    ):
+        """Teardown re-reads handle from store, picking up a handle that was
+        persisted after the transition snapshot was taken."""
+        from tanren_api.state import EnvironmentRecord  # noqa: PLC0415
+
+        store = app.state.api_store
+        handle = mock_execution_env.provision.return_value
+
+        # Create env with handle=None (simulating transition snapshot)
+        env_id = "env-reread-handle"
+        record = EnvironmentRecord(
+            env_id=env_id,
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONED,
+            started_at="2026-01-01T00:00:00Z",
+        )
+        await store.add_environment(record)
+
+        # Provision completes and persists the handle (Window B scenario)
+        await store.update_environment(env_id, handle=handle, vm_id="vm-1", host="10.0.0.1")
+
+        # Teardown — should re-read and find the persisted handle
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Wait for background teardown
+        await asyncio.sleep(0.1)
+
+        # teardown must have been called with the real handle
+        mock_execution_env.teardown.assert_awaited_once_with(handle)
+
+    async def test_teardown_removes_record_when_provision_cleaned_up(
+        self, client, auth_headers, app, mock_execution_env
+    ):
+        """When provision was cancelled and cleaned up its own handle,
+        teardown re-reads handle=None and just removes the record."""
+        from tanren_api.state import EnvironmentRecord  # noqa: PLC0415
+
+        store = app.state.api_store
+
+        # Env with handle=None — provision's finally block already cleaned up the VM
+        env_id = "env-already-cleaned"
+        record = EnvironmentRecord(
+            env_id=env_id,
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONING,
+            started_at="2026-01-01T00:00:00Z",
+        )
+        await store.add_environment(record)
+
+        # Teardown — should just remove the record
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Wait for background teardown
+        await asyncio.sleep(0.1)
+
+        # Record should be removed
+        assert await store.get_environment(env_id) is None
+        # teardown should NOT have been called (no handle)
+        mock_execution_env.teardown.assert_not_awaited()
+
     async def test_status_vm_id_null_before_provisioned(
         self, client, auth_headers, app, mock_execution_env
     ):
@@ -795,3 +912,122 @@ class TestRun:
         # Cleanup
         provision_release.set()
         await asyncio.sleep(0.05)
+
+    async def test_teardown_waits_for_noncancellable_provision(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Teardown waits for a non-cancellable provision task to finish,
+        then tears down the handle that provision persisted."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Make provision block in a "non-cancellable" section: it suppresses
+        # the first CancelledError and then persists the handle normally.
+        provision_entered = asyncio.Event()
+        provision_release = asyncio.Event()
+
+        async def _noncancellable_provision(*args, **kwargs):
+            provision_entered.set()
+            try:
+                await provision_release.wait()
+            except asyncio.CancelledError:
+                # Resist cancellation — simulate a provider call that
+                # cannot be interrupted (e.g. Hetzner API).
+                asyncio.current_task().uncancel()  # type: ignore[union-attr]
+                await provision_release.wait()
+            return original_handle
+
+        mock_execution_env.provision = AsyncMock(side_effect=_noncancellable_provision)
+
+        # Reduce cancel_environment_task timeout to avoid slow tests
+        original_cancel = store.cancel_environment_task
+
+        async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+            return await original_cancel(eid, wait_secs=wait_secs)
+
+        monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+        # Start provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert prov_resp.status_code == 200
+        env_id = prov_resp.json()["env_id"]
+        await provision_entered.wait()
+
+        # Teardown while provision is still running
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Unblock provision — it finishes and persists the handle
+        provision_release.set()
+
+        # Wait for the teardown background task to complete
+        await asyncio.sleep(0.2)
+
+        # Teardown should have been called with the handle that provision persisted
+        mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+        # Environment record should be removed
+        assert await store.get_environment(env_id) is None
+
+    async def test_teardown_during_provision_cancel_succeeds_provision_cleans_up(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Provision cancelled successfully → its finally block cleans up.
+        Teardown awaits the prior task, reads handle=None, removes record.
+        execution_env.teardown called exactly once (by provision's finally)."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Make provision block so we can cancel it; it does NOT resist cancellation.
+        provision_entered = asyncio.Event()
+
+        async def _cancellable_provision(*args, **kwargs):
+            provision_entered.set()
+            await asyncio.sleep(3600)  # Will be cancelled
+            return original_handle
+
+        mock_execution_env.provision = AsyncMock(side_effect=_cancellable_provision)
+
+        # Reduce cancel_environment_task timeout
+        original_cancel = store.cancel_environment_task
+
+        async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+            return await original_cancel(eid, wait_secs=wait_secs)
+
+        monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+        # Start provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert prov_resp.status_code == 200
+        env_id = prov_resp.json()["env_id"]
+        await provision_entered.wait()
+
+        # Teardown while provision is still running — cancel succeeds this time
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Wait for teardown background task
+        await asyncio.sleep(0.2)
+
+        # Provision was cancelled before obtaining a handle, so teardown
+        # should NOT have been called by _teardown_background (handle=None).
+        # Provision's finally block also has handle=None (never returned),
+        # so teardown is never called at all.
+        mock_execution_env.teardown.assert_not_awaited()
+
+        # Environment record should be removed
+        assert await store.get_environment(env_id) is None

--- a/tests/unit/api/test_run.py
+++ b/tests/unit/api/test_run.py
@@ -704,3 +704,94 @@ class TestRun:
         )
         assert teardown_resp.status_code == 200
         assert teardown_resp.json()["status"] == "tearing_down"
+
+    async def test_teardown_uses_fresh_handle_from_transition(
+        self, client, auth_headers, app, mock_execution_env
+    ):
+        """Teardown uses the transitioned record's handle, not the stale snapshot."""
+        from tanren_api.state import EnvironmentRecord  # noqa: PLC0415
+
+        store = app.state.api_store
+
+        # Manually add an environment with handle=None (simulating a stale snapshot)
+        env_id = "env-stale-handle"
+        stale_record = EnvironmentRecord(
+            env_id=env_id,
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONED,
+            started_at="2026-01-01T00:00:00Z",
+        )
+        await store.add_environment(stale_record)
+
+        # Now update the store with a real handle (simulating provision completing)
+        handle = mock_execution_env.provision.return_value
+        await store.update_environment(env_id, handle=handle, vm_id="vm-1", host="10.0.0.1")
+
+        # Teardown — should use the handle from the transitioned record
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Wait for background teardown to complete
+        await asyncio.sleep(0.1)
+
+        # execution_env.teardown must have been called with the real handle
+        mock_execution_env.teardown.assert_awaited_once_with(handle)
+
+    async def test_status_includes_vm_id_and_host(self, client, auth_headers, app):
+        """GET /run/{env_id}/status includes vm_id and host after provisioning."""
+        # Provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        env_id = prov_resp.json()["env_id"]
+        await _wait_provisioned(client, env_id, auth_headers)
+
+        resp = await client.get(
+            f"/api/v1/run/{env_id}/status",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["vm_id"] == "vm-test-1"
+        assert data["host"] == "10.0.0.1"
+
+    async def test_status_vm_id_null_before_provisioned(
+        self, client, auth_headers, app, mock_execution_env
+    ):
+        """GET /run/{env_id}/status returns null vm_id/host while provisioning."""
+        # Make provision hang
+        provision_started = asyncio.Event()
+        provision_release = asyncio.Event()
+
+        async def _slow_provision(*args, **kwargs):
+            provision_started.set()
+            await provision_release.wait()
+            return mock_execution_env.provision.return_value
+
+        mock_execution_env.provision = AsyncMock(side_effect=_slow_provision)
+
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        env_id = prov_resp.json()["env_id"]
+        await provision_started.wait()
+
+        resp = await client.get(
+            f"/api/v1/run/{env_id}/status",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["vm_id"] is None
+        assert data["host"] is None
+
+        # Cleanup
+        provision_release.set()
+        await asyncio.sleep(0.05)

--- a/tests/unit/api/test_run.py
+++ b/tests/unit/api/test_run.py
@@ -764,22 +764,25 @@ class TestRun:
         self, client, auth_headers, app, mock_execution_env, monkeypatch
     ):
         """Provision cancelled after handle obtained → finally block calls teardown."""
+        from tanren_api.state import _UNSET  # noqa: PLC0415, PLC2701
+
         store = app.state.api_store
         original_handle = mock_execution_env.provision.return_value
 
-        # Block update_environment when it tries to persist the handle,
+        # Block try_transition_environment when it tries to persist the handle,
         # giving us a window to cancel the task.
         persist_reached = asyncio.Event()
         persist_release = asyncio.Event()
-        original_update = store.update_environment
+        original_try = store.try_transition_environment
 
-        async def _intercept_update(env_id, **kwargs):
-            if kwargs.get("handle") is not None:
+        async def _intercept_try(env_id, **kwargs):
+            h = kwargs.get("handle", _UNSET)
+            if not isinstance(h, type(_UNSET)) and h is not None:
                 persist_reached.set()
                 await persist_release.wait()
-            return await original_update(env_id, **kwargs)
+            return await original_try(env_id, **kwargs)
 
-        monkeypatch.setattr(store, "update_environment", _intercept_update)
+        monkeypatch.setattr(store, "try_transition_environment", _intercept_try)
 
         resp = await client.post(
             "/api/v1/run/provision",
@@ -1031,3 +1034,186 @@ class TestRun:
 
         # Environment record should be removed
         assert await store.get_environment(env_id) is None
+
+    async def test_provision_does_not_overwrite_tearing_down_status(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Provision completing after teardown transitions to TEARING_DOWN must
+        not overwrite the status back to PROVISIONED.  Provision's finally block
+        cleans up the handle instead."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Make provision block so we can interleave teardown
+        provision_entered = asyncio.Event()
+        provision_release = asyncio.Event()
+
+        async def _blocking_provision(*args, **kwargs):
+            provision_entered.set()
+            try:
+                await provision_release.wait()
+            except asyncio.CancelledError:
+                # Resist cancellation — simulate non-cancellable provider
+                asyncio.current_task().uncancel()  # type: ignore[union-attr]
+                await provision_release.wait()
+            return original_handle
+
+        mock_execution_env.provision = AsyncMock(side_effect=_blocking_provision)
+
+        # Reduce cancel_environment_task timeout
+        original_cancel = store.cancel_environment_task
+
+        async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+            return await original_cancel(eid, wait_secs=wait_secs)
+
+        monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+        # Start provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert prov_resp.status_code == 200
+        env_id = prov_resp.json()["env_id"]
+        await provision_entered.wait()
+
+        # Teardown while provision is blocked — transitions to TEARING_DOWN
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Verify status is TEARING_DOWN before releasing provision
+        record = await store.get_environment(env_id)
+        assert record is not None
+        assert record.status == RunEnvironmentStatus.TEARING_DOWN
+
+        # Release provision — it completes and tries to transition
+        provision_release.set()
+        await asyncio.sleep(0.3)
+
+        # teardown should have been called exactly once (by provision's finally block)
+        mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+        # Environment record should be removed by teardown background task
+        assert await store.get_environment(env_id) is None
+
+    async def test_provision_error_does_not_overwrite_tearing_down_status(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Provision raising after teardown transitions to TEARING_DOWN must
+        not overwrite the status to FAILED."""
+        store = app.state.api_store
+
+        # Make provision block then raise
+        provision_entered = asyncio.Event()
+        provision_release = asyncio.Event()
+
+        async def _failing_provision(*args, **kwargs):
+            provision_entered.set()
+            try:
+                await provision_release.wait()
+            except asyncio.CancelledError:
+                asyncio.current_task().uncancel()  # type: ignore[union-attr]
+                await provision_release.wait()
+            raise RuntimeError("provider error")
+
+        mock_execution_env.provision = AsyncMock(side_effect=_failing_provision)
+
+        # Reduce cancel_environment_task timeout
+        original_cancel = store.cancel_environment_task
+
+        async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+            return await original_cancel(eid, wait_secs=wait_secs)
+
+        monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+
+        # Start provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert prov_resp.status_code == 200
+        env_id = prov_resp.json()["env_id"]
+        await provision_entered.wait()
+
+        # Teardown while provision is blocked
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Release provision — it raises RuntimeError
+        provision_release.set()
+        await asyncio.sleep(0.3)
+
+        # teardown should NOT have been called (no handle obtained)
+        mock_execution_env.teardown.assert_not_awaited()
+
+        # Environment record should be removed by teardown background task
+        assert await store.get_environment(env_id) is None
+
+    async def test_teardown_does_not_hang_on_stuck_prior_task(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """Prior task that hangs forever does not block teardown indefinitely."""
+        import tanren_api.routers.run as run_module  # noqa: PLC0415
+
+        store = app.state.api_store
+
+        # Make provision hang forever and resist cancellation
+        provision_entered = asyncio.Event()
+        stop_provision = asyncio.Event()
+
+        async def _stuck_provision(*args, **kwargs):
+            provision_entered.set()
+            while not stop_provision.is_set():
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    asyncio.current_task().uncancel()  # type: ignore[union-attr]
+
+        mock_execution_env.provision = AsyncMock(side_effect=_stuck_provision)
+
+        # Reduce timeouts for fast test
+        original_cancel = store.cancel_environment_task
+
+        async def _fast_cancel(eid: str, *, wait_secs: float = 0.1) -> bool:
+            return await original_cancel(eid, wait_secs=wait_secs)
+
+        monkeypatch.setattr(store, "cancel_environment_task", _fast_cancel)
+        monkeypatch.setattr(run_module, "_PRIOR_TASK_TIMEOUT", 0.1)
+
+        # Start provision
+        prov_resp = await client.post(
+            "/api/v1/run/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert prov_resp.status_code == 200
+        env_id = prov_resp.json()["env_id"]
+        await provision_entered.wait()
+
+        # Teardown — should not hang despite stuck prior task
+        resp = await client.post(
+            f"/api/v1/run/{env_id}/teardown",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Teardown should complete within a few seconds (not hang)
+        deadline = asyncio.get_event_loop().time() + 3.0
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+            record = await store.get_environment(env_id)
+            if record is None:
+                break
+        assert await store.get_environment(env_id) is None
+
+        # Cleanup: unblock the stuck provision task so it doesn't leak
+        stop_provision.set()
+        await asyncio.sleep(0.05)

--- a/tests/unit/api/test_state.py
+++ b/tests/unit/api/test_state.py
@@ -445,6 +445,67 @@ class TestAPIStateStore:
         assert result.outcome == Outcome.SUCCESS
         assert result.completed_at == "2026-01-01T01:00:00Z"
 
+    async def test_try_transition_environment_persists_handle_and_vm_identity(self):
+        """Transition with handle/vm_id/host persists all three fields atomically."""
+        store = APIStateStore()
+        record = EnvironmentRecord(
+            env_id="env-1",
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONING,
+        )
+        await store.add_environment(record)
+
+        handle = _make_env_handle("env-1")
+        result = await store.try_transition_environment(
+            "env-1",
+            from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+            to_status=RunEnvironmentStatus.PROVISIONED,
+            handle=handle,
+            vm_id="vm-99",
+            host="192.168.1.1",
+        )
+        assert result is not None
+        assert result.status == RunEnvironmentStatus.PROVISIONED
+        assert result.handle is handle
+        assert result.vm_id == "vm-99"
+        assert result.host == "192.168.1.1"
+
+        # Verify the internal record was updated too
+        fetched = await store.get_environment("env-1")
+        assert fetched is not None
+        assert fetched.handle is handle
+        assert fetched.vm_id == "vm-99"
+        assert fetched.host == "192.168.1.1"
+
+    async def test_try_transition_environment_rejects_handle_on_wrong_status(self):
+        """Transition rejected when status doesn't match — fields not persisted."""
+        store = APIStateStore()
+        record = EnvironmentRecord(
+            env_id="env-1",
+            handle=None,
+            status=RunEnvironmentStatus.TEARING_DOWN,
+        )
+        await store.add_environment(record)
+
+        handle = _make_env_handle("env-1")
+        result = await store.try_transition_environment(
+            "env-1",
+            from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+            to_status=RunEnvironmentStatus.PROVISIONED,
+            handle=handle,
+            vm_id="vm-99",
+            host="192.168.1.1",
+        )
+        assert result is None
+
+        # Stored record must be unchanged
+        fetched = await store.get_environment("env-1")
+        assert fetched is not None
+        assert fetched.handle is None
+        assert not fetched.vm_id
+        assert not fetched.host
+        assert fetched.status == RunEnvironmentStatus.TEARING_DOWN
+
     async def test_reap_preserves_recent_terminal_dispatches(self):
         store = APIStateStore()
         recent_time = datetime.now(UTC).isoformat()

--- a/tests/unit/api/test_state.py
+++ b/tests/unit/api/test_state.py
@@ -520,3 +520,49 @@ class TestAPIStateStore:
         await store.add_dispatch(_make_dispatch_record("trigger2"))
 
         assert await store.get_dispatch("recent-done") is not None
+
+    async def test_reap_terminal_environments_on_add(self):
+        store = APIStateStore()
+        old_time = (datetime.now(UTC) - timedelta(seconds=3660)).isoformat()
+
+        old_env = _make_env_record("old-provisioned")
+        old_env.status = RunEnvironmentStatus.PROVISIONED
+        old_env.completed_at = old_time
+        async with store._lock:
+            store._environments["old-provisioned"] = old_env
+
+        # Trigger reap via add_environment
+        await store.add_environment(_make_env_record("trigger"))
+
+        assert await store.get_environment("old-provisioned") is None
+        assert await store.get_environment("trigger") is not None
+
+    async def test_reap_preserves_active_environments(self):
+        store = APIStateStore()
+        old_time = (datetime.now(UTC) - timedelta(seconds=3660)).isoformat()
+
+        active_env = _make_env_record("active-env")
+        active_env.status = RunEnvironmentStatus.PROVISIONING
+        active_env.started_at = old_time
+        async with store._lock:
+            store._environments["active-env"] = active_env
+
+        # Trigger reap
+        await store.add_environment(_make_env_record("trigger"))
+
+        assert await store.get_environment("active-env") is not None
+
+    async def test_reap_preserves_recent_terminal_environments(self):
+        store = APIStateStore()
+        recent_time = datetime.now(UTC).isoformat()
+
+        recent_env = _make_env_record("recent-env")
+        recent_env.status = RunEnvironmentStatus.PROVISIONED
+        recent_env.completed_at = recent_time
+        async with store._lock:
+            store._environments["recent-env"] = recent_env
+
+        # Trigger reap
+        await store.add_environment(_make_env_record("trigger"))
+
+        assert await store.get_environment("recent-env") is not None

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
 from tanren_core.adapters.remote_types import VMAssignment, VMHandle
+
+
+async def _wait_vm_provisioned(client, env_id, auth_headers, *, max_secs: float = 2.0):
+    """Poll until VM provision reaches 'active' status."""
+    deadline = asyncio.get_event_loop().time() + max_secs
+    while asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+        r = await client.get(f"/api/v1/vm/provision/{env_id}", headers=auth_headers)
+        if r.json()["status"] == "active":
+            return
+    raise AssertionError(f"VM provision {env_id} did not reach 'active' within {max_secs}s")
 
 
 @pytest.mark.api
@@ -62,7 +74,7 @@ class TestVM:
         assert data["vm_id"] == "vm-1"
         assert data["status"] == "released"
 
-    async def test_provision_vm_returns_handle(self, client, auth_headers):
+    async def test_provision_vm_returns_accepted(self, client, auth_headers):
         resp = await client.post(
             "/api/v1/vm/provision",
             json={"project": "test", "branch": "main"},
@@ -70,9 +82,15 @@ class TestVM:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert "vm_id" in data
-        assert "host" in data
-        assert "provider" in data
+        assert "env_id" in data
+        assert data["status"] == "provisioning"
+
+        # Wait for background to complete and verify via status endpoint
+        await _wait_vm_provisioned(client, data["env_id"], auth_headers)
+        status = await client.get(f"/api/v1/vm/provision/{data['env_id']}", headers=auth_headers)
+        status_data = status.json()
+        assert status_data["vm_id"] is not None
+        assert status_data["host"] is not None
 
     async def test_provision_vm_no_execution_env(self, client, auth_headers, app):
         app.state.execution_env = None
@@ -105,13 +123,18 @@ class TestVM:
     async def test_provision_vm_closes_ssh_connection(
         self, client, auth_headers, mock_execution_env
     ):
-        """provision_vm closes the SSH connection to prevent leak."""
+        """provision_vm closes the SSH connection in background task."""
         resp = await client.post(
             "/api/v1/vm/provision",
             json={"project": "test", "branch": "main"},
             headers=auth_headers,
         )
         assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for background provision to complete
+        await _wait_vm_provisioned(client, env_id, auth_headers)
+
         handle = mock_execution_env.provision.return_value
         handle.runtime.connection.close.assert_called_once()
 
@@ -138,7 +161,7 @@ class TestVM:
     async def test_provision_vm_wraps_provider_exception(
         self, client, auth_headers, mock_execution_env
     ):
-        """provision_vm wraps provider exceptions in ServiceError (500)."""
+        """provision_vm surfaces provider failure via status polling."""
         mock_execution_env.provision = AsyncMock(side_effect=RuntimeError("boom"))
 
         resp = await client.post(
@@ -146,10 +169,15 @@ class TestVM:
             json={"project": "test", "branch": "main"},
             headers=auth_headers,
         )
-        assert resp.status_code == 500
-        data = resp.json()
-        assert data["error_code"] == "service_error"
-        assert "boom" not in data["detail"]
+        # Returns 200 immediately (non-blocking)
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for background task to fail
+        await asyncio.sleep(0.05)
+
+        status_resp = await client.get(f"/api/v1/run/{env_id}/status", headers=auth_headers)
+        assert status_resp.json()["status"] == "failed"
 
     async def test_derive_provider_raises_on_bad_config(self, client, auth_headers, app):
         """_derive_provider wraps config load errors in ServiceError (500)."""

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -226,21 +226,25 @@ class TestVM:
         self, client, auth_headers, app, mock_execution_env, monkeypatch
     ):
         """VM provision cancelled after handle obtained → finally block calls teardown."""
+        from tanren_api.state import _UNSET  # noqa: PLC0415, PLC2701
+
         store = app.state.api_store
         original_handle = mock_execution_env.provision.return_value
 
-        # Block update_environment when it tries to persist the handle
+        # Block try_transition_environment when it tries to persist the handle,
+        # giving us a window to cancel the task.
         persist_reached = asyncio.Event()
         persist_release = asyncio.Event()
-        original_update = store.update_environment
+        original_try = store.try_transition_environment
 
-        async def _intercept_update(env_id, **kwargs):
-            if kwargs.get("handle") is not None:
+        async def _intercept_try(env_id, **kwargs):
+            h = kwargs.get("handle", _UNSET)
+            if not isinstance(h, type(_UNSET)) and h is not None:
                 persist_reached.set()
                 await persist_release.wait()
-            return await original_update(env_id, **kwargs)
+            return await original_try(env_id, **kwargs)
 
-        monkeypatch.setattr(store, "update_environment", _intercept_update)
+        monkeypatch.setattr(store, "try_transition_environment", _intercept_try)
 
         resp = await client.post(
             "/api/v1/vm/provision",
@@ -266,6 +270,46 @@ class TestVM:
             await bg_task
 
         # Finally block should have called teardown with the handle
+        mock_execution_env.teardown.assert_awaited_once_with(original_handle)
+
+    async def test_provision_does_not_orphan_handle_when_record_removed(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """VM provision cleans up handle when environment record is removed mid-provision."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Make provision block so we can remove the record while it's in-flight
+        provision_entered = asyncio.Event()
+        provision_release = asyncio.Event()
+
+        async def _blocking_provision(*args, **kwargs):
+            provision_entered.set()
+            await provision_release.wait()
+            return original_handle
+
+        mock_execution_env.provision = AsyncMock(side_effect=_blocking_provision)
+
+        resp = await client.post(
+            "/api/v1/vm/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for provision to start
+        await provision_entered.wait()
+
+        # Remove the environment record (simulating concurrent teardown)
+        removed = await store.remove_environment(env_id)
+        assert removed is not None
+
+        # Release provision — try_transition_environment returns None (record gone)
+        provision_release.set()
+        await asyncio.sleep(0.1)
+
+        # Finally block should have called teardown with the handle (no orphan)
         mock_execution_env.teardown.assert_awaited_once_with(original_handle)
 
     async def test_provision_status_shows_failed_on_failure(

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -312,6 +312,22 @@ class TestVM:
         # Finally block should have called teardown with the handle (no orphan)
         mock_execution_env.teardown.assert_awaited_once_with(original_handle)
 
+    async def test_provision_sets_completed_at_on_success(self, client, auth_headers, app):
+        """Successful provision sets completed_at on the environment record."""
+        resp = await client.post(
+            "/api/v1/vm/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        await _wait_vm_provisioned(client, env_id, auth_headers)
+
+        record = await app.state.api_store.get_environment(env_id)
+        assert record is not None
+        assert record.completed_at is not None
+
     async def test_provision_status_shows_failed_on_failure(
         self, client, auth_headers, mock_execution_env
     ):

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock
 
 import pytest
@@ -220,6 +221,52 @@ class TestVM:
         assert resp.status_code == 200
         data = resp.json()
         assert "requirements" in data
+
+    async def test_provision_cancelled_after_handle_triggers_cleanup(
+        self, client, auth_headers, app, mock_execution_env, monkeypatch
+    ):
+        """VM provision cancelled after handle obtained → finally block calls teardown."""
+        store = app.state.api_store
+        original_handle = mock_execution_env.provision.return_value
+
+        # Block update_environment when it tries to persist the handle
+        persist_reached = asyncio.Event()
+        persist_release = asyncio.Event()
+        original_update = store.update_environment
+
+        async def _intercept_update(env_id, **kwargs):
+            if kwargs.get("handle") is not None:
+                persist_reached.set()
+                await persist_release.wait()
+            return await original_update(env_id, **kwargs)
+
+        monkeypatch.setattr(store, "update_environment", _intercept_update)
+
+        resp = await client.post(
+            "/api/v1/vm/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for provision to reach the persist step
+        await persist_reached.wait()
+
+        # Cancel the task while it's blocked before persisting handle
+        record = await store.get_environment(env_id)
+        assert record is not None
+        bg_task = record.task
+        assert bg_task is not None
+        bg_task.cancel()
+
+        # Let the intercepted update proceed — task sees CancelledError
+        persist_release.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await bg_task
+
+        # Finally block should have called teardown with the handle
+        mock_execution_env.teardown.assert_awaited_once_with(original_handle)
 
     async def test_provision_status_shows_failed_on_failure(
         self, client, auth_headers, mock_execution_env

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -220,3 +220,27 @@ class TestVM:
         assert resp.status_code == 200
         data = resp.json()
         assert "requirements" in data
+
+    async def test_provision_status_shows_failed_on_failure(
+        self, client, auth_headers, mock_execution_env
+    ):
+        """GET /vm/provision/{env_id} returns 'failed' when provisioning fails."""
+        mock_execution_env.provision = AsyncMock(side_effect=RuntimeError("boom"))
+
+        resp = await client.post(
+            "/api/v1/vm/provision",
+            json={"project": "test", "branch": "main"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        env_id = resp.json()["env_id"]
+
+        # Wait for background task to fail
+        await asyncio.sleep(0.05)
+
+        status_resp = await client.get(
+            f"/api/v1/vm/provision/{env_id}",
+            headers=auth_headers,
+        )
+        assert status_resp.status_code == 200
+        assert status_resp.json()["status"] == "failed"

--- a/tests/unit/test_hetzner_vm.py
+++ b/tests/unit/test_hetzner_vm.py
@@ -68,7 +68,9 @@ def _build_client(server: _FakeServer):
     return SimpleNamespace(
         locations=SimpleNamespace(get_by_name=Mock(return_value=location)),
         ssh_keys=SimpleNamespace(get_by_name=Mock(return_value=ssh_key)),
-        images=SimpleNamespace(get_by_name=Mock(return_value=SimpleNamespace(name="ubuntu-24.04"))),
+        images=SimpleNamespace(
+            get_by_name_and_architecture=Mock(return_value=SimpleNamespace(name="ubuntu-24.04"))
+        ),
         server_types=SimpleNamespace(get_by_name=Mock(return_value=server_type)),
         servers=servers,
     )

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -123,6 +123,45 @@ class TestRemoteConfigDefaults:
         assert cfg.repos == []
 
 
+class TestSSHReadyTimeoutSecs:
+    def test_default_value(self):
+        cfg = RemoteSSHConfig()
+        assert cfg.ssh_ready_timeout_secs == 300
+
+    def test_custom_value(self):
+        cfg = RemoteSSHConfig(ssh_ready_timeout_secs=600)
+        assert cfg.ssh_ready_timeout_secs == 600
+
+    def test_minimum_value_30(self):
+        cfg = RemoteSSHConfig(ssh_ready_timeout_secs=30)
+        assert cfg.ssh_ready_timeout_secs == 30
+
+    def test_below_minimum_rejected(self):
+        with pytest.raises(ValidationError, match="ssh_ready_timeout_secs"):
+            RemoteSSHConfig(ssh_ready_timeout_secs=29)
+
+    def test_loaded_from_yaml(self, tmp_path):
+        cfg_file = tmp_path / "remote.yml"
+        cfg_file.write_text(
+            "provisioner:\n"
+            "  type: manual\n"
+            "  settings:\n"
+            "    vms:\n"
+            "      - id: vm-1\n"
+            "        host: 10.0.0.1\n"
+            "ssh:\n"
+            "  ssh_ready_timeout_secs: 600\n"
+        )
+        cfg = load_remote_config(cfg_file)
+        assert cfg.ssh.ssh_ready_timeout_secs == 600
+
+    def test_default_when_omitted_from_yaml(self, tmp_path):
+        cfg_file = tmp_path / "remote.yml"
+        cfg_file.write_text(MINIMAL_YAML)
+        cfg = load_remote_config(cfg_file)
+        assert cfg.ssh.ssh_ready_timeout_secs == 300
+
+
 class TestRepoBindings:
     def test_repos_map_coerces_to_bindings(self, tmp_path: Path):
         cfg_file = tmp_path / "remote.yml"

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -77,7 +78,7 @@ class TestEnsureConnected:
         result = conn._ensure_connected()
 
         assert result is mock_client
-        mock_client.load_system_host_keys.assert_called_once()
+        mock_client.load_system_host_keys.assert_not_called()
         mock_client.set_missing_host_key_policy.assert_called_once_with(
             mock_paramiko.AutoAddPolicy()
         )
@@ -158,6 +159,39 @@ class TestEnsureConnected:
             "AuthenticationException", (mock_paramiko.SSHException,), {}
         )
         mock_client.connect.side_effect = mock_paramiko.SSHException("network")
+
+        conn = _make_conn()
+        with pytest.raises(ConnectionError, match="SSH connection failed"):
+            conn._ensure_connected()
+
+    def test_os_error_wraps_to_connection_error(self, mock_paramiko):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+        mock_paramiko.AuthenticationException = type("AuthenticationException", (Exception,), {})
+        mock_paramiko.SSHException = type("SSHException", (Exception,), {})
+        mock_client.connect.side_effect = ConnectionRefusedError("Connection refused")
+
+        conn = _make_conn()
+        with pytest.raises(ConnectionError, match="SSH connection failed"):
+            conn._ensure_connected()
+
+    def test_connection_reset_wraps_to_connection_error(self, mock_paramiko):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+        mock_paramiko.AuthenticationException = type("AuthenticationException", (Exception,), {})
+        mock_paramiko.SSHException = type("SSHException", (Exception,), {})
+        mock_client.connect.side_effect = ConnectionResetError("Connection reset by peer")
+
+        conn = _make_conn()
+        with pytest.raises(ConnectionError, match="SSH connection failed"):
+            conn._ensure_connected()
+
+    def test_socket_timeout_wraps_to_connection_error(self, mock_paramiko):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+        mock_paramiko.AuthenticationException = type("AuthenticationException", (Exception,), {})
+        mock_paramiko.SSHException = type("SSHException", (Exception,), {})
+        mock_client.connect.side_effect = TimeoutError("timed out")
 
         conn = _make_conn()
         with pytest.raises(ConnectionError, match="SSH connection failed"):
@@ -347,6 +381,63 @@ class TestSFTP:
 
 
 # ---------------------------------------------------------------------------
+# check_ssh_banner
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSSHBanner:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_banner_received(self):
+        conn = _make_conn()
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b"SSH-2.0-OpenSSH_9.6p1 Ubuntu\r\n"
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+
+        with patch("tanren_core.adapters.ssh.socket.create_connection", return_value=mock_sock):
+            assert await conn.check_ssh_banner() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_connection_refused(self):
+        conn = _make_conn()
+        with patch(
+            "tanren_core.adapters.ssh.socket.create_connection",
+            side_effect=ConnectionRefusedError("refused"),
+        ):
+            assert await conn.check_ssh_banner() is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_timeout(self):
+        conn = _make_conn()
+        with patch(
+            "tanren_core.adapters.ssh.socket.create_connection",
+            side_effect=TimeoutError("timed out"),
+        ):
+            assert await conn.check_ssh_banner() is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_non_ssh_data(self):
+        conn = _make_conn()
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b"HTTP/1.1 200 OK\r\n"
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+
+        with patch("tanren_core.adapters.ssh.socket.create_connection", return_value=mock_sock):
+            assert await conn.check_ssh_banner() is False
+
+    @pytest.mark.asyncio
+    async def test_uses_configured_host_and_port(self):
+        conn = _make_conn(host="192.168.1.1", port=2222)
+        with patch(
+            "tanren_core.adapters.ssh.socket.create_connection",
+            side_effect=ConnectionRefusedError("refused"),
+        ) as mock_create:
+            await conn.check_ssh_banner()
+        mock_create.assert_called_once_with(("192.168.1.1", 2222), timeout=10)
+
+
+# ---------------------------------------------------------------------------
 # check_connection / get_host_identifier / close
 # ---------------------------------------------------------------------------
 
@@ -371,6 +462,19 @@ class TestMisc:
 
         conn = _make_conn()
         assert await conn.check_connection() is False
+
+    @pytest.mark.asyncio
+    async def test_check_connection_logs_failure_at_debug(self, mock_paramiko, caplog):
+        mock_client = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_client
+        mock_client.get_transport.side_effect = Exception("connection reset")
+
+        conn = _make_conn()
+        with caplog.at_level(logging.DEBUG, logger="tanren_core.adapters.ssh"):
+            result = await conn.check_connection()
+
+        assert result is False
+        assert "check_connection failed" in caplog.text
 
     def test_get_host_identifier(self, mock_paramiko):
         conn = _make_conn(user="deploy", port=2222)

--- a/tests/unit/test_ssh_environment.py
+++ b/tests/unit/test_ssh_environment.py
@@ -451,7 +451,7 @@ class TestProvision:
         config = env_kit["config"]
         call_order: list[str] = []
 
-        async def _track_ssh_ready(conn):  # noqa: RUF029
+        async def _track_ssh_ready(conn, **kwargs):  # noqa: RUF029
             call_order.append("ssh_ready")
 
         async def _track_bootstrap(conn):  # noqa: RUF029
@@ -894,6 +894,47 @@ class TestClose:
         env = env_kit["env"]
         await env.close()
         env_kit["state_store"].close.assert_awaited_once()
+
+
+class TestSSHReadyTimeoutConfigurable:
+    def test_default_timeout_is_300(self, env_kit):
+        env = env_kit["env"]
+        assert env._ssh_ready_timeout_secs == 300
+
+    def test_custom_timeout_stored(self):
+        env = SSHExecutionEnvironment(
+            vm_provisioner=AsyncMock(),
+            bootstrapper=AsyncMock(),
+            workspace_mgr=AsyncMock(),
+            runner=AsyncMock(),
+            state_store=AsyncMock(),
+            secret_loader=MagicMock(),
+            emitter=AsyncMock(),
+            ssh_config_defaults=SSHConfig(host="placeholder"),
+            repo_urls={},
+            ssh_ready_timeout_secs=600,
+        )
+        assert env._ssh_ready_timeout_secs == 600
+
+    async def test_provision_passes_configured_timeout(self, env_kit):
+        """provision() passes _ssh_ready_timeout_secs to _await_ssh_ready."""
+        env = env_kit["env"]
+        env._ssh_ready_timeout_secs = 450
+        dispatch = _make_dispatch()
+        config = env_kit["config"]
+
+        with (
+            patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(env, "_load_project_env", return_value={}),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock) as mock_await,
+            patch("tanren_core.adapters.ssh_environment.SSHConnection") as MockSSH,
+        ):
+            MockSSH.return_value = AsyncMock()
+            await env.provision(dispatch, config)
+
+        mock_await.assert_awaited_once()
+        _, kwargs = mock_await.call_args
+        assert kwargs["timeout"] == 450
 
 
 class TestAwaitSshReady:


### PR DESCRIPTION
## Summary
- Implement all 4 VM lifecycle endpoints: provision, release, list, dry-run (closes #9)
- Fix SSH host key conflicts that caused perpetual connection failures on Hetzner VMs
- Add configurable SSH readiness timeout and improve error observability

## Key fixes
- **Root cause of SSH failures**: `load_system_host_keys()` loaded stale `known_hosts` entries for recycled Hetzner IPs, causing `BadHostKeyException` disguised as "Error reading SSH protocol banner". Skipped for `auto_add` policy (ephemeral VMs).
- **Silent exception audit**: Added `exc_info=True` to all warning-level exception handlers in teardown/cleanup paths, added debug logging to `check_connection()` and SFTP staleness checks.
- **OSError handling**: `_ensure_connected()` now catches `ConnectionRefusedError`, `ConnectionResetError`, `socket.timeout` and wraps them as `ConnectionError`.
- **hcloud deprecation**: Migrated from `get_by_name()` to `get_by_name_and_architecture()` for image lookups.

## Test plan
- [x] `make check` passes (825 unit + 327 integration tests)
- [x] Hetzner integration tests pass — real VM provision + SSH + release (~47s)
- [x] API manual test — provision, list, delete via HTTP endpoints
- [x] OpenAPI spec is current

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)