### PR TITLE
feat: Claude/Codex subscription auth injection & ccusage shlex fix

### DIFF
--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -3,6 +3,17 @@
 Protocols define the contract; concrete classes wrap existing module functions.
 """
 
+from tanren_core.adapters.credentials import (
+    CLI_CREDENTIAL_PROVIDERS,
+    DEFAULT_CREDENTIAL_PROVIDERS,
+    ClaudeCredentialProvider,
+    CodexCredentialProvider,
+    CredentialProvider,
+    OpencodeCredentialProvider,
+    all_credential_cleanup_paths,
+    inject_all_cli_credentials,
+    providers_for_clis,
+)
 from tanren_core.adapters.dotenv_provisioner import DotenvEnvProvisioner
 from tanren_core.adapters.dotenv_validator import DotenvEnvValidator
 from tanren_core.adapters.events import (
@@ -82,9 +93,14 @@ from tanren_core.adapters.types import (
 from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
 
 __all__ = [
+    "CLI_CREDENTIAL_PROVIDERS",
+    "DEFAULT_CREDENTIAL_PROVIDERS",
     "AccessInfo",
     "BootstrapCompleted",
     "BootstrapResult",
+    "ClaudeCredentialProvider",
+    "CodexCredentialProvider",
+    "CredentialProvider",
     "DispatchReceived",
     "DotenvEnvProvisioner",
     "DotenvEnvValidator",
@@ -109,6 +125,7 @@ __all__ = [
     "ManualVMProvisioner",
     "NoVMAvailableError",
     "NullEventEmitter",
+    "OpencodeCredentialProvider",
     "PhaseCompleted",
     "PhaseResult",
     "PhaseStarted",
@@ -144,4 +161,7 @@ __all__ = [
     "WorkspacePath",
     "WorkspaceSpec",
     "WorktreeManager",
+    "all_credential_cleanup_paths",
+    "inject_all_cli_credentials",
+    "providers_for_clis",
 ]

--- a/packages/tanren-core/src/tanren_core/adapters/credentials.py
+++ b/packages/tanren-core/src/tanren_core/adapters/credentials.py
@@ -1,0 +1,265 @@
+"""Credential injection for remote CLI execution.
+
+Each CLI's auth needs are encapsulated in a CredentialProvider.
+All credentials are injected at provision time; execute does no auth injection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from tanren_core.adapters.remote_types import SecretBundle
+from tanren_core.schemas import Cli
+
+if TYPE_CHECKING:
+    from tanren_core.adapters.protocols import RemoteConnection
+
+logger = logging.getLogger(__name__)
+
+
+async def _resolve_remote_home(conn: RemoteConnection) -> str:
+    """Resolve the remote user's home directory.
+
+    Returns:
+        Absolute path to the remote home directory.
+
+    Raises:
+        RuntimeError: If the ``echo $HOME`` command fails.
+    """
+    result = await conn.run("echo $HOME", timeout=10)
+    home = result.stdout.strip()
+    if not home or result.exit_code != 0:
+        raise RuntimeError(f"Failed to resolve remote $HOME: {result.stderr}")
+    return home
+
+
+@runtime_checkable
+class CredentialProvider(Protocol):
+    """Protocol for CLI credential providers."""
+
+    @property
+    def name(self) -> str:
+        """Human-readable provider name."""
+        ...
+
+    @property
+    def cleanup_paths(self) -> tuple[str, ...]:
+        """Shell paths (tilde-prefixed) to remove during cleanup."""
+        ...
+
+    async def inject(
+        self, conn: RemoteConnection, secrets: SecretBundle, *, home_dir: str | None = None
+    ) -> bool:
+        """Inject credentials onto the remote host.
+
+        Args:
+            conn: RemoteConnection to the VM.
+            secrets: SecretBundle with credential data.
+            home_dir: If set, use this as the remote home instead of $HOME.
+
+        Returns:
+            True if credentials were written, False if the key was missing.
+        """
+        ...
+
+
+class OpencodeCredentialProvider:
+    """Inject opencode auth.json for Z.ai API key auth."""
+
+    _SUFFIX = ".local/share/opencode/auth.json"
+    _SHELL_PATH = f"~/{_SUFFIX}"
+
+    @property
+    def name(self) -> str:
+        """Return provider name."""
+        return "opencode"
+
+    @property
+    def cleanup_paths(self) -> tuple[str, ...]:
+        """Return shell paths to clean up."""
+        return (self._SHELL_PATH,)
+
+    async def inject(
+        self, conn: RemoteConnection, secrets: SecretBundle, *, home_dir: str | None = None
+    ) -> bool:
+        """Write opencode auth.json if OPENCODE_ZAI_API_KEY is present.
+
+        Returns:
+            True if credentials were written, False if the key was missing.
+        """
+        zai_key = secrets.developer.get("OPENCODE_ZAI_API_KEY") or secrets.project.get(
+            "OPENCODE_ZAI_API_KEY"
+        )
+        if not zai_key:
+            logger.warning("OPENCODE_ZAI_API_KEY not found in secrets — opencode auth skipped")
+            return False
+
+        auth_data = {"zai-coding-plan": {"type": "api", "key": zai_key}}
+        content = json.dumps(auth_data, indent=2)
+
+        remote_home = home_dir or await _resolve_remote_home(conn)
+        auth_dir = f"{remote_home}/{Path(self._SUFFIX).parent}"
+        abs_auth_path = f"{remote_home}/{self._SUFFIX}"
+        await conn.run(f"mkdir -p {auth_dir}", timeout=10)
+        await conn.upload_content(content, abs_auth_path)
+        await conn.run(f"chmod 600 {abs_auth_path}", timeout=10)
+        if home_dir:
+            user = Path(home_dir).name
+            await conn.run(f"chown -R {user}:{user} {auth_dir}", timeout=10)
+        logger.info("Injected opencode auth.json (zai-coding-plan)")
+        return True
+
+
+class ClaudeCredentialProvider:
+    """Inject Claude credentials.json for subscription (Max/Pro) auth."""
+
+    _SUFFIX = ".claude/.credentials.json"
+    _SHELL_PATH = f"~/{_SUFFIX}"
+
+    @property
+    def name(self) -> str:
+        """Return provider name."""
+        return "claude"
+
+    @property
+    def cleanup_paths(self) -> tuple[str, ...]:
+        """Return shell paths to clean up."""
+        return (self._SHELL_PATH,)
+
+    async def inject(
+        self, conn: RemoteConnection, secrets: SecretBundle, *, home_dir: str | None = None
+    ) -> bool:
+        """Write Claude credentials.json if CLAUDE_CREDENTIALS_JSON is present.
+
+        Returns:
+            True if credentials were written, False if the key was missing.
+        """
+        content = secrets.developer.get("CLAUDE_CREDENTIALS_JSON")
+        if not content:
+            logger.warning("CLAUDE_CREDENTIALS_JSON not found in secrets — claude auth skipped")
+            return False
+
+        remote_home = home_dir or await _resolve_remote_home(conn)
+        auth_dir = f"{remote_home}/{Path(self._SUFFIX).parent}"
+        abs_auth_path = f"{remote_home}/{self._SUFFIX}"
+        await conn.run(f"mkdir -p {auth_dir}", timeout=10)
+        await conn.upload_content(content, abs_auth_path)
+        await conn.run(f"chmod 600 {abs_auth_path}", timeout=10)
+        if home_dir:
+            user = Path(home_dir).name
+            await conn.run(f"chown -R {user}:{user} {auth_dir}", timeout=10)
+        logger.info("Injected claude credentials.json (subscription)")
+        return True
+
+
+class CodexCredentialProvider:
+    """Inject Codex auth.json for subscription (ChatGPT Plus) auth."""
+
+    _SUFFIX = ".codex/auth.json"
+    _SHELL_PATH = f"~/{_SUFFIX}"
+
+    @property
+    def name(self) -> str:
+        """Return provider name."""
+        return "codex"
+
+    @property
+    def cleanup_paths(self) -> tuple[str, ...]:
+        """Return shell paths to clean up."""
+        return (self._SHELL_PATH,)
+
+    async def inject(
+        self, conn: RemoteConnection, secrets: SecretBundle, *, home_dir: str | None = None
+    ) -> bool:
+        """Write Codex auth.json if CODEX_AUTH_JSON is present.
+
+        Returns:
+            True if credentials were written, False if the key was missing.
+        """
+        content = secrets.developer.get("CODEX_AUTH_JSON")
+        if not content:
+            logger.warning("CODEX_AUTH_JSON not found in secrets — codex auth skipped")
+            return False
+
+        remote_home = home_dir or await _resolve_remote_home(conn)
+        auth_dir = f"{remote_home}/{Path(self._SUFFIX).parent}"
+        abs_auth_path = f"{remote_home}/{self._SUFFIX}"
+        await conn.run(f"mkdir -p {auth_dir}", timeout=10)
+        await conn.upload_content(content, abs_auth_path)
+        await conn.run(f"chmod 600 {abs_auth_path}", timeout=10)
+        if home_dir:
+            user = Path(home_dir).name
+            await conn.run(f"chown -R {user}:{user} {auth_dir}", timeout=10)
+        logger.info("Injected codex auth.json (subscription)")
+        return True
+
+
+DEFAULT_CREDENTIAL_PROVIDERS: tuple[CredentialProvider, ...] = (
+    OpencodeCredentialProvider(),
+    ClaudeCredentialProvider(),
+    CodexCredentialProvider(),
+)
+
+CLI_CREDENTIAL_PROVIDERS: dict[Cli, type[CredentialProvider]] = {
+    Cli.OPENCODE: OpencodeCredentialProvider,
+    Cli.CLAUDE: ClaudeCredentialProvider,
+    Cli.CODEX: CodexCredentialProvider,
+}
+
+
+def providers_for_clis(clis: frozenset[Cli]) -> tuple[CredentialProvider, ...]:
+    """Build credential provider instances for the given CLI set.
+
+    Returns:
+        Tuple of CredentialProvider instances, sorted by CLI value.
+    """
+    return tuple(
+        CLI_CREDENTIAL_PROVIDERS[cli]()
+        for cli in sorted(clis, key=lambda c: c.value)
+        if cli in CLI_CREDENTIAL_PROVIDERS
+    )
+
+
+async def inject_all_cli_credentials(
+    conn: RemoteConnection,
+    secrets: SecretBundle,
+    providers: tuple[CredentialProvider, ...] = DEFAULT_CREDENTIAL_PROVIDERS,
+    *,
+    target_home: str | None = None,
+) -> list[str]:
+    """Inject all CLI credentials onto the remote host.
+
+    Args:
+        conn: RemoteConnection to the VM.
+        secrets: SecretBundle with credential data.
+        providers: Credential providers to inject.
+        target_home: If set, inject credentials into this home directory.
+
+    Returns:
+        List of provider names that were successfully injected.
+    """
+    injected: list[str] = []
+    for provider in providers:
+        try:
+            if await provider.inject(conn, secrets, home_dir=target_home):
+                injected.append(provider.name)
+        except Exception:
+            logger.warning("Credential injection failed for %s", provider.name, exc_info=True)
+    return injected
+
+
+def all_credential_cleanup_paths(
+    providers: tuple[CredentialProvider, ...] = DEFAULT_CREDENTIAL_PROVIDERS,
+) -> list[str]:
+    """Aggregate cleanup paths from all providers.
+
+    Returns:
+        List of shell paths to remove during cleanup.
+    """
+    paths: list[str] = []
+    for provider in providers:
+        paths.extend(provider.cleanup_paths)
+    return paths

--- a/packages/tanren-core/src/tanren_core/adapters/git_workspace.py
+++ b/packages/tanren-core/src/tanren_core/adapters/git_workspace.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import shlex
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from tanren_core.adapters.remote_types import SecretBundle, WorkspacePath, WorkspaceSpec
 from tanren_core.remote_config import GitAuthMethod
-from tanren_core.roles import AuthMode
-from tanren_core.schemas import Cli
 
 if TYPE_CHECKING:
     from tanren_core.adapters.protocols import RemoteConnection
@@ -122,21 +118,11 @@ class GitWorkspaceManager:
             branch=spec.branch,
         )
 
-    _OPENCODE_AUTH_SUFFIX = ".local/share/opencode/auth.json"
-    _OPENCODE_AUTH_SHELL_PATH = f"~/{_OPENCODE_AUTH_SUFFIX}"
-
-    _CLAUDE_AUTH_SUFFIX = ".claude/.credentials.json"
-    _CLAUDE_AUTH_SHELL_PATH = f"~/{_CLAUDE_AUTH_SUFFIX}"
-    _CODEX_AUTH_SUFFIX = ".codex/auth.json"
-    _CODEX_AUTH_SHELL_PATH = f"~/{_CODEX_AUTH_SUFFIX}"
-
     async def inject_secrets(
         self,
         conn: RemoteConnection,
         workspace: WorkspacePath,
         secrets: SecretBundle,
-        *,
-        cli_auth: tuple[Cli, AuthMode] | None = None,
     ) -> None:
         """Write secret files to remote workspace. Files are chmod 600."""
         # Developer secrets -> /workspace/.developer-secrets
@@ -154,132 +140,6 @@ class GitWorkspaceManager:
             await conn.upload_content(content, env_path)
             await conn.run(f"chmod 600 {shlex.quote(env_path)}", timeout=10)
 
