### PR TITLE
feat: FastMCP server with service layer refactor

### DIFF
--- a/services/tanren-api/pyproject.toml
+++ b/services/tanren-api/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastapi>=0.128.0, <1",
     "uvicorn>=0.40.0, <1",
     "pydantic-settings>=2.0, <3",
+    "fastmcp>=2.14.5",
 ]
 
 [project.scripts]

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
+from typing import Any
 
 import uvicorn
 from fastapi import Depends, FastAPI
@@ -14,6 +15,8 @@ from starlette.middleware import Middleware
 
 from tanren_api.auth import verify_api_key
 from tanren_api.errors import TanrenAPIError, tanren_error_handler
+from tanren_api.mcp_auth import MCPApiKeyAuth
+from tanren_api.mcp_server import mcp, set_services
 from tanren_api.middleware import RequestIDMiddleware, RequestLoggingMiddleware
 from tanren_api.routers import config as config_router_mod
 from tanren_api.routers import dispatch as dispatch_router_mod
@@ -21,6 +24,14 @@ from tanren_api.routers import events as events_router_mod
 from tanren_api.routers import health as health_router_mod
 from tanren_api.routers import run as run_router_mod
 from tanren_api.routers import vm as vm_router_mod
+from tanren_api.services import (
+    ConfigService,
+    DispatchService,
+    EventsService,
+    HealthService,
+    RunService,
+    VMService,
+)
 from tanren_api.settings import APISettings
 from tanren_api.state import APIStateStore
 from tanren_core.adapters.null_emitter import NullEventEmitter
@@ -40,8 +51,11 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     settings = settings or APISettings()
 
     @asynccontextmanager
-    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async def lifespan(app: FastAPI) -> AsyncIterator[Mapping[str, Any] | None]:
         app.state.settings = settings
+
+        # Register MCP auth middleware
+        mcp.add_middleware(MCPApiKeyAuth(settings.api_key))
         load_config_env()
         try:
             app.state.config = Config.from_env()
@@ -79,6 +93,31 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
                     except Exception:
                         logger.warning("Failed to recover stale VM assignments", exc_info=True)
 
+        # Wire MCP service layer
+        config_svc = ConfigService(app.state.config) if app.state.config else None
+        set_services(
+            health=HealthService(),
+            dispatch=DispatchService(
+                store=app.state.api_store,
+                config=app.state.config,
+                emitter=app.state.emitter,
+                execution_env=app.state.execution_env,
+            ),
+            vm=VMService(
+                store=app.state.api_store,
+                config=app.state.config,
+                execution_env=app.state.execution_env,
+                vm_state_store=app.state.vm_state_store,
+            ),
+            run=RunService(
+                store=app.state.api_store,
+                config=app.state.config,
+                execution_env=app.state.execution_env,
+            ),
+            config=config_svc,
+            events=EventsService(settings, app.state.config),
+        )
+
         yield
 
         # Shutdown
@@ -103,13 +142,23 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
             )
         )
 
+    # Create MCP sub-application and combine lifespans
+    mcp_app = mcp.http_app(path="/")
+
+    from fastmcp.utilities.lifespan import combine_lifespans  # noqa: PLC0415
+
+    combined_lifespan = combine_lifespans(lifespan, mcp_app.lifespan)  # type: ignore[arg-type]
+
     app = FastAPI(
         title="tanren",
         description="Tanren worker-manager HTTP API",
         version="0.1.0",
-        lifespan=lifespan,
+        lifespan=combined_lifespan,
         middleware=middleware_stack,
     )
+
+    # Mount MCP sub-application
+    app.mount("/mcp", mcp_app)
 
     # Routers
     app.include_router(health_router_mod.router)

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -54,7 +54,8 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[Mapping[str, Any] | None]:
         app.state.settings = settings
 
-        # Register MCP auth middleware
+        # Register MCP auth middleware (clear any stale instances first)
+        mcp.middleware[:] = [m for m in mcp.middleware if not isinstance(m, MCPApiKeyAuth)]
         mcp.add_middleware(MCPApiKeyAuth(settings.api_key))
         load_config_env()
         try:

--- a/services/tanren-api/src/tanren_api/mcp_auth.py
+++ b/services/tanren-api/src/tanren_api/mcp_auth.py
@@ -1,0 +1,49 @@
+"""MCP authentication middleware — reuses APIKeyVerifier for API key validation."""
+# ruff: noqa: DOC201,DOC501,ANN401
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.server.dependencies import get_http_headers
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from tanren_api.auth import APIKeyVerifier
+from tanren_api.errors import AuthenticationError
+
+logger = logging.getLogger(__name__)
+
+# Tools that bypass authentication (matching REST health endpoints).
+_PUBLIC_TOOLS = frozenset({"health_check", "readiness_check"})
+
+
+class MCPApiKeyAuth(Middleware):
+    """FastMCP middleware that validates X-API-Key header on tool calls.
+
+    Health tools are exempt from auth, matching the REST API behaviour.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        """Initialize with the expected API key."""
+        self._verifier = APIKeyVerifier(api_key)
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next: Any) -> Any:
+        """Verify API key before executing a tool call."""
+        tool_name: str = context.message.name
+        if tool_name in _PUBLIC_TOOLS:
+            return await call_next(context)
+
+        headers = get_http_headers() or {}
+        api_key = headers.get("x-api-key", "")
+        try:
+            await self._verifier.verify(api_key)
+        except AuthenticationError:
+            from mcp import McpError  # noqa: PLC0415
+            from mcp.types import ErrorData  # noqa: PLC0415
+
+            raise McpError(
+                error=ErrorData(code=-32001, message="Invalid or missing API key")
+            ) from None
+
+        return await call_next(context)

--- a/services/tanren-api/src/tanren_api/mcp_server.py
+++ b/services/tanren-api/src/tanren_api/mcp_server.py
@@ -1,0 +1,423 @@
+"""MCP server — exposes tanren-api capabilities as MCP tools for LLM agents.
+
+Tools are organized by domain: health, dispatch, VM, run, config, events.
+Prefer ``dispatch_create`` for fire-and-forget jobs and ``run_full`` for
+end-to-end lifecycle management.  Use the granular run_* tools only when
+you need step-by-step control over provision → execute → teardown.
+"""
+# ruff: noqa: DOC201,ANN401,ASYNC109
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from tanren_api.services import (
+        ConfigService,
+        DispatchService,
+        EventsService,
+        HealthService,
+        RunService,
+        VMService,
+    )
+
+mcp = FastMCP("tanren")
+
+
+# ---------------------------------------------------------------------------
+# Service accessors — set during lifespan via set_services()
+# ---------------------------------------------------------------------------
+
+_health_svc: HealthService | None = None
+_dispatch_svc: DispatchService | None = None
+_vm_svc: VMService | None = None
+_run_svc: RunService | None = None
+_config_svc: ConfigService | None = None
+_events_svc: EventsService | None = None
+
+
+def set_services(
+    *,
+    health: HealthService,
+    dispatch: DispatchService,
+    vm: VMService,
+    run: RunService,
+    config: ConfigService | None = None,
+    events: EventsService,
+) -> None:
+    """Wire service instances into the MCP tool layer (called during app lifespan)."""
+    global _health_svc, _dispatch_svc, _vm_svc, _run_svc, _config_svc, _events_svc
+    _health_svc = health
+    _dispatch_svc = dispatch
+    _vm_svc = vm
+    _run_svc = run
+    _config_svc = config
+    _events_svc = events
+
+
+def _model_dump(obj: Any) -> dict[str, Any]:
+    """Serialize a Pydantic model to dict (JSON-safe)."""
+    return obj.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Health tools (no auth required)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Check whether the tanren API service is running and healthy. "
+        "Returns service status, version, and uptime. No authentication required."
+    ),
+)
+async def health_check() -> dict[str, Any]:
+    """Check service health."""
+    assert _health_svc is not None
+    return _model_dump(await _health_svc.health())
+
+
+@mcp.tool(
+    description=(
+        "Check whether the tanren API is ready to accept requests. "
+        "Returns readiness status. No authentication required."
+    ),
+)
+async def readiness_check() -> dict[str, Any]:
+    """Check service readiness."""
+    assert _health_svc is not None
+    return _model_dump(await _health_svc.readiness())
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Submit a new dispatch — a request to run a coding agent against a "
+        "project spec. Returns a dispatch_id for status polling via "
+        "dispatch_get_status. The dispatch is executed asynchronously.\n\n"
+        "Required fields: project, phase, branch, spec_folder, cli.\n"
+        "Phases: do-task, review, gate, sweep.\n"
+        "CLIs: claude, codex, opencode."
+    ),
+)
+async def dispatch_create(
+    project: str,
+    phase: str,
+    branch: str,
+    spec_folder: str,
+    cli: str,
+    model: str | None = None,
+    timeout: int = 1800,
+    context: str | None = None,
+    gate_cmd: str | None = None,
+    issue: int = 0,
+) -> dict[str, Any]:
+    """Create a new dispatch."""
+    from tanren_api.models import DispatchRequest  # noqa: PLC0415
+
+    assert _dispatch_svc is not None
+    body = DispatchRequest(
+        project=project,
+        phase=phase,  # type: ignore[arg-type]
+        branch=branch,
+        spec_folder=spec_folder,
+        cli=cli,  # type: ignore[arg-type]
+        model=model,
+        timeout=timeout,
+        context=context,
+        gate_cmd=gate_cmd,
+        issue=issue,
+    )
+    return _model_dump(await _dispatch_svc.create(body))
+
+
+@mcp.tool(
+    description=(
+        "Get the current status of a dispatch by its workflow ID. "
+        "Returns phase, project, status (pending/running/completed/failed/cancelled), "
+        "outcome, and timestamps."
+    ),
+)
+async def dispatch_get_status(dispatch_id: str) -> dict[str, Any]:
+    """Get dispatch status."""
+    assert _dispatch_svc is not None
+    return _model_dump(await _dispatch_svc.get(dispatch_id))
+
+
+@mcp.tool(
+    description=(
+        "Cancel a pending or running dispatch. Returns confirmation or "
+        "an error if the dispatch is already in a terminal state."
+    ),
+)
+async def dispatch_cancel(dispatch_id: str) -> dict[str, Any]:
+    """Cancel a dispatch."""
+    assert _dispatch_svc is not None
+    return _model_dump(await _dispatch_svc.cancel(dispatch_id))
+
+
+# ---------------------------------------------------------------------------
+# VM tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "List all active VM assignments. Returns vm_id, host, provider, "
+        "associated workflow, project, and status for each VM."
+    ),
+)
+async def vm_list() -> list[dict[str, Any]]:
+    """List active VMs."""
+    assert _vm_svc is not None
+    return [_model_dump(vm) for vm in await _vm_svc.list_vms()]
+
+
+@mcp.tool(
+    description=(
+        "Start provisioning a new VM (non-blocking). Returns an env_id "
+        "for polling via vm_provision_status. Use when you need a VM "
+        "without immediately running a dispatch against it."
+    ),
+)
+async def vm_provision(
+    project: str,
+    branch: str,
+    environment_profile: str = "default",
+) -> dict[str, Any]:
+    """Provision a VM."""
+    from tanren_api.models import ProvisionRequest  # noqa: PLC0415
+
+    assert _vm_svc is not None
+    body = ProvisionRequest(project=project, branch=branch, environment_profile=environment_profile)
+    return _model_dump(await _vm_svc.provision(body))
+
+
+@mcp.tool(
+    description=(
+        "Poll the status of a VM provisioning request. Returns status "
+        "(provisioning/active/failed), vm_id, and host once ready."
+    ),
+)
+async def vm_provision_status(env_id: str) -> dict[str, Any]:
+    """Get VM provision status."""
+    assert _vm_svc is not None
+    return _model_dump(await _vm_svc.get_provision_status(env_id))
+
+
+@mcp.tool(
+    description="Release a VM by its vm_id. Destroys the VM and frees resources.",
+)
+async def vm_release(vm_id: str) -> dict[str, Any]:
+    """Release a VM."""
+    assert _vm_svc is not None
+    return _model_dump(await _vm_svc.release(vm_id))
+
+
+@mcp.tool(
+    description=(
+        "Dry-run a VM provision — shows what provider and server type would "
+        "be used without actually creating resources. Useful for cost estimation."
+    ),
+)
+async def vm_dry_run(
+    project: str,
+    branch: str,
+    environment_profile: str = "default",
+) -> dict[str, Any]:
+    """Dry-run VM provision."""
+    from tanren_api.models import ProvisionRequest  # noqa: PLC0415
+
+    assert _vm_svc is not None
+    body = ProvisionRequest(project=project, branch=branch, environment_profile=environment_profile)
+    return _model_dump(await _vm_svc.dry_run(body))
+
+
+# ---------------------------------------------------------------------------
+# Run tools — granular lifecycle management
+#
+# TIP: For most use cases, prefer ``run_full`` which handles the entire
+# provision → execute → teardown lifecycle automatically. Use the individual
+# run_provision / run_execute / run_teardown tools only when you need
+# fine-grained control (e.g., running multiple phases on the same VM).
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Provision a run environment (non-blocking). Returns env_id for "
+        "polling via run_status. After provisioning completes, use "
+        "run_execute to run phases against the environment, then "
+        "run_teardown to release resources.\n\n"
+        "TIP: For simple cases, use run_full instead — it handles "
+        "provision + execute + teardown automatically."
+    ),
+)
+async def run_provision(
+    project: str,
+    branch: str,
+    environment_profile: str = "default",
+) -> dict[str, Any]:
+    """Provision a run environment."""
+    from tanren_api.models import ProvisionRequest  # noqa: PLC0415
+
+    assert _run_svc is not None
+    body = ProvisionRequest(project=project, branch=branch, environment_profile=environment_profile)
+    return _model_dump(await _run_svc.provision(body))
+
+
+@mcp.tool(
+    description=(
+        "Execute a phase against an already-provisioned environment. "
+        "The environment must be in 'provisioned' or 'completed' status. "
+        "Returns a dispatch_id for tracking."
+    ),
+)
+async def run_execute(
+    env_id: str,
+    project: str,
+    spec_path: str,
+    phase: str,
+    cli: str,
+    auth: str = "api-key",
+    model: str | None = None,
+    timeout: int = 1800,
+    context: str | None = None,
+    gate_cmd: str | None = None,
+) -> dict[str, Any]:
+    """Execute a phase on a provisioned environment."""
+    from tanren_api.models import ExecuteRequest  # noqa: PLC0415
+
+    assert _run_svc is not None
+    body = ExecuteRequest(
+        project=project,
+        spec_path=spec_path,
+        phase=phase,  # type: ignore[arg-type]
+        cli=cli,  # type: ignore[arg-type]
+        auth=auth,  # type: ignore[arg-type]
+        model=model,
+        timeout=timeout,
+        context=context,
+        gate_cmd=gate_cmd,
+    )
+    return _model_dump(await _run_svc.execute(env_id, body))
+
+
+@mcp.tool(
+    description=(
+        "Teardown a provisioned environment, releasing the backing VM. "
+        "Call this after you are done executing phases. Safe to call "
+        "in any environment state."
+    ),
+)
+async def run_teardown(env_id: str) -> dict[str, Any]:
+    """Teardown a run environment."""
+    assert _run_svc is not None
+    return _model_dump(await _run_svc.teardown(env_id))
+
+
+@mcp.tool(
+    description=(
+        "Run a full lifecycle: provision a VM, execute a phase, then "
+        "teardown — all in one call. This is the recommended tool for "
+        "most use cases. Returns a dispatch_id for status polling via "
+        "dispatch_get_status.\n\n"
+        "Required fields: project, branch, spec_path, phase, cli, auth."
+    ),
+)
+async def run_full(
+    project: str,
+    branch: str,
+    spec_path: str,
+    phase: str,
+    cli: str,
+    auth: str = "api-key",
+    environment_profile: str = "default",
+    timeout: int = 1800,
+    context: str | None = None,
+    gate_cmd: str | None = None,
+) -> dict[str, Any]:
+    """Run full lifecycle (provision + execute + teardown)."""
+    from tanren_api.models import RunFullRequest  # noqa: PLC0415
+
+    assert _run_svc is not None
+    body = RunFullRequest(
+        project=project,
+        branch=branch,
+        spec_path=spec_path,
+        phase=phase,  # type: ignore[arg-type]
+        cli=cli,  # type: ignore[arg-type]
+        auth=auth,  # type: ignore[arg-type]
+        environment_profile=environment_profile,
+        timeout=timeout,
+        context=context,
+        gate_cmd=gate_cmd,
+    )
+    return _model_dump(await _run_svc.full(body))
+
+
+@mcp.tool(
+    description=(
+        "Poll the status of a run environment. Returns status "
+        "(provisioning/provisioned/executing/completed/failed), "
+        "current phase, outcome, and duration."
+    ),
+)
+async def run_status(env_id: str) -> dict[str, Any]:
+    """Get run environment status."""
+    assert _run_svc is not None
+    return _model_dump(await _run_svc.status(env_id))
+
+
+# ---------------------------------------------------------------------------
+# Config tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Get the current tanren configuration (non-secret fields only). "
+        "Shows IPC directory, poll intervals, concurrency limits, and "
+        "whether events and remote execution are enabled."
+    ),
+)
+async def config_get() -> dict[str, Any]:
+    """Get non-secret configuration."""
+    if _config_svc is None:
+        return {"error": "Configuration unavailable — WM_* environment variables not set"}
+    return _model_dump(await _config_svc.get())
+
+
+# ---------------------------------------------------------------------------
+# Events tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Query structured events with optional filters. Returns paginated "
+        "typed event records (dispatch received, phase started/completed, "
+        "VM provisioned/released, errors, retries, token usage, etc.)."
+    ),
+)
+async def events_query(
+    workflow_id: str | None = None,
+    event_type: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Query events."""
+    assert _events_svc is not None
+    result = await _events_svc.query(
+        workflow_id=workflow_id,
+        event_type=event_type,
+        limit=limit,
+        offset=offset,
+    )
+    return _model_dump(result)