-        # CLI-specific auth files
-        if cli_auth is not None:
-            await self.inject_cli_auth(conn, secrets, cli_auth)
-
-    async def inject_cli_auth(
-        self,
-        conn: RemoteConnection,
-        secrets: SecretBundle,
-        cli_auth: tuple[Cli, AuthMode],
-    ) -> None:
-        """Set up CLI-specific auth files based on auth mode.
-
-        Stateless per-connection: always clears stale auth from other CLIs
-        before writing new credentials, so the manager is safe for concurrent
-        use across multiple VMs.
-        """
-        cli, auth = cli_auth
-
-        if cli == Cli.OPENCODE and auth == AuthMode.API_KEY:
-            await self._inject_opencode_api_key(conn, secrets)
-            await self._remove_stale_auth(conn, claude=True, codex=True)
-        elif cli == Cli.CLAUDE and auth == AuthMode.SUBSCRIPTION:
-            await self._inject_claude_subscription(conn, secrets)
-            await self._remove_stale_auth(conn, opencode=True, codex=True)
-        elif cli == Cli.CODEX and auth == AuthMode.SUBSCRIPTION:
-            await self._inject_codex_subscription(conn, secrets)
-            await self._remove_stale_auth(conn, opencode=True, claude=True)
-        else:
-            await self._remove_stale_auth(conn, opencode=True, claude=True, codex=True)
-
-    async def _remove_stale_auth(
-        self,
-        conn: RemoteConnection,
-        *,
-        opencode: bool = False,
-        claude: bool = False,
-        codex: bool = False,
-    ) -> None:
-        """Remove auth files for the specified CLIs."""
-        if opencode:
-            await conn.run(f"rm -f {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
-        if claude:
-            await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
-        if codex:
-            await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
-
-    async def _resolve_remote_home(self, conn: RemoteConnection) -> str:
-        """Resolve the remote user's home directory.
-
-        Returns:
-            Absolute path to the remote home directory.
-
-        Raises:
-            RuntimeError: If the ``echo $HOME`` command fails.
-        """
-        result = await conn.run("echo $HOME", timeout=10)
-        home = result.stdout.strip()
-        if not home or result.exit_code != 0:
-            raise RuntimeError(f"Failed to resolve remote $HOME: {result.stderr}")
-        return home
-
-    async def _inject_opencode_api_key(
-        self,
-        conn: RemoteConnection,
-        secrets: SecretBundle,
-    ) -> None:
-        """Write opencode auth.json for Z.ai API key auth."""
-        zai_key = secrets.developer.get("OPENCODE_ZAI_API_KEY") or secrets.project.get(
-            "OPENCODE_ZAI_API_KEY"
-        )
-        if not zai_key:
-            logger.warning("OPENCODE_ZAI_API_KEY not found in secrets — opencode auth will fail")
-            await conn.run(f"rm -f {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
-            return
-
-        auth_data = {"zai-coding-plan": {"type": "api", "key": zai_key}}
-        content = json.dumps(auth_data, indent=2)
-
-        auth_dir_shell = f"~/{Path(self._OPENCODE_AUTH_SUFFIX).parent}"
-        await conn.run(f"mkdir -p {auth_dir_shell}", timeout=10)
-        remote_home = await self._resolve_remote_home(conn)
-        abs_auth_path = f"{remote_home}/{self._OPENCODE_AUTH_SUFFIX}"
-        await conn.upload_content(content, abs_auth_path)
-        await conn.run(f"chmod 600 {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
-        logger.info("Injected opencode auth.json (zai-coding-plan)")
-
-    async def _inject_claude_subscription(
-        self,
-        conn: RemoteConnection,
-        secrets: SecretBundle,
-    ) -> None:
-        """Write Claude credentials.json for subscription (Max/Pro) auth."""
-        content = secrets.developer.get("CLAUDE_CREDENTIALS_JSON")
-        if not content:
-            logger.warning("CLAUDE_CREDENTIALS_JSON not found in secrets — claude auth will fail")
-            await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
-            return
-
-        auth_dir_shell = f"~/{Path(self._CLAUDE_AUTH_SUFFIX).parent}"
-        await conn.run(f"mkdir -p {auth_dir_shell}", timeout=10)
-        remote_home = await self._resolve_remote_home(conn)
-        abs_auth_path = f"{remote_home}/{self._CLAUDE_AUTH_SUFFIX}"
-        await conn.upload_content(content, abs_auth_path)
-        await conn.run(f"chmod 600 {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
-        logger.info("Injected claude credentials.json (subscription)")
-
-    async def _inject_codex_subscription(
-        self,
-        conn: RemoteConnection,
-        secrets: SecretBundle,
-    ) -> None:
-        """Write Codex auth.json for subscription (ChatGPT Plus) auth."""
-        content = secrets.developer.get("CODEX_AUTH_JSON")
-        if not content:
-            logger.warning("CODEX_AUTH_JSON not found in secrets — codex auth will fail")
-            await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
-            return
-
-        auth_dir_shell = f"~/{Path(self._CODEX_AUTH_SUFFIX).parent}"
-        await conn.run(f"mkdir -p {auth_dir_shell}", timeout=10)
-        remote_home = await self._resolve_remote_home(conn)
-        abs_auth_path = f"{remote_home}/{self._CODEX_AUTH_SUFFIX}"
-        await conn.upload_content(content, abs_auth_path)
-        await conn.run(f"chmod 600 {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
-        logger.info("Injected codex auth.json (subscription)")
-
     def push_command(self, workspace_path: str, branch: str) -> str:
         """Return an auth-prefixed git push command string."""
         quoted_path = shlex.quote(workspace_path)
@@ -291,6 +151,3 @@ class GitWorkspaceManager:
         await conn.run("rm -f /workspace/.developer-secrets", timeout=10)
         await conn.run(f"rm -f {shlex.quote(workspace.path + '/.env')}", timeout=10)
         await conn.run(f"rm -f {self._ASKPASS_PATH}", timeout=10)
-        await conn.run(f"rm -f {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
-        await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
-        await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)

--- a/packages/tanren-core/src/tanren_core/adapters/git_workspace.py
+++ b/packages/tanren-core/src/tanren_core/adapters/git_workspace.py
@@ -125,6 +125,11 @@ class GitWorkspaceManager:
     _OPENCODE_AUTH_SUFFIX = ".local/share/opencode/auth.json"
     _OPENCODE_AUTH_SHELL_PATH = f"~/{_OPENCODE_AUTH_SUFFIX}"
 
+    _CLAUDE_AUTH_SUFFIX = ".claude/.credentials.json"
+    _CLAUDE_AUTH_SHELL_PATH = f"~/{_CLAUDE_AUTH_SUFFIX}"
+    _CODEX_AUTH_SUFFIX = ".codex/auth.json"
+    _CODEX_AUTH_SHELL_PATH = f"~/{_CODEX_AUTH_SUFFIX}"
+
     async def inject_secrets(
         self,
         conn: RemoteConnection,
@@ -161,18 +166,39 @@ class GitWorkspaceManager:
     ) -> None:
         """Set up CLI-specific auth files based on auth mode.
 
-        Stateless per-connection: always clears stale opencode auth before
-        writing new credentials, so the manager is safe for concurrent use
-        across multiple VMs.
+        Stateless per-connection: always clears stale auth from other CLIs
+        before writing new credentials, so the manager is safe for concurrent
+        use across multiple VMs.
         """
         cli, auth = cli_auth
 
         if cli == Cli.OPENCODE and auth == AuthMode.API_KEY:
             await self._inject_opencode_api_key(conn, secrets)
+            await self._remove_stale_auth(conn, claude=True, codex=True)
+        elif cli == Cli.CLAUDE and auth == AuthMode.SUBSCRIPTION:
+            await self._inject_claude_subscription(conn, secrets)
+            await self._remove_stale_auth(conn, opencode=True, codex=True)
+        elif cli == Cli.CODEX and auth == AuthMode.SUBSCRIPTION:
+            await self._inject_codex_subscription(conn, secrets)
+            await self._remove_stale_auth(conn, opencode=True, claude=True)
         else:
-            # Remove any opencode auth that a previous dispatch may have left
-            # on this VM. rm -f is a no-op if the file doesn't exist.
+            await self._remove_stale_auth(conn, opencode=True, claude=True, codex=True)
+
+    async def _remove_stale_auth(
+        self,
+        conn: RemoteConnection,
+        *,
+        opencode: bool = False,
+        claude: bool = False,
+        codex: bool = False,
+    ) -> None:
+        """Remove auth files for the specified CLIs."""
+        if opencode:
             await conn.run(f"rm -f {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
+        if claude:
+            await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
+        if codex:
+            await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
 
     async def _resolve_remote_home(self, conn: RemoteConnection) -> str:
         """Resolve the remote user's home directory.
@@ -214,6 +240,46 @@ class GitWorkspaceManager:
         await conn.run(f"chmod 600 {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
         logger.info("Injected opencode auth.json (zai-coding-plan)")
 
+    async def _inject_claude_subscription(
+        self,
+        conn: RemoteConnection,
+        secrets: SecretBundle,
+    ) -> None:
+        """Write Claude credentials.json for subscription (Max/Pro) auth."""
+        content = secrets.developer.get("CLAUDE_CREDENTIALS_JSON")
+        if not content:
+            logger.warning("CLAUDE_CREDENTIALS_JSON not found in secrets — claude auth will fail")
+            await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
+            return
+
+        auth_dir_shell = f"~/{Path(self._CLAUDE_AUTH_SUFFIX).parent}"
+        await conn.run(f"mkdir -p {auth_dir_shell}", timeout=10)
+        remote_home = await self._resolve_remote_home(conn)
+        abs_auth_path = f"{remote_home}/{self._CLAUDE_AUTH_SUFFIX}"
+        await conn.upload_content(content, abs_auth_path)
+        await conn.run(f"chmod 600 {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
+        logger.info("Injected claude credentials.json (subscription)")
+
+    async def _inject_codex_subscription(
+        self,
+        conn: RemoteConnection,
+        secrets: SecretBundle,
+    ) -> None:
+        """Write Codex auth.json for subscription (ChatGPT Plus) auth."""
+        content = secrets.developer.get("CODEX_AUTH_JSON")
+        if not content:
+            logger.warning("CODEX_AUTH_JSON not found in secrets — codex auth will fail")
+            await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
+            return
+
+        auth_dir_shell = f"~/{Path(self._CODEX_AUTH_SUFFIX).parent}"
+        await conn.run(f"mkdir -p {auth_dir_shell}", timeout=10)
+        remote_home = await self._resolve_remote_home(conn)
+        abs_auth_path = f"{remote_home}/{self._CODEX_AUTH_SUFFIX}"
+        await conn.upload_content(content, abs_auth_path)
+        await conn.run(f"chmod 600 {self._CODEX_AUTH_SHELL_PATH}", timeout=10)
+        logger.info("Injected codex auth.json (subscription)")
+
     def push_command(self, workspace_path: str, branch: str) -> str:
         """Return an auth-prefixed git push command string."""
         quoted_path = shlex.quote(workspace_path)
@@ -226,3 +292,5 @@ class GitWorkspaceManager:
         await conn.run(f"rm -f {shlex.quote(workspace.path + '/.env')}", timeout=10)
         await conn.run(f"rm -f {self._ASKPASS_PATH}", timeout=10)
         await conn.run(f"rm -f {self._OPENCODE_AUTH_SHELL_PATH}", timeout=10)
+        await conn.run(f"rm -f {self._CLAUDE_AUTH_SHELL_PATH}", timeout=10)
+        await conn.run(f"rm -f {self._CODEX_AUTH_SHELL_PATH}", timeout=10)

--- a/packages/tanren-core/src/tanren_core/adapters/protocols.py
+++ b/packages/tanren-core/src/tanren_core/adapters/protocols.py
@@ -27,7 +27,7 @@ from tanren_core.env.validator import EnvReport
 from tanren_core.postflight import PostflightResult
 from tanren_core.preflight import PreflightResult
 from tanren_core.process import ProcessResult
-from tanren_core.schemas import AuthMode, Cli, Dispatch
+from tanren_core.schemas import Dispatch
 
 
 @runtime_checkable
@@ -274,19 +274,8 @@ class WorkspaceManager(Protocol):
         conn: RemoteConnection,
         workspace: WorkspacePath,
         secrets: SecretBundle,
-        *,
-        cli_auth: tuple[Cli, AuthMode] | None = None,
     ) -> None:
         """Write secret files into the remote workspace."""
-        ...
-
-    async def inject_cli_auth(
-        self,
-        conn: RemoteConnection,
-        secrets: SecretBundle,
-        cli_auth: tuple[Cli, AuthMode],
-    ) -> None:
-        """Inject CLI-specific auth files (e.g. opencode auth.json)."""
         ...
 
     def push_command(self, workspace_path: str, branch: str) -> str:

--- a/packages/tanren-core/src/tanren_core/adapters/remote_runner.py
+++ b/packages/tanren-core/src/tanren_core/adapters/remote_runner.py
@@ -51,9 +51,14 @@ class RemoteAgentRunner:
         """
         start = time.monotonic()
 
-        # Upload prompt file
+        # Upload prompt file (chown to agent user so su-based execution can read it)
         prompt_path = f"{workspace.path}/.tanren-prompt.md"
         await conn.upload_content(prompt_content, prompt_path)
+        if self._run_as_user:
+            await conn.run(
+                f"chown {shlex.quote(self._run_as_user)} {shlex.quote(prompt_path)}",
+                timeout=10,
+            )
 
         # Build command with PATH augmentation and secret sourcing
         ws = shlex.quote(workspace.path)

--- a/packages/tanren-core/src/tanren_core/adapters/remote_runner.py
+++ b/packages/tanren-core/src/tanren_core/adapters/remote_runner.py
@@ -22,6 +22,10 @@ class RemoteAgentRunner:
     and extracts signal content from the remote filesystem.
     """
 
+    def __init__(self, *, run_as_user: str | None = None) -> None:
+        """Initialize with an optional user to run commands as."""
+        self._run_as_user = run_as_user
+
     async def run(
         self,
         conn: RemoteConnection,
@@ -62,6 +66,9 @@ class RemoteAgentRunner:
             f"cd {ws} && "
             f"{cli_command}"
         )
+
+        if self._run_as_user:
+            command = f"su - {shlex.quote(self._run_as_user)} -c {shlex.quote(command)}"
 
         logger.info("Executing remote agent: %s", cli_command)
         result = await conn.run(command, timeout=timeout, request_pty=True)

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -513,10 +513,8 @@ class SSHExecutionEnvironment:
                 await self._workspace_mgr.cleanup(conn, workspace)
                 # Remove credential files (best-effort, after workspace cleanup)
                 raw_paths = all_credential_cleanup_paths(self._credential_providers)
-                if self._agent_user:
-                    cred_paths = [p.replace("~", f"/home/{self._agent_user}") for p in raw_paths]
-                else:
-                    cred_paths = raw_paths
+                home = f"/home/{self._agent_user}" if self._agent_user else "/root"
+                cred_paths = [p.replace("~", home) for p in raw_paths]
                 for cred_path in cred_paths:
                     try:
                         await conn.run(f"rm -f {shlex.quote(cred_path)}", timeout=10)

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -235,6 +235,14 @@ class SSHExecutionEnvironment:
             )
             logger.info("Injected credentials: %s", injected)
 
+            # 8b. Ensure agent user owns their entire home directory
+            # (bootstrap and credential injection run as root, leaving root-owned dirs)
+            if self._agent_user:
+                await conn.run(
+                    f"chown -R {self._agent_user}:{self._agent_user} /home/{self._agent_user}",
+                    timeout=10,
+                )
+
             # 9. Record assignment
             await self._state_store.record_assignment(
                 vm_id=vm_handle.vm_id,

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -221,10 +221,12 @@ class SSHExecutionEnvironment:
 
             # 7b. Make workspace secrets readable by agent user
             if self._agent_user:
+                quoted_user = shlex.quote(self._agent_user)
+                quoted_ws = shlex.quote(workspace_path.path)
                 await conn.run(
-                    f"chown {self._agent_user}:{self._agent_user}"
+                    f"chown {quoted_user}:{quoted_user}"
                     f" /workspace/.developer-secrets /workspace/.git-askpass 2>/dev/null;"
-                    f" chown -R {self._agent_user}:{self._agent_user} {workspace_path.path}",
+                    f" chown -R {quoted_user}:{quoted_user} {quoted_ws}",
                     timeout=10,
                 )
 
@@ -517,7 +519,7 @@ class SSHExecutionEnvironment:
                     cred_paths = raw_paths
                 for cred_path in cred_paths:
                     try:
-                        await conn.run(f"rm -f {cred_path}", timeout=10)
+                        await conn.run(f"rm -f {shlex.quote(cred_path)}", timeout=10)
                     except Exception:
                         logger.warning("Credential cleanup failed: %s", cred_path, exc_info=True)
             except Exception:

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -14,6 +14,12 @@ from typing import cast
 import yaml
 from dotenv import dotenv_values
 
+from tanren_core.adapters.credentials import (
+    DEFAULT_CREDENTIAL_PROVIDERS,
+    CredentialProvider,
+    all_credential_cleanup_paths,
+    inject_all_cli_credentials,
+)
 from tanren_core.adapters.events import BootstrapCompleted, VMProvisioned, VMReleased
 from tanren_core.adapters.protocols import (
     EnvironmentBootstrapper,
@@ -80,6 +86,8 @@ class SSHExecutionEnvironment:
         repo_urls: dict[str, str],
         provider: VMProvider = VMProvider.MANUAL,
         ssh_ready_timeout_secs: int = _SSH_READY_TIMEOUT_SECS,
+        credential_providers: tuple[CredentialProvider, ...] = DEFAULT_CREDENTIAL_PROVIDERS,
+        agent_user: str | None = None,
     ) -> None:
         """Initialize with remote execution adapters and configuration."""
         self._vm_provisioner = vm_provisioner
@@ -93,6 +101,8 @@ class SSHExecutionEnvironment:
         self._repo_urls = repo_urls
         self._provider = provider
         self._ssh_ready_timeout_secs = ssh_ready_timeout_secs
+        self._credential_providers = credential_providers
+        self._agent_user = agent_user
 
     @property
     def ssh_defaults(self) -> SSHConfig:
@@ -207,14 +217,25 @@ class SSHExecutionEnvironment:
             # 7. Inject secrets
             project_env = self._load_project_env(dispatch, config)
             bundle = self._secret_loader.build_bundle(project_env)
-            await self._workspace_mgr.inject_secrets(
-                conn,
-                workspace_path,
-                bundle,
-                cli_auth=(dispatch.cli, dispatch.auth),
-            )
+            await self._workspace_mgr.inject_secrets(conn, workspace_path, bundle)
 
-            # 8. Record assignment
+            # 7b. Make workspace secrets readable by agent user
+            if self._agent_user:
+                await conn.run(
+                    f"chown {self._agent_user}:{self._agent_user}"
+                    f" /workspace/.developer-secrets /workspace/.git-askpass 2>/dev/null;"
+                    f" chown -R {self._agent_user}:{self._agent_user} {workspace_path.path}",
+                    timeout=10,
+                )
+
+            # 8. Inject all CLI credentials
+            target_home = f"/home/{self._agent_user}" if self._agent_user else None
+            injected = await inject_all_cli_credentials(
+                conn, bundle, self._credential_providers, target_home=target_home
+            )
+            logger.info("Injected credentials: %s", injected)
+
+            # 9. Record assignment
             await self._state_store.record_assignment(
                 vm_id=vm_handle.vm_id,
                 workflow_id=dispatch.workflow_id,
@@ -236,7 +257,7 @@ class SSHExecutionEnvironment:
                 )
             )
 
-            # 9. Return handle
+            # 10. Return handle
             return EnvironmentHandle(
                 env_id=str(uuid.uuid4()),
                 worktree_path=Path(workspace_path.path),
@@ -303,10 +324,6 @@ class SSHExecutionEnvironment:
         prompt_content = assemble_prompt(
             command_file, dispatch.spec_folder, command_name, dispatch.context
         )
-
-        # Inject CLI-specific auth for this dispatch's tool (may differ from provision)
-        bundle = self._secret_loader.build_bundle(self._load_project_env(dispatch, config))
-        await self._workspace_mgr.inject_cli_auth(conn, bundle, (dispatch.cli, dispatch.auth))
 
         while True:
             # Build CLI command
@@ -483,6 +500,17 @@ class SSHExecutionEnvironment:
         finally:
             try:
                 await self._workspace_mgr.cleanup(conn, workspace)
+                # Remove credential files (best-effort, after workspace cleanup)
+                raw_paths = all_credential_cleanup_paths(self._credential_providers)
+                if self._agent_user:
+                    cred_paths = [p.replace("~", f"/home/{self._agent_user}") for p in raw_paths]
+                else:
+                    cred_paths = raw_paths
+                for cred_path in cred_paths:
+                    try:
+                        await conn.run(f"rm -f {cred_path}", timeout=10)
+                    except Exception:
+                        logger.warning("Credential cleanup failed: %s", cred_path, exc_info=True)
             except Exception:
                 logger.warning("Workspace cleanup failed", exc_info=True)
             finally:

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -404,7 +404,7 @@ class SSHExecutionEnvironment:
         final_stdout = agent_result.stdout
         if dispatch.phase in _PUSH_PHASES and outcome not in (Outcome.ERROR, Outcome.TIMEOUT):
             push_cmd = self._workspace_mgr.push_command(workspace.path, dispatch.branch)
-            push_result = await conn.run(push_cmd, timeout=120)
+            push_result = await conn.run(self._wrap_for_agent_user(push_cmd), timeout=120)
             if push_result.exit_code != 0:
                 logger.error(
                     "Remote git push failed (exit %d) for %s branch %s: %s",
@@ -425,7 +425,7 @@ class SSHExecutionEnvironment:
         if dispatch.cli != Cli.BASH:
             dispatch_end_utc = datetime.now(UTC)
             dispatch_start_utc = dispatch_end_utc - timedelta(seconds=duration)
-            usage_runner = RemoteCommandRunner(conn)
+            usage_runner = RemoteCommandRunner(conn, run_as_user=self._agent_user)
             usage = await collect_token_usage(
                 dispatch.cli,
                 workspace.path,
@@ -499,8 +499,9 @@ class SSHExecutionEnvironment:
         try:
             for cmd in teardown_cmds:
                 try:
+                    teardown_cmd = f"cd {shlex.quote(workspace.path)} && {cmd}"
                     await conn.run(
-                        f"cd {shlex.quote(workspace.path)} && {cmd}",
+                        self._wrap_for_agent_user(teardown_cmd),
                         timeout=120,
                     )
                 except Exception:
@@ -629,6 +630,16 @@ class SSHExecutionEnvironment:
             return {}
         values = dotenv_values(env_file)
         return {k: v for k, v in values.items() if v is not None}
+
+    def _wrap_for_agent_user(self, command: str) -> str:
+        """Wrap a shell command to run as the agent user via ``su -``.
+
+        Returns:
+            The command wrapped with ``su -``, or unchanged when no agent_user is configured.
+        """
+        if self._agent_user:
+            return f"su - {shlex.quote(self._agent_user)} -c {shlex.quote(command)}"
+        return command
 
     def _build_cli_command(self, dispatch: Dispatch, config: Config) -> str:
         """Build the CLI command string for remote execution.

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -7,7 +7,7 @@ import logging
 import shlex
 import time
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -326,6 +326,7 @@ class SSHExecutionEnvironment:
         workspace = remote_runtime.workspace_path
 
         start = time.monotonic()
+        dispatch_start_utc = datetime.now(UTC)
         transient_retries = 0
 
         # Build full prompt (same as local path)
@@ -426,7 +427,6 @@ class SSHExecutionEnvironment:
         token_usage_data = None
         if dispatch.cli != Cli.BASH:
             dispatch_end_utc = datetime.now(UTC)
-            dispatch_start_utc = dispatch_end_utc - timedelta(seconds=duration)
             usage_runner = RemoteCommandRunner(conn, run_as_user=self._agent_user)
             usage = await collect_token_usage(
                 dispatch.cli,

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -195,11 +195,15 @@ class UbuntuBootstrapper:
             f"id -u {_AGENT_USER} >/dev/null 2>&1"
             f" || useradd --create-home --shell /bin/bash {_AGENT_USER}"
         )
-        await conn.run(useradd_cmd, timeout=30)
-        await conn.run(
+        useradd_result = await conn.run(useradd_cmd, timeout=30)
+        if useradd_result.exit_code != 0:
+            raise RuntimeError(f"Agent user setup failed: {useradd_result.stderr}")
+        workspace_result = await conn.run(
             f"mkdir -p /workspace && chown {_AGENT_USER}:{_AGENT_USER} /workspace",
             timeout=10,
         )
+        if workspace_result.exit_code != 0:
+            raise RuntimeError(f"Workspace directory setup failed: {workspace_result.stderr}")
 
         # Extra script (if configured)
         if self._extra_script is not None:

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -106,11 +106,11 @@ class UbuntuBootstrapper:
     def __init__(
         self,
         *,
-        required_clis: frozenset[Cli] | None = None,
+        required_clis: frozenset[Cli],
         extra_script: str | None = None,
     ) -> None:
         """Initialize with required CLIs and an optional extra bootstrap script."""
-        self._required_clis = required_clis or frozenset({Cli.CLAUDE, Cli.OPENCODE})
+        self._required_clis = required_clis
         self._extra_script = extra_script
 
     def _build_steps(self) -> tuple[tuple[str, str, str], ...]:

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -26,7 +26,12 @@ _NODE_INSTALL = (
 _INFRA_STEPS: tuple[tuple[str, str, str], ...] = (
     ("docker", "command -v docker", "curl -fsSL https://get.docker.com | sh"),
     ("node", "command -v node", _NODE_INSTALL),
-    ("uv", "command -v uv", "curl -LsSf https://astral.sh/uv/install.sh | sh"),
+    (
+        "uv",
+        "command -v uv",
+        "curl -LsSf https://astral.sh/uv/install.sh | sh"
+        " && cp $HOME/.local/bin/uv /usr/local/bin/uv",
+    ),
 )
 
 # Per-CLI install steps — only installed when the CLI is in required_clis.

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, ConfigDict, Field
 
 from tanren_core.adapters.remote_types import BootstrapResult
+from tanren_core.schemas import Cli
 
 if TYPE_CHECKING:
     from tanren_core.adapters.protocols import RemoteConnection
@@ -21,20 +22,58 @@ _NODE_INSTALL = (
     "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs"
 )
 
-_BOOTSTRAP_STEPS: tuple[tuple[str, str, str], ...] = (
+# Infrastructure steps — always installed regardless of required CLIs.
+_INFRA_STEPS: tuple[tuple[str, str, str], ...] = (
     ("docker", "command -v docker", "curl -fsSL https://get.docker.com | sh"),
     ("node", "command -v node", _NODE_INSTALL),
     ("uv", "command -v uv", "curl -LsSf https://astral.sh/uv/install.sh | sh"),
-    ("claude", "command -v claude", "npm install -g @anthropic-ai/claude-code"),
-    ("opencode", "command -v opencode", "curl -fsSL https://opencode.ai/install | bash"),
-    (
-        "ccusage",
-        "npx ccusage --version && npx @ccusage/codex --version && npx @ccusage/opencode --version",
-        "npm install -g ccusage @ccusage/codex @ccusage/opencode",
-    ),
 )
 
+# Per-CLI install steps — only installed when the CLI is in required_clis.
+_CLI_STEPS: dict[Cli, tuple[str, str, str]] = {
+    Cli.CLAUDE: ("claude", "command -v claude", "npm install -g @anthropic-ai/claude-code"),
+    Cli.OPENCODE: (
+        "opencode",
+        "command -v opencode",
+        "curl -fsSL https://opencode.ai/install | bash"
+        " && cp $HOME/.opencode/bin/opencode /usr/local/bin/opencode",
+    ),
+    Cli.CODEX: ("codex", "command -v codex", "npm install -g @openai/codex"),
+}
+
+# Per-CLI ccusage packages.
+_CCUSAGE_PACKAGES: dict[Cli, str] = {
+    Cli.CLAUDE: "ccusage",
+    Cli.CODEX: "@ccusage/codex",
+    Cli.OPENCODE: "@ccusage/opencode",
+}
+
+_AGENT_USER = "tanren"
+
 _MARKER_PATH = "~/.tanren-bootstrapped"
+
+# Backward-compatible alias: flat list of all steps for tests that import it.
+_BOOTSTRAP_STEPS: tuple[tuple[str, str, str], ...] = (
+    *_INFRA_STEPS,
+    *(_CLI_STEPS[cli] for cli in (Cli.CLAUDE, Cli.OPENCODE, Cli.CODEX)),
+)
+
+
+def _build_ccusage_step(required_clis: frozenset[Cli]) -> tuple[str, str, str]:
+    """Build the ccusage install step for the given CLI set.
+
+    Returns:
+        Tuple of (name, check_command, install_command).
+    """
+    packages = [
+        _CCUSAGE_PACKAGES[cli]
+        for cli in sorted(required_clis, key=lambda c: c.value)
+        if cli in _CCUSAGE_PACKAGES
+    ]
+    if not packages:
+        packages = ["ccusage"]
+    check_parts = [f"npx {pkg} --version" for pkg in packages]
+    return ("ccusage", " && ".join(check_parts), f"npm install -g {' '.join(packages)}")
 
 
 class BootstrapInstallStep(BaseModel):
@@ -64,13 +103,33 @@ class UbuntuBootstrapper:
     a marker file on completion.
     """
 
-    def __init__(self, *, extra_script: str | None = None) -> None:
-        """Initialize with an optional extra bootstrap script."""
+    def __init__(
+        self,
+        *,
+        required_clis: frozenset[Cli] | None = None,
+        extra_script: str | None = None,
+    ) -> None:
+        """Initialize with required CLIs and an optional extra bootstrap script."""
+        self._required_clis = required_clis or frozenset({Cli.CLAUDE, Cli.OPENCODE})
         self._extra_script = extra_script
 
-    @classmethod
-    def plan(cls) -> BootstrapPlan:
-        """Return the static bootstrap plan used by this bootstrapper."""
+    def _build_steps(self) -> tuple[tuple[str, str, str], ...]:
+        """Build the full step list from infra + required CLI steps + ccusage.
+
+        Returns:
+            Tuple of (name, check_command, install_command) for each step.
+        """
+        cli_steps = tuple(
+            _CLI_STEPS[cli]
+            for cli in sorted(self._required_clis, key=lambda c: c.value)
+            if cli in _CLI_STEPS
+        )
+        ccusage_step = _build_ccusage_step(self._required_clis)
+        return (*_INFRA_STEPS, *cli_steps, ccusage_step)
+
+    def plan(self) -> BootstrapPlan:
+        """Return the bootstrap plan used by this bootstrapper."""
+        steps = self._build_steps()
         return BootstrapPlan(
             apt_packages=_APT_PACKAGES,
             install_steps=tuple(
@@ -79,7 +138,7 @@ class UbuntuBootstrapper:
                     check_command=check_cmd,
                     install_command=install_cmd,
                 )
-                for name, check_cmd, install_cmd in _BOOTSTRAP_STEPS
+                for name, check_cmd, install_cmd in steps
             ),
         )
 
@@ -116,8 +175,9 @@ class UbuntuBootstrapper:
             raise RuntimeError(f"apt install failed: {apt_result.stderr}")
         installed.append("apt-packages")
 
-        # Step 2-5: Individual tools
-        for name, check_cmd, install_cmd in _BOOTSTRAP_STEPS:
+        # Step 2+: Infra + CLI + ccusage steps
+        steps = self._build_steps()
+        for name, check_cmd, install_cmd in steps:
             check = await conn.run(check_cmd, timeout=10)
             if check.exit_code == 0 and not force:
                 skipped.append(name)
@@ -130,10 +190,18 @@ class UbuntuBootstrapper:
                 raise RuntimeError(f"Failed to install {name}: {result.stderr}")
             installed.append(name)
 
-        # Step 6: Create workspace directory
-        await conn.run("mkdir -p /workspace", timeout=10)
+        # Create workspace directory and agent user
+        useradd_cmd = (
+            f"id -u {_AGENT_USER} &>/dev/null"
+            f" || useradd --create-home --shell /bin/bash {_AGENT_USER}"
+        )
+        await conn.run(useradd_cmd, timeout=30)
+        await conn.run(
+            f"mkdir -p /workspace && chown {_AGENT_USER}:{_AGENT_USER} /workspace",
+            timeout=10,
+        )
 
-        # Step 7: Extra script (if configured)
+        # Extra script (if configured)
         if self._extra_script is not None:
             logger.info("Running extra bootstrap script...")
             await conn.upload_content(self._extra_script, "/tmp/tanren-extra-bootstrap.sh")
@@ -142,7 +210,7 @@ class UbuntuBootstrapper:
                 raise RuntimeError(f"Extra bootstrap script failed: {extra_result.stderr}")
             installed.append("extra-script")
 
-        # Step 8: Write marker
+        # Write marker
         await conn.run(f"touch {_MARKER_PATH}", timeout=10)
 
         duration = int(time.monotonic() - start)

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -192,7 +192,7 @@ class UbuntuBootstrapper:
 
         # Create workspace directory and agent user
         useradd_cmd = (
-            f"id -u {_AGENT_USER} &>/dev/null"
+            f"id -u {_AGENT_USER} >/dev/null 2>&1"
             f" || useradd --create-home --shell /bin/bash {_AGENT_USER}"
         )
         await conn.run(useradd_cmd, timeout=30)

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -11,6 +11,7 @@ import logging
 import os
 from pathlib import Path
 
+from tanren_core.adapters.credentials import providers_for_clis
 from tanren_core.adapters.git_workspace import GitAuthConfig, GitWorkspaceManager
 from tanren_core.adapters.manual_vm import ManualProvisionerSettings, ManualVMProvisioner
 from tanren_core.adapters.protocols import EventEmitter
@@ -22,9 +23,12 @@ from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
 from tanren_core.config import Config
 from tanren_core.remote_config import ProvisionerType, load_remote_config
+from tanren_core.roles_config import load_roles_config
 from tanren_core.secrets import SecretConfig, SecretLoader
 
 logger = logging.getLogger(__name__)
+
+_AGENT_USER = "tanren"
 
 
 def build_ssh_execution_environment(
@@ -42,6 +46,10 @@ def build_ssh_execution_environment(
     if config.remote_config_path is None:
         raise ValueError("remote_config_path is required to build SSH execution environment")
     remote_cfg = load_remote_config(config.remote_config_path)
+
+    # Load roles config to determine required CLIs
+    roles = load_roles_config(config.roles_config_path)
+    required_clis = roles.required_clis()
 
     ssh_defaults = SSHConfig(
         host="",  # placeholder — overridden per VM
@@ -71,7 +79,7 @@ def build_ssh_execution_environment(
             remote_cfg.secrets.developer_secrets_path or SecretConfig().developer_secrets_path
         ),
     )
-    secret_loader = SecretLoader(secret_config)
+    secret_loader = SecretLoader(secret_config, required_clis=required_clis)
     secret_loader.autoload_into_env(override=False)
 
     token = os.environ.get(remote_cfg.git.token_env, "")
@@ -98,9 +106,12 @@ def build_ssh_execution_environment(
 
     env = SSHExecutionEnvironment(
         vm_provisioner=vm_provisioner,
-        bootstrapper=UbuntuBootstrapper(extra_script=extra_script),
+        bootstrapper=UbuntuBootstrapper(
+            required_clis=required_clis,
+            extra_script=extra_script,
+        ),
         workspace_mgr=GitWorkspaceManager(git_auth),
-        runner=RemoteAgentRunner(),
+        runner=RemoteAgentRunner(run_as_user=_AGENT_USER),
         state_store=state_store,
         secret_loader=secret_loader,
         emitter=emitter,
@@ -108,6 +119,8 @@ def build_ssh_execution_environment(
         repo_urls={binding.project: binding.repo_url for binding in remote_cfg.repos},
         provider=provider,
         ssh_ready_timeout_secs=remote_cfg.ssh.ssh_ready_timeout_secs,
+        credential_providers=providers_for_clis(required_clis),
+        agent_user=_AGENT_USER,
     )
 
     return env, state_store

--- a/packages/tanren-core/src/tanren_core/ccusage.py
+++ b/packages/tanren-core/src/tanren_core/ccusage.py
@@ -84,9 +84,10 @@ class LocalCommandRunner:
 class RemoteCommandRunner:
     """Run commands via an SSH connection."""
 
-    def __init__(self, connection: object) -> None:
+    def __init__(self, connection: object, *, run_as_user: str | None = None) -> None:
         """Initialize with an SSH connection object."""
         self._connection = connection
+        self._run_as_user = run_as_user
 
     async def run_command(self, cmd: list[str], timeout: float) -> tuple[int, str]:  # noqa: ASYNC109
         """Run a command on a remote host via SSH.
@@ -95,6 +96,8 @@ class RemoteCommandRunner:
             Tuple of (exit_code, stdout_text).
         """
         cmd_str = " ".join(shlex.quote(c) for c in cmd)
+        if self._run_as_user:
+            cmd_str = f"su - {shlex.quote(self._run_as_user)} -c {shlex.quote(cmd_str)}"
         result = await self._connection.run(cmd_str, timeout=timeout)  # type: ignore[union-attr]
         return result.exit_code, result.stdout
 

--- a/packages/tanren-core/src/tanren_core/ccusage.py
+++ b/packages/tanren-core/src/tanren_core/ccusage.py
@@ -149,7 +149,7 @@ async def _collect_claude(
     session_id = _derive_session_id(worktree_path)
     since = dispatch_start_utc.strftime("%Y%m%d")
 
-    base_cmd = config.ccusage_claude_cmd.split()
+    base_cmd = shlex.split(config.ccusage_claude_cmd)
     cmd = [
         *base_cmd,
         "session",
@@ -190,7 +190,7 @@ async def _collect_codex(
     """
     since = dispatch_start_utc.strftime("%Y%m%d")
 
-    base_cmd = config.ccusage_codex_cmd.split()
+    base_cmd = shlex.split(config.ccusage_codex_cmd)
     cmd = [*base_cmd, "session", "--json", "--since", since, "--offline", "--noColor"]
 
     exit_code, stdout = await runner.run_command(cmd, timeout=_COLLECTION_TIMEOUT)
@@ -219,7 +219,7 @@ async def _collect_opencode(
     Returns:
         TokenUsage if a matching session is found, None otherwise.
     """
-    base_cmd = config.ccusage_opencode_cmd.split()
+    base_cmd = shlex.split(config.ccusage_opencode_cmd)
     cmd = [*base_cmd, "session", "--json"]
 
     exit_code, stdout = await runner.run_command(cmd, timeout=_COLLECTION_TIMEOUT)

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -12,7 +12,7 @@ import os
 import signal
 import subprocess
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -583,6 +583,7 @@ class WorkerManager:
             return
 
         # 2. Execute
+        dispatch_start_utc = datetime.now(UTC)
         try:
             phase_result = await self._execution_env.execute(
                 handle, dispatch, self._config, dispatch_stem=dispatch_stem
@@ -652,7 +653,6 @@ class WorkerManager:
                     token_usage_data = phase_result.token_usage
                 else:
                     # Local execution: collect here
-                    dispatch_start_utc = exec_end_utc - timedelta(seconds=duration)
                     runner = LocalCommandRunner()
                     usage = await collect_token_usage(
                         dispatch.cli,

--- a/packages/tanren-core/src/tanren_core/roles.py
+++ b/packages/tanren-core/src/tanren_core/roles.py
@@ -58,3 +58,17 @@ class RoleMapping(BaseModel):
         role_name = role.value if isinstance(role, RoleName) else role
         resolved = getattr(self, role_name, None)
         return resolved or self.default
+
+    def required_clis(self) -> frozenset[Cli]:
+        """Return the set of CLIs needed by all configured roles.
+
+        Bash is excluded because it does not require installation or
+        credential injection.
+        """
+        clis: set[Cli] = {self.default.cli}
+        for field in ("conversation", "implementation", "audit", "feedback", "conflict_resolution"):
+            tool = getattr(self, field)
+            if tool is not None:
+                clis.add(tool.cli)
+        clis.discard(Cli.BASH)
+        return frozenset(clis)

--- a/packages/tanren-core/src/tanren_core/secrets.py
+++ b/packages/tanren-core/src/tanren_core/secrets.py
@@ -66,14 +66,40 @@ class SecretLoader:
                 result[var] = val
         return result
 
+    def load_credential_files(self) -> dict[str, str]:
+        """Load CLI credential files from the secrets directory.
+
+        Reads ``claude_credentials.json`` and ``codex_auth.json`` from the
+        parent directory of ``developer_secrets_path`` (the tanren secrets dir).
+
+        Returns:
+            Dict mapping credential keys to file contents for files that exist
+            and are non-empty.
+        """
+        secrets_dir = Path(self._config.developer_secrets_path).expanduser().parent
+        mapping = {
+            "CLAUDE_CREDENTIALS_JSON": "claude_credentials.json",
+            "CODEX_AUTH_JSON": "codex_auth.json",
+        }
+        result: dict[str, str] = {}
+        for key, filename in mapping.items():
+            path = secrets_dir / filename
+            if path.exists():
+                content = path.read_text().strip()
+                if content:
+                    result[key] = content
+        return result
+
     def build_bundle(self, project_secrets: dict[str, str] | None = None) -> SecretBundle:
         """Build a SecretBundle from all secret sources.
 
         Returns:
             SecretBundle combining developer, project, and infrastructure secrets.
         """
+        developer = self.load_developer()
+        developer.update(self.load_credential_files())
         return SecretBundle(
-            developer=self.load_developer(),
+            developer=developer,
             project=project_secrets or {},
             infrastructure=self.load_infrastructure(),
         )

--- a/packages/tanren-core/src/tanren_core/secrets.py
+++ b/packages/tanren-core/src/tanren_core/secrets.py
@@ -40,9 +40,9 @@ class SecretLoader:
         self,
         config: SecretConfig | None = None,
         *,
-        required_clis: frozenset[Cli] | None = None,
+        required_clis: frozenset[Cli],
     ) -> None:
-        """Initialize with optional secret configuration and CLI filter."""
+        """Initialize with secret configuration and required CLIs."""
         self._config = config or SecretConfig()
         self._required_clis = required_clis
 
@@ -81,8 +81,7 @@ class SecretLoader:
     def load_credential_files(self) -> dict[str, str]:
         """Load CLI credential files from the secrets directory.
 
-        When ``required_clis`` is set, only loads files for those CLIs.
-        When ``None``, loads all known credential files (backward compat).
+        Only loads files for CLIs in ``required_clis``.
 
         Returns:
             Dict mapping credential keys to file contents for files that exist
@@ -90,19 +89,16 @@ class SecretLoader:
         """
         secrets_dir = Path(self._config.developer_secrets_path).expanduser().parent
 
-        if self._required_clis is not None:
-            mapping = {
-                key: filename
-                for cli, (key, filename) in _CLI_CREDENTIAL_FILES.items()
-                if cli in self._required_clis
-            }
-        else:
-            mapping = dict(_CLI_CREDENTIAL_FILES.values())
+        mapping = {
+            key: filename
+            for cli, (key, filename) in _CLI_CREDENTIAL_FILES.items()
+            if cli in self._required_clis
+        }
 
         result: dict[str, str] = {}
         for key, filename in mapping.items():
             path = secrets_dir / filename
-            if path.exists():
+            if path.is_file():
                 content = path.read_text().strip()
                 if content:
                     result[key] = content

--- a/packages/tanren-core/src/tanren_core/secrets.py
+++ b/packages/tanren-core/src/tanren_core/secrets.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from tanren_core.adapters.remote_types import SecretBundle
 from tanren_core.env.secrets import DEFAULT_SECRETS_DIR
+from tanren_core.schemas import Cli
+
+_CLI_CREDENTIAL_FILES: dict[Cli, tuple[str, str]] = {
+    Cli.CLAUDE: ("CLAUDE_CREDENTIALS_JSON", "claude_credentials.json"),
+    Cli.CODEX: ("CODEX_AUTH_JSON", "codex_auth.json"),
+}
 
 
 class SecretConfig(BaseModel):
@@ -30,9 +36,15 @@ class SecretLoader:
     - infrastructure: from environment variables (e.g., GIT_TOKEN)
     """
 
-    def __init__(self, config: SecretConfig | None = None) -> None:
-        """Initialize with optional secret configuration."""
+    def __init__(
+        self,
+        config: SecretConfig | None = None,
+        *,
+        required_clis: frozenset[Cli] | None = None,
+    ) -> None:
+        """Initialize with optional secret configuration and CLI filter."""
         self._config = config or SecretConfig()
+        self._required_clis = required_clis
 
     def autoload_into_env(self, *, override: bool = False) -> None:
         """Load developer secrets into process env."""
@@ -69,18 +81,24 @@ class SecretLoader:
     def load_credential_files(self) -> dict[str, str]:
         """Load CLI credential files from the secrets directory.
 
-        Reads ``claude_credentials.json`` and ``codex_auth.json`` from the
-        parent directory of ``developer_secrets_path`` (the tanren secrets dir).
+        When ``required_clis`` is set, only loads files for those CLIs.
+        When ``None``, loads all known credential files (backward compat).
 
         Returns:
             Dict mapping credential keys to file contents for files that exist
             and are non-empty.
         """
         secrets_dir = Path(self._config.developer_secrets_path).expanduser().parent
-        mapping = {
-            "CLAUDE_CREDENTIALS_JSON": "claude_credentials.json",
-            "CODEX_AUTH_JSON": "codex_auth.json",
-        }
+
+        if self._required_clis is not None:
+            mapping = {
+                key: filename
+                for cli, (key, filename) in _CLI_CREDENTIAL_FILES.items()
+                if cli in self._required_clis
+            }
+        else:
+            mapping = dict(_CLI_CREDENTIAL_FILES.values())
+
         result: dict[str, str] = {}
         for key, filename in mapping.items():
             path = secrets_dir / filename

--- a/services/tanren-cli/src/tanren_cli/vm_cli.py
+++ b/services/tanren-cli/src/tanren_cli/vm_cli.py
@@ -16,6 +16,7 @@ from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
 from tanren_core.config import Config
 from tanren_core.env.environment_schema import EnvironmentProfile, parse_environment_profiles
 from tanren_core.remote_config import ProvisionerType, RemoteSSHConfig, load_remote_config
+from tanren_core.roles_config import load_roles_config
 from tanren_core.secrets import SecretConfig, SecretLoader
 
 vm_app = typer.Typer(help="Manage remote VM assignments.")
@@ -199,8 +200,17 @@ def vm_dry_run(
         typer.echo(f"unsupported provisioner type: {remote_cfg.provisioner.type}", err=True)
         raise typer.Exit(code=1)
 
+    # Load roles to determine required CLIs
+    try:
+        roles = load_roles_config(config.roles_config_path)
+        required_clis = roles.required_clis()
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(f"Warning: could not load roles config: {exc}", err=True)
+        required_clis = None
+
     typer.echo("bootstrap_steps:")
-    bootstrap_plan = UbuntuBootstrapper.plan()
+    bootstrapper = UbuntuBootstrapper(required_clis=required_clis)
+    bootstrap_plan = bootstrapper.plan()
     typer.echo(f"  apt: {' '.join(bootstrap_plan.apt_packages)}")
     for step in bootstrap_plan.install_steps:
         typer.echo(f"  install: {step.name}")

--- a/services/tanren-cli/src/tanren_cli/vm_cli.py
+++ b/services/tanren-cli/src/tanren_cli/vm_cli.py
@@ -201,12 +201,8 @@ def vm_dry_run(
         raise typer.Exit(code=1)
 
     # Load roles to determine required CLIs
-    try:
-        roles = load_roles_config(config.roles_config_path)
-        required_clis = roles.required_clis()
-    except (FileNotFoundError, ValueError) as exc:
-        typer.echo(f"Warning: could not load roles config: {exc}", err=True)
-        required_clis = None
+    roles = load_roles_config(config.roles_config_path)
+    required_clis = roles.required_clis()
 
     typer.echo("bootstrap_steps:")
     bootstrapper = UbuntuBootstrapper(required_clis=required_clis)
@@ -240,7 +236,7 @@ def vm_dry_run(
             remote_cfg.secrets.developer_secrets_path or SecretConfig().developer_secrets_path
         ),
     )
-    loader = SecretLoader(secret_config)
+    loader = SecretLoader(secret_config, required_clis=required_clis)
     developer_secret_keys = sorted(loader.load_developer().keys())
     infrastructure_secret_keys = sorted(secret_config.infrastructure_env_vars)
 

--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -8,11 +8,14 @@ import pytest
 
 from tanren_core.adapters.remote_types import RemoteResult
 from tanren_core.adapters.ubuntu_bootstrap import (
-    _APT_PACKAGES,  # noqa: PLC2701
-    _BOOTSTRAP_STEPS,  # noqa: PLC2701
+    _AGENT_USER,  # noqa: PLC2701
     _MARKER_PATH,  # noqa: PLC2701
     UbuntuBootstrapper,
 )
+from tanren_core.schemas import Cli
+
+# Default required CLIs for integration tests
+_DEFAULT_CLIS = frozenset({Cli.CLAUDE, Cli.OPENCODE, Cli.CODEX})
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -62,15 +65,29 @@ def _make_conn(
                 return RemoteResult(exit_code=0, stdout="1.0.0")
             return RemoteResult(exit_code=1, stdout="")
 
-        # Tool install commands — match against _BOOTSTRAP_STEPS
-        for name, _check, install_cmd in _BOOTSTRAP_STEPS:
-            if command == install_cmd:
-                if name == fail_step:
-                    return RemoteResult(exit_code=1, stdout="", stderr=f"{name} install failed")
-                return RemoteResult(exit_code=0, stdout="")
+        # Tool install commands — check for known install patterns
+        if fail_step:
+            # Match by step name in install command
+            step_patterns = {
+                "docker": "get.docker.com",
+                "node": "nodesource.com",
+                "uv": "astral.sh",
+                "claude": "@anthropic-ai/claude-code",
+                "opencode": "opencode.ai/install",
+                "codex": "@openai/codex",
+                "ccusage": "ccusage",
+            }
+            pattern = step_patterns.get(fail_step, "")
+            if pattern and pattern in command:
+                return RemoteResult(exit_code=1, stdout="", stderr=f"{fail_step} install failed")
 
-        # mkdir -p /workspace
-        if "mkdir -p /workspace" in command:
+        # mkdir, chown, useradd, etc.
+        if (
+            "mkdir -p" in command
+            or "chown" in command
+            or "useradd" in command
+            or "id -u" in command
+        ):
             return RemoteResult(exit_code=0, stdout="")
 
         # touch marker
@@ -100,7 +117,7 @@ class TestBootstrapRunsExpectedSteps:
     async def test_all_steps_executed(self) -> None:
         """Full bootstrap installs apt packages, all tools, creates workspace, writes marker."""
         conn = _make_conn()
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         result = await bootstrapper.bootstrap(conn)
 
@@ -108,16 +125,25 @@ class TestBootstrapRunsExpectedSteps:
         apt_calls = [c for c in conn.run.call_args_list if c[0][0].startswith("apt-get update")]
         assert len(apt_calls) == 1
 
-        # Verify each tool was checked and installed
-        for name, check_cmd, install_cmd in _BOOTSTRAP_STEPS:
-            check_calls = [c for c in conn.run.call_args_list if c[0][0] == check_cmd]
-            assert len(check_calls) >= 1, f"Check for {name} not called"
-            install_calls = [c for c in conn.run.call_args_list if c[0][0] == install_cmd]
-            assert len(install_calls) == 1, f"Install for {name} not called"
+        # Verify each infra tool was installed
+        assert "docker" in result.installed
+        assert "node" in result.installed
+        assert "uv" in result.installed
 
-        # Verify workspace dir created
-        mkdir_calls = [c for c in conn.run.call_args_list if "mkdir -p /workspace" in c[0][0]]
-        assert len(mkdir_calls) == 1
+        # Verify CLI tools installed
+        assert "claude" in result.installed
+        assert "opencode" in result.installed
+        assert "codex" in result.installed
+
+        # Verify ccusage installed
+        assert "ccusage" in result.installed
+
+        # Verify agent user created
+        run_cmds = [c[0][0] for c in conn.run.call_args_list]
+        assert any("useradd" in c and _AGENT_USER in c for c in run_cmds)
+
+        # Verify workspace dir created with chown
+        assert any(f"chown {_AGENT_USER}:{_AGENT_USER} /workspace" in c for c in run_cmds)
 
         # Verify marker written
         marker_calls = [c for c in conn.run.call_args_list if f"touch {_MARKER_PATH}" in c[0][0]]
@@ -125,15 +151,13 @@ class TestBootstrapRunsExpectedSteps:
 
         # Verify result
         assert "apt-packages" in result.installed
-        for name, _, _ in _BOOTSTRAP_STEPS:
-            assert name in result.installed
 
 
 class TestBootstrapSkipsWhenMarkerExists:
     async def test_skips_on_marker(self) -> None:
         """When marker file exists and force=False, bootstrap returns immediately."""
         conn = _make_conn(marker_exists=True)
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         result = await bootstrapper.bootstrap(conn)
 
@@ -148,7 +172,10 @@ class TestBootstrapWithExtraScript:
         """When extra_script is provided, it should be uploaded and run."""
         conn = _make_conn()
         script_content = "#!/bin/bash\necho 'custom setup'"
-        bootstrapper = UbuntuBootstrapper(extra_script=script_content)
+        bootstrapper = UbuntuBootstrapper(
+            required_clis=_DEFAULT_CLIS,
+            extra_script=script_content,
+        )
 
         result = await bootstrapper.bootstrap(conn)
 
@@ -170,7 +197,7 @@ class TestBootstrapForceFlag:
     async def test_force_ignores_marker(self) -> None:
         """force=True should run bootstrap even when marker exists."""
         conn = _make_conn(marker_exists=True)
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         result = await bootstrapper.bootstrap(conn, force=True)
 
@@ -186,13 +213,14 @@ class TestBootstrapForceFlag:
     async def test_force_reinstalls_existing_tools(self) -> None:
         """force=True should install tools even when check passes."""
         conn = _make_conn(all_tools_installed=True)
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         result = await bootstrapper.bootstrap(conn, force=True)
 
-        # All tools should be installed despite being already present
-        for name, _, _ in _BOOTSTRAP_STEPS:
-            assert name in result.installed
+        # All infra and cli tools should be installed despite being present
+        assert "docker" in result.installed
+        assert "claude" in result.installed
+        assert "codex" in result.installed
         assert result.skipped == ()
 
 
@@ -207,7 +235,7 @@ class TestBootstrapStepFailure:
                 RemoteResult(exit_code=1, stdout="", stderr="apt broken"),  # apt install
             ]
         )
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         with pytest.raises(RuntimeError, match="apt install failed"):
             await bootstrapper.bootstrap(conn)
@@ -215,7 +243,7 @@ class TestBootstrapStepFailure:
     async def test_tool_install_failure_raises(self) -> None:
         """Individual tool install failure should raise RuntimeError."""
         conn = _make_conn(fail_step="docker")
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         with pytest.raises(RuntimeError, match="Failed to install docker"):
             await bootstrapper.bootstrap(conn)
@@ -223,7 +251,10 @@ class TestBootstrapStepFailure:
     async def test_extra_script_failure_raises(self) -> None:
         """Extra script failure should raise RuntimeError."""
         conn = _make_conn(extra_script_fails=True)
-        bootstrapper = UbuntuBootstrapper(extra_script="#!/bin/bash\nexit 1")
+        bootstrapper = UbuntuBootstrapper(
+            required_clis=_DEFAULT_CLIS,
+            extra_script="#!/bin/bash\nexit 1",
+        )
 
         with pytest.raises(RuntimeError, match="Extra bootstrap script failed"):
             await bootstrapper.bootstrap(conn)
@@ -233,51 +264,55 @@ class TestBootstrapCreatesWorkspaceDir:
     async def test_mkdir_workspace_called(self) -> None:
         """Bootstrap should always create /workspace directory."""
         conn = _make_conn()
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         await bootstrapper.bootstrap(conn)
 
-        mkdir_calls = [c for c in conn.run.call_args_list if c[0][0] == "mkdir -p /workspace"]
-        assert len(mkdir_calls) == 1
+        mkdir_calls = [c for c in conn.run.call_args_list if "mkdir -p /workspace" in c[0][0]]
+        assert len(mkdir_calls) >= 1
 
 
 class TestIsBootstrapped:
     async def test_returns_true_when_marker_exists(self) -> None:
         conn = AsyncMock()
         conn.run = AsyncMock(return_value=RemoteResult(exit_code=0, stdout="exists"))
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         assert await bootstrapper.is_bootstrapped(conn) is True
 
     async def test_returns_false_when_no_marker(self) -> None:
         conn = AsyncMock()
         conn.run = AsyncMock(return_value=RemoteResult(exit_code=1, stdout=""))
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         assert await bootstrapper.is_bootstrapped(conn) is False
 
 
 class TestBootstrapPlan:
     def test_plan_returns_expected_structure(self) -> None:
-        plan = UbuntuBootstrapper.plan()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
+        plan = bootstrapper.plan()
 
-        assert plan.apt_packages == _APT_PACKAGES
-        assert len(plan.install_steps) == len(_BOOTSTRAP_STEPS)
-        for step, (name, check, install) in zip(plan.install_steps, _BOOTSTRAP_STEPS, strict=True):
-            assert step.name == name
-            assert step.check_command == check
-            assert step.install_command == install
+        step_names = [s.name for s in plan.install_steps]
+        assert "docker" in step_names
+        assert "node" in step_names
+        assert "uv" in step_names
+        assert "claude" in step_names
+        assert "opencode" in step_names
+        assert "codex" in step_names
+        assert "ccusage" in step_names
 
 
 class TestBootstrapSkipsInstalledTools:
     async def test_skips_already_installed(self) -> None:
         """When all tools pass the check command, they should be skipped (not force)."""
         conn = _make_conn(all_tools_installed=True)
-        bootstrapper = UbuntuBootstrapper()
+        bootstrapper = UbuntuBootstrapper(required_clis=_DEFAULT_CLIS)
 
         result = await bootstrapper.bootstrap(conn)
 
-        for name, _, _ in _BOOTSTRAP_STEPS:
-            assert name in result.skipped
+        assert "docker" in result.skipped
+        assert "claude" in result.skipped
+        assert "codex" in result.skipped
         # Only apt-packages should be in installed
         assert result.installed == ("apt-packages",)

--- a/tests/integration/test_config_secrets_integration.py
+++ b/tests/integration/test_config_secrets_integration.py
@@ -7,7 +7,10 @@ import pytest
 
 from tanren_core.adapters.remote_types import SecretBundle
 from tanren_core.config import Config, DotenvConfigSource, load_config_env
+from tanren_core.schemas import Cli
 from tanren_core.secrets import SecretConfig, SecretLoader
+
+_ALL_CLIS = frozenset({Cli.CLAUDE, Cli.CODEX, Cli.OPENCODE})
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -174,14 +177,17 @@ class TestSecretLoaderDeveloper:
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("API_KEY=sk-123\n")
 
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        )
         result = loader.load_developer()
 
         assert result == {"API_KEY": "sk-123"}
 
     def test_load_developer_missing(self, tmp_path: Path):
         loader = SecretLoader(
-            SecretConfig(developer_secrets_path=str(tmp_path / "nonexistent.env"))
+            SecretConfig(developer_secrets_path=str(tmp_path / "nonexistent.env")),
+            required_clis=_ALL_CLIS,
         )
         result = loader.load_developer()
 
@@ -192,7 +198,7 @@ class TestSecretLoaderInfrastructure:
     def test_load_infrastructure(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("GIT_TOKEN", "tok")
 
-        loader = SecretLoader()
+        loader = SecretLoader(required_clis=_ALL_CLIS)
         result = loader.load_infrastructure()
 
         assert result == {"GIT_TOKEN": "tok"}
@@ -200,7 +206,7 @@ class TestSecretLoaderInfrastructure:
     def test_load_infrastructure_missing(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("GIT_TOKEN", raising=False)
 
-        loader = SecretLoader()
+        loader = SecretLoader(required_clis=_ALL_CLIS)
         result = loader.load_infrastructure()
 
         assert result == {}
@@ -212,7 +218,9 @@ class TestSecretLoaderBundle:
         secrets_file.write_text("DEV_KEY=dev_val\n")
         monkeypatch.setenv("GIT_TOKEN", "infra_tok")
 
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        )
         bundle = loader.build_bundle(project_secrets={"PK": "v"})
 
         assert isinstance(bundle, SecretBundle)
@@ -228,7 +236,9 @@ class TestSecretLoaderAutoload:
         # Ensure the key is not already in the environment.
         monkeypatch.delenv("AUTOLOAD_TEST_KEY", raising=False)
 
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        )
         loader.autoload_into_env()
 
         assert os.environ["AUTOLOAD_TEST_KEY"] == "autoloaded"

--- a/tests/integration/test_hetzner_provisioning.py
+++ b/tests/integration/test_hetzner_provisioning.py
@@ -19,6 +19,7 @@ import pytest
 from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 from tanren_core.adapters.remote_types import VMProvider, VMRequirements
 from tanren_core.adapters.ssh import SSHConfig, SSHConnection
+from tanren_core.schemas import Cli
 from tanren_core.secrets import SecretLoader
 
 pytestmark = pytest.mark.hetzner
@@ -26,7 +27,7 @@ pytestmark = pytest.mark.hetzner
 
 def _load_token() -> str | None:
     """Load HETZNER_API_TOKEN from the developer secrets file."""
-    loader = SecretLoader()
+    loader = SecretLoader(required_clis=frozenset({Cli.CLAUDE}))
     loader.autoload_into_env(override=False)
     secrets = loader.load_developer()
     return secrets.get("HETZNER_API_TOKEN")

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -13,15 +13,25 @@ from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 from tanren_core.builder import build_ssh_execution_environment
 from tanren_core.config import Config
 
+_ROLES_YML = """\
+agents:
+  default:
+    cli: claude
+    auth: subscription
+    model: opus
+"""
+
 
 def _make_config(tmp_path: Path, remote_config_path: str | None) -> Config:
+    roles_path = tmp_path / "roles.yml"
+    roles_path.write_text(_ROLES_YML)
     return Config(
         ipc_dir=str(tmp_path / "ipc"),
         github_dir=str(tmp_path / "github"),
         data_dir=str(tmp_path / "data"),
         worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
         remote_config_path=remote_config_path,
-        roles_config_path=str(tmp_path / "roles.yml"),
+        roles_config_path=str(roles_path),
     )
 
 
@@ -87,3 +97,65 @@ repos: []
 
         with pytest.raises(ValueError, match="remote_config_path is required"):
             build_ssh_execution_environment(config, emitter)
+
+    def test_build_uses_roles_for_credential_providers(self, tmp_path):
+        """Builder uses roles.yml to determine credential providers."""
+        roles_path = tmp_path / "roles.yml"
+        roles_path.write_text("""\
+agents:
+  default:
+    cli: claude
+    auth: subscription
+    model: opus
+  audit:
+    cli: codex
+    auth: subscription
+    model: o3
+""")
+        remote_yml = tmp_path / "remote.yml"
+        remote_yml.write_text("""\
+provisioner:
+  type: manual
+  settings:
+    vms:
+      - id: vm-1
+        host: "10.0.0.1"
+repos:
+  - project: test
+    repo_url: https://github.com/test/test.git
+""")
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(tmp_path / "github"),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            remote_config_path=str(remote_yml),
+            roles_config_path=str(roles_path),
+        )
+        emitter = NullEventEmitter()
+
+        env, _ = build_ssh_execution_environment(config, emitter)
+
+        provider_names = sorted(p.name for p in env._credential_providers)
+        assert provider_names == ["claude", "codex"]
+
+    def test_build_sets_agent_user(self, tmp_path):
+        """Builder configures agent_user on SSHExecutionEnvironment."""
+        remote_yml = tmp_path / "remote.yml"
+        remote_yml.write_text("""\
+provisioner:
+  type: manual
+  settings:
+    vms:
+      - id: vm-1
+        host: "10.0.0.1"
+repos:
+  - project: test
+    repo_url: https://github.com/test/test.git
+""")
+        config = _make_config(tmp_path, str(remote_yml))
+        emitter = NullEventEmitter()
+
+        env, _ = build_ssh_execution_environment(config, emitter)
+
+        assert env._agent_user == "tanren"

--- a/tests/unit/test_ccusage.py
+++ b/tests/unit/test_ccusage.py
@@ -10,6 +10,7 @@ import pytest
 
 from tanren_core.ccusage import (
     LocalCommandRunner,
+    RemoteCommandRunner,
     _derive_session_id,  # noqa: PLC2701
     _match_session_by_time,  # noqa: PLC2701
     _normalize_claude,  # noqa: PLC2701
@@ -371,3 +372,37 @@ class TestLocalCommandRunnerTimeout:
 
         mock_proc.kill.assert_called_once()
         mock_proc.wait.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# RemoteCommandRunner — su wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteCommandRunner:
+    @pytest.mark.asyncio
+    async def test_wraps_with_su_when_run_as_user_set(self):
+        """RemoteCommandRunner wraps command with su when run_as_user is set."""
+        conn = AsyncMock()
+        conn.run.return_value = AsyncMock(exit_code=0, stdout="ok")
+        runner = RemoteCommandRunner(conn, run_as_user="tanren")
+
+        await runner.run_command(["ccusage", "session", "--json"], timeout=30)
+
+        cmd_str = conn.run.call_args[0][0]
+        assert cmd_str.startswith("su - tanren -c ")
+        # The inner command should be quoted
+        assert "ccusage" in cmd_str
+
+    @pytest.mark.asyncio
+    async def test_no_wrap_without_run_as_user(self):
+        """RemoteCommandRunner passes command through when run_as_user is None."""
+        conn = AsyncMock()
+        conn.run.return_value = AsyncMock(exit_code=0, stdout="ok")
+        runner = RemoteCommandRunner(conn)
+
+        await runner.run_command(["ccusage", "session", "--json"], timeout=30)
+
+        cmd_str = conn.run.call_args[0][0]
+        assert cmd_str == "ccusage session --json"
+        assert "su -" not in cmd_str

--- a/tests/unit/test_ccusage.py
+++ b/tests/unit/test_ccusage.py
@@ -326,6 +326,29 @@ class TestCollectTokenUsage:
         assert result.provider == "opencode"
         assert result.session_id == "ses_41448dad"
 
+    @pytest.mark.asyncio
+    async def test_quoted_cmd_path_split_correctly(self):
+        """shlex.split preserves quoted paths with spaces."""
+        payload = json.dumps({"sessions": [CLAUDE_SESSION]})
+        runner = _make_runner(exit_code=0, stdout=payload)
+        config = _make_config()
+        config = config.model_copy(
+            update={"ccusage_claude_cmd": '"/opt/my tools/ccusage" --offline'},
+        )
+        await collect_token_usage(
+            Cli.CLAUDE,
+            "/home/trevor/github/tanren",
+            datetime(2026, 3, 14, 0, 0, 0, tzinfo=UTC),
+            datetime(2026, 3, 14, 1, 0, 0, tzinfo=UTC),
+            config,
+            runner,
+        )
+        cmd = runner.run_command.call_args[0][0]
+        # The quoted path must survive as a single element, not split on space
+        assert cmd[0] == "/opt/my tools/ccusage"
+        assert cmd[1] == "--offline"
+        assert "session" in cmd
+
 
 # ---------------------------------------------------------------------------
 # LocalCommandRunner — orphaned process kill on timeout

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1,0 +1,374 @@
+"""Tests for credential providers."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tanren_core.adapters.credentials import (
+    ClaudeCredentialProvider,
+    CodexCredentialProvider,
+    OpencodeCredentialProvider,
+    all_credential_cleanup_paths,
+    inject_all_cli_credentials,
+    providers_for_clis,
+)
+from tanren_core.adapters.remote_types import RemoteResult, SecretBundle
+from tanren_core.schemas import Cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(stdout: str = "") -> RemoteResult:
+    return RemoteResult(exit_code=0, stdout=stdout, stderr="")
+
+
+def _make_conn(home: str = "/root") -> AsyncMock:
+    conn = AsyncMock()
+
+    def _side_effect(cmd: str, **_kwargs: object) -> RemoteResult:
+        if cmd == "echo $HOME":
+            return _ok(f"{home}\n")
+        return _ok()
+
+    conn.run = AsyncMock(side_effect=_side_effect)
+    conn.upload_content = AsyncMock()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# OpencodeCredentialProvider
+# ---------------------------------------------------------------------------
+
+
+class TestOpencodeCredentialProvider:
+    @pytest.mark.asyncio
+    async def test_injects_auth_json_from_developer_secrets(self):
+        conn = _make_conn("/home/deploy")
+        provider = OpencodeCredentialProvider()
+        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key-123"})
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is True
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
+        assert len(auth_uploads) == 1
+        assert auth_uploads[0].args[1] == "/home/deploy/.local/share/opencode/auth.json"
+        data = json.loads(auth_uploads[0].args[0])
+        assert data["zai-coding-plan"]["type"] == "api"
+        assert data["zai-coding-plan"]["key"] == "zai-key-123"
+        conn.run.assert_any_call(
+            "chmod 600 /home/deploy/.local/share/opencode/auth.json", timeout=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_injects_auth_json_from_project_secrets(self):
+        conn = _make_conn("/root")
+        provider = OpencodeCredentialProvider()
+        secrets = SecretBundle(project={"OPENCODE_ZAI_API_KEY": "proj-key-456"})
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is True
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
+        assert len(auth_uploads) == 1
+        assert auth_uploads[0].args[1] == "/root/.local/share/opencode/auth.json"
+        data = json.loads(auth_uploads[0].args[0])
+        assert data["zai-coding-plan"]["key"] == "proj-key-456"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_missing(self):
+        conn = _make_conn()
+        provider = OpencodeCredentialProvider()
+        secrets = SecretBundle()
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is False
+        conn.upload_content.assert_not_called()
+
+    def test_cleanup_paths(self):
+        provider = OpencodeCredentialProvider()
+        assert provider.cleanup_paths == ("~/.local/share/opencode/auth.json",)
+
+    def test_name(self):
+        assert OpencodeCredentialProvider().name == "opencode"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCredentialProvider
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCredentialProvider:
+    @pytest.mark.asyncio
+    async def test_injects_credentials_json(self):
+        conn = _make_conn("/home/deploy")
+        provider = ClaudeCredentialProvider()
+        creds = '{"token": "claude-tok"}'
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": creds})
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is True
+        upload_calls = conn.upload_content.call_args_list
+        cred_uploads = [c for c in upload_calls if ".credentials.json" in str(c)]
+        assert len(cred_uploads) == 1
+        assert cred_uploads[0].args[1] == "/home/deploy/.claude/.credentials.json"
+        assert cred_uploads[0].args[0] == creds
+        conn.run.assert_any_call("mkdir -p /home/deploy/.claude", timeout=10)
+        conn.run.assert_any_call("chmod 600 /home/deploy/.claude/.credentials.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_missing(self):
+        conn = _make_conn()
+        provider = ClaudeCredentialProvider()
+        secrets = SecretBundle()
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is False
+        conn.upload_content.assert_not_called()
+
+    def test_cleanup_paths(self):
+        provider = ClaudeCredentialProvider()
+        assert provider.cleanup_paths == ("~/.claude/.credentials.json",)
+
+    def test_name(self):
+        assert ClaudeCredentialProvider().name == "claude"
+
+
+# ---------------------------------------------------------------------------
+# CodexCredentialProvider
+# ---------------------------------------------------------------------------
+
+
+class TestCodexCredentialProvider:
+    @pytest.mark.asyncio
+    async def test_injects_auth_json(self):
+        conn = _make_conn("/root")
+        provider = CodexCredentialProvider()
+        auth = '{"session": "codex-tok"}'
+        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": auth})
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is True
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if ".codex/auth.json" in str(c)]
+        assert len(auth_uploads) == 1
+        assert auth_uploads[0].args[1] == "/root/.codex/auth.json"
+        assert auth_uploads[0].args[0] == auth
+        conn.run.assert_any_call("mkdir -p /root/.codex", timeout=10)
+        conn.run.assert_any_call("chmod 600 /root/.codex/auth.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_missing(self):
+        conn = _make_conn()
+        provider = CodexCredentialProvider()
+        secrets = SecretBundle()
+
+        result = await provider.inject(conn, secrets)
+
+        assert result is False
+        conn.upload_content.assert_not_called()
+
+    def test_cleanup_paths(self):
+        provider = CodexCredentialProvider()
+        assert provider.cleanup_paths == ("~/.codex/auth.json",)
+
+    def test_name(self):
+        assert CodexCredentialProvider().name == "codex"
+
+
+# ---------------------------------------------------------------------------
+# home_dir parameter
+# ---------------------------------------------------------------------------
+
+
+class TestHomeDirParameter:
+    @pytest.mark.asyncio
+    async def test_opencode_uses_home_dir(self):
+        conn = _make_conn("/root")
+        provider = OpencodeCredentialProvider()
+        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "key"})
+
+        await provider.inject(conn, secrets, home_dir="/home/tanren")
+
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
+        assert auth_uploads[0].args[1] == "/home/tanren/.local/share/opencode/auth.json"
+        conn.run.assert_any_call("mkdir -p /home/tanren/.local/share/opencode", timeout=10)
+        conn.run.assert_any_call(
+            "chmod 600 /home/tanren/.local/share/opencode/auth.json", timeout=10
+        )
+        conn.run.assert_any_call(
+            "chown -R tanren:tanren /home/tanren/.local/share/opencode", timeout=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_claude_uses_home_dir(self):
+        conn = _make_conn("/root")
+        provider = ClaudeCredentialProvider()
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": '{"t": "c"}'})
+
+        await provider.inject(conn, secrets, home_dir="/home/tanren")
+
+        upload_calls = conn.upload_content.call_args_list
+        cred_uploads = [c for c in upload_calls if ".credentials.json" in str(c)]
+        assert cred_uploads[0].args[1] == "/home/tanren/.claude/.credentials.json"
+        conn.run.assert_any_call("mkdir -p /home/tanren/.claude", timeout=10)
+        conn.run.assert_any_call("chown -R tanren:tanren /home/tanren/.claude", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_codex_uses_home_dir(self):
+        conn = _make_conn("/root")
+        provider = CodexCredentialProvider()
+        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": '{"s": "x"}'})
+
+        await provider.inject(conn, secrets, home_dir="/home/tanren")
+
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if ".codex/auth.json" in str(c)]
+        assert auth_uploads[0].args[1] == "/home/tanren/.codex/auth.json"
+        conn.run.assert_any_call("mkdir -p /home/tanren/.codex", timeout=10)
+        conn.run.assert_any_call("chown -R tanren:tanren /home/tanren/.codex", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_no_chown_without_home_dir(self):
+        conn = _make_conn("/root")
+        provider = ClaudeCredentialProvider()
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": '{"t": "c"}'})
+
+        await provider.inject(conn, secrets)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert not any("chown" in c for c in run_cmds)
+
+
+# ---------------------------------------------------------------------------
+# inject_all_cli_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestInjectAllCliCredentials:
+    @pytest.mark.asyncio
+    async def test_all_present(self):
+        conn = _make_conn("/root")
+        secrets = SecretBundle(
+            developer={
+                "OPENCODE_ZAI_API_KEY": "zai-key",
+                "CLAUDE_CREDENTIALS_JSON": '{"t": "c"}',
+                "CODEX_AUTH_JSON": '{"s": "x"}',
+            }
+        )
+
+        injected = await inject_all_cli_credentials(conn, secrets)
+
+        assert sorted(injected) == ["claude", "codex", "opencode"]
+
+    @pytest.mark.asyncio
+    async def test_some_missing(self):
+        conn = _make_conn("/root")
+        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key"})
+
+        injected = await inject_all_cli_credentials(conn, secrets)
+
+        assert injected == ["opencode"]
+
+    @pytest.mark.asyncio
+    async def test_none_present(self):
+        conn = _make_conn()
+        secrets = SecretBundle()
+
+        injected = await inject_all_cli_credentials(conn, secrets)
+
+        assert injected == []
+
+    @pytest.mark.asyncio
+    async def test_inject_raises_graceful(self):
+        """A failing provider is logged but does not stop other providers."""
+        conn = _make_conn("/root")
+        secrets = SecretBundle(
+            developer={
+                "OPENCODE_ZAI_API_KEY": "zai-key",
+                "CODEX_AUTH_JSON": '{"s": "x"}',
+            }
+        )
+
+        # Create a provider that raises
+        failing = AsyncMock()
+        failing.name = "broken"
+        failing.inject = AsyncMock(side_effect=RuntimeError("boom"))
+
+        opencode = OpencodeCredentialProvider()
+        codex = CodexCredentialProvider()
+
+        injected = await inject_all_cli_credentials(conn, secrets, (opencode, failing, codex))
+
+        assert sorted(injected) == ["codex", "opencode"]
+
+    @pytest.mark.asyncio
+    async def test_passes_target_home(self):
+        conn = _make_conn("/root")
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": '{"t": "c"}'})
+        providers = (ClaudeCredentialProvider(),)
+
+        await inject_all_cli_credentials(conn, secrets, providers, target_home="/home/tanren")
+
+        upload_calls = conn.upload_content.call_args_list
+        cred_uploads = [c for c in upload_calls if ".credentials.json" in str(c)]
+        assert cred_uploads[0].args[1] == "/home/tanren/.claude/.credentials.json"
+
+
+# ---------------------------------------------------------------------------
+# all_credential_cleanup_paths
+# ---------------------------------------------------------------------------
+
+
+class TestAllCredentialCleanupPaths:
+    def test_default_providers(self):
+        paths = all_credential_cleanup_paths()
+        assert "~/.local/share/opencode/auth.json" in paths
+        assert "~/.claude/.credentials.json" in paths
+        assert "~/.codex/auth.json" in paths
+        assert len(paths) == 3
+
+    def test_custom_providers(self):
+        provider = OpencodeCredentialProvider()
+        paths = all_credential_cleanup_paths((provider,))
+        assert paths == ["~/.local/share/opencode/auth.json"]
+
+
+# ---------------------------------------------------------------------------
+# providers_for_clis
+# ---------------------------------------------------------------------------
+
+
+class TestProvidersForClis:
+    def test_single_cli(self):
+        providers = providers_for_clis(frozenset({Cli.CLAUDE}))
+        assert len(providers) == 1
+        assert providers[0].name == "claude"
+
+    def test_multiple_clis(self):
+        providers = providers_for_clis(frozenset({Cli.CLAUDE, Cli.CODEX, Cli.OPENCODE}))
+        names = [p.name for p in providers]
+        assert sorted(names) == ["claude", "codex", "opencode"]
+
+    def test_empty_set(self):
+        providers = providers_for_clis(frozenset())
+        assert providers == ()
+
+    def test_bash_only(self):
+        providers = providers_for_clis(frozenset({Cli.BASH}))
+        assert providers == ()
+
+    def test_bash_ignored(self):
+        providers = providers_for_clis(frozenset({Cli.CLAUDE, Cli.BASH}))
+        assert len(providers) == 1
+        assert providers[0].name == "claude"

--- a/tests/unit/test_git_workspace.py
+++ b/tests/unit/test_git_workspace.py
@@ -1,6 +1,5 @@
 """Tests for git workspace manager."""
 
-import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,8 +12,6 @@ from tanren_core.adapters.remote_types import (
     WorkspaceSpec,
 )
 from tanren_core.remote_config import GitAuthMethod
-from tanren_core.roles import AuthMode
-from tanren_core.schemas import Cli
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,17 +31,6 @@ def _make_conn() -> AsyncMock:
     conn.run = AsyncMock(return_value=_ok())
     conn.upload_content = AsyncMock()
     return conn
-
-
-def _run_with_home(home: str = "/root"):
-    """Return a side_effect callable that resolves ``echo $HOME`` and returns _ok() otherwise."""
-
-    def _side_effect(cmd: str, **_kwargs: object) -> RemoteResult:
-        if cmd == "echo $HOME":
-            return _ok(f"{home}\n")
-        return _ok()
-
-    return _side_effect
 
 
 def _spec(**overrides: object) -> WorkspaceSpec:
@@ -300,7 +286,7 @@ class TestPushCommand:
 
 class TestCleanup:
     @pytest.mark.asyncio
-    async def test_removes_secret_files_askpass_and_cli_auth(self):
+    async def test_removes_secret_files_and_askpass(self):
         conn = _make_conn()
         mgr = GitWorkspaceManager(GitAuthConfig())
         await mgr.cleanup(conn, _workspace())
@@ -308,271 +294,4 @@ class TestCleanup:
         conn.run.assert_any_call("rm -f /workspace/.developer-secrets", timeout=10)
         conn.run.assert_any_call("rm -f /workspace/myapp/.env", timeout=10)
         conn.run.assert_any_call("rm -f /workspace/.git-askpass", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-        assert conn.run.call_count == 6
-
-
-# ---------------------------------------------------------------------------
-# CLI auth injection
-# ---------------------------------------------------------------------------
-
-
-class TestCliAuthInjection:
-    @pytest.mark.asyncio
-    async def test_opencode_api_key_writes_auth_json(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/home/deploy")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key-123"})
-        await mgr.inject_secrets(
-            conn,
-            _workspace(),
-            secrets,
-            cli_auth=(Cli.OPENCODE, AuthMode.API_KEY),
-        )
-
-        # Find the auth.json upload — SFTP uses resolved absolute path
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
-        assert len(auth_uploads) == 1
-        assert auth_uploads[0].args[1] == "/home/deploy/.local/share/opencode/auth.json"
-        content = auth_uploads[0].args[0]
-        data = json.loads(content)
-        assert data["zai-coding-plan"]["type"] == "api"
-        assert data["zai-coding-plan"]["key"] == "zai-key-123"
-
-        # Shell commands use tilde path
-        conn.run.assert_any_call("chmod 600 ~/.local/share/opencode/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_opencode_api_key_from_project_secrets(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(project={"OPENCODE_ZAI_API_KEY": "proj-key-456"})
-        await mgr.inject_secrets(
-            conn,
-            _workspace(),
-            secrets,
-            cli_auth=(Cli.OPENCODE, AuthMode.API_KEY),
-        )
-
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
-        assert len(auth_uploads) == 1
-        assert auth_uploads[0].args[1] == "/root/.local/share/opencode/auth.json"
-        content = auth_uploads[0].args[0]
-        data = json.loads(content)
-        assert data["zai-coding-plan"]["key"] == "proj-key-456"
-
-    @pytest.mark.asyncio
-    async def test_opencode_api_key_missing_clears_stale_auth(self):
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle()  # no OPENCODE_ZAI_API_KEY
-        await mgr.inject_secrets(
-            conn,
-            _workspace(),
-            secrets,
-            cli_auth=(Cli.OPENCODE, AuthMode.API_KEY),
-        )
-
-        # No auth.json should be uploaded
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
-        assert len(auth_uploads) == 0
-
-        # Stale auth.json must be removed
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_fallback_cli_removes_all_stale_auth(self):
-        """Unhandled cli/auth combo removes all three auth paths."""
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle()
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.BASH, AuthMode.API_KEY))
-
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_opencode_api_key_does_not_remove_own_auth(self):
-        """opencode/api_key writes auth.json, never removes its own."""
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key-123"})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
-
-        rm_calls = [str(c) for c in conn.run.call_args_list]
-        assert not any("rm -f" in c and "opencode" in c and "auth.json" in c for c in rm_calls)
-
-    @pytest.mark.asyncio
-    async def test_stateless_across_connections(self):
-        """Manager holds no per-connection state between calls."""
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(
-            developer={
-                "OPENCODE_ZAI_API_KEY": "zai-key-123",
-                "CODEX_AUTH_JSON": '{"session": "xyz"}',
-            }
-        )
-
-        # VM A: inject opencode auth
-        conn_a = _make_conn()
-        conn_a.run.side_effect = _run_with_home("/root")
-        await mgr.inject_cli_auth(conn_a, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
-
-        # VM B: different cli — should still clean up opencode + claude on B
-        conn_b = _make_conn()
-        conn_b.run.side_effect = _run_with_home("/root")
-        await mgr.inject_cli_auth(conn_b, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
-
-        conn_b.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn_b.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        # VM A: opencode's own auth path was not rm'd
-        conn_a_rm_calls = [str(c) for c in conn_a.run.call_args_list]
-        assert not any(
-            "rm -f" in c and "opencode" in c and "auth.json" in c for c in conn_a_rm_calls
-        )
-
-    @pytest.mark.asyncio
-    async def test_claude_oauth_no_auth_file(self):
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "key"})
-        await mgr.inject_secrets(
-            conn,
-            _workspace(),
-            secrets,
-            cli_auth=(Cli.CLAUDE, AuthMode.OAUTH),
-        )
-
-        # No CLI auth should be uploaded for claude/oauth (fallback branch)
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [
-            c for c in upload_calls if "auth.json" in str(c) or ".credentials.json" in str(c)
-        ]
-        assert len(auth_uploads) == 0
-
-    @pytest.mark.asyncio
-    async def test_no_cli_auth_no_auth_file(self):
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "key"})
-        await mgr.inject_secrets(conn, _workspace(), secrets)
-
-        # No auth.json should be uploaded when cli_auth is None
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
-        assert len(auth_uploads) == 0
-
-    @pytest.mark.asyncio
-    async def test_claude_subscription_writes_credentials(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/home/deploy")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        creds = '{"token": "claude-tok"}'
-        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": creds})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
-
-        upload_calls = conn.upload_content.call_args_list
-        cred_uploads = [c for c in upload_calls if ".credentials.json" in str(c)]
-        assert len(cred_uploads) == 1
-        assert cred_uploads[0].args[1] == "/home/deploy/.claude/.credentials.json"
-        assert cred_uploads[0].args[0] == creds
-        conn.run.assert_any_call("mkdir -p ~/.claude", timeout=10)
-        conn.run.assert_any_call("chmod 600 ~/.claude/.credentials.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_codex_subscription_writes_auth(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        auth = '{"session": "codex-tok"}'
-        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": auth})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
-
-        upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if ".codex/auth.json" in str(c)]
-        assert len(auth_uploads) == 1
-        assert auth_uploads[0].args[1] == "/root/.codex/auth.json"
-        assert auth_uploads[0].args[0] == auth
-        conn.run.assert_any_call("mkdir -p ~/.codex", timeout=10)
-        conn.run.assert_any_call("chmod 600 ~/.codex/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_claude_subscription_missing_key_warns_and_cleans(self):
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle()
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
-
-        conn.upload_content.assert_not_called()
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_codex_subscription_missing_key_warns_and_cleans(self):
-        conn = _make_conn()
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle()
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
-
-        conn.upload_content.assert_not_called()
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_opencode_removes_claude_and_codex_auth(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key"})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
-
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-
-    @pytest.mark.asyncio
-    async def test_claude_removes_opencode_and_codex_auth(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": '{"t": "x"}'})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
-
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
-        # Own path NOT removed
-        rm_calls = [str(c) for c in conn.run.call_args_list]
-        assert not any("rm -f" in c and ".claude/.credentials.json" in c for c in rm_calls)
-
-    @pytest.mark.asyncio
-    async def test_codex_removes_opencode_and_claude_auth(self):
-        conn = _make_conn()
-        conn.run.side_effect = _run_with_home("/root")
-        mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": '{"s": "y"}'})
-
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
-
-        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
-        # Own path NOT removed
-        rm_calls = [str(c) for c in conn.run.call_args_list]
-        assert not any("rm -f" in c and ".codex/auth.json" in c for c in rm_calls)
+        assert conn.run.call_count == 3

--- a/tests/unit/test_git_workspace.py
+++ b/tests/unit/test_git_workspace.py
@@ -309,7 +309,9 @@ class TestCleanup:
         conn.run.assert_any_call("rm -f /workspace/myapp/.env", timeout=10)
         conn.run.assert_any_call("rm -f /workspace/.git-askpass", timeout=10)
         conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        assert conn.run.call_count == 4
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
+        assert conn.run.call_count == 6
 
 
 # ---------------------------------------------------------------------------
@@ -386,19 +388,21 @@ class TestCliAuthInjection:
         conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
 
     @pytest.mark.asyncio
-    async def test_non_opencode_cli_removes_stale_auth(self):
-        """Any non-opencode/api_key combo unconditionally removes auth.json."""
+    async def test_fallback_cli_removes_all_stale_auth(self):
+        """Unhandled cli/auth combo removes all three auth paths."""
         conn = _make_conn()
         mgr = GitWorkspaceManager(GitAuthConfig())
         secrets = SecretBundle()
 
-        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
+        await mgr.inject_cli_auth(conn, secrets, (Cli.BASH, AuthMode.API_KEY))
 
         conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
 
     @pytest.mark.asyncio
-    async def test_opencode_api_key_does_not_remove_auth(self):
-        """opencode/api_key writes auth.json, never removes it."""
+    async def test_opencode_api_key_does_not_remove_own_auth(self):
+        """opencode/api_key writes auth.json, never removes its own."""
         conn = _make_conn()
         conn.run.side_effect = _run_with_home("/root")
         mgr = GitWorkspaceManager(GitAuthConfig())
@@ -407,27 +411,36 @@ class TestCliAuthInjection:
         await mgr.inject_cli_auth(conn, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
 
         rm_calls = [str(c) for c in conn.run.call_args_list]
-        assert not any("rm -f" in c and "auth.json" in c for c in rm_calls)
+        assert not any("rm -f" in c and "opencode" in c and "auth.json" in c for c in rm_calls)
 
     @pytest.mark.asyncio
     async def test_stateless_across_connections(self):
         """Manager holds no per-connection state between calls."""
         mgr = GitWorkspaceManager(GitAuthConfig())
-        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key-123"})
+        secrets = SecretBundle(
+            developer={
+                "OPENCODE_ZAI_API_KEY": "zai-key-123",
+                "CODEX_AUTH_JSON": '{"session": "xyz"}',
+            }
+        )
 
         # VM A: inject opencode auth
         conn_a = _make_conn()
         conn_a.run.side_effect = _run_with_home("/root")
         await mgr.inject_cli_auth(conn_a, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
 
-        # VM B: different cli — should still clean up on B, independent of A
+        # VM B: different cli — should still clean up opencode + claude on B
         conn_b = _make_conn()
+        conn_b.run.side_effect = _run_with_home("/root")
         await mgr.inject_cli_auth(conn_b, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
 
         conn_b.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
-        # VM A was not touched
+        conn_b.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        # VM A: opencode's own auth path was not rm'd
         conn_a_rm_calls = [str(c) for c in conn_a.run.call_args_list]
-        assert not any("rm -f" in c and "auth.json" in c for c in conn_a_rm_calls)
+        assert not any(
+            "rm -f" in c and "opencode" in c and "auth.json" in c for c in conn_a_rm_calls
+        )
 
     @pytest.mark.asyncio
     async def test_claude_oauth_no_auth_file(self):
@@ -441,9 +454,11 @@ class TestCliAuthInjection:
             cli_auth=(Cli.CLAUDE, AuthMode.OAUTH),
         )
 
-        # No auth.json should be uploaded for claude/oauth
+        # No CLI auth should be uploaded for claude/oauth (fallback branch)
         upload_calls = conn.upload_content.call_args_list
-        auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
+        auth_uploads = [
+            c for c in upload_calls if "auth.json" in str(c) or ".credentials.json" in str(c)
+        ]
         assert len(auth_uploads) == 0
 
     @pytest.mark.asyncio
@@ -457,3 +472,107 @@ class TestCliAuthInjection:
         upload_calls = conn.upload_content.call_args_list
         auth_uploads = [c for c in upload_calls if "auth.json" in str(c)]
         assert len(auth_uploads) == 0
+
+    @pytest.mark.asyncio
+    async def test_claude_subscription_writes_credentials(self):
+        conn = _make_conn()
+        conn.run.side_effect = _run_with_home("/home/deploy")
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        creds = '{"token": "claude-tok"}'
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": creds})
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
+
+        upload_calls = conn.upload_content.call_args_list
+        cred_uploads = [c for c in upload_calls if ".credentials.json" in str(c)]
+        assert len(cred_uploads) == 1
+        assert cred_uploads[0].args[1] == "/home/deploy/.claude/.credentials.json"
+        assert cred_uploads[0].args[0] == creds
+        conn.run.assert_any_call("mkdir -p ~/.claude", timeout=10)
+        conn.run.assert_any_call("chmod 600 ~/.claude/.credentials.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_codex_subscription_writes_auth(self):
+        conn = _make_conn()
+        conn.run.side_effect = _run_with_home("/root")
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        auth = '{"session": "codex-tok"}'
+        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": auth})
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
+
+        upload_calls = conn.upload_content.call_args_list
+        auth_uploads = [c for c in upload_calls if ".codex/auth.json" in str(c)]
+        assert len(auth_uploads) == 1
+        assert auth_uploads[0].args[1] == "/root/.codex/auth.json"
+        assert auth_uploads[0].args[0] == auth
+        conn.run.assert_any_call("mkdir -p ~/.codex", timeout=10)
+        conn.run.assert_any_call("chmod 600 ~/.codex/auth.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_claude_subscription_missing_key_warns_and_cleans(self):
+        conn = _make_conn()
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        secrets = SecretBundle()
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
+
+        conn.upload_content.assert_not_called()
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_codex_subscription_missing_key_warns_and_cleans(self):
+        conn = _make_conn()
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        secrets = SecretBundle()
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
+
+        conn.upload_content.assert_not_called()
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_opencode_removes_claude_and_codex_auth(self):
+        conn = _make_conn()
+        conn.run.side_effect = _run_with_home("/root")
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        secrets = SecretBundle(developer={"OPENCODE_ZAI_API_KEY": "zai-key"})
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.OPENCODE, AuthMode.API_KEY))
+
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_claude_removes_opencode_and_codex_auth(self):
+        conn = _make_conn()
+        conn.run.side_effect = _run_with_home("/root")
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        secrets = SecretBundle(developer={"CLAUDE_CREDENTIALS_JSON": '{"t": "x"}'})
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CLAUDE, AuthMode.SUBSCRIPTION))
+
+        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.codex/auth.json", timeout=10)
+        # Own path NOT removed
+        rm_calls = [str(c) for c in conn.run.call_args_list]
+        assert not any("rm -f" in c and ".claude/.credentials.json" in c for c in rm_calls)
+
+    @pytest.mark.asyncio
+    async def test_codex_removes_opencode_and_claude_auth(self):
+        conn = _make_conn()
+        conn.run.side_effect = _run_with_home("/root")
+        mgr = GitWorkspaceManager(GitAuthConfig())
+        secrets = SecretBundle(developer={"CODEX_AUTH_JSON": '{"s": "y"}'})
+
+        await mgr.inject_cli_auth(conn, secrets, (Cli.CODEX, AuthMode.SUBSCRIPTION))
+
+        conn.run.assert_any_call("rm -f ~/.local/share/opencode/auth.json", timeout=10)
+        conn.run.assert_any_call("rm -f ~/.claude/.credentials.json", timeout=10)
+        # Own path NOT removed
+        rm_calls = [str(c) for c in conn.run.call_args_list]
+        assert not any("rm -f" in c and ".codex/auth.json" in c for c in rm_calls)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -76,13 +76,18 @@ class TestWorkerManagerInit:
             "  demo: https://github.com/org/demo.git\n"
         )
 
+        roles_yml = tmp_path / "roles.yml"
+        roles_yml.write_text(
+            "agents:\n  default:\n    cli: claude\n    auth: subscription\n    model: opus\n"
+        )
+
         config = Config(
             ipc_dir=str(tmp_path / "ipc"),
             github_dir=str(tmp_path / "github"),
             data_dir=str(tmp_path / "data"),
             worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
             remote_config_path=str(remote_cfg),
-            roles_config_path=str(tmp_path / "roles.yml"),
+            roles_config_path=str(roles_yml),
         )
 
         monkeypatch.delenv("CUSTOM_GIT_TOKEN", raising=False)
@@ -90,7 +95,7 @@ class TestWorkerManagerInit:
         seen: dict[str, object] = {}
 
         class _FakeSecretLoader:
-            def __init__(self, config):
+            def __init__(self, config, *, required_clis=None):
                 seen["secret_config"] = config
 
             def autoload_into_env(self, *, override: bool = False) -> None:
@@ -129,7 +134,7 @@ class TestWorkerManagerInit:
         )
         monkeypatch.setattr(
             "tanren_core.builder.RemoteAgentRunner",
-            lambda: object(),
+            lambda **kwargs: object(),
         )
 
         manager = WorkerManager(config=config, emitter=NullEventEmitter())

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -95,7 +95,7 @@ class TestWorkerManagerInit:
         seen: dict[str, object] = {}
 
         class _FakeSecretLoader:
-            def __init__(self, config, *, required_clis=None):
+            def __init__(self, config, *, required_clis):
                 seen["secret_config"] = config
 
             def autoload_into_env(self, *, override: bool = False) -> None:

--- a/tests/unit/test_remote_runner.py
+++ b/tests/unit/test_remote_runner.py
@@ -215,7 +215,11 @@ class TestRunAsUser:
             signal_path="/workspace/myproj/.signal",
         )
 
-        agent_call = conn.run.call_args_list[0]
+        # First call is chown of prompt file for agent user
+        chown_call = conn.run.call_args_list[0]
+        assert "chown tanren" in chown_call.args[0]
+        # Second call is the agent command wrapped with su
+        agent_call = conn.run.call_args_list[1]
         cmd = agent_call.args[0]
         assert cmd.startswith("su - tanren -c ")
 

--- a/tests/unit/test_remote_runner.py
+++ b/tests/unit/test_remote_runner.py
@@ -199,3 +199,39 @@ class TestRemoteAgentRunnerRun:
 
         assert result.timed_out is True
         assert result.exit_code == 124
+
+
+class TestRunAsUser:
+    async def test_command_wrapped_with_su(self):
+        conn = _make_conn()
+        ws = _make_workspace()
+        runner = RemoteAgentRunner(run_as_user="tanren")
+
+        await runner.run(
+            conn,
+            ws,
+            prompt_content="prompt",
+            cli_command="claude -p --dangerously-skip-permissions < .tanren-prompt.md",
+            signal_path="/workspace/myproj/.signal",
+        )
+
+        agent_call = conn.run.call_args_list[0]
+        cmd = agent_call.args[0]
+        assert cmd.startswith("su - tanren -c ")
+
+    async def test_no_wrapping_without_run_as_user(self):
+        conn = _make_conn()
+        ws = _make_workspace()
+        runner = RemoteAgentRunner()
+
+        await runner.run(
+            conn,
+            ws,
+            prompt_content="prompt",
+            cli_command="claude -p --dangerously-skip-permissions",
+            signal_path="/workspace/myproj/.signal",
+        )
+
+        agent_call = conn.run.call_args_list[0]
+        cmd = agent_call.args[0]
+        assert not cmd.startswith("su -")

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -56,3 +56,43 @@ class TestRoleMapping:
         )
         assert mapping.resolve("audit").cli == "codex"
         assert mapping.resolve("feedback").model == "sonnet"
+
+
+class TestRequiredClis:
+    def test_single_cli(self):
+        mapping = RoleMapping(default=AgentTool(cli=Cli.CLAUDE))
+        assert mapping.required_clis() == frozenset({Cli.CLAUDE})
+
+    def test_multi_cli(self):
+        mapping = RoleMapping(
+            default=AgentTool(cli=Cli.CLAUDE),
+            implementation=AgentTool(cli=Cli.OPENCODE),
+            audit=AgentTool(cli=Cli.CODEX),
+        )
+        assert mapping.required_clis() == frozenset({Cli.CLAUDE, Cli.OPENCODE, Cli.CODEX})
+
+    def test_bash_excluded(self):
+        mapping = RoleMapping(
+            default=AgentTool(cli=Cli.CLAUDE),
+            feedback=AgentTool(cli=Cli.BASH),
+        )
+        assert mapping.required_clis() == frozenset({Cli.CLAUDE})
+
+    def test_deduplication(self):
+        mapping = RoleMapping(
+            default=AgentTool(cli=Cli.CLAUDE),
+            conversation=AgentTool(cli=Cli.CLAUDE, model="opus"),
+            feedback=AgentTool(cli=Cli.CLAUDE, model="sonnet"),
+        )
+        assert mapping.required_clis() == frozenset({Cli.CLAUDE})
+
+    def test_all_roles_multi_cli(self):
+        mapping = RoleMapping(
+            default=AgentTool(cli=Cli.CLAUDE),
+            conversation=AgentTool(cli=Cli.CLAUDE, model="opus"),
+            implementation=AgentTool(cli=Cli.OPENCODE),
+            audit=AgentTool(cli=Cli.CODEX),
+            feedback=AgentTool(cli=Cli.CLAUDE, model="sonnet"),
+            conflict_resolution=AgentTool(cli=Cli.CODEX),
+        )
+        assert mapping.required_clis() == frozenset({Cli.CLAUDE, Cli.OPENCODE, Cli.CODEX})

--- a/tests/unit/test_secrets_loader.py
+++ b/tests/unit/test_secrets_loader.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 from tanren_core.adapters.remote_types import SecretBundle
+from tanren_core.schemas import Cli
 from tanren_core.secrets import SecretConfig, SecretLoader
 
 
@@ -91,6 +92,60 @@ class TestLoadCredentialFiles:
         result = loader.load_credential_files()
 
         assert result == {}
+
+
+class TestRequiredClisFiltering:
+    def test_only_claude_file_loaded(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
+        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CLAUDE}),
+        )
+
+        result = loader.load_credential_files()
+
+        assert result == {"CLAUDE_CREDENTIALS_JSON": '{"token": "abc"}'}
+
+    def test_only_codex_file_loaded(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
+        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CODEX}),
+        )
+
+        result = loader.load_credential_files()
+
+        assert result == {"CODEX_AUTH_JSON": '{"session": "xyz"}'}
+
+    def test_opencode_has_no_credential_file(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.OPENCODE}),
+        )
+
+        result = loader.load_credential_files()
+
+        assert result == {}
+
+    def test_none_required_clis_loads_all(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
+        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert "CLAUDE_CREDENTIALS_JSON" in result
+        assert "CODEX_AUTH_JSON" in result
 
 
 class TestBuildBundle:

--- a/tests/unit/test_secrets_loader.py
+++ b/tests/unit/test_secrets_loader.py
@@ -7,13 +7,15 @@ from tanren_core.adapters.remote_types import SecretBundle
 from tanren_core.schemas import Cli
 from tanren_core.secrets import SecretConfig, SecretLoader
 
+_ALL_CLIS = frozenset({Cli.CLAUDE, Cli.CODEX, Cli.OPENCODE})
+
 
 class TestLoadDeveloper:
     def test_reads_from_secrets_file(self, tmp_path: Path):
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("API_KEY=sk-abc123\nDB_URL=postgres://localhost\n")
         config = SecretConfig(developer_secrets_path=str(secrets_file))
-        loader = SecretLoader(config)
+        loader = SecretLoader(config, required_clis=_ALL_CLIS)
 
         result = loader.load_developer()
 
@@ -21,7 +23,7 @@ class TestLoadDeveloper:
 
     def test_returns_empty_dict_when_file_missing(self, tmp_path: Path):
         config = SecretConfig(developer_secrets_path=str(tmp_path / "nonexistent.env"))
-        loader = SecretLoader(config)
+        loader = SecretLoader(config, required_clis=_ALL_CLIS)
 
         result = loader.load_developer()
 
@@ -32,7 +34,7 @@ class TestLoadInfrastructure:
     def test_reads_from_env_vars(self, monkeypatch):
         monkeypatch.setenv("GIT_TOKEN", "ghp_abc123")
         config = SecretConfig(infrastructure_env_vars=("GIT_TOKEN",))
-        loader = SecretLoader(config)
+        loader = SecretLoader(config, required_clis=_ALL_CLIS)
 
         result = loader.load_infrastructure()
 
@@ -44,7 +46,10 @@ class TestLoadCredentialFiles:
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("")
         (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CLAUDE}),
+        )
 
         result = loader.load_credential_files()
 
@@ -54,7 +59,10 @@ class TestLoadCredentialFiles:
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("")
         (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CODEX}),
+        )
 
         result = loader.load_credential_files()
 
@@ -65,7 +73,10 @@ class TestLoadCredentialFiles:
         secrets_file.write_text("")
         (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
         (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CLAUDE, Cli.CODEX}),
+        )
 
         result = loader.load_credential_files()
 
@@ -77,7 +88,10 @@ class TestLoadCredentialFiles:
     def test_returns_empty_when_no_files(self, tmp_path: Path):
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("")
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=_ALL_CLIS,
+        )
 
         result = loader.load_credential_files()
 
@@ -87,7 +101,10 @@ class TestLoadCredentialFiles:
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("")
         (tmp_path / "claude_credentials.json").write_text("   \n  ")
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        loader = SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)),
+            required_clis=frozenset({Cli.CLAUDE}),
+        )
 
         result = loader.load_credential_files()
 
@@ -135,18 +152,6 @@ class TestRequiredClisFiltering:
 
         assert result == {}
 
-    def test_none_required_clis_loads_all(self, tmp_path: Path):
-        secrets_file = tmp_path / "secrets.env"
-        secrets_file.write_text("")
-        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
-        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
-        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
-
-        result = loader.load_credential_files()
-
-        assert "CLAUDE_CREDENTIALS_JSON" in result
-        assert "CODEX_AUTH_JSON" in result
-
 
 class TestBuildBundle:
     def test_combines_all_sources(self, tmp_path: Path, monkeypatch):
@@ -158,7 +163,7 @@ class TestBuildBundle:
             developer_secrets_path=str(secrets_file),
             infrastructure_env_vars=("GIT_TOKEN",),
         )
-        loader = SecretLoader(config)
+        loader = SecretLoader(config, required_clis=frozenset({Cli.CLAUDE}))
 
         bundle = loader.build_bundle(project_secrets={"PROJ_KEY": "proj_val"})
 
@@ -184,7 +189,9 @@ class TestAutoload:
         secrets_file.write_text("HCLOUD_TOKEN=from-file\n")
         monkeypatch.delenv("HCLOUD_TOKEN", raising=False)
 
-        SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+        SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        )
 
         assert os.environ.get("HCLOUD_TOKEN") is None
 
@@ -193,7 +200,9 @@ class TestAutoload:
         secrets_file.write_text("HCLOUD_TOKEN=from-file\n")
         monkeypatch.delenv("HCLOUD_TOKEN", raising=False)
 
-        SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file))).autoload_into_env()
+        SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        ).autoload_into_env()
 
         assert os.environ.get("HCLOUD_TOKEN") == "from-file"
 
@@ -202,6 +211,8 @@ class TestAutoload:
         secrets_file.write_text("HCLOUD_TOKEN=from-file\n")
         monkeypatch.setenv("HCLOUD_TOKEN", "explicit")
 
-        SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file))).autoload_into_env()
+        SecretLoader(
+            SecretConfig(developer_secrets_path=str(secrets_file)), required_clis=_ALL_CLIS
+        ).autoload_into_env()
 
         assert os.environ.get("HCLOUD_TOKEN") == "explicit"

--- a/tests/unit/test_secrets_loader.py
+++ b/tests/unit/test_secrets_loader.py
@@ -38,10 +38,66 @@ class TestLoadInfrastructure:
         assert result == {"GIT_TOKEN": "ghp_abc123"}
 
 
+class TestLoadCredentialFiles:
+    def test_reads_claude_credentials(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert result == {"CLAUDE_CREDENTIALS_JSON": '{"token": "abc"}'}
+
+    def test_reads_codex_auth(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert result == {"CODEX_AUTH_JSON": '{"session": "xyz"}'}
+
+    def test_reads_both_files(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
+        (tmp_path / "codex_auth.json").write_text('{"session": "xyz"}')
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert result == {
+            "CLAUDE_CREDENTIALS_JSON": '{"token": "abc"}',
+            "CODEX_AUTH_JSON": '{"session": "xyz"}',
+        }
+
+    def test_returns_empty_when_no_files(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert result == {}
+
+    def test_skips_empty_files(self, tmp_path: Path):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        (tmp_path / "claude_credentials.json").write_text("   \n  ")
+        loader = SecretLoader(SecretConfig(developer_secrets_path=str(secrets_file)))
+
+        result = loader.load_credential_files()
+
+        assert result == {}
+
+
 class TestBuildBundle:
     def test_combines_all_sources(self, tmp_path: Path, monkeypatch):
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("DEV_SECRET=dev_val\n")
+        (tmp_path / "claude_credentials.json").write_text('{"token": "abc"}')
         monkeypatch.setenv("GIT_TOKEN", "ghp_xyz")
         config = SecretConfig(
             developer_secrets_path=str(secrets_file),
@@ -52,7 +108,8 @@ class TestBuildBundle:
         bundle = loader.build_bundle(project_secrets={"PROJ_KEY": "proj_val"})
 
         assert isinstance(bundle, SecretBundle)
-        assert bundle.developer == {"DEV_SECRET": "dev_val"}
+        assert bundle.developer["DEV_SECRET"] == "dev_val"
+        assert bundle.developer["CLAUDE_CREDENTIALS_JSON"] == '{"token": "abc"}'
         assert bundle.project == {"PROJ_KEY": "proj_val"}
         assert bundle.infrastructure == {"GIT_TOKEN": "ghp_xyz"}
 

--- a/tests/unit/test_ssh_environment.py
+++ b/tests/unit/test_ssh_environment.py
@@ -754,8 +754,8 @@ class TestExecute:
         assert result.token_usage is None
         assert result.outcome == Outcome.SUCCESS
 
-    async def test_execute_injects_cli_auth(self, env_kit):
-        """execute() calls inject_cli_auth with the dispatch's cli/auth."""
+    async def test_execute_does_not_inject_cli_auth(self, env_kit):
+        """execute() does NOT inject CLI auth — all auth happens at provision."""
         env = env_kit["env"]
         conn = AsyncMock()
         conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
@@ -767,13 +767,11 @@ class TestExecute:
             patch(f"{_SSH_ENV}.assemble_prompt", return_value="prompt"),
             patch(f"{_SSH_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
             patch(f"{_SSH_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+            patch(f"{_SSH_ENV}.inject_all_cli_credentials", new_callable=AsyncMock) as mock_inject,
         ):
             await env.execute(handle, dispatch, config)
 
-        env_kit["workspace_mgr"].inject_cli_auth.assert_awaited_once()
-        call_args = env_kit["workspace_mgr"].inject_cli_auth.call_args
-        assert call_args[0][0] is conn  # connection
-        assert call_args[0][2] == (Cli.OPENCODE, dispatch.auth)  # cli_auth tuple
+        mock_inject.assert_not_awaited()
 
 
 class TestGetAccessInfo:
@@ -1019,6 +1017,59 @@ class TestProvisionWorkflowId:
 
         assert handle.runtime.kind == "remote"
         assert handle.runtime.workflow_id == "wf-myproj-42-1000"
+
+
+class TestAgentUser:
+    async def test_provision_passes_target_home(self, env_kit):
+        """provision() passes agent_user home as target_home to credential injection."""
+        env = env_kit["env"]
+        env._agent_user = "tanren"
+        dispatch = _make_dispatch()
+        config = env_kit["config"]
+
+        with (
+            patch.object(env, "_resolve_profile", return_value=_make_profile()),
+            patch.object(env, "_load_project_env", return_value={}),
+            patch.object(env, "_await_ssh_ready", new_callable=AsyncMock),
+            patch("tanren_core.adapters.ssh_environment.SSHConnection") as MockSSH,
+            patch(
+                "tanren_core.adapters.ssh_environment.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=["claude"],
+            ) as mock_inject,
+        ):
+            MockSSH.return_value = AsyncMock()
+            await env.provision(dispatch, config)
+
+        mock_inject.assert_awaited_once()
+        _, kwargs = mock_inject.call_args
+        assert kwargs["target_home"] == "/home/tanren"
+
+    async def test_teardown_uses_absolute_paths_for_credential_cleanup(self, env_kit):
+        """teardown() uses /home/tanren paths (not tilde) when agent_user is set."""
+        env = env_kit["env"]
+        env._agent_user = "tanren"
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(
+            exit_code=0,
+            stdout="",
+            stderr="",
+            timed_out=False,
+        )
+        vm_handle = _make_vm_handle()
+        workspace = _make_workspace()
+        handle = _make_handle(conn=conn, vm_handle=vm_handle, workspace=workspace)
+
+        await env.teardown(handle)
+
+        # Check that credential cleanup uses absolute paths
+        rm_calls = [
+            call.args[0] for call in conn.run.call_args_list if call.args[0].startswith("rm -f ")
+        ]
+        for rm_cmd in rm_calls:
+            path = rm_cmd.replace("rm -f ", "")
+            assert path.startswith("/home/tanren"), f"Expected absolute path, got: {path}"
+            assert "~" not in path
 
 
 class TestClose:

--- a/tests/unit/test_ssh_environment.py
+++ b/tests/unit/test_ssh_environment.py
@@ -1045,6 +1045,100 @@ class TestAgentUser:
         _, kwargs = mock_inject.call_args
         assert kwargs["target_home"] == "/home/tanren"
 
+    async def test_execute_wraps_push_with_su(self, env_kit):
+        """execute() wraps git push with su when agent_user is set."""
+        env = env_kit["env"]
+        env._agent_user = "tanren"
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = env_kit["config"]
+
+        env_kit["workspace_mgr"].push_command.return_value = "git push origin feature-1"
+
+        with (
+            patch(f"{_SSH_ENV}.assemble_prompt", return_value="prompt"),
+            patch(f"{_SSH_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_SSH_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            await env.execute(handle, dispatch, config)
+
+        push_calls = [c for c in conn.run.call_args_list if "git push" in str(c)]
+        assert len(push_calls) == 1
+        assert push_calls[0].args[0].startswith("su - tanren -c ")
+
+    async def test_execute_no_push_wrap_without_agent_user(self, env_kit):
+        """execute() does NOT wrap git push when agent_user is None."""
+        env = env_kit["env"]
+        assert env._agent_user is None
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = env_kit["config"]
+
+        env_kit["workspace_mgr"].push_command.return_value = "git push origin feature-1"
+
+        with (
+            patch(f"{_SSH_ENV}.assemble_prompt", return_value="prompt"),
+            patch(f"{_SSH_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_SSH_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            await env.execute(handle, dispatch, config)
+
+        push_calls = [c for c in conn.run.call_args_list if "git push" in str(c)]
+        assert len(push_calls) == 1
+        assert push_calls[0].args[0] == "git push origin feature-1"
+
+    async def test_teardown_wraps_commands_with_su(self, env_kit):
+        """teardown() wraps user teardown commands with su when agent_user is set."""
+        env = env_kit["env"]
+        env._agent_user = "tanren"
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        teardown_calls = [c for c in conn.run.call_args_list if "make clean" in str(c)]
+        assert len(teardown_calls) == 1
+        assert teardown_calls[0].args[0].startswith("su - tanren -c ")
+
+    async def test_teardown_no_wrap_without_agent_user(self, env_kit):
+        """teardown() does NOT wrap teardown commands when agent_user is None."""
+        env = env_kit["env"]
+        assert env._agent_user is None
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        teardown_calls = [c for c in conn.run.call_args_list if "make clean" in str(c)]
+        assert len(teardown_calls) == 1
+        assert teardown_calls[0].args[0] == "cd /workspace/myproj && make clean"
+
+    async def test_execute_passes_agent_user_to_ccusage_runner(self, env_kit):
+        """execute() passes agent_user as run_as_user to RemoteCommandRunner."""
+        env = env_kit["env"]
+        env._agent_user = "tanren"
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(cli=Cli.CLAUDE)
+        config = env_kit["config"]
+
+        with (
+            patch(f"{_SSH_ENV}.assemble_prompt", return_value="prompt"),
+            patch(f"{_SSH_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_SSH_ENV}.RemoteCommandRunner") as MockRunner,
+            patch(f"{_SSH_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            await env.execute(handle, dispatch, config)
+
+        MockRunner.assert_called_once_with(conn, run_as_user="tanren")
+
     async def test_teardown_uses_absolute_paths_for_credential_cleanup(self, env_kit):
         """teardown() uses /home/tanren paths (not tilde) when agent_user is set."""
         env = env_kit["env"]

--- a/tests/unit/test_ubuntu_bootstrap.py
+++ b/tests/unit/test_ubuntu_bootstrap.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from tanren_core.adapters.remote_types import RemoteResult
-from tanren_core.adapters.ubuntu_bootstrap import _MARKER_PATH, UbuntuBootstrapper  # noqa: PLC2701
+from tanren_core.adapters.ubuntu_bootstrap import (
+    _AGENT_USER,  # noqa: PLC2701
+    _MARKER_PATH,  # noqa: PLC2701
+    UbuntuBootstrapper,
+)
+from tanren_core.schemas import Cli
 
 
 def _ok(stdout: str = "") -> RemoteResult:
@@ -53,7 +58,7 @@ class TestFreshBootstrap:
     @pytest.mark.asyncio
     async def test_installs_all_tools_and_writes_marker(self):
         conn = _make_conn()
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE, Cli.OPENCODE}))
 
         result = await bs.bootstrap(conn)
 
@@ -72,7 +77,7 @@ class TestIdempotent:
     @pytest.mark.asyncio
     async def test_marker_exists_skips_all(self):
         conn = _make_conn(marker_exists=True)
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
 
         result = await bs.bootstrap(conn)
 
@@ -87,7 +92,7 @@ class TestSkipInstalledTools:
     @pytest.mark.asyncio
     async def test_already_installed_tools_are_skipped(self):
         conn = _make_conn(installed_tools=frozenset({"docker", "uv"}))
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE, Cli.OPENCODE}))
 
         result = await bs.bootstrap(conn)
 
@@ -104,7 +109,7 @@ class TestForceFlag:
     @pytest.mark.asyncio
     async def test_force_reruns_when_marker_exists(self):
         conn = _make_conn(marker_exists=True, installed_tools=frozenset({"docker"}))
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE, Cli.OPENCODE}))
 
         result = await bs.bootstrap(conn, force=True)
 
@@ -128,7 +133,7 @@ class TestStepFailure:
             return _ok()
 
         conn.run = AsyncMock(side_effect=_run)
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
 
         with pytest.raises(RuntimeError, match="apt install failed"):
             await bs.bootstrap(conn)
@@ -147,7 +152,7 @@ class TestStepFailure:
             return _ok()
 
         conn.run = AsyncMock(side_effect=_run)
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
 
         with pytest.raises(RuntimeError, match="Failed to install docker"):
             await bs.bootstrap(conn)
@@ -158,7 +163,7 @@ class TestExtraScript:
     async def test_extra_script_uploaded_and_executed(self):
         conn = _make_conn()
         script = "#!/bin/bash\necho hello"
-        bs = UbuntuBootstrapper(extra_script=script)
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}), extra_script=script)
 
         result = await bs.bootstrap(conn)
 
@@ -181,7 +186,10 @@ class TestExtraScript:
             return _ok()
 
         conn.run = AsyncMock(side_effect=_run)
-        bs = UbuntuBootstrapper(extra_script="#!/bin/bash\nexit 1")
+        bs = UbuntuBootstrapper(
+            required_clis=frozenset({Cli.CLAUDE}),
+            extra_script="#!/bin/bash\nexit 1",
+        )
 
         with pytest.raises(RuntimeError, match="Extra bootstrap script failed"):
             await bs.bootstrap(conn)
@@ -191,13 +199,105 @@ class TestIsBootstrapped:
     @pytest.mark.asyncio
     async def test_returns_true_when_marker_exists(self):
         conn = _make_conn(marker_exists=True)
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
 
         assert await bs.is_bootstrapped(conn) is True
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_marker(self):
         conn = _make_conn(marker_exists=False)
-        bs = UbuntuBootstrapper()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
 
         assert await bs.is_bootstrapped(conn) is False
+
+
+class TestCodexInstalled:
+    @pytest.mark.asyncio
+    async def test_codex_installed_when_configured(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CODEX}))
+
+        result = await bs.bootstrap(conn)
+
+        assert "codex" in result.installed
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert any("npm install -g @openai/codex" in c for c in run_cmds)
+
+    @pytest.mark.asyncio
+    async def test_codex_not_installed_when_not_configured(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        result = await bs.bootstrap(conn)
+
+        assert "codex" not in result.installed
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert not any("@openai/codex" in c for c in run_cmds)
+
+
+class TestCcusageAdaptsToConfiguredClis:
+    @pytest.mark.asyncio
+    async def test_ccusage_only_claude_packages(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        result = await bs.bootstrap(conn)
+
+        assert "ccusage" in result.installed
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        install_cmds = [c for c in run_cmds if "npm install -g" in c and "ccusage" in c]
+        assert len(install_cmds) == 1
+        assert "ccusage" in install_cmds[0]
+        assert "@ccusage/codex" not in install_cmds[0]
+
+    @pytest.mark.asyncio
+    async def test_ccusage_all_cli_packages(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE, Cli.CODEX, Cli.OPENCODE}))
+
+        result = await bs.bootstrap(conn)
+
+        assert "ccusage" in result.installed
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        install_cmds = [c for c in run_cmds if "npm install -g" in c and "ccusage" in c]
+        assert len(install_cmds) == 1
+        assert "ccusage" in install_cmds[0]
+        assert "@ccusage/codex" in install_cmds[0]
+        assert "@ccusage/opencode" in install_cmds[0]
+
+
+class TestAgentUserCreation:
+    @pytest.mark.asyncio
+    async def test_creates_tanren_user_and_chowns_workspace(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert any("useradd" in c and _AGENT_USER in c for c in run_cmds)
+        assert any(f"chown {_AGENT_USER}:{_AGENT_USER} /workspace" in c for c in run_cmds)
+
+
+class TestPlan:
+    def test_plan_returns_only_configured_clis(self):
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+        plan = bs.plan()
+
+        step_names = [s.name for s in plan.install_steps]
+        assert "claude" in step_names
+        assert "opencode" not in step_names
+        assert "codex" not in step_names
+        assert "ccusage" in step_names
+        # Infra always present
+        assert "docker" in step_names
+        assert "node" in step_names
+        assert "uv" in step_names
+
+    def test_plan_includes_codex_when_configured(self):
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE, Cli.CODEX}))
+        plan = bs.plan()
+
+        step_names = [s.name for s in plan.install_steps]
+        assert "claude" in step_names
+        assert "codex" in step_names

--- a/tests/unit/test_vm_cli.py
+++ b/tests/unit/test_vm_cli.py
@@ -11,6 +11,8 @@ from tanren_cli.vm_cli import vm
 from tanren_core.adapters.remote_types import VMAssignment
 from tanren_core.config import Config
 
+_ROLES_YML = "agents:\n  default:\n    cli: claude\n    model: sonnet\n    auth: subscription\n"
+
 
 def _mock_config(tmp_path=None) -> Config:
     base = str(tmp_path) if tmp_path else "/tmp"
@@ -177,6 +179,7 @@ class TestVmDryRun:
             "repos:\n"
             "  myproject: https://github.com/org/myproject.git\n"
         )
+        (tmp_path / "roles.yml").write_text(_ROLES_YML)
 
         config = Config(
             ipc_dir=str(tmp_path / "ipc"),
@@ -222,6 +225,7 @@ class TestVmDryRun:
             "    image: ubuntu-24.04\n"
             "    ssh_key_name: tanren\n"
         )
+        (tmp_path / "roles.yml").write_text(_ROLES_YML)
 
         config = Config(
             ipc_dir=str(tmp_path / "ipc"),
@@ -259,6 +263,7 @@ class TestVmDryRun:
             "secrets:\n"
             f"  developer_secrets_path: {secrets_file}\n"
         )