--- a/services/tanren-api/src/tanren_api/mcp_server.py
+++ b/services/tanren-api/src/tanren_api/mcp_server.py
@@ -285,7 +285,7 @@ async def run_execute(
     spec_path: str,
     phase: str,
     cli: str,
-    auth: str = "api-key",
+    auth: str = "api_key",
     model: str | None = None,
     timeout: int = 1800,
     context: str | None = None,
@@ -337,7 +337,7 @@ async def run_full(
     spec_path: str,
     phase: str,
     cli: str,
-    auth: str = "api-key",
+    auth: str = "api_key",
     environment_profile: str = "default",
     timeout: int = 1800,
     context: str | None = None,
@@ -414,6 +414,8 @@ async def events_query(
 ) -> dict[str, Any]:
     """Query events."""
     assert _events_svc is not None
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
     result = await _events_svc.query(
         workflow_id=workflow_id,
         event_type=event_type,

--- a/services/tanren-api/src/tanren_api/routers/config.py
+++ b/services/tanren-api/src/tanren_api/routers/config.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends
 
 from tanren_api.dependencies import get_config
 from tanren_api.models import ConfigResponse
+from tanren_api.services import ConfigService
 from tanren_core.config import Config
 
 router = APIRouter(tags=["config"])
@@ -16,14 +17,4 @@ async def get_configuration(
     config: Annotated[Config, Depends(get_config)],
 ) -> ConfigResponse:
     """Return non-secret config fields."""
-    return ConfigResponse(
-        ipc_dir=config.ipc_dir,
-        github_dir=config.github_dir,
-        poll_interval=config.poll_interval,
-        heartbeat_interval=config.heartbeat_interval,
-        max_opencode=config.max_opencode,
-        max_codex=config.max_codex,
-        max_gate=config.max_gate,
-        events_enabled=config.events_db is not None,
-        remote_enabled=config.remote_config_path is not None,
-    )
+    return await ConfigService(config).get()

--- a/services/tanren-api/src/tanren_api/routers/dispatch.py
+++ b/services/tanren-api/src/tanren_api/routers/dispatch.py
@@ -1,150 +1,26 @@
 """Dispatch endpoints — accept, query, and cancel dispatch requests."""
-# ruff: noqa: DOC201,DOC501
+# ruff: noqa: DOC201
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import logging
-import time
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from fastapi import Path as PathParam
 
 from tanren_api.dependencies import get_api_store, get_config, get_emitter, get_execution_env
-from tanren_api.errors import ConflictError, NotFoundError
 from tanren_api.models import (
     DispatchAccepted,
     DispatchCancelled,
     DispatchDetail,
     DispatchRequest,
-    DispatchRunStatus,
 )
-from tanren_api.state import APIStateStore, DispatchRecord
-from tanren_core.adapters.events import DispatchReceived
+from tanren_api.services import DispatchService
+from tanren_api.state import APIStateStore
 from tanren_core.adapters.protocols import EventEmitter, ExecutionEnvironment
 from tanren_core.config import Config
-from tanren_core.ipc import atomic_write, generate_filename
-from tanren_core.schemas import Dispatch, Outcome, Result
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["dispatch"])
-
-_COMPLETED_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
-
-
-def _status_for_outcome(outcome: Outcome) -> DispatchRunStatus:
-    """Map execution outcome to terminal dispatch status."""
-    if outcome in _COMPLETED_OUTCOMES:
-        return DispatchRunStatus.COMPLETED
-    return DispatchRunStatus.FAILED
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-async def _check_daemon_result(
-    config: Config, workflow_id: str, store: APIStateStore, created_at: str
-) -> None:
-    """Scan IPC results directory for a daemon-produced result matching workflow_id."""
-    results_dir = Path(config.ipc_dir) / "results"
-    if not results_dir.exists():
-        return
-
-    # Parse created_at to millisecond timestamp for filename filtering
-    try:
-        created_dt = datetime.fromisoformat(created_at)
-        created_ms = int(created_dt.timestamp() * 1000)
-    except ValueError, TypeError:
-        created_ms = 0
-
-    def _scan() -> Result | None:
-        entries = sorted(results_dir.iterdir(), reverse=True)
-        for entry in entries:
-            if entry.suffix != ".json":
-                continue
-            # Skip files older than dispatch creation
-            stem = entry.stem.split("-")[0]
-            try:
-                file_ts = int(stem)
-                if file_ts < created_ms:
-                    break  # Sorted newest-first — all remaining are older
-            except ValueError, IndexError:
-                pass
-            try:
-                content = entry.read_text()
-                result = Result.model_validate_json(content)
-                if result.workflow_id == workflow_id:
-                    return result
-            except Exception:
-                continue
-        return None
-
-    result = await asyncio.to_thread(_scan)
-    if result is None:
-        return
-
-    await store.update_dispatch(
-        workflow_id,
-        status=_status_for_outcome(result.outcome),
-        outcome=result.outcome,
-        completed_at=_now(),
-    )
-
-
-async def _dispatch_background(
-    dispatch: Dispatch,
-    dispatch_id: str,
-    execution_env: ExecutionEnvironment,
-    config: Config,
-    store: APIStateStore,
-) -> None:
-    """Background task: provision -> execute -> teardown."""
-    transitioned = await store.try_transition_dispatch(
-        dispatch_id,
-        from_statuses=frozenset({DispatchRunStatus.PENDING}),
-        to_status=DispatchRunStatus.RUNNING,
-        started_at=_now(),
-    )
-    if transitioned is None:
-        return  # Cancelled (or otherwise transitioned) before we started
-    handle = None
-    try:
-        handle = await execution_env.provision(dispatch, config)
-        result = await execution_env.execute(handle, dispatch, config)
-        await store.try_transition_dispatch(
-            dispatch_id,
-            from_statuses=frozenset({DispatchRunStatus.RUNNING}),
-            to_status=_status_for_outcome(result.outcome),
-            outcome=result.outcome,
-            completed_at=_now(),
-        )
-    except asyncio.CancelledError:
-        logger.info("Dispatch %s cancelled", dispatch_id)
-        raise
-    except Exception:
-        logger.exception("Dispatch %s failed", dispatch_id)
-        await store.try_transition_dispatch(
-            dispatch_id,
-            from_statuses=frozenset({DispatchRunStatus.RUNNING}),
-            to_status=DispatchRunStatus.FAILED,
-            outcome=Outcome.ERROR,
-            completed_at=_now(),
-        )
-    finally:
-        if handle is not None:
-            inner = asyncio.ensure_future(execution_env.teardown(handle))
-            try:
-                await asyncio.shield(inner)
-            except asyncio.CancelledError, Exception:
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await inner
-                logger.warning("Teardown failed for dispatch %s", dispatch_id)
 
 
 @router.post("/dispatch")
@@ -156,61 +32,7 @@ async def create_dispatch(
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
 ) -> DispatchAccepted:
     """Accept a new dispatch request."""
-    epoch = time.time_ns()
-    issue = body.issue if body.issue != 0 else epoch
-    workflow_id = f"wf-{body.project}-{issue}-{epoch}"
-
-    dispatch = Dispatch(
-        workflow_id=workflow_id,
-        project=body.project,
-        phase=body.phase,
-        branch=body.branch,
-        spec_folder=body.spec_folder,
-        cli=body.cli,
-        auth=body.auth,
-        model=body.model,
-        timeout=body.timeout,
-        environment_profile=body.environment_profile,
-        context=body.context,
-        gate_cmd=body.gate_cmd,
-    )
-
-    # Write dispatch to IPC only when delegating to daemon (no local execution env)
-    dispatch_path = None
-    if execution_env is None:
-        dispatch_dir = Path(config.ipc_dir) / "dispatch"
-        dispatch_dir.mkdir(parents=True, exist_ok=True)
-        dispatch_path = dispatch_dir / generate_filename()
-        await atomic_write(dispatch_path, dispatch.model_dump_json(indent=2))
-
-    # Register in state store
-    record = DispatchRecord(
-        dispatch_id=workflow_id,
-        dispatch=dispatch,
-        status=DispatchRunStatus.PENDING,
-        created_at=_now(),
-    )
-    record.dispatch_path = dispatch_path
-    await store.add_dispatch(record)
-
-    # Launch background task if execution env available
-    if execution_env is not None:
-        # Emit event — daemon-delegated dispatches emit on pickup instead
-        await emitter.emit(
-            DispatchReceived(
-                timestamp=_now(),
-                workflow_id=workflow_id,
-                phase=body.phase.value,
-                project=body.project,
-                cli=body.cli.value,
-            )
-        )
-        task = asyncio.create_task(
-            _dispatch_background(dispatch, workflow_id, execution_env, config, store)
-        )
-        await store.update_dispatch(workflow_id, task=task)
-
-    return DispatchAccepted(dispatch_id=workflow_id)
+    return await DispatchService(store, config, emitter, execution_env).create(body)
 
 
 @router.get("/dispatch/{dispatch_id}")
@@ -220,41 +42,7 @@ async def get_dispatch(
     config: Annotated[Config, Depends(get_config)],
 ) -> DispatchDetail:
     """Query dispatch status by workflow ID."""
-    record = await store.get_dispatch(dispatch_id)
-    if record is None:
-        raise NotFoundError(f"Dispatch {dispatch_id} not found")
-
-    # Lazy-check daemon results for IPC-delegated dispatches still pending
-    if (
-        record.status == DispatchRunStatus.PENDING
-        and record.dispatch_path is not None
-        and record.task is None
-    ):
-        await _check_daemon_result(config, dispatch_id, store, record.created_at)
-        record = await store.get_dispatch(dispatch_id)
-        if record is None:
-            raise NotFoundError(f"Dispatch {dispatch_id} not found")
-
-    d = record.dispatch
-    return DispatchDetail(
-        workflow_id=d.workflow_id,
-        phase=d.phase,
-        project=d.project,
-        spec_folder=d.spec_folder,
-        branch=d.branch,
-        cli=d.cli,
-        auth=d.auth,
-        model=d.model,
-        timeout=d.timeout,
-        environment_profile=d.environment_profile,
-        context=d.context,
-        gate_cmd=d.gate_cmd,
-        status=record.status,
-        outcome=record.outcome,
-        created_at=record.created_at,
-        started_at=record.started_at,
-        completed_at=record.completed_at,
-    )
+    return await DispatchService(store, config).get(dispatch_id)
 
 
 @router.delete("/dispatch/{dispatch_id}")
@@ -263,56 +51,4 @@ async def cancel_dispatch(
     store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> DispatchCancelled:
     """Cancel a pending dispatch."""
-    record = await store.get_dispatch(dispatch_id)
-    if record is None:
-        raise NotFoundError(f"Dispatch {dispatch_id} not found")
-
-    if record.status in (
-        DispatchRunStatus.COMPLETED,
-        DispatchRunStatus.FAILED,
-        DispatchRunStatus.CANCELLED,
-    ):
-        raise ConflictError(f"Dispatch {dispatch_id} is already {record.status}")
-
-    if record.status == DispatchRunStatus.PENDING:
-        # For daemon-delegated: reclaim IPC file before marking cancelled.
-        # If the daemon already picked it up (deleted), we cannot cancel.
-        # Narrow race: daemon may have read but not yet deleted — microseconds
-        # between scan and delete in the poll loop, acceptable.
-        if record.dispatch_path is not None and record.task is None:
-            try:
-                record.dispatch_path.unlink()
-            except FileNotFoundError:
-                raise ConflictError(
-                    f"Dispatch {dispatch_id} has been picked up by the daemon "
-                    "and cannot be cancelled"
-                ) from None
-            except OSError:
-                raise ConflictError(
-                    f"Dispatch {dispatch_id} could not be cancelled: "
-                    "failed to remove dispatch file. Please retry."
-                ) from None
-        transitioned = await store.try_transition_dispatch(
-            dispatch_id,
-            from_statuses=frozenset({DispatchRunStatus.PENDING}),
-            to_status=DispatchRunStatus.CANCELLED,
-            completed_at=_now(),
-        )
-        if transitioned is None:
-            raise ConflictError(f"Dispatch {dispatch_id} status has changed; cannot cancel")
-        if record.task is not None and not record.task.done():
-            record.task.cancel()
-    elif record.status == DispatchRunStatus.RUNNING:
-        logger.warning("Cancelling running dispatch %s — best effort", dispatch_id)
-        transitioned = await store.try_transition_dispatch(
-            dispatch_id,
-            from_statuses=frozenset({DispatchRunStatus.RUNNING}),
-            to_status=DispatchRunStatus.CANCELLED,
-            completed_at=_now(),
-        )
-        if transitioned is None:
-            raise ConflictError(f"Dispatch {dispatch_id} status has changed; cannot cancel")
-        if record.task is not None and not record.task.done():
-            record.task.cancel()
-
-    return DispatchCancelled(dispatch_id=dispatch_id)
+    return await DispatchService(store).cancel(dispatch_id)

--- a/services/tanren-api/src/tanren_api/routers/events.py
+++ b/services/tanren-api/src/tanren_api/routers/events.py
@@ -3,22 +3,16 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import TypeAdapter
 
 from tanren_api.dependencies import get_settings
-from tanren_api.models import EventPayload, PaginatedEvents
+from tanren_api.models import PaginatedEvents
+from tanren_api.services import EventsService
 from tanren_api.settings import APISettings
-from tanren_core.adapters.event_reader import query_events
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["events"])
-
-_event_adapter = TypeAdapter(EventPayload)
 
 
 @router.get("/events")
@@ -31,41 +25,10 @@ async def list_events(
     offset: Annotated[int, Query(ge=0, description="Pagination offset")] = 0,
 ) -> PaginatedEvents:
     """Query structured events with optional filters."""
-    # Determine DB path — settings first, then config fallback
-    db_path = settings.events_db
-    if db_path is None:
-        config = getattr(request.app.state, "config", None)
-        if config is not None:
-            db_path = config.events_db
-
-    if not db_path:
-        return PaginatedEvents(events=[], total=0, limit=limit, offset=offset)
-
-    result = await query_events(
-        db_path,
+    config = getattr(request.app.state, "config", None)
+    return await EventsService(settings, config).query(
         workflow_id=workflow_id,
         event_type=event_type,
         limit=limit,
         offset=offset,
-    )
-
-    # Parse payloads into typed events
-    events = []
-    skipped = 0
-    for row in result.events:
-        try:
-            event = _event_adapter.validate_python(row.payload)
-            events.append(event)
-        except Exception:
-            skipped += 1
-            logger.warning(
-                "Skipping unparseable event %d: %s", row.id, row.event_type, exc_info=True
-            )
-
-    return PaginatedEvents(
-        events=events,
-        total=result.total,
-        limit=limit,
-        offset=offset,
-        skipped=skipped + result.skipped,
     )

--- a/services/tanren-api/src/tanren_api/routers/health.py
+++ b/services/tanren-api/src/tanren_api/routers/health.py
@@ -1,31 +1,23 @@
 """Health check endpoints — no auth required."""
+# ruff: noqa: DOC201
 
-import time
-
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 
 from tanren_api.models import HealthResponse, ReadinessResponse
+from tanren_api.services import HealthService
 
 router = APIRouter(tags=["health"])
 
-_start_time = time.monotonic()
+_svc = HealthService()
 
 
 @router.get("/api/v1/health")
-async def health(request: Request) -> HealthResponse:
+async def health() -> HealthResponse:
     """Return service health and version info."""
-    return HealthResponse(
-        status="ok",
-        version="0.1.0",
-        uptime_seconds=round(time.monotonic() - _start_time, 2),
-    )
+    return await _svc.health()
 
 
 @router.get("/api/v1/health/ready")
-async def readiness(request: Request) -> ReadinessResponse:
-    """Readiness probe.
-
-    Returns:
-        ReadinessResponse with status key indicating readiness.
-    """
-    return ReadinessResponse(status="ready")
+async def readiness() -> ReadinessResponse:
+    """Readiness probe."""
+    return await _svc.readiness()

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -1,60 +1,37 @@
 """Run lifecycle endpoints — provision, execute, teardown, full."""
-# ruff: noqa: DOC201,DOC501
+# ruff: noqa: DOC201
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import logging
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path
 
 from tanren_api.dependencies import get_api_store, get_config, get_execution_env
-from tanren_api.errors import ConflictError, NotFoundError, ServiceError
 from tanren_api.models import (
     DispatchAccepted,
-    DispatchRunStatus,
     ExecuteRequest,
     ProvisionRequest,
     RunEnvironment,
-    RunEnvironmentStatus,
     RunExecuteAccepted,
     RunFullRequest,
     RunStatus,
     RunTeardownAccepted,
 )
-from tanren_api.state import APIStateStore, DispatchRecord, EnvironmentRecord
+from tanren_api.services import RunService
+from tanren_api.state import APIStateStore
 from tanren_core.adapters.protocols import ExecutionEnvironment
-from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
-from tanren_core.roles import RoleName
-from tanren_core.roles_config import load_roles_config
-from tanren_core.schemas import Dispatch, Outcome, Phase
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["run"])
 
-_EXECUTE_FROM = frozenset({RunEnvironmentStatus.PROVISIONED, RunEnvironmentStatus.COMPLETED})
-_TEARDOWN_FROM = frozenset({
-    RunEnvironmentStatus.PROVISIONING,
-    RunEnvironmentStatus.PROVISIONED,
-    RunEnvironmentStatus.EXECUTING,
-    RunEnvironmentStatus.COMPLETED,
-    RunEnvironmentStatus.FAILED,
-})
 
-_PRIOR_TASK_TIMEOUT: float = 30.0
-
-_COMPLETED_DISPATCH_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
-_COMPLETED_ENV_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
+def _run_service(
+    store: APIStateStore,
+    config: Config | None = None,
+    execution_env: ExecutionEnvironment | None = None,
+) -> RunService:
+    return RunService(store, config, execution_env)
 
 
 @router.post("/run/provision")
@@ -64,87 +41,8 @@ async def run_provision(
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
 ) -> RunEnvironment:
-    """Provision a remote execution environment (non-blocking).
-
-    Returns immediately with status=provisioning. Poll GET /run/{env_id}/status
-    for progress.
-    """
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    env_id = str(uuid.uuid4())
-
-    roles = load_roles_config(config.roles_config_path)
-    resolved_tool = roles.resolve(RoleName.DEFAULT)
-
-    dispatch = Dispatch(
-        workflow_id=f"run-{uuid.uuid4().hex[:8]}",
-        project=body.project,
-        phase=Phase.DO_TASK,
-        branch=body.branch,
-        spec_folder="",
-        cli=resolved_tool.cli,
-        auth=resolved_tool.auth,
-        timeout=1800,
-        environment_profile=body.environment_profile,
-    )
-
-    record = EnvironmentRecord(
-        env_id=env_id,
-        handle=None,
-        status=RunEnvironmentStatus.PROVISIONING,
-        started_at=_now(),
-    )
-    await store.add_environment(record)
-
-    async def _provision_background() -> None:
-        handle: EnvironmentHandle | None = None
-        try:
-            handle = await execution_env.provision(dispatch, config)
-            runtime = handle.runtime
-            if not isinstance(runtime, RemoteEnvironmentRuntime):
-                raise ServiceError("Provisioned environment is not a remote runtime")
-            updated = await store.try_transition_environment(
-                env_id,
-                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
-                to_status=RunEnvironmentStatus.PROVISIONED,
-                handle=handle,
-                vm_id=runtime.vm_handle.vm_id,
-                host=runtime.vm_handle.host,
-            )
-            if updated is not None:
-                handle = None  # Persisted — suppress finally cleanup
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            handle = None  # Error handler owns cleanup
-            logger.exception("Provision failed for %s", env_id)
-            await store.try_transition_environment(
-                env_id,
-                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
-                to_status=RunEnvironmentStatus.FAILED,
-                outcome=Outcome.ERROR,
-                completed_at=_now(),
-            )
-        finally:
-            if handle is not None:
-                logger.warning("Cleaning up orphaned provision for %s", env_id)
-                inner = asyncio.ensure_future(execution_env.teardown(handle))
-                try:
-                    await asyncio.shield(inner)
-                except asyncio.CancelledError, Exception:
-                    with contextlib.suppress(asyncio.CancelledError, Exception):
-                        await inner
-
-    task = asyncio.create_task(_provision_background())
-    await store.update_environment(env_id, task=task)
-
-    return RunEnvironment(
-        env_id=env_id,
-        vm_id="",
-        host="",
-        status=RunEnvironmentStatus.PROVISIONING,
-    )
+    """Provision a remote execution environment (non-blocking)."""
+    return await _run_service(store, config, execution_env).provision(body)
 
 
 @router.post("/run/{env_id}/execute")
@@ -156,88 +54,7 @@ async def run_execute(
     config: Annotated[Config, Depends(get_config)],
 ) -> RunExecuteAccepted:
     """Execute a phase against a provisioned environment."""
-    record = await store.get_environment(env_id)
-    if record is None:
-        raise NotFoundError(f"Environment {env_id} not found")
-
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    if record.handle is None:
-        raise ConflictError(f"Environment {env_id} is still provisioning")
-
-    if body.project != record.handle.project:
-        raise ConflictError(
-            f"Project mismatch: environment provisioned for '{record.handle.project}', "
-            f"request specifies '{body.project}'"
-        )
-
-    dispatch_id = f"exec-{uuid.uuid4().hex[:8]}"
-
-    dispatch = Dispatch(
-        workflow_id=dispatch_id,
-        project=body.project,
-        phase=body.phase,
-        branch=record.handle.branch,
-        spec_folder=body.spec_path,
-        cli=body.cli,
-        auth=body.auth,
-        model=body.model,
-        timeout=body.timeout,
-        context=body.context,
-        gate_cmd=body.gate_cmd,
-    )
-
-    gate = asyncio.Event()
-
-    handle = record.handle  # already guarded above; bind for type narrowing
-
-    async def _execute_background() -> None:
-        await gate.wait()
-        try:
-            result = await execution_env.execute(handle, dispatch, config)
-            env_status = (
-                RunEnvironmentStatus.COMPLETED
-                if result.outcome in _COMPLETED_ENV_OUTCOMES
-                else RunEnvironmentStatus.FAILED
-            )
-            await store.update_environment(
-                env_id,
-                status=env_status,
-                outcome=result.outcome,
-                completed_at=_now(),
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("Execute failed for env %s", env_id)
-            await store.update_environment(
-                env_id,
-                status=RunEnvironmentStatus.FAILED,
-                outcome=Outcome.ERROR,
-                completed_at=_now(),
-            )
-
-    task = asyncio.create_task(_execute_background())
-    updated = await store.try_transition_environment(
-        env_id,
-        from_statuses=_EXECUTE_FROM,
-        to_status=RunEnvironmentStatus.EXECUTING,
-        phase=body.phase,
-        dispatch_id=dispatch_id,
-        started_at=_now(),
-        outcome=None,
-        completed_at=None,
-        task=task,
-    )
-    if updated is None:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-        raise ConflictError(f"Environment {env_id} cannot transition to executing")
-    gate.set()
-
-    return RunExecuteAccepted(env_id=env_id, dispatch_id=dispatch_id)
+    return await _run_service(store, config, execution_env).execute(env_id, body)
 
 
 @router.post("/run/{env_id}/teardown")
@@ -247,65 +64,7 @@ async def run_teardown(
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
 ) -> RunTeardownAccepted:
     """Teardown a provisioned environment."""
-    record = await store.get_environment(env_id)
-    if record is None:
-        raise NotFoundError(f"Environment {env_id} not found")
-
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    # Bail early if already tearing down — do NOT cancel an in-flight teardown task.
-    if record.status not in _TEARDOWN_FROM:
-        raise ConflictError(f"Environment {env_id} is already being torn down")
-
-    # Claim ownership of teardown BEFORE cancelling any running task.
-    # This prevents a race where two concurrent teardown requests both
-    # pass the status check but one destroys the other's teardown task.
-    updated = await store.try_transition_environment(
-        env_id,
-        from_statuses=_TEARDOWN_FROM,
-        to_status=RunEnvironmentStatus.TEARING_DOWN,
-    )
-    if updated is None:
-        raise ConflictError(f"Environment {env_id} is already being torn down")
-
-    # Best-effort cancel of any stale execute task — we already own teardown.
-    await store.cancel_environment_task(env_id)
-
-    # Capture the prior task before the teardown task overwrites it.
-    pre = await store.get_environment(env_id)
-    prior_task = pre.task if pre is not None else None
-
-    async def _teardown_background() -> None:
-        # Wait for any in-flight provision to finish before inspecting
-        # the handle.  Without this, we can remove the record while
-        # provision is still running; provision then silently fails to
-        # persist its handle and skips its own finally cleanup,
-        # orphaning the VM.
-        if prior_task is not None and not prior_task.done():
-            logger.debug("Waiting for prior task to complete before teardown for %s", env_id)
-            with contextlib.suppress(TimeoutError, asyncio.CancelledError, Exception):
-                await asyncio.wait_for(asyncio.shield(prior_task), timeout=_PRIOR_TASK_TIMEOUT)
-
-        current = await store.get_environment(env_id)
-        handle = current.handle if current is not None else None
-        if handle is None:
-            await store.remove_environment(env_id)
-            return
-        inner = asyncio.ensure_future(execution_env.teardown(handle))
-        try:
-            await asyncio.shield(inner)
-        except asyncio.CancelledError, Exception:
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await inner
-            logger.warning("Teardown failed for env %s", env_id)
-        finally:
-            await store.remove_environment(env_id)
-
-    task = asyncio.create_task(_teardown_background())
-    await store.update_environment(env_id, task=task)
-
-    return RunTeardownAccepted(env_id=env_id)
+    return await _run_service(store, execution_env=execution_env).teardown(env_id)
 
 
 @router.post("/run/full")
@@ -316,108 +75,7 @@ async def run_full(
     config: Annotated[Config, Depends(get_config)],
 ) -> DispatchAccepted:
     """Full lifecycle: provision, execute, teardown. Returns ID for polling."""
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    workflow_id = f"full-{uuid.uuid4().hex[:8]}"
-
-    dispatch = Dispatch(
-        workflow_id=workflow_id,
-        project=body.project,
-        phase=body.phase,
-        branch=body.branch,
-        spec_folder=body.spec_path,
-        cli=body.cli,
-        auth=body.auth,
-        timeout=body.timeout,
-        environment_profile=body.environment_profile,
-        context=body.context,
-        gate_cmd=body.gate_cmd,
-    )
-
-    async def _full_lifecycle() -> None:
-        handle: EnvironmentHandle | None = None
-        try:
-            handle = await execution_env.provision(dispatch, config)
-            if not isinstance(handle.runtime, RemoteEnvironmentRuntime):
-                raise ServiceError("Provisioned environment is not a remote runtime")
-            vm_handle = handle.runtime.vm_handle
-
-            env_record = EnvironmentRecord(
-                env_id=handle.env_id,
-                handle=handle,
-                status=RunEnvironmentStatus.EXECUTING,
-                phase=body.phase,
-                vm_id=vm_handle.vm_id,
-                host=vm_handle.host,
-                dispatch_id=workflow_id,
-                started_at=_now(),
-            )
-            await store.add_environment(env_record)
-
-            result = await execution_env.execute(handle, dispatch, config)
-            dispatch_status = (
-                DispatchRunStatus.COMPLETED
-                if result.outcome in _COMPLETED_DISPATCH_OUTCOMES
-                else DispatchRunStatus.FAILED
-            )
-            env_status = (
-                RunEnvironmentStatus.COMPLETED
-                if result.outcome in _COMPLETED_ENV_OUTCOMES
-                else RunEnvironmentStatus.FAILED
-            )
-            await store.try_transition_dispatch(
-                workflow_id,
-                from_statuses=frozenset({DispatchRunStatus.RUNNING}),
-                to_status=dispatch_status,
-                outcome=result.outcome,
-                completed_at=_now(),
-            )
-            await store.update_environment(
-                handle.env_id,
-                status=env_status,
-                outcome=result.outcome,
-                completed_at=_now(),
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("Full lifecycle failed for %s", workflow_id)
-            await store.try_transition_dispatch(
-                workflow_id,
-                from_statuses=frozenset({DispatchRunStatus.RUNNING}),
-                to_status=DispatchRunStatus.FAILED,
-                outcome=Outcome.ERROR,
-                completed_at=_now(),
-            )
-        finally:
-            if handle is not None:
-                inner = asyncio.ensure_future(execution_env.teardown(handle))
-                try:
-                    await asyncio.shield(inner)
-                except asyncio.CancelledError, Exception:
-                    with contextlib.suppress(asyncio.CancelledError, Exception):
-                        await inner
-                    logger.warning("Teardown failed for %s", workflow_id)
-                finally:
-                    try:
-                        await store.remove_environment(handle.env_id)
-                    except asyncio.CancelledError, Exception:
-                        logger.warning("Failed to remove environment %s", handle.env_id)
-
-    dispatch_record = DispatchRecord(
-        dispatch_id=workflow_id,
-        dispatch=dispatch,
-        status=DispatchRunStatus.RUNNING,
-        created_at=_now(),
-        started_at=_now(),
-    )
-    await store.add_dispatch(dispatch_record)
-
-    task = asyncio.create_task(_full_lifecycle())
-    await store.update_dispatch(workflow_id, task=task)
-
-    return DispatchAccepted(dispatch_id=workflow_id)
+    return await _run_service(store, config, execution_env).full(body)
 
 
 @router.get("/run/{env_id}/status")
@@ -426,25 +84,4 @@ async def run_status(
     store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> RunStatus:
     """Poll status of a running environment."""
-    record = await store.get_environment(env_id)
-    if record is None:
-        raise NotFoundError(f"Environment {env_id} not found")
-
-    duration_secs = None
-    if record.started_at is not None:
-        try:
-            started = datetime.fromisoformat(record.started_at)
-            duration_secs = int((datetime.now(UTC) - started).total_seconds())
-        except ValueError, TypeError:
-            pass
-
-    return RunStatus(
-        env_id=env_id,
-        status=record.status,
-        phase=record.phase,
-        outcome=record.outcome,
-        started_at=record.started_at,
-        duration_secs=duration_secs,
-        vm_id=record.vm_id or None,
-        host=record.host or None,
-    )
+    return await _run_service(store).status(env_id)

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -1,86 +1,47 @@
 """VM management endpoints."""
-# ruff: noqa: DOC201,DOC501
+# ruff: noqa: DOC201
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import logging
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path
 
 from tanren_api.dependencies import get_api_store, get_config, get_execution_env, get_vm_state_store
-from tanren_api.errors import NotFoundError, ServiceError
 from tanren_api.models import (
     ProvisionRequest,
-    RunEnvironmentStatus,
     VMDryRunResult,
     VMProvisionAccepted,
     VMProvisionStatus,
     VMReleaseConfirmed,
-    VMStatus,
     VMSummary,
 )
-from tanren_api.state import APIStateStore, EnvironmentRecord
+from tanren_api.services import VMService
+from tanren_api.state import APIStateStore
 from tanren_core.adapters.protocols import ExecutionEnvironment
-from tanren_core.adapters.remote_types import VMHandle, VMProvider, VMRequirements
 from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
-from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
-from tanren_core.remote_config import ProvisionerType, load_remote_config
-from tanren_core.roles import RoleName
-from tanren_core.roles_config import load_roles_config
-from tanren_core.schemas import Dispatch, Outcome, Phase
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["vm"])
 
 
-def _derive_provider(config: Config) -> VMProvider:
-    """Derive VM provider from remote config."""
-    if not config.remote_config_path:
-        return VMProvider.MANUAL
-    try:
-        remote_cfg = load_remote_config(config.remote_config_path)
-    except Exception as exc:
-        logger.exception("Failed to load remote config from %s", config.remote_config_path)
-        raise ServiceError("Failed to load remote config") from exc
-    if remote_cfg.provisioner.type == ProvisionerType.HETZNER:
-        return VMProvider.HETZNER
-    return VMProvider.MANUAL
+def _vm_service(
+    store: APIStateStore,
+    config: Config,
+    execution_env: ExecutionEnvironment | None = None,
+    vm_state_store: SqliteVMStateStore | None = None,
+) -> VMService:
+    return VMService(store, config, execution_env, vm_state_store)
 
 
 @router.get("/vm")
 async def list_vms(
     vm_state_store: Annotated[SqliteVMStateStore | None, Depends(get_vm_state_store)],
     config: Annotated[Config, Depends(get_config)],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> list[VMSummary]:
     """List active VM assignments."""
-    if vm_state_store is None:
-        return []
-
-    provider = _derive_provider(config)
-    assignments = await vm_state_store.get_active_assignments()
-    return [
-        VMSummary(
-            vm_id=a.vm_id,
-            host=a.host,
-            provider=provider,
-            workflow_id=a.workflow_id,
-            project=a.project,
-            status=VMStatus.ACTIVE,
-            created_at=a.assigned_at,
-        )
-        for a in assignments
-    ]
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
+    return await _vm_service(store, config, vm_state_store=vm_state_store).list_vms()
 
 
 @router.post("/vm/provision")
@@ -90,92 +51,8 @@ async def provision_vm(
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
 ) -> VMProvisionAccepted:
-    """Provision a new VM (non-blocking).
-
-    Returns immediately with env_id for polling via GET /vm/provision/{env_id}.
-    """
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    env_id = str(uuid.uuid4())
-
-    roles = load_roles_config(config.roles_config_path)
-    resolved_tool = roles.resolve(RoleName.DEFAULT)
-
-    dispatch = Dispatch(
-        workflow_id=f"vm-provision-{body.project}-{uuid.uuid4().hex[:8]}",
-        project=body.project,
-        phase=Phase.DO_TASK,
-        branch=body.branch,
-        spec_folder="",
-        cli=resolved_tool.cli,
-        auth=resolved_tool.auth,
-        timeout=1800,
-        environment_profile=body.environment_profile,
-    )
-
-    record = EnvironmentRecord(
-        env_id=env_id,
-        handle=None,
-        status=RunEnvironmentStatus.PROVISIONING,
-        started_at=_now(),
-    )
-    await store.add_environment(record)
-
-    async def _provision_background() -> None:
-        handle: EnvironmentHandle | None = None
-        try:
-            handle = await execution_env.provision(dispatch, config)
-            runtime = handle.runtime
-            if not isinstance(runtime, RemoteEnvironmentRuntime):
-                raise ServiceError("Provisioned environment is not a remote runtime")
-            vm_handle = runtime.vm_handle
-            # Close SSH connection to prevent leak (not full teardown — that releases the VM)
-            try:
-                close_fn = getattr(runtime.connection, "close", None)
-                if close_fn is not None:
-                    await close_fn()
-            except Exception:
-                logger.debug(
-                    "Failed to close provision-time SSH connection for %s", vm_handle.vm_id
-                )
-            updated = await store.try_transition_environment(
-                env_id,
-                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
-                to_status=RunEnvironmentStatus.PROVISIONED,
-                handle=handle,
-                vm_id=vm_handle.vm_id,
-                host=vm_handle.host,
-                completed_at=_now(),
-            )
-            if updated is not None:
-                handle = None  # Persisted — suppress finally cleanup
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            handle = None  # Error handler owns cleanup
-            logger.exception("VM provision failed for %s", env_id)
-            await store.try_transition_environment(
-                env_id,
-                from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
-                to_status=RunEnvironmentStatus.FAILED,
-                outcome=Outcome.ERROR,
-                completed_at=_now(),
-            )
-        finally:
-            if handle is not None:
-                logger.warning("Cleaning up orphaned VM provision for %s", env_id)
-                inner = asyncio.ensure_future(execution_env.teardown(handle))
-                try:
-                    await asyncio.shield(inner)
-                except asyncio.CancelledError, Exception:
-                    with contextlib.suppress(asyncio.CancelledError, Exception):
-                        await inner
-
-    task = asyncio.create_task(_provision_background())
-    await store.update_environment(env_id, task=task)
-
-    return VMProvisionAccepted(env_id=env_id)
+    """Provision a new VM (non-blocking)."""
+    return await _vm_service(store, config, execution_env).provision(body)
 
 
 @router.get("/vm/provision/{env_id}")
@@ -185,26 +62,7 @@ async def get_provision_status(
     config: Annotated[Config, Depends(get_config)],
 ) -> VMProvisionStatus:
     """Poll status of an in-progress or completed VM provisioning."""
-    record = await store.get_environment(env_id)
-    if record is None:
-        raise NotFoundError(f"Provision {env_id} not found")
-
-    provider = _derive_provider(config)
-    if record.status == RunEnvironmentStatus.PROVISIONED:
-        vm_status = VMStatus.ACTIVE
-    elif record.status == RunEnvironmentStatus.FAILED:
-        vm_status = VMStatus.FAILED
-    else:
-        vm_status = VMStatus.PROVISIONING
-
-    return VMProvisionStatus(
-        env_id=env_id,
-        status=vm_status,
-        vm_id=record.vm_id or None,
-        host=record.host or None,
-        provider=provider if record.vm_id else None,
-        created_at=record.started_at,
-    )
+    return await _vm_service(store, config).get_provision_status(env_id)
 
 
 @router.delete("/vm/{vm_id}")
@@ -213,35 +71,10 @@ async def release_vm(
     vm_state_store: Annotated[SqliteVMStateStore | None, Depends(get_vm_state_store)],
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> VMReleaseConfirmed:
     """Release a VM assignment."""
-    if vm_state_store is None:
-        raise NotFoundError(f"VM {vm_id} not found")
-
-    assignment = await vm_state_store.get_assignment(vm_id)
-    if assignment is None:
-        raise NotFoundError(f"VM {vm_id} not found")
-
-    if execution_env is None:
-        raise ServiceError("Remote execution environment not configured")
-
-    # Release via provider first — must succeed before updating state
-    provider = _derive_provider(config)
-    vm_handle = VMHandle(
-        vm_id=assignment.vm_id,
-        host=assignment.host,
-        provider=provider,
-        created_at=assignment.assigned_at,
-    )
-    try:
-        await execution_env.release_vm(vm_handle)
-    except Exception as exc:
-        logger.exception("VM release failed for %s", vm_id)
-        raise ServiceError("Failed to release VM") from exc
-
-    # Update state tracking only after successful provider release
-    await vm_state_store.record_release(vm_id)
-    return VMReleaseConfirmed(vm_id=vm_id)
+    return await _vm_service(store, config, execution_env, vm_state_store).release(vm_id)
 
 
 @router.post("/vm/dry-run")
@@ -249,12 +82,7 @@ async def dry_run_provision(
     body: ProvisionRequest,
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> VMDryRunResult:
     """Dry-run provision — show what would happen without creating resources."""
-    provider = _derive_provider(config)
-    requirements = VMRequirements(profile=body.environment_profile)
-    return VMDryRunResult(
-        provider=provider,
-        would_provision=execution_env is not None,
-        requirements=requirements,
-    )
+    return await _vm_service(store, config, execution_env).dry_run(body)

--- a/services/tanren-api/src/tanren_api/services/__init__.py
+++ b/services/tanren-api/src/tanren_api/services/__init__.py
@@ -1,0 +1,15 @@
+"""Service layer — business logic shared by REST routers and MCP tools."""
+
+from tanren_api.services.core import ConfigService, EventsService, HealthService
+from tanren_api.services.dispatch import DispatchService
+from tanren_api.services.run import RunService
+from tanren_api.services.vm import VMService
+
+__all__ = [
+    "ConfigService",
+    "DispatchService",
+    "EventsService",
+    "HealthService",
+    "RunService",
+    "VMService",
+]

--- a/services/tanren-api/src/tanren_api/services/core.py
+++ b/services/tanren-api/src/tanren_api/services/core.py
@@ -1,0 +1,131 @@
+"""Simple services — health, config, events."""
+# ruff: noqa: DOC201
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from tanren_api.models import ConfigResponse, HealthResponse, PaginatedEvents, ReadinessResponse
+
+if TYPE_CHECKING:
+    from pydantic import TypeAdapter
+
+    from tanren_api.models import EventPayload
+    from tanren_api.settings import APISettings
+    from tanren_core.config import Config
+
+logger = logging.getLogger(__name__)
+
+_start_time = time.monotonic()
+
+
+class HealthService:
+    """Service for health and readiness checks."""
+
+    async def health(self) -> HealthResponse:
+        """Return service health and version info."""
+        return HealthResponse(
+            status="ok",
+            version="0.1.0",
+            uptime_seconds=round(time.monotonic() - _start_time, 2),
+        )
+
+    async def readiness(self) -> ReadinessResponse:
+        """Return readiness probe response."""
+        return ReadinessResponse(status="ready")
+
+
+class ConfigService:
+    """Service for non-secret config projection."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize with core config."""
+        self._config = config
+
+    async def get(self) -> ConfigResponse:
+        """Return non-secret config fields."""
+        c = self._config
+        return ConfigResponse(
+            ipc_dir=c.ipc_dir,
+            github_dir=c.github_dir,
+            poll_interval=c.poll_interval,
+            heartbeat_interval=c.heartbeat_interval,
+            max_opencode=c.max_opencode,
+            max_codex=c.max_codex,
+            max_gate=c.max_gate,
+            events_enabled=c.events_db is not None,
+            remote_enabled=c.remote_config_path is not None,
+        )
+
+
+class EventsService:
+    """Service for querying structured events."""
+
+    def __init__(self, settings: APISettings, config: Config | None = None) -> None:
+        """Initialize with settings and optional config for DB path fallback."""
+        self._settings = settings
+        self._config = config
+
+    async def query(
+        self,
+        *,
+        workflow_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> PaginatedEvents:
+        """Query structured events with optional filters."""
+        from tanren_core.adapters.event_reader import query_events  # noqa: PLC0415
+
+        db_path = self._settings.events_db
+        if db_path is None and self._config is not None:
+            db_path = self._config.events_db
+
+        if not db_path:
+            return PaginatedEvents(events=[], total=0, limit=limit, offset=offset)
+
+        result = await query_events(
+            db_path,
+            workflow_id=workflow_id,
+            event_type=event_type,
+            limit=limit,
+            offset=offset,
+        )
+
+        events: list[EventPayload] = []
+        skipped = 0
+        adapter: TypeAdapter[EventPayload] = _get_event_adapter()
+        for row in result.events:
+            try:
+                event = adapter.validate_python(row.payload)
+                events.append(event)
+            except Exception:
+                skipped += 1
+                logger.warning(
+                    "Skipping unparseable event %d: %s", row.id, row.event_type, exc_info=True
+                )
+
+        return PaginatedEvents(
+            events=events,
+            total=result.total,
+            limit=limit,
+            offset=offset,
+            skipped=skipped + result.skipped,
+        )
+
+
+def _get_event_adapter() -> TypeAdapter[EventPayload]:
+    """Lazy-initialize the event TypeAdapter (avoids import-time cost)."""
+    from pydantic import TypeAdapter as TA  # noqa: PLC0415
+
+    from tanren_api.models import EventPayload as EP  # noqa: PLC0415
+
+    global _event_adapter
+    if _event_adapter is None:
+        _event_adapter = TA(EP)
+    return _event_adapter
+
+
+_event_adapter: TypeAdapter[EventPayload] | None = None

--- a/services/tanren-api/src/tanren_api/services/dispatch.py
+++ b/services/tanren-api/src/tanren_api/services/dispatch.py
@@ -1,0 +1,305 @@
+"""Dispatch service — create, query, and cancel dispatch requests."""
+# ruff: noqa: DOC201,DOC501
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tanren_api.errors import ConflictError, NotFoundError, ServiceError
+from tanren_api.models import (
+    DispatchAccepted,
+    DispatchCancelled,
+    DispatchDetail,
+    DispatchRequest,
+    DispatchRunStatus,
+)
+from tanren_api.state import APIStateStore, DispatchRecord
+from tanren_core.adapters.events import DispatchReceived
+from tanren_core.adapters.protocols import EventEmitter, ExecutionEnvironment
+from tanren_core.config import Config
+from tanren_core.ipc import atomic_write, generate_filename
+from tanren_core.schemas import Dispatch, Outcome, Result
+
+logger = logging.getLogger(__name__)
+
+_COMPLETED_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
+
+
+def _status_for_outcome(outcome: Outcome) -> DispatchRunStatus:
+    """Map execution outcome to terminal dispatch status."""
+    if outcome in _COMPLETED_OUTCOMES:
+        return DispatchRunStatus.COMPLETED
+    return DispatchRunStatus.FAILED
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class DispatchService:
+    """Service for dispatch lifecycle management."""
+
+    def __init__(
+        self,
+        store: APIStateStore,
+        config: Config | None = None,
+        emitter: EventEmitter | None = None,
+        execution_env: ExecutionEnvironment | None = None,
+    ) -> None:
+        """Initialize with dependencies."""
+        self._store = store
+        self._config = config
+        self._emitter = emitter
+        self._execution_env = execution_env
+
+    def _require_config(self) -> Config:
+        if self._config is None:
+            raise ServiceError("Configuration unavailable — WM_* environment variables not set")
+        return self._config
+
+    async def create(self, body: DispatchRequest) -> DispatchAccepted:
+        """Accept a new dispatch request."""
+        config = self._require_config()
+        epoch = time.time_ns()
+        issue = body.issue if body.issue != 0 else epoch
+        workflow_id = f"wf-{body.project}-{issue}-{epoch}"
+
+        dispatch = Dispatch(
+            workflow_id=workflow_id,
+            project=body.project,
+            phase=body.phase,
+            branch=body.branch,
+            spec_folder=body.spec_folder,
+            cli=body.cli,
+            auth=body.auth,
+            model=body.model,
+            timeout=body.timeout,
+            environment_profile=body.environment_profile,
+            context=body.context,
+            gate_cmd=body.gate_cmd,
+        )
+
+        # Write dispatch to IPC only when delegating to daemon (no local execution env)
+        dispatch_path = None
+        if self._execution_env is None:
+            dispatch_dir = Path(config.ipc_dir) / "dispatch"
+            dispatch_dir.mkdir(parents=True, exist_ok=True)
+            dispatch_path = dispatch_dir / generate_filename()
+            await atomic_write(dispatch_path, dispatch.model_dump_json(indent=2))
+
+        record = DispatchRecord(
+            dispatch_id=workflow_id,
+            dispatch=dispatch,
+            status=DispatchRunStatus.PENDING,
+            created_at=_now(),
+        )
+        record.dispatch_path = dispatch_path
+        await self._store.add_dispatch(record)
+
+        # Launch background task if execution env available
+        if self._execution_env is not None:
+            assert self._emitter is not None
+            await self._emitter.emit(
+                DispatchReceived(
+                    timestamp=_now(),
+                    workflow_id=workflow_id,
+                    phase=body.phase.value,
+                    project=body.project,
+                    cli=body.cli.value,
+                )
+            )
+            task = asyncio.create_task(self._dispatch_background(dispatch, workflow_id))
+            await self._store.update_dispatch(workflow_id, task=task)
+
+        return DispatchAccepted(dispatch_id=workflow_id)
+
+    async def get(self, dispatch_id: str) -> DispatchDetail:
+        """Query dispatch status by workflow ID."""
+        config = self._require_config()
+        record = await self._store.get_dispatch(dispatch_id)
+        if record is None:
+            raise NotFoundError(f"Dispatch {dispatch_id} not found")
+
+        # Lazy-check daemon results for IPC-delegated dispatches still pending
+        if (
+            record.status == DispatchRunStatus.PENDING
+            and record.dispatch_path is not None
+            and record.task is None
+        ):
+            await self._check_daemon_result(config, dispatch_id, record.created_at)
+            record = await self._store.get_dispatch(dispatch_id)
+            if record is None:
+                raise NotFoundError(f"Dispatch {dispatch_id} not found")
+
+        d = record.dispatch
+        return DispatchDetail(
+            workflow_id=d.workflow_id,
+            phase=d.phase,
+            project=d.project,
+            spec_folder=d.spec_folder,
+            branch=d.branch,
+            cli=d.cli,
+            auth=d.auth,
+            model=d.model,
+            timeout=d.timeout,
+            environment_profile=d.environment_profile,
+            context=d.context,
+            gate_cmd=d.gate_cmd,
+            status=record.status,
+            outcome=record.outcome,
+            created_at=record.created_at,
+            started_at=record.started_at,
+            completed_at=record.completed_at,
+        )
+
+    async def cancel(self, dispatch_id: str) -> DispatchCancelled:
+        """Cancel a pending or running dispatch."""
+        record = await self._store.get_dispatch(dispatch_id)
+        if record is None:
+            raise NotFoundError(f"Dispatch {dispatch_id} not found")
+
+        if record.status in (
+            DispatchRunStatus.COMPLETED,
+            DispatchRunStatus.FAILED,
+            DispatchRunStatus.CANCELLED,
+        ):
+            raise ConflictError(f"Dispatch {dispatch_id} is already {record.status}")
+
+        if record.status == DispatchRunStatus.PENDING:
+            # For daemon-delegated: reclaim IPC file before marking cancelled.
+            if record.dispatch_path is not None and record.task is None:
+                try:
+                    record.dispatch_path.unlink()
+                except FileNotFoundError:
+                    raise ConflictError(
+                        f"Dispatch {dispatch_id} has been picked up by the daemon "
+                        "and cannot be cancelled"
+                    ) from None
+                except OSError:
+                    raise ConflictError(
+                        f"Dispatch {dispatch_id} could not be cancelled: "
+                        "failed to remove dispatch file. Please retry."
+                    ) from None
+            transitioned = await self._store.try_transition_dispatch(
+                dispatch_id,
+                from_statuses=frozenset({DispatchRunStatus.PENDING}),
+                to_status=DispatchRunStatus.CANCELLED,
+                completed_at=_now(),
+            )
+            if transitioned is None:
+                raise ConflictError(f"Dispatch {dispatch_id} status has changed; cannot cancel")
+            if record.task is not None and not record.task.done():
+                record.task.cancel()
+        elif record.status == DispatchRunStatus.RUNNING:
+            logger.warning("Cancelling running dispatch %s — best effort", dispatch_id)
+            transitioned = await self._store.try_transition_dispatch(
+                dispatch_id,
+                from_statuses=frozenset({DispatchRunStatus.RUNNING}),
+                to_status=DispatchRunStatus.CANCELLED,
+                completed_at=_now(),
+            )
+            if transitioned is None:
+                raise ConflictError(f"Dispatch {dispatch_id} status has changed; cannot cancel")
+            if record.task is not None and not record.task.done():
+                record.task.cancel()
+
+        return DispatchCancelled(dispatch_id=dispatch_id)
+
+    # -- Background tasks --
+
+    async def _dispatch_background(self, dispatch: Dispatch, dispatch_id: str) -> None:
+        """Background task: provision -> execute -> teardown."""
+        assert self._execution_env is not None
+        assert self._config is not None
+        execution_env = self._execution_env
+        config = self._config
+
+        transitioned = await self._store.try_transition_dispatch(
+            dispatch_id,
+            from_statuses=frozenset({DispatchRunStatus.PENDING}),
+            to_status=DispatchRunStatus.RUNNING,
+            started_at=_now(),
+        )
+        if transitioned is None:
+            return  # Cancelled (or otherwise transitioned) before we started
+        handle = None
+        try:
+            handle = await execution_env.provision(dispatch, config)
+            result = await execution_env.execute(handle, dispatch, config)
+            await self._store.try_transition_dispatch(
+                dispatch_id,
+                from_statuses=frozenset({DispatchRunStatus.RUNNING}),
+                to_status=_status_for_outcome(result.outcome),
+                outcome=result.outcome,
+                completed_at=_now(),
+            )
+        except asyncio.CancelledError:
+            logger.info("Dispatch %s cancelled", dispatch_id)
+            raise
+        except Exception:
+            logger.exception("Dispatch %s failed", dispatch_id)
+            await self._store.try_transition_dispatch(
+                dispatch_id,
+                from_statuses=frozenset({DispatchRunStatus.RUNNING}),
+                to_status=DispatchRunStatus.FAILED,
+                outcome=Outcome.ERROR,
+                completed_at=_now(),
+            )
+        finally:
+            if handle is not None:
+                inner = asyncio.ensure_future(execution_env.teardown(handle))
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError, Exception:
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await inner
+                    logger.warning("Teardown failed for dispatch %s", dispatch_id)
+
+    async def _check_daemon_result(self, config: Config, workflow_id: str, created_at: str) -> None:
+        """Scan IPC results directory for a daemon-produced result."""
+        results_dir = Path(config.ipc_dir) / "results"
+        if not results_dir.exists():
+            return
+
+        try:
+            created_dt = datetime.fromisoformat(created_at)
+            created_ms = int(created_dt.timestamp() * 1000)
+        except ValueError, TypeError:
+            created_ms = 0
+
+        def _scan() -> Result | None:
+            entries = sorted(results_dir.iterdir(), reverse=True)
+            for entry in entries:
+                if entry.suffix != ".json":
+                    continue
+                stem = entry.stem.split("-")[0]
+                try:
+                    file_ts = int(stem)
+                    if file_ts < created_ms:
+                        break  # Sorted newest-first — all remaining are older
+                except ValueError, IndexError:
+                    pass
+                try:
+                    content = entry.read_text()
+                    result = Result.model_validate_json(content)
+                    if result.workflow_id == workflow_id:
+                        return result
+                except Exception:
+                    continue
+            return None
+
+        result = await asyncio.to_thread(_scan)
+        if result is None:
+            return
+
+        await self._store.update_dispatch(
+            workflow_id,
+            status=_status_for_outcome(result.outcome),
+            outcome=result.outcome,
+            completed_at=_now(),
+        )

--- a/services/tanren-api/src/tanren_api/services/run.py
+++ b/services/tanren-api/src/tanren_api/services/run.py
@@ -1,0 +1,418 @@
+"""Run lifecycle service — provision, execute, teardown, full lifecycle, status."""
+# ruff: noqa: DOC201,DOC501
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from tanren_api.errors import ConflictError, NotFoundError, ServiceError
+from tanren_api.models import (
+    DispatchAccepted,
+    DispatchRunStatus,
+    ExecuteRequest,
+    ProvisionRequest,
+    RunEnvironment,
+    RunEnvironmentStatus,
+    RunExecuteAccepted,
+    RunFullRequest,
+    RunStatus,
+    RunTeardownAccepted,
+)
+from tanren_api.state import APIStateStore, DispatchRecord, EnvironmentRecord
+from tanren_core.adapters.protocols import ExecutionEnvironment
+from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
+from tanren_core.config import Config
+from tanren_core.roles import RoleName
+from tanren_core.roles_config import load_roles_config
+from tanren_core.schemas import Dispatch, Outcome, Phase
+
+logger = logging.getLogger(__name__)
+
+_EXECUTE_FROM = frozenset({RunEnvironmentStatus.PROVISIONED, RunEnvironmentStatus.COMPLETED})
+_TEARDOWN_FROM = frozenset({
+    RunEnvironmentStatus.PROVISIONING,
+    RunEnvironmentStatus.PROVISIONED,
+    RunEnvironmentStatus.EXECUTING,
+    RunEnvironmentStatus.COMPLETED,
+    RunEnvironmentStatus.FAILED,
+})
+
+_PRIOR_TASK_TIMEOUT: float = 30.0
+
+_COMPLETED_DISPATCH_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
+_COMPLETED_ENV_OUTCOMES = frozenset({Outcome.SUCCESS, Outcome.FAIL, Outcome.BLOCKED})
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class RunService:
+    """Service for run lifecycle management."""
+
+    def __init__(
+        self,
+        store: APIStateStore,
+        config: Config | None = None,
+        execution_env: ExecutionEnvironment | None = None,
+    ) -> None:
+        """Initialize with dependencies."""
+        self._store = store
+        self._config = config
+        self._execution_env = execution_env
+
+    def _require_config(self) -> Config:
+        if self._config is None:
+            raise ServiceError("Configuration unavailable — WM_* environment variables not set")
+        return self._config
+
+    def _require_execution_env(self) -> ExecutionEnvironment:
+        if self._execution_env is None:
+            raise ServiceError("Remote execution environment not configured")
+        return self._execution_env
+
+    async def provision(self, body: ProvisionRequest) -> RunEnvironment:
+        """Provision a remote execution environment (non-blocking)."""
+        config = self._require_config()
+        execution_env = self._require_execution_env()
+
+        env_id = str(uuid.uuid4())
+
+        roles = load_roles_config(config.roles_config_path)
+        resolved_tool = roles.resolve(RoleName.DEFAULT)
+
+        dispatch = Dispatch(
+            workflow_id=f"run-{uuid.uuid4().hex[:8]}",
+            project=body.project,
+            phase=Phase.DO_TASK,
+            branch=body.branch,
+            spec_folder="",
+            cli=resolved_tool.cli,
+            auth=resolved_tool.auth,
+            timeout=1800,
+            environment_profile=body.environment_profile,
+        )
+
+        record = EnvironmentRecord(
+            env_id=env_id,
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONING,
+            started_at=_now(),
+        )
+        await self._store.add_environment(record)
+
+        async def _provision_background() -> None:
+            handle: EnvironmentHandle | None = None
+            try:
+                handle = await execution_env.provision(dispatch, config)
+                runtime = handle.runtime
+                if not isinstance(runtime, RemoteEnvironmentRuntime):
+                    raise ServiceError("Provisioned environment is not a remote runtime")
+                updated = await self._store.try_transition_environment(
+                    env_id,
+                    from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                    to_status=RunEnvironmentStatus.PROVISIONED,
+                    handle=handle,
+                    vm_id=runtime.vm_handle.vm_id,
+                    host=runtime.vm_handle.host,
+                )
+                if updated is not None:
+                    handle = None  # Persisted — suppress finally cleanup
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                handle = None  # Error handler owns cleanup
+                logger.exception("Provision failed for %s", env_id)
+                await self._store.try_transition_environment(
+                    env_id,
+                    from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                    to_status=RunEnvironmentStatus.FAILED,
+                    outcome=Outcome.ERROR,
+                    completed_at=_now(),
+                )
+            finally:
+                if handle is not None:
+                    logger.warning("Cleaning up orphaned provision for %s", env_id)
+                    inner = asyncio.ensure_future(execution_env.teardown(handle))
+                    try:
+                        await asyncio.shield(inner)
+                    except asyncio.CancelledError, Exception:
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await inner
+
+        task = asyncio.create_task(_provision_background())
+        await self._store.update_environment(env_id, task=task)
+
+        return RunEnvironment(
+            env_id=env_id,
+            vm_id="",
+            host="",
+            status=RunEnvironmentStatus.PROVISIONING,
+        )
+
+    async def execute(self, env_id: str, body: ExecuteRequest) -> RunExecuteAccepted:
+        """Execute a phase against a provisioned environment."""
+        config = self._require_config()
+        execution_env = self._require_execution_env()
+
+        record = await self._store.get_environment(env_id)
+        if record is None:
+            raise NotFoundError(f"Environment {env_id} not found")
+        if record.handle is None:
+            raise ConflictError(f"Environment {env_id} is still provisioning")
+        if body.project != record.handle.project:
+            raise ConflictError(
+                f"Project mismatch: environment provisioned for '{record.handle.project}', "
+                f"request specifies '{body.project}'"
+            )
+
+        dispatch_id = f"exec-{uuid.uuid4().hex[:8]}"
+
+        dispatch = Dispatch(
+            workflow_id=dispatch_id,
+            project=body.project,
+            phase=body.phase,
+            branch=record.handle.branch,
+            spec_folder=body.spec_path,
+            cli=body.cli,
+            auth=body.auth,
+            model=body.model,
+            timeout=body.timeout,
+            context=body.context,
+            gate_cmd=body.gate_cmd,
+        )
+
+        gate = asyncio.Event()
+        handle = record.handle
+
+        async def _execute_background() -> None:
+            await gate.wait()
+            try:
+                result = await execution_env.execute(handle, dispatch, config)
+                env_status = (
+                    RunEnvironmentStatus.COMPLETED
+                    if result.outcome in _COMPLETED_ENV_OUTCOMES
+                    else RunEnvironmentStatus.FAILED
+                )
+                await self._store.update_environment(
+                    env_id,
+                    status=env_status,
+                    outcome=result.outcome,
+                    completed_at=_now(),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Execute failed for env %s", env_id)
+                await self._store.update_environment(
+                    env_id,
+                    status=RunEnvironmentStatus.FAILED,
+                    outcome=Outcome.ERROR,
+                    completed_at=_now(),
+                )
+
+        task = asyncio.create_task(_execute_background())
+        updated = await self._store.try_transition_environment(
+            env_id,
+            from_statuses=_EXECUTE_FROM,
+            to_status=RunEnvironmentStatus.EXECUTING,
+            phase=body.phase,
+            dispatch_id=dispatch_id,
+            started_at=_now(),
+            outcome=None,
+            completed_at=None,
+            task=task,
+        )
+        if updated is None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            raise ConflictError(f"Environment {env_id} cannot transition to executing")
+        gate.set()
+
+        return RunExecuteAccepted(env_id=env_id, dispatch_id=dispatch_id)
+
+    async def teardown(self, env_id: str) -> RunTeardownAccepted:
+        """Teardown a provisioned environment."""
+        execution_env = self._require_execution_env()
+
+        record = await self._store.get_environment(env_id)
+        if record is None:
+            raise NotFoundError(f"Environment {env_id} not found")
+
+        if record.status not in _TEARDOWN_FROM:
+            raise ConflictError(f"Environment {env_id} is already being torn down")
+
+        # Claim ownership of teardown BEFORE cancelling any running task.
+        updated = await self._store.try_transition_environment(
+            env_id,
+            from_statuses=_TEARDOWN_FROM,
+            to_status=RunEnvironmentStatus.TEARING_DOWN,
+        )
+        if updated is None:
+            raise ConflictError(f"Environment {env_id} is already being torn down")
+
+        await self._store.cancel_environment_task(env_id)
+
+        pre = await self._store.get_environment(env_id)
+        prior_task = pre.task if pre is not None else None
+
+        async def _teardown_background() -> None:
+            if prior_task is not None and not prior_task.done():
+                logger.debug("Waiting for prior task before teardown for %s", env_id)
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError, Exception):
+                    await asyncio.wait_for(asyncio.shield(prior_task), timeout=_PRIOR_TASK_TIMEOUT)
+
+            current = await self._store.get_environment(env_id)
+            handle = current.handle if current is not None else None
+            if handle is None:
+                await self._store.remove_environment(env_id)
+                return
+            inner = asyncio.ensure_future(execution_env.teardown(handle))
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError, Exception:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await inner
+                logger.warning("Teardown failed for env %s", env_id)
+            finally:
+                await self._store.remove_environment(env_id)
+
+        task = asyncio.create_task(_teardown_background())
+        await self._store.update_environment(env_id, task=task)
+
+        return RunTeardownAccepted(env_id=env_id)
+
+    async def full(self, body: RunFullRequest) -> DispatchAccepted:
+        """Full lifecycle: provision, execute, teardown. Returns ID for polling."""
+        config = self._require_config()
+        execution_env = self._require_execution_env()
+
+        workflow_id = f"full-{uuid.uuid4().hex[:8]}"
+
+        dispatch = Dispatch(
+            workflow_id=workflow_id,
+            project=body.project,
+            phase=body.phase,
+            branch=body.branch,
+            spec_folder=body.spec_path,
+            cli=body.cli,
+            auth=body.auth,
+            timeout=body.timeout,
+            environment_profile=body.environment_profile,
+            context=body.context,
+            gate_cmd=body.gate_cmd,
+        )
+
+        async def _full_lifecycle() -> None:
+            handle: EnvironmentHandle | None = None
+            try:
+                handle = await execution_env.provision(dispatch, config)
+                if not isinstance(handle.runtime, RemoteEnvironmentRuntime):
+                    raise ServiceError("Provisioned environment is not a remote runtime")
+                vm_handle = handle.runtime.vm_handle
+
+                env_record = EnvironmentRecord(
+                    env_id=handle.env_id,
+                    handle=handle,
+                    status=RunEnvironmentStatus.EXECUTING,
+                    phase=body.phase,
+                    vm_id=vm_handle.vm_id,
+                    host=vm_handle.host,
+                    dispatch_id=workflow_id,
+                    started_at=_now(),
+                )
+                await self._store.add_environment(env_record)
+
+                result = await execution_env.execute(handle, dispatch, config)
+                dispatch_status = (
+                    DispatchRunStatus.COMPLETED
+                    if result.outcome in _COMPLETED_DISPATCH_OUTCOMES
+                    else DispatchRunStatus.FAILED
+                )
+                env_status = (
+                    RunEnvironmentStatus.COMPLETED
+                    if result.outcome in _COMPLETED_ENV_OUTCOMES
+                    else RunEnvironmentStatus.FAILED
+                )
+                await self._store.try_transition_dispatch(
+                    workflow_id,
+                    from_statuses=frozenset({DispatchRunStatus.RUNNING}),
+                    to_status=dispatch_status,
+                    outcome=result.outcome,
+                    completed_at=_now(),
+                )
+                await self._store.update_environment(
+                    handle.env_id,
+                    status=env_status,
+                    outcome=result.outcome,
+                    completed_at=_now(),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Full lifecycle failed for %s", workflow_id)
+                await self._store.try_transition_dispatch(
+                    workflow_id,
+                    from_statuses=frozenset({DispatchRunStatus.RUNNING}),
+                    to_status=DispatchRunStatus.FAILED,
+                    outcome=Outcome.ERROR,
+                    completed_at=_now(),
+                )
+            finally:
+                if handle is not None:
+                    inner = asyncio.ensure_future(execution_env.teardown(handle))
+                    try:
+                        await asyncio.shield(inner)
+                    except asyncio.CancelledError, Exception:
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await inner
+                        logger.warning("Teardown failed for %s", workflow_id)
+                    finally:
+                        try:
+                            await self._store.remove_environment(handle.env_id)
+                        except asyncio.CancelledError, Exception:
+                            logger.warning("Failed to remove environment %s", handle.env_id)
+
+        dispatch_record = DispatchRecord(
+            dispatch_id=workflow_id,
+            dispatch=dispatch,
+            status=DispatchRunStatus.RUNNING,
+            created_at=_now(),
+            started_at=_now(),
+        )
+        await self._store.add_dispatch(dispatch_record)
+
+        task = asyncio.create_task(_full_lifecycle())
+        await self._store.update_dispatch(workflow_id, task=task)
+
+        return DispatchAccepted(dispatch_id=workflow_id)
+
+    async def status(self, env_id: str) -> RunStatus:
+        """Poll status of a running environment."""
+        record = await self._store.get_environment(env_id)
+        if record is None:
+            raise NotFoundError(f"Environment {env_id} not found")
+
+        duration_secs = None
+        if record.started_at is not None:
+            try:
+                started = datetime.fromisoformat(record.started_at)
+                duration_secs = int((datetime.now(UTC) - started).total_seconds())
+            except ValueError, TypeError:
+                pass
+
+        return RunStatus(
+            env_id=env_id,
+            status=record.status,
+            phase=record.phase,
+            outcome=record.outcome,
+            started_at=record.started_at,
+            duration_secs=duration_secs,
+            vm_id=record.vm_id or None,
+            host=record.host or None,
+        )

--- a/services/tanren-api/src/tanren_api/services/vm.py
+++ b/services/tanren-api/src/tanren_api/services/vm.py
@@ -1,0 +1,246 @@
+"""VM service — list, provision, poll, release, and dry-run VMs."""
+# ruff: noqa: DOC201,DOC501
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from tanren_api.errors import NotFoundError, ServiceError
+from tanren_api.models import (
+    ProvisionRequest,
+    RunEnvironmentStatus,
+    VMDryRunResult,
+    VMProvisionAccepted,
+    VMProvisionStatus,
+    VMReleaseConfirmed,
+    VMStatus,
+    VMSummary,
+)
+from tanren_api.state import APIStateStore, EnvironmentRecord
+from tanren_core.adapters.protocols import ExecutionEnvironment
+from tanren_core.adapters.remote_types import VMHandle, VMProvider, VMRequirements
+from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
+from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
+from tanren_core.config import Config
+from tanren_core.remote_config import ProvisionerType, load_remote_config
+from tanren_core.roles import RoleName
+from tanren_core.roles_config import load_roles_config
+from tanren_core.schemas import Dispatch, Outcome, Phase
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _derive_provider(config: Config) -> VMProvider:
+    """Derive VM provider from remote config."""
+    if not config.remote_config_path:
+        return VMProvider.MANUAL
+    try:
+        remote_cfg = load_remote_config(config.remote_config_path)
+    except Exception as exc:
+        logger.exception("Failed to load remote config from %s", config.remote_config_path)
+        raise ServiceError("Failed to load remote config") from exc
+    if remote_cfg.provisioner.type == ProvisionerType.HETZNER:
+        return VMProvider.HETZNER
+    return VMProvider.MANUAL
+
+
+class VMService:
+    """Service for VM lifecycle management."""
+
+    def __init__(
+        self,
+        store: APIStateStore,
+        config: Config | None = None,
+        execution_env: ExecutionEnvironment | None = None,
+        vm_state_store: SqliteVMStateStore | None = None,
+    ) -> None:
+        """Initialize with dependencies."""
+        self._store = store
+        self._config = config
+        self._execution_env = execution_env
+        self._vm_state_store = vm_state_store
+
+    def _require_config(self) -> Config:
+        if self._config is None:
+            raise ServiceError("Configuration unavailable — WM_* environment variables not set")
+        return self._config
+
+    async def list_vms(self) -> list[VMSummary]:
+        """List active VM assignments."""
+        config = self._require_config()
+        if self._vm_state_store is None:
+            return []
+
+        provider = _derive_provider(config)
+        assignments = await self._vm_state_store.get_active_assignments()
+        return [
+            VMSummary(
+                vm_id=a.vm_id,
+                host=a.host,
+                provider=provider,
+                workflow_id=a.workflow_id,
+                project=a.project,
+                status=VMStatus.ACTIVE,
+                created_at=a.assigned_at,
+            )
+            for a in assignments
+        ]
+
+    async def provision(self, body: ProvisionRequest) -> VMProvisionAccepted:
+        """Provision a new VM (non-blocking)."""
+        config = self._require_config()
+        if self._execution_env is None:
+            raise ServiceError("Remote execution environment not configured")
+
+        env_id = str(uuid.uuid4())
+        execution_env = self._execution_env
+
+        roles = load_roles_config(config.roles_config_path)
+        resolved_tool = roles.resolve(RoleName.DEFAULT)
+
+        dispatch = Dispatch(
+            workflow_id=f"vm-provision-{body.project}-{uuid.uuid4().hex[:8]}",
+            project=body.project,
+            phase=Phase.DO_TASK,
+            branch=body.branch,
+            spec_folder="",
+            cli=resolved_tool.cli,
+            auth=resolved_tool.auth,
+            timeout=1800,
+            environment_profile=body.environment_profile,
+        )
+
+        record = EnvironmentRecord(
+            env_id=env_id,
+            handle=None,
+            status=RunEnvironmentStatus.PROVISIONING,
+            started_at=_now(),
+        )
+        await self._store.add_environment(record)
+
+        async def _provision_background() -> None:
+            handle: EnvironmentHandle | None = None
+            try:
+                handle = await execution_env.provision(dispatch, config)
+                runtime = handle.runtime
+                if not isinstance(runtime, RemoteEnvironmentRuntime):
+                    raise ServiceError("Provisioned environment is not a remote runtime")
+                vm_handle = runtime.vm_handle
+                # Close SSH connection to prevent leak
+                try:
+                    close_fn = getattr(runtime.connection, "close", None)
+                    if close_fn is not None:
+                        await close_fn()
+                except Exception:
+                    logger.debug(
+                        "Failed to close provision-time SSH connection for %s", vm_handle.vm_id
+                    )
+                updated = await self._store.try_transition_environment(
+                    env_id,
+                    from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                    to_status=RunEnvironmentStatus.PROVISIONED,
+                    handle=handle,
+                    vm_id=vm_handle.vm_id,
+                    host=vm_handle.host,
+                    completed_at=_now(),
+                )
+                if updated is not None:
+                    handle = None  # Persisted — suppress finally cleanup
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                handle = None  # Error handler owns cleanup
+                logger.exception("VM provision failed for %s", env_id)
+                await self._store.try_transition_environment(
+                    env_id,
+                    from_statuses=frozenset({RunEnvironmentStatus.PROVISIONING}),
+                    to_status=RunEnvironmentStatus.FAILED,
+                    outcome=Outcome.ERROR,
+                    completed_at=_now(),
+                )
+            finally:
+                if handle is not None:
+                    logger.warning("Cleaning up orphaned VM provision for %s", env_id)
+                    inner = asyncio.ensure_future(execution_env.teardown(handle))
+                    try:
+                        await asyncio.shield(inner)
+                    except asyncio.CancelledError, Exception:
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await inner
+
+        task = asyncio.create_task(_provision_background())
+        await self._store.update_environment(env_id, task=task)
+
+        return VMProvisionAccepted(env_id=env_id)
+
+    async def get_provision_status(self, env_id: str) -> VMProvisionStatus:
+        """Poll status of an in-progress or completed VM provisioning."""
+        config = self._require_config()
+        record = await self._store.get_environment(env_id)
+        if record is None:
+            raise NotFoundError(f"Provision {env_id} not found")
+
+        provider = _derive_provider(config)
+        if record.status == RunEnvironmentStatus.PROVISIONED:
+            vm_status = VMStatus.ACTIVE
+        elif record.status == RunEnvironmentStatus.FAILED:
+            vm_status = VMStatus.FAILED
+        else:
+            vm_status = VMStatus.PROVISIONING
+
+        return VMProvisionStatus(
+            env_id=env_id,
+            status=vm_status,
+            vm_id=record.vm_id or None,
+            host=record.host or None,
+            provider=provider if record.vm_id else None,
+            created_at=record.started_at,
+        )
+
+    async def release(self, vm_id: str) -> VMReleaseConfirmed:
+        """Release a VM assignment."""
+        config = self._require_config()
+        if self._vm_state_store is None:
+            raise NotFoundError(f"VM {vm_id} not found")
+
+        assignment = await self._vm_state_store.get_assignment(vm_id)
+        if assignment is None:
+            raise NotFoundError(f"VM {vm_id} not found")
+
+        if self._execution_env is None:
+            raise ServiceError("Remote execution environment not configured")
+
+        provider = _derive_provider(config)
+        vm_handle = VMHandle(
+            vm_id=assignment.vm_id,
+            host=assignment.host,
+            provider=provider,
+            created_at=assignment.assigned_at,
+        )
+        try:
+            await self._execution_env.release_vm(vm_handle)
+        except Exception as exc:
+            logger.exception("VM release failed for %s", vm_id)
+            raise ServiceError("Failed to release VM") from exc
+
+        await self._vm_state_store.record_release(vm_id)
+        return VMReleaseConfirmed(vm_id=vm_id)
+
+    async def dry_run(self, body: ProvisionRequest) -> VMDryRunResult:
+        """Dry-run provision — show what would happen without creating resources."""
+        config = self._require_config()
+        provider = _derive_provider(config)
+        requirements = VMRequirements(profile=body.environment_profile)
+        return VMDryRunResult(
+            provider=provider,
+            would_provision=self._execution_env is not None,
+            requirements=requirements,
+        )

--- a/tests/unit/api/test_dispatch.py
+++ b/tests/unit/api/test_dispatch.py
@@ -486,7 +486,7 @@ class TestDispatch:
         self, client, auth_headers, app
     ):
         """Background task exits without provisioning when dispatch is already CANCELLED."""
-        from tanren_api.routers.dispatch import _dispatch_background  # noqa: PLC0415,PLC2701
+        from tanren_api.services import DispatchService  # noqa: PLC0415
 
         store = app.state.api_store
         mock_env = app.state.execution_env
@@ -509,7 +509,8 @@ class TestDispatch:
         )
         await store.add_dispatch(record)
 
-        await _dispatch_background(dispatch, "wf-early-cancel", mock_env, app.state.config, store)
+        svc = DispatchService(store, app.state.config, execution_env=mock_env)
+        await svc._dispatch_background(dispatch, "wf-early-cancel")
 
         # provision/execute should never have been called
         mock_env.provision.assert_not_called()
@@ -564,7 +565,7 @@ class TestDispatch:
     async def test_dispatch_teardown_shielded_from_cancellation(self, client, auth_headers, app):
         """Teardown is shielded from cancellation in _dispatch_background
         and the task doesn't return until teardown actually finishes."""
-        from tanren_api.routers.dispatch import _dispatch_background  # noqa: PLC0415,PLC2701
+        from tanren_api.services import DispatchService  # noqa: PLC0415
 
         store = app.state.api_store
         mock_env = app.state.execution_env
@@ -605,9 +606,8 @@ class TestDispatch:
 
         mock_env.teardown = AsyncMock(side_effect=_blocking_teardown)
 
-        task = asyncio.create_task(
-            _dispatch_background(dispatch, "wf-shield-test", mock_env, app.state.config, store)
-        )
+        svc = DispatchService(store, app.state.config, execution_env=mock_env)
+        task = asyncio.create_task(svc._dispatch_background(dispatch, "wf-shield-test"))
 
         # Wait for execute to start, then cancel
         await execute_started.wait()
@@ -670,7 +670,7 @@ class TestDispatch:
 
     async def test_background_task_does_not_overwrite_cancelled(self, client, auth_headers, app):
         """Background task completing after cancellation does not overwrite CANCELLED status."""
-        from tanren_api.routers.dispatch import _dispatch_background  # noqa: PLC0415,PLC2701
+        from tanren_api.services import DispatchService  # noqa: PLC0415
 
         store = app.state.api_store
         mock_env = app.state.execution_env
@@ -708,7 +708,8 @@ class TestDispatch:
         mock_env.execute = AsyncMock(side_effect=_cancel_then_return)
 
         # Run the background task — it should NOT overwrite CANCELLED
-        await _dispatch_background(dispatch, "wf-race-test", mock_env, app.state.config, store)
+        svc = DispatchService(store, app.state.config, execution_env=mock_env)
+        await svc._dispatch_background(dispatch, "wf-race-test")
 
         final = await store.get_dispatch("wf-race-test")
         assert final is not None

--- a/tests/unit/api/test_mcp.py
+++ b/tests/unit/api/test_mcp.py
@@ -1,0 +1,304 @@
+"""Tests for MCP server — tool registration, auth middleware, and tool execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from tanren_api.mcp_auth import MCPApiKeyAuth
+from tanren_api.mcp_server import mcp, set_services
+from tanren_api.services import (
+    ConfigService,
+    DispatchService,
+    EventsService,
+    HealthService,
+    RunService,
+    VMService,
+)
+from tanren_api.settings import APISettings
+from tanren_api.state import APIStateStore
+from tanren_core.config import Config
+
+TEST_API_KEY = "test-mcp-key-12345"
+
+
+def _text(result) -> str:
+    """Extract text from the first content block of a CallToolResult."""
+    return result.content[0].text
+
+
+@pytest.fixture(autouse=True)
+def _clear_mcp_middleware():
+    """Ensure a clean middleware stack for every test."""
+    saved = list(mcp.middleware)
+    mcp.middleware.clear()
+    yield
+    mcp.middleware.clear()
+    mcp.middleware.extend(saved)
+
+
+@pytest.fixture
+def _seed_mcp_services(tmp_path, mock_execution_env, mock_vm_state_store):
+    """Seed MCP service singletons with mocked dependencies for testing."""
+    roles_yml = tmp_path / "roles.yml"
+    roles_yml.write_text(
+        "agents:\n  default:\n    cli: claude\n    model: sonnet\n    auth: oauth\n"
+    )
+    config = Config(
+        ipc_dir=str(tmp_path / "ipc"),
+        github_dir=str(tmp_path / "github"),
+        data_dir=str(tmp_path / "data"),
+        worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+        roles_config_path=str(roles_yml),
+    )
+    store = APIStateStore()
+    settings = APISettings(api_key=TEST_API_KEY)
+
+    set_services(
+        health=HealthService(),
+        dispatch=DispatchService(
+            store=store, config=config, emitter=AsyncMock(), execution_env=mock_execution_env
+        ),
+        vm=VMService(
+            store=store,
+            config=config,
+            execution_env=mock_execution_env,
+            vm_state_store=mock_vm_state_store,
+        ),
+        run=RunService(store=store, config=config, execution_env=mock_execution_env),
+        config=ConfigService(config),
+        events=EventsService(settings, config),
+    )
+
+
+@pytest.fixture
+def _mcp_auth():
+    """Add auth middleware to the MCP server for this test scope."""
+    mcp.add_middleware(MCPApiKeyAuth(TEST_API_KEY))
+
+
+@pytest.mark.api
+class TestMCPToolRegistration:
+    """Verify all expected tools are registered on the MCP server."""
+
+    async def test_all_tools_registered(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+
+        expected_tools = {
+            # Health
+            "health_check",
+            "readiness_check",
+            # Dispatch
+            "dispatch_create",
+            "dispatch_get_status",
+            "dispatch_cancel",
+            # VM
+            "vm_list",
+            "vm_provision",
+            "vm_provision_status",
+            "vm_release",
+            "vm_dry_run",
+            # Run
+            "run_provision",
+            "run_execute",
+            "run_teardown",
+            "run_full",
+            "run_status",
+            # Config
+            "config_get",
+            # Events
+            "events_query",
+        }
+        assert expected_tools.issubset(tool_names), f"Missing tools: {expected_tools - tool_names}"
+
+    async def test_tool_descriptions_present(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        for tool in tools:
+            assert tool.description, f"Tool {tool.name} has no description"
+
+
+@pytest.mark.api
+class TestMCPAuth:
+    """Test MCP API key authentication middleware."""
+
+    async def test_health_no_auth_required(self, _seed_mcp_services, _mcp_auth):
+        """Health tools should work even with auth middleware active."""
+        async with Client(mcp) as client:
+            result = await client.call_tool("health_check", {})
+        assert "ok" in _text(result)
+
+    async def test_readiness_no_auth_required(self, _seed_mcp_services, _mcp_auth):
+        """Readiness tools should work even with auth middleware active."""
+        async with Client(mcp) as client:
+            result = await client.call_tool("readiness_check", {})
+        assert "ready" in _text(result)
+
+    async def test_non_health_tool_rejected_without_auth(self, _seed_mcp_services, _mcp_auth):
+        """Non-health tools should fail without API key (stdio has no headers)."""
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match="Invalid or missing API key"):
+                await client.call_tool("config_get", {})
+
+
+@pytest.mark.api
+class TestMCPHealthTools:
+    """Test health tool execution (no auth middleware)."""
+
+    async def test_health_check_returns_status(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool("health_check", {})
+        data = json.loads(_text(result))
+        assert data["status"] == "ok"
+        assert data["version"] == "0.1.0"
+        assert "uptime_seconds" in data
+
+    async def test_readiness_check_returns_ready(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool("readiness_check", {})
+        data = json.loads(_text(result))
+        assert data["status"] == "ready"
+
+
+@pytest.mark.api
+class TestMCPDispatchTools:
+    """Test dispatch tool execution (no auth middleware)."""
+
+    async def test_dispatch_create(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "dispatch_create",
+                {
+                    "project": "test-project",
+                    "phase": "do-task",
+                    "branch": "main",
+                    "spec_folder": "specs/test",
+                    "cli": "claude",
+                },
+            )
+        data = json.loads(_text(result))
+        assert "dispatch_id" in data
+        assert data["status"] == "accepted"
+
+    async def test_dispatch_get_status(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            # Create first
+            create_result = await client.call_tool(
+                "dispatch_create",
+                {
+                    "project": "test-project",
+                    "phase": "do-task",
+                    "branch": "main",
+                    "spec_folder": "specs/test",
+                    "cli": "claude",
+                },
+            )
+            created = json.loads(_text(create_result))
+            dispatch_id = created["dispatch_id"]
+
+            # Get status
+            result = await client.call_tool(
+                "dispatch_get_status",
+                {"dispatch_id": dispatch_id},
+            )
+        data = json.loads(_text(result))
+        assert data["workflow_id"] == dispatch_id
+        assert data["project"] == "test-project"
+
+    async def test_dispatch_cancel(self, _seed_mcp_services, tmp_path):
+        # Use a separate store with no execution env so dispatch stays PENDING
+        roles_yml = tmp_path / "cancel_roles.yml"
+        roles_yml.write_text(
+            "agents:\n  default:\n    cli: claude\n    model: sonnet\n    auth: oauth\n"
+        )
+        ipc_dir = tmp_path / "cancel_ipc"
+        ipc_dir.mkdir()
+        config = Config(
+            ipc_dir=str(ipc_dir),
+            github_dir=str(tmp_path / "github"),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            roles_config_path=str(roles_yml),
+        )
+        store = APIStateStore()
+        set_services(
+            health=HealthService(),
+            dispatch=DispatchService(
+                store=store, config=config, emitter=AsyncMock(), execution_env=None
+            ),
+            vm=VMService(store=store),
+            run=RunService(store=store),
+            config=None,
+            events=EventsService(MagicMock(events_db=None)),
+        )
+
+        async with Client(mcp) as client:
+            create_result = await client.call_tool(
+                "dispatch_create",
+                {
+                    "project": "test-project",
+                    "phase": "do-task",
+                    "branch": "main",
+                    "spec_folder": "specs/test",
+                    "cli": "claude",
+                },
+            )
+            created = json.loads(_text(create_result))
+            dispatch_id = created["dispatch_id"]
+
+            cancel_result = await client.call_tool(
+                "dispatch_cancel",
+                {"dispatch_id": dispatch_id},
+            )
+        data = json.loads(_text(cancel_result))
+        assert data["status"] == "cancelled"
+
+
+@pytest.mark.api
+class TestMCPVMTools:
+    """Test VM tool execution."""
+
+    async def test_vm_list_empty(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool("vm_list", {})
+        # Empty list → FastMCP returns empty content
+        assert result.content == [] or _text(result) == "[]"
+
+    async def test_vm_dry_run(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "vm_dry_run",
+                {"project": "test", "branch": "main"},
+            )
+        data = json.loads(_text(result))
+        assert "requirements" in data
+
+
+@pytest.mark.api
+class TestMCPConfigTools:
+    """Test config tool execution."""
+
+    async def test_config_get(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool("config_get", {})
+        data = json.loads(_text(result))
+        assert "ipc_dir" in data
+        assert "poll_interval" in data
+
+
+@pytest.mark.api
+class TestMCPEventsTools:
+    """Test events tool execution."""
+
+    async def test_events_query_empty(self, _seed_mcp_services):
+        async with Client(mcp) as client:
+            result = await client.call_tool("events_query", {})
+        data = json.loads(_text(result))
+        assert "events" in data
+        assert data["total"] == 0

--- a/tests/unit/api/test_mcp.py
+++ b/tests/unit/api/test_mcp.py
@@ -302,3 +302,45 @@ class TestMCPEventsTools:
         data = json.loads(_text(result))
         assert "events" in data
         assert data["total"] == 0
+
+    async def test_events_query_clamps_limit(self, _seed_mcp_services):
+        """Negative or oversized limits are clamped to [1, 100]."""
+        async with Client(mcp) as client:
+            # Negative limit clamped to 1
+            r1 = await client.call_tool("events_query", {"limit": -1})
+            d1 = json.loads(_text(r1))
+            assert d1["limit"] == 1
+
+            # Oversized limit clamped to 100
+            r2 = await client.call_tool("events_query", {"limit": 999})
+            d2 = json.loads(_text(r2))
+            assert d2["limit"] == 100
+
+    async def test_events_query_clamps_offset(self, _seed_mcp_services):
+        """Negative offset is clamped to 0."""
+        async with Client(mcp) as client:
+            result = await client.call_tool("events_query", {"offset": -5})
+        data = json.loads(_text(result))
+        assert data["offset"] == 0
+
+
+@pytest.mark.api
+class TestMCPMiddlewareStacking:
+    """Test that auth middleware doesn't accumulate on repeated lifespan entries."""
+
+    async def test_no_duplicate_auth_middleware(self):
+        """Adding auth middleware twice should replace, not stack."""
+        saved = list(mcp.middleware)
+        try:
+            mcp.middleware.clear()
+
+            # Simulate two lifespan entries (same pattern as main.py)
+            for _ in range(3):
+                mcp.middleware[:] = [m for m in mcp.middleware if not isinstance(m, MCPApiKeyAuth)]
+                mcp.add_middleware(MCPApiKeyAuth("test-key"))
+
+            auth_count = sum(1 for m in mcp.middleware if isinstance(m, MCPApiKeyAuth))
+            assert auth_count == 1, f"Expected 1 auth middleware, got {auth_count}"
+        finally:
+            mcp.middleware.clear()
+            mcp.middleware.extend(saved)

--- a/tests/unit/api/test_run.py
+++ b/tests/unit/api/test_run.py
@@ -1183,7 +1183,7 @@ class TestRun:
         self, client, auth_headers, app, mock_execution_env, monkeypatch
     ):
         """Prior task that hangs forever does not block teardown indefinitely."""
-        import tanren_api.routers.run as run_module  # noqa: PLC0415
+        import tanren_api.services.run as run_module  # noqa: PLC0415
 
         store = app.state.api_store
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ members = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -48,6 +60,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
 ]
 
 [[package]]
@@ -99,6 +132,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -282,6 +346,70 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/06/d68a5d5d292c2ad2bc6a02e5ca2cb1bb9c15e941ab02f004a06a342d7f0f/cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7", size = 204097, upload-time = "2026-03-14T14:09:32.504Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +423,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
 ]
 
 [[package]]
@@ -348,6 +508,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -357,12 +526,133 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -378,12 +668,71 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
 ]
 
 [[package]]
@@ -410,12 +759,55 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -440,6 +832,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -505,6 +902,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +948,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -615,6 +1035,34 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -638,6 +1086,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -681,6 +1142,56 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.6"
 source = { registry = "https://pypi.org/simple" }
@@ -706,6 +1217,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -721,6 +1245,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/2f/9223c24f568bb7a0c03d751e609844dce0968f13b39a3f73fbb3a96cd27a/sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049", size = 32420, upload-time = "2026-03-17T20:05:55.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/e2/b8cff57a67dddf9a464d7e943218e031617fb3ddc133aeeb0602ff5f6c85/sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d", size = 14329, upload-time = "2026-03-17T20:05:54.35Z" },
 ]
 
 [[package]]
@@ -741,6 +1278,7 @@ version = "0.1.0"
 source = { editable = "services/tanren-api" }
 dependencies = [
     { name = "fastapi" },
+    { name = "fastmcp" },
     { name = "pydantic-settings" },
     { name = "tanren-core" },
     { name = "uvicorn" },
@@ -749,6 +1287,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0,<1" },
+    { name = "fastmcp", specifier = ">=2.14.5" },
     { name = "pydantic-settings", specifier = ">=2.0,<3" },
     { name = "tanren-core", editable = "packages/tanren-core" },
     { name = "uvicorn", specifier = ">=0.40.0,<1" },
@@ -908,6 +1447,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/7c/b5b7d8136f872e3f13b0584e576886de0489d7213a12de6bebf29ff6ebfc/uncalled_for-0.2.0.tar.gz", hash = "sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f", size = 49488, upload-time = "2026-02-27T17:40:58.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/7f/4320d9ce3be404e6310b915c3629fe27bf1e2f438a1a7a3cb0396e32e9a9/uncalled_for-0.2.0-py3-none-any.whl", hash = "sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f", size = 11351, upload-time = "2026-02-27T17:40:56.804Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -927,4 +1475,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
## Summary

- **Service layer extraction**: Moved business logic from router handlers into dedicated service classes (`DispatchService`, `VMService`, `RunService`, `HealthService`, `ConfigService`, `EventsService`). Routers are now thin wrappers that delegate to services.
- **FastMCP server**: Added MCP server mounted at `/mcp` with 17 tools covering the full tanren-api surface — dispatch, VM, run lifecycle, config, events, and health.
- **Auth middleware**: `MCPApiKeyAuth` reuses `APIKeyVerifier` for constant-time API key comparison. Health tools bypass auth, matching REST behaviour.
- **Combined lifespans**: MCP and FastAPI lifespans composed via `combine_lifespans`.

### MCP tools

| Domain | Tools |
|--------|-------|
| Health | `health_check`, `readiness_check` |
| Dispatch | `dispatch_create`, `dispatch_get_status`, `dispatch_cancel` |
| VM | `vm_list`, `vm_provision`, `vm_provision_status`, `vm_release`, `vm_dry_run` |
| Run | `run_provision`, `run_execute`, `run_teardown`, `run_full`, `run_status` |
| Config | `config_get` |
| Events | `events_query` |

### Setup for MCP clients

The MCP endpoint is available at `/mcp` on the same host/port as the REST API. Clients connect via Streamable HTTP transport:

```json
{
  "mcpServers": {
    "tanren": {
      "url": "http://localhost:8000/mcp",
      "headers": {
        "x-api-key": "<your-api-key>"
      }
    }
  }
}
```

Health tools (`health_check`, `readiness_check`) do not require authentication.

## Test plan

- [x] All 166 API unit tests pass (152 existing + 14 new MCP tests)
- [x] All 957 unit tests pass (86% coverage)
- [x] All 342 integration tests pass (76% coverage)
- [x] Format, lint, and type checks pass (`make check`)
- [x] MCP tool registration verified (all 17 tools discoverable)
- [x] MCP auth middleware tested (valid key, missing key, health bypass)
- [x] MCP tool execution tested (health, dispatch create/get/cancel, VM list/dry-run, config, events)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)