+        (tmp_path / "roles.yml").write_text(_ROLES_YML)
         monkeypatch.delenv("HCLOUD_TOKEN", raising=False)
 
         config = Config(


### PR DESCRIPTION
## Summary
- Extend `inject_cli_auth()` with `CLAUDE+SUBSCRIPTION` and `CODEX+SUBSCRIPTION` branches that upload credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) to remote VMs, mirroring the existing opencode pattern
- Add `SecretLoader.load_credential_files()` to read `claude_credentials.json` and `codex_auth.json` from the secrets directory into the bundle
- Refactor stale-auth cleanup into `_remove_stale_auth()` — each CLI branch clears the other two for stateless concurrent VM use
- Extend `cleanup()` to remove claude/codex auth files on teardown
- Fix 3 ccusage command-splitting sites: `str.split()` → `shlex.split()` so quoted paths with spaces are tokenized correctly

## Test plan
- [x] New unit tests for claude subscription injection (write, missing-key warning, cross-CLI cleanup)
- [x] New unit tests for codex subscription injection (write, missing-key warning, cross-CLI cleanup)
- [x] Updated existing tests for new cleanup call counts and stale-auth assertions
- [x] New test for shlex.split preserving quoted command paths
- [x] New tests for `load_credential_files()` (both files, one file, empty, missing)
- [x] `make check` passes (format, lint, type, 901 unit + 342 integration tests, docs)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)