### PR TITLE
feat: configurable Postgres backend for events and VM state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ unit:
 
 integration:
 	uv run pytest tests/integration -q --tb=short --timeout=30 \
-		-m "not ssh and not local_env and not hetzner and not gcp" \
+		-m "not ssh and not local_env and not hetzner and not gcp and not postgres" \
 		--cov=packages --cov=services --cov-fail-under=75
 
 docs-check:

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "PyYAML>=6.0, <7",
     "aiosqlite>=0.20, <1",
     "paramiko>=3.0, <4",
+    "asyncpg>=0.30, <1",
 ]
 
 [project.optional-dependencies]

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -43,6 +43,7 @@ try:  # noqa: SIM105, RUF067
     from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 except ImportError:  # hcloud not installed
     pass
+from tanren_core.adapters.event_reader import EventReader, SqliteEventReader
 from tanren_core.adapters.local_environment import LocalExecutionEnvironment
 from tanren_core.adapters.manual_vm import (
     ManualProvisionerSettings,
@@ -51,6 +52,10 @@ from tanren_core.adapters.manual_vm import (
     NoVMAvailableError,
 )
 from tanren_core.adapters.null_emitter import NullEventEmitter
+from tanren_core.adapters.postgres_emitter import PostgresEventEmitter
+from tanren_core.adapters.postgres_event_reader import PostgresEventReader
+from tanren_core.adapters.postgres_pool import create_postgres_pool, is_postgres_url
+from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore
 from tanren_core.adapters.protocols import (
     EnvironmentBootstrapper,
     EnvProvisioner,
@@ -115,6 +120,7 @@ __all__ = [
     "ErrorOccurred",
     "Event",
     "EventEmitter",
+    "EventReader",
     "ExecutionEnvironment",
     "GCPProvisionerSettings",
     "GCPVMProvisioner",
@@ -137,6 +143,9 @@ __all__ = [
     "PhaseStarted",
     "PostflightCompleted",
     "PostflightRunner",
+    "PostgresEventEmitter",
+    "PostgresEventReader",
+    "PostgresVMStateStore",
     "PreflightCompleted",
     "PreflightRunner",
     "ProcessSpawner",
@@ -151,6 +160,7 @@ __all__ = [
     "SSHExecutionEnvironment",
     "SecretBundle",
     "SqliteEventEmitter",
+    "SqliteEventReader",
     "SqliteVMStateStore",
     "SubprocessSpawner",
     "TokenUsageRecorded",
@@ -168,6 +178,8 @@ __all__ = [
     "WorkspaceSpec",
     "WorktreeManager",
     "all_credential_cleanup_paths",
+    "create_postgres_pool",
     "inject_all_cli_credentials",
+    "is_postgres_url",
     "providers_for_clis",
 ]

--- a/packages/tanren-core/src/tanren_core/adapters/event_reader.py
+++ b/packages/tanren-core/src/tanren_core/adapters/event_reader.py
@@ -1,4 +1,4 @@
-"""Read-only event query function for the SQLite events database."""
+"""Event reader protocol and SQLite implementation."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 import aiosqlite
 
@@ -32,6 +33,102 @@ class EventQueryResult:
     skipped: int = 0
 
 
+@runtime_checkable
+class EventReader(Protocol):
+    """Protocol for querying structured events."""
+
+    async def query_events(
+        self,
+        *,
+        workflow_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> EventQueryResult:
+        """Query events with optional filters and pagination."""
+        ...
+
+
+class SqliteEventReader:
+    """Reads events from a SQLite database.
+
+    Satisfies the EventReader protocol via structural typing.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        """Initialize with the path to the SQLite events database."""
+        self._db_path = Path(db_path)
+
+    async def query_events(
+        self,
+        *,
+        workflow_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> EventQueryResult:
+        """Query events from the SQLite events database.
+
+        Opens a read-only connection. Builds WHERE clause from filters.
+        Returns events ordered by timestamp DESC with pagination.
+
+        Returns:
+            EventQueryResult with matching events and total count.
+        """
+        if not self._db_path.exists():
+            return EventQueryResult()
+
+        where_clauses: list[str] = []
+        params: list[str | int] = []
+
+        if workflow_id is not None:
+            where_clauses.append("workflow_id = ?")
+            params.append(workflow_id)
+        if event_type is not None:
+            where_clauses.append("event_type = ?")
+            params.append(event_type)
+
+        where_sql = ""
+        if where_clauses:
+            where_sql = " WHERE " + " AND ".join(where_clauses)
+
+        async with aiosqlite.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
+            # Total count
+            count_sql = f"SELECT COUNT(*) FROM events{where_sql}"
+            cursor = await conn.execute(count_sql, params)
+            row = await cursor.fetchone()
+            total = row[0] if row else 0
+
+            # Fetch page
+            select_sql = (
+                f"SELECT id, timestamp, workflow_id, event_type, payload "
+                f"FROM events{where_sql} ORDER BY timestamp DESC LIMIT ? OFFSET ?"
+            )
+            cursor = await conn.execute(select_sql, [*params, limit, offset])
+            rows = await cursor.fetchall()
+
+        events: list[EventRow] = []
+        skipped = 0
+        for r in rows:
+            try:
+                payload = json.loads(r[4])
+            except json.JSONDecodeError, TypeError:
+                skipped += 1
+                logger.warning("Skipping event %d: malformed JSON payload", r[0])
+                continue
+            events.append(
+                EventRow(
+                    id=r[0],
+                    timestamp=r[1],
+                    workflow_id=r[2],
+                    event_type=r[3],
+                    payload=payload,
+                )
+            )
+
+        return EventQueryResult(events=events, total=total, skipped=skipped)
+
+
 async def query_events(
     db_path: str | Path,
     *,
@@ -42,62 +139,15 @@ async def query_events(
 ) -> EventQueryResult:
     """Query events from the SQLite events database.
 
-    Opens a read-only connection. Builds WHERE clause from filters.
-    Returns events ordered by timestamp DESC with pagination.
+    Backward-compatible wrapper that delegates to SqliteEventReader.
 
     Returns:
         EventQueryResult with matching events and total count.
     """
-    db_path = Path(db_path)
-    if not db_path.exists():
-        return EventQueryResult()
-
-    where_clauses: list[str] = []
-    params: list[str | int] = []
-
-    if workflow_id is not None:
-        where_clauses.append("workflow_id = ?")
-        params.append(workflow_id)
-    if event_type is not None:
-        where_clauses.append("event_type = ?")
-        params.append(event_type)
-
-    where_sql = ""
-    if where_clauses:
-        where_sql = " WHERE " + " AND ".join(where_clauses)
-
-    async with aiosqlite.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
-        # Total count
-        count_sql = f"SELECT COUNT(*) FROM events{where_sql}"
-        cursor = await conn.execute(count_sql, params)
-        row = await cursor.fetchone()
-        total = row[0] if row else 0
-
-        # Fetch page
-        select_sql = (
-            f"SELECT id, timestamp, workflow_id, event_type, payload "
-            f"FROM events{where_sql} ORDER BY timestamp DESC LIMIT ? OFFSET ?"
-        )
-        cursor = await conn.execute(select_sql, [*params, limit, offset])
-        rows = await cursor.fetchall()
-
-    events: list[EventRow] = []
-    skipped = 0
-    for r in rows:
-        try:
-            payload = json.loads(r[4])
-        except json.JSONDecodeError, TypeError:
-            skipped += 1
-            logger.warning("Skipping event %d: malformed JSON payload", r[0])
-            continue
-        events.append(
-            EventRow(
-                id=r[0],
-                timestamp=r[1],
-                workflow_id=r[2],
-                event_type=r[3],
-                payload=payload,
-            )
-        )
-
-    return EventQueryResult(events=events, total=total, skipped=skipped)
+    reader = SqliteEventReader(db_path)
+    return await reader.query_events(
+        workflow_id=workflow_id,
+        event_type=event_type,
+        limit=limit,
+        offset=offset,
+    )

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_emitter.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_emitter.py
@@ -1,0 +1,40 @@
+"""Postgres-backed event emitter for structured observability."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import asyncpg
+
+from tanren_core.adapters.events import Event
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresEventEmitter:
+    """Writes events to a Postgres database via a shared pool.
+
+    Satisfies the EventEmitter protocol via structural typing.
+    The pool is owned externally; close() is a no-op.
+    """
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        """Initialize with an existing asyncpg pool."""
+        self._pool = pool
+
+    async def emit(self, event: Event) -> None:
+        """Persist an event to the Postgres database."""
+        event_type = type(event).__name__
+        payload = json.dumps(event.model_dump(mode="json"))
+        await self._pool.execute(
+            "INSERT INTO events (timestamp, workflow_id, event_type, payload) "
+            "VALUES ($1, $2, $3, $4)",
+            event.timestamp,
+            event.workflow_id,
+            event_type,
+            payload,
+        )
+
+    async def close(self) -> None:
+        """No-op — pool is owned externally."""

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_emitter.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_emitter.py
@@ -11,6 +11,11 @@ from tanren_core.adapters.events import Event
 
 logger = logging.getLogger(__name__)
 
+# asyncpg's built-in JSONB codec calls json.dumps() internally, so we must
+# pass a Python dict — not a pre-serialised string — to avoid double-encoding.
+# The codec is registered per-connection by default in asyncpg ≥ 0.14.
+_JSONB_OID = 3802
+
 
 class PostgresEventEmitter:
     """Writes events to a Postgres database via a shared pool.
@@ -24,16 +29,20 @@ class PostgresEventEmitter:
         self._pool = pool
 
     async def emit(self, event: Event) -> None:
-        """Persist an event to the Postgres database."""
+        """Persist an event to the Postgres database.
+
+        Passes the payload as a JSON string and casts to jsonb in SQL
+        to avoid double-encoding by asyncpg's built-in JSONB codec.
+        """
         event_type = type(event).__name__
-        payload = json.dumps(event.model_dump(mode="json"))
+        payload_str = json.dumps(event.model_dump(mode="json"))
         await self._pool.execute(
             "INSERT INTO events (timestamp, workflow_id, event_type, payload) "
-            "VALUES ($1, $2, $3, $4)",
+            "VALUES ($1, $2, $3, $4::jsonb)",
             event.timestamp,
             event.workflow_id,
             event_type,
-            payload,
+            payload_str,
         )
 
     async def close(self) -> None:

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_event_reader.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_event_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 import asyncpg
@@ -67,7 +68,16 @@ class PostgresEventReader:
         skipped = 0
         for r in rows:
             payload = r["payload"]
-            # asyncpg returns JSONB as dicts/lists directly
+            # asyncpg normally returns JSONB as dicts via its built-in codec,
+            # but a string can arrive if the codec is overridden or the value
+            # was stored as a JSON string scalar.
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError, TypeError:
+                    skipped += 1
+                    logger.warning("Skipping event %d: malformed JSON payload", r["id"])
+                    continue
             if not isinstance(payload, dict):
                 skipped += 1
                 logger.warning("Skipping event %d: unexpected payload type", r["id"])

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_event_reader.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_event_reader.py
@@ -1,0 +1,85 @@
+"""Postgres-backed event reader for querying structured events."""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from tanren_core.adapters.event_reader import EventQueryResult, EventRow
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresEventReader:
+    """Reads events from a Postgres database via a shared pool.
+
+    Satisfies the EventReader protocol via structural typing.
+    """
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        """Initialize with an existing asyncpg pool."""
+        self._pool = pool
+
+    async def query_events(
+        self,
+        *,
+        workflow_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> EventQueryResult:
+        """Query events with optional filters and pagination.
+
+        Returns:
+            EventQueryResult with matching events and total count.
+        """
+        where_clauses: list[str] = []
+        params: list[str | int] = []
+        idx = 1
+
+        if workflow_id is not None:
+            where_clauses.append(f"workflow_id = ${idx}")
+            params.append(workflow_id)
+            idx += 1
+        if event_type is not None:
+            where_clauses.append(f"event_type = ${idx}")
+            params.append(event_type)
+            idx += 1
+
+        where_sql = ""
+        if where_clauses:
+            where_sql = " WHERE " + " AND ".join(where_clauses)
+
+        # Total count
+        count_sql = f"SELECT COUNT(*) FROM events{where_sql}"
+        total = await self._pool.fetchval(count_sql, *params)
+
+        # Fetch page
+        select_sql = (
+            f"SELECT id, timestamp, workflow_id, event_type, payload "
+            f"FROM events{where_sql} ORDER BY timestamp DESC "
+            f"LIMIT ${idx} OFFSET ${idx + 1}"
+        )
+        rows = await self._pool.fetch(select_sql, *params, limit, offset)
+
+        events: list[EventRow] = []
+        skipped = 0
+        for r in rows:
+            payload = r["payload"]
+            # asyncpg returns JSONB as dicts/lists directly
+            if not isinstance(payload, dict):
+                skipped += 1
+                logger.warning("Skipping event %d: unexpected payload type", r["id"])
+                continue
+            events.append(
+                EventRow(
+                    id=r["id"],
+                    timestamp=r["timestamp"],
+                    workflow_id=r["workflow_id"],
+                    event_type=r["event_type"],
+                    payload=payload,
+                )
+            )
+
+        return EventQueryResult(events=events, total=total or 0, skipped=skipped)

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_pool.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_pool.py
@@ -40,7 +40,7 @@ def is_postgres_url(url: str | None) -> bool:
     """Return True if *url* looks like a Postgres DSN."""
     if not url:
         return False
-    return url.startswith(("postgresql://", "postgres://"))
+    return url.lower().startswith(("postgresql://", "postgres://"))
 
 
 async def ensure_schema(pool: asyncpg.Pool) -> None:

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_pool.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_pool.py
@@ -1,0 +1,78 @@
+"""Shared asyncpg pool factory and schema initialization."""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+_EVENTS_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS events (
+    id BIGSERIAL PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    workflow_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_events_workflow ON events(workflow_id);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+"""
+
+_VM_STATE_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS vm_assignments (
+    vm_id TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    project TEXT NOT NULL,
+    spec TEXT NOT NULL,
+    host TEXT NOT NULL,
+    assigned_at TEXT NOT NULL,
+    released_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_vm_active
+    ON vm_assignments(released_at) WHERE released_at IS NULL;
+"""
+
+
+def is_postgres_url(url: str | None) -> bool:
+    """Return True if *url* looks like a Postgres DSN."""
+    if not url:
+        return False
+    return url.startswith(("postgresql://", "postgres://"))
+
+
+async def ensure_schema(pool: asyncpg.Pool) -> None:
+    """Create tables and indexes idempotently."""
+    async with pool.acquire() as conn:
+        for statement in _EVENTS_SCHEMA.strip().split(";"):
+            statement = statement.strip()
+            if statement:
+                await conn.execute(statement)
+        for statement in _VM_STATE_SCHEMA.strip().split(";"):
+            statement = statement.strip()
+            if statement:
+                await conn.execute(statement)
+
+
+async def create_postgres_pool(
+    dsn: str,
+    *,
+    min_size: int = 2,
+    max_size: int = 10,
+) -> asyncpg.Pool:
+    """Create an asyncpg pool and ensure the schema exists.
+
+    Args:
+        dsn: PostgreSQL connection string.
+        min_size: Minimum pool connections.
+        max_size: Maximum pool connections.
+
+    Returns:
+        Initialized asyncpg.Pool.
+    """
+    pool = await asyncpg.create_pool(dsn, min_size=min_size, max_size=max_size)
+    await ensure_schema(pool)
+    logger.info("Postgres pool created (%d-%d connections)", min_size, max_size)
+    return pool

--- a/packages/tanren-core/src/tanren_core/adapters/postgres_vm_state.py
+++ b/packages/tanren-core/src/tanren_core/adapters/postgres_vm_state.py
@@ -1,0 +1,109 @@
+"""Postgres-backed VM state store for tracking assignments."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import asyncpg
+
+from tanren_core.adapters.remote_types import VMAssignment
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresVMStateStore:
+    """Persists VM assignment state to Postgres via a shared pool.
+
+    Satisfies the VMStateStore protocol via structural typing.
+    The pool is owned externally; close() is a no-op.
+    """
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        """Initialize with an existing asyncpg pool."""
+        self._pool = pool
+
+    async def record_assignment(
+        self,
+        vm_id: str,
+        workflow_id: str,
+        project: str,
+        spec: str,
+        host: str,
+    ) -> None:
+        """Record a new VM assignment."""
+        now = datetime.now(UTC).isoformat()
+        await self._pool.execute(
+            "INSERT INTO vm_assignments "
+            "(vm_id, workflow_id, project, spec, host, assigned_at) "
+            "VALUES ($1, $2, $3, $4, $5, $6) "
+            "ON CONFLICT (vm_id) DO UPDATE SET "
+            "workflow_id = EXCLUDED.workflow_id, "
+            "project = EXCLUDED.project, "
+            "spec = EXCLUDED.spec, "
+            "host = EXCLUDED.host, "
+            "assigned_at = EXCLUDED.assigned_at, "
+            "released_at = NULL",
+            vm_id,
+            workflow_id,
+            project,
+            spec,
+            host,
+            now,
+        )
+
+    async def record_release(self, vm_id: str) -> None:
+        """Mark a VM assignment as released."""
+        now = datetime.now(UTC).isoformat()
+        await self._pool.execute(
+            "UPDATE vm_assignments SET released_at = $1 WHERE vm_id = $2 AND released_at IS NULL",
+            now,
+            vm_id,
+        )
+
+    async def get_active_assignments(self) -> list[VMAssignment]:
+        """Get all currently active (unreleased) VM assignments.
+
+        Returns:
+            List of active VMAssignment records.
+        """
+        rows = await self._pool.fetch(
+            "SELECT vm_id, workflow_id, project, spec, host, assigned_at "
+            "FROM vm_assignments WHERE released_at IS NULL"
+        )
+        return [
+            VMAssignment(
+                vm_id=row["vm_id"],
+                workflow_id=row["workflow_id"],
+                project=row["project"],
+                spec=row["spec"],
+                host=row["host"],
+                assigned_at=row["assigned_at"],
+            )
+            for row in rows
+        ]
+
+    async def get_assignment(self, vm_id: str) -> VMAssignment | None:
+        """Get a specific VM assignment by ID.
+
+        Returns:
+            VMAssignment if found, None otherwise.
+        """
+        row = await self._pool.fetchrow(
+            "SELECT vm_id, workflow_id, project, spec, host, assigned_at "
+            "FROM vm_assignments WHERE vm_id = $1 AND released_at IS NULL",
+            vm_id,
+        )
+        if row is None:
+            return None
+        return VMAssignment(
+            vm_id=row["vm_id"],
+            workflow_id=row["workflow_id"],
+            project=row["project"],
+            spec=row["spec"],
+            host=row["host"],
+            assigned_at=row["assigned_at"],
+        )
+
+    async def close(self) -> None:
+        """No-op — pool is owned externally."""

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncpg
 
 from tanren_core.adapters.credentials import providers_for_clis
 from tanren_core.adapters.git_workspace import GitAuthConfig, GitWorkspaceManager
 from tanren_core.adapters.manual_vm import ManualProvisionerSettings, ManualVMProvisioner
-from tanren_core.adapters.protocols import EventEmitter
+from tanren_core.adapters.protocols import EventEmitter, VMStateStore
 from tanren_core.adapters.remote_runner import RemoteAgentRunner
 from tanren_core.adapters.remote_types import VMProvider
-from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
 from tanren_core.adapters.ssh import SSHConfig
 from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
@@ -34,7 +37,8 @@ _AGENT_USER = "tanren"
 def build_ssh_execution_environment(
     config: Config,
     emitter: EventEmitter,
-) -> tuple[SSHExecutionEnvironment, SqliteVMStateStore]:
+    pool: asyncpg.Pool | None = None,
+) -> tuple[SSHExecutionEnvironment, VMStateStore]:
     """Construct an SSHExecutionEnvironment from config and emitter.
 
     Returns:
@@ -60,7 +64,14 @@ def build_ssh_execution_environment(
         host_key_policy=remote_cfg.ssh.host_key_policy,
     )
 
-    state_store = SqliteVMStateStore(f"{config.data_dir}/vm-state.db")
+    if pool is not None:
+        from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore  # noqa: PLC0415
+
+        state_store: VMStateStore = PostgresVMStateStore(pool)
+    else:
+        from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore  # noqa: PLC0415
+
+        state_store = SqliteVMStateStore(f"{config.data_dir}/vm-state.db")
 
     # Read extra bootstrap script if configured
     extra_script = None

--- a/packages/tanren-core/src/tanren_core/config.py
+++ b/packages/tanren-core/src/tanren_core/config.py
@@ -22,6 +22,15 @@ def _expand_optional(path: str | None) -> str | None:
     return _expand(path)
 
 
+def _pg_or_expand(value: str | None) -> str | None:
+    """Return Postgres URLs as-is; expand filesystem paths."""
+    if not value or not value.strip():
+        return None
+    if value.startswith(("postgresql://", "postgres://")):
+        return value
+    return _expand(value)
+
+
 @runtime_checkable
 class ConfigSource(Protocol):
     """Provide WM_* configuration values from an external source.
@@ -168,7 +177,7 @@ class Config(BaseModel):
     )
     events_db: str | None = Field(
         default=None,
-        description="Path to SQLite events DB (enables event emission)",
+        description="SQLite path or postgresql:// URL for events and VM state",
     )
     remote_config_path: str | None = Field(
         default=None,
@@ -234,7 +243,7 @@ class Config(BaseModel):
             max_opencode=int(resolved["WM_MAX_OPENCODE"]),
             max_codex=int(resolved["WM_MAX_CODEX"]),
             max_gate=int(resolved["WM_MAX_GATE"]),
-            events_db=_expand_optional(resolved.get("WM_EVENTS_DB")),
+            events_db=_pg_or_expand(resolved.get("WM_EVENTS_DB")),
             remote_config_path=_expand_optional(resolved.get("WM_REMOTE_CONFIG")),
             ccusage_claude_cmd=resolved.get("WM_CCUSAGE_CLAUDE_CMD", "npx ccusage"),
             ccusage_codex_cmd=resolved.get("WM_CCUSAGE_CODEX_CMD", "npx @ccusage/codex"),

--- a/packages/tanren-core/src/tanren_core/config.py
+++ b/packages/tanren-core/src/tanren_core/config.py
@@ -26,7 +26,7 @@ def _pg_or_expand(value: str | None) -> str | None:
     """Return Postgres URLs as-is; expand filesystem paths."""
     if not value or not value.strip():
         return None
-    if value.startswith(("postgresql://", "postgres://")):
+    if value.lower().startswith(("postgresql://", "postgres://")):
         return value
     return _expand(value)
 

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -192,6 +192,7 @@ class WorkerManager:
             self._emitter = NullEventEmitter()
 
         # Build execution environment — use injected or construct from config
+        self._execution_env_injected = execution_env is not None
         if execution_env is not None:
             self._execution_env = execution_env
         elif self._config.remote_config_path:
@@ -350,8 +351,9 @@ class WorkerManager:
         self._pg_pool = pool
         self._emitter = PostgresEventEmitter(pool)
 
-        # Rebuild remote execution environment with Postgres-backed state store
-        if self._config.remote_config_path:
+        # Rebuild remote execution environment with Postgres-backed state store,
+        # but only if the execution environment was not explicitly injected.
+        if self._config.remote_config_path and not self._execution_env_injected:
             if hasattr(self, "_remote_state_store"):
                 await self._remote_state_store.close()
             self._execution_env = self._build_remote_env(pool=pool)

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -14,7 +14,10 @@ import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    import asyncpg
 
 from pydantic import JsonValue
 
@@ -36,6 +39,7 @@ from tanren_core.adapters import (
 )
 from tanren_core.adapters.local_environment import LocalExecutionEnvironment
 from tanren_core.adapters.manual_vm import ManualProvisionerSettings, ManualVMProvisioner
+from tanren_core.adapters.postgres_pool import is_postgres_url
 from tanren_core.adapters.protocols import (
     EnvProvisioner,
     EnvValidator,
@@ -170,10 +174,18 @@ class WorkerManager:
         self._env_validator = env_validator or DotenvEnvValidator()
         self._env_provisioner = env_provisioner or DotenvEnvProvisioner()
 
+        # Postgres state (populated in run() if events_db is a Postgres URL)
+        self._pg_dsn: str | None = None
+        self._pg_pool: asyncpg.Pool | None = None
+
         # Event emitter — auto-configure from config if not injected
         # Must be initialized before execution environment (remote env references it)
         if emitter is not None:
             self._emitter: EventEmitter = emitter
+        elif self._config.events_db and is_postgres_url(self._config.events_db):
+            # Defer Postgres pool creation to run() (needs async context)
+            self._pg_dsn = self._config.events_db
+            self._emitter = NullEventEmitter()
         elif self._config.events_db:
             self._emitter = SqliteEventEmitter(self._config.events_db)
         else:
@@ -208,6 +220,9 @@ class WorkerManager:
         logger.info("Worker manager starting")
         logger.info("IPC dir: %s", self._config.ipc_dir)
         logger.info("Data dir: %s", self._config.data_dir)
+
+        # Initialize Postgres pool if configured
+        await self._init_postgres()
 
         # Register signal handlers
         loop = asyncio.get_running_loop()
@@ -257,6 +272,10 @@ class WorkerManager:
         if hasattr(self, "_remote_state_store"):
             await self._remote_state_store.close()
 
+        # Close Postgres pool if present
+        if self._pg_pool is not None:
+            await self._pg_pool.close()
+
         logger.info("Worker manager stopped")
 
     def _signal_shutdown(self) -> None:
@@ -304,17 +323,38 @@ class WorkerManager:
         health_path = Path(self._config.ipc_dir) / "worker-health.json"
         await atomic_write(health_path, health.model_dump_json(indent=2))
 
-    def _build_remote_env(self) -> ExecutionEnvironment:
+    def _build_remote_env(self, pool: asyncpg.Pool | None = None) -> ExecutionEnvironment:
         """Construct SSHExecutionEnvironment from remote.yml.
+
+        Args:
+            pool: Optional asyncpg.Pool for Postgres-backed state store.
 
         Returns:
             Configured SSHExecutionEnvironment.
         """
         from tanren_core.builder import build_ssh_execution_environment  # noqa: PLC0415
 
-        env, state_store = build_ssh_execution_environment(self._config, self._emitter)
+        env, state_store = build_ssh_execution_environment(self._config, self._emitter, pool=pool)
         self._remote_state_store = state_store
         return env
+
+    async def _init_postgres(self) -> None:
+        """Create Postgres pool and rebuild adapters if configured."""
+        if self._pg_dsn is None:
+            return
+
+        from tanren_core.adapters.postgres_emitter import PostgresEventEmitter  # noqa: PLC0415
+        from tanren_core.adapters.postgres_pool import create_postgres_pool  # noqa: PLC0415
+
+        pool = await create_postgres_pool(self._pg_dsn)
+        self._pg_pool = pool
+        self._emitter = PostgresEventEmitter(pool)
+
+        # Rebuild remote execution environment with Postgres-backed state store
+        if self._config.remote_config_path:
+            if hasattr(self, "_remote_state_store"):
+                await self._remote_state_store.close()
+            self._execution_env = self._build_remote_env(pool=pool)
 
     async def _recover_vm_state(self) -> None:
         """Startup recovery: release stale assignments via provider cleanup.
@@ -327,7 +367,12 @@ class WorkerManager:
 
         remote_cfg = load_remote_config(self._config.remote_config_path)
 
-        store = SqliteVMStateStore(f"{self._config.data_dir}/vm-state.db")
+        if self._pg_pool is not None:
+            from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore  # noqa: PLC0415
+
+            store = PostgresVMStateStore(self._pg_pool)
+        else:
+            store = SqliteVMStateStore(f"{self._config.data_dir}/vm-state.db")
         try:
             assignments = await store.get_active_assignments()
             if not assignments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ markers = [
     "api: API-specific tests",
     "hetzner: requires Hetzner API token and provisions real VMs",
     "gcp: requires GCP credentials and provisions real VMs",
+    "postgres: requires a real Postgres database",
 ]
 
 # ===== COVERAGE =====

--- a/services/tanren-api/src/tanren_api/dependencies.py
+++ b/services/tanren-api/src/tanren_api/dependencies.py
@@ -7,6 +7,7 @@ from fastapi import Request
 from tanren_api.errors import ServiceError
 from tanren_api.settings import APISettings
 from tanren_api.state import APIStateStore
+from tanren_core.adapters.event_reader import EventReader
 from tanren_core.adapters.protocols import EventEmitter, ExecutionEnvironment, VMStateStore
 from tanren_core.config import Config
 
@@ -41,6 +42,11 @@ def get_api_store(request: Request) -> APIStateStore:
 def get_execution_env(request: Request) -> ExecutionEnvironment | None:
     """Return the execution environment, or None if not configured."""
     return request.app.state.execution_env
+
+
+def get_event_reader(request: Request) -> EventReader | None:
+    """Return the event reader, or None if not configured."""
+    return getattr(request.app.state, "event_reader", None)
 
 
 def get_vm_state_store(request: Request) -> VMStateStore | None:

--- a/services/tanren-api/src/tanren_api/dependencies.py
+++ b/services/tanren-api/src/tanren_api/dependencies.py
@@ -7,8 +7,7 @@ from fastapi import Request
 from tanren_api.errors import ServiceError
 from tanren_api.settings import APISettings
 from tanren_api.state import APIStateStore
-from tanren_core.adapters.protocols import EventEmitter, ExecutionEnvironment
-from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
+from tanren_core.adapters.protocols import EventEmitter, ExecutionEnvironment, VMStateStore
 from tanren_core.config import Config
 
 
@@ -44,6 +43,6 @@ def get_execution_env(request: Request) -> ExecutionEnvironment | None:
     return request.app.state.execution_env
 
 
-def get_vm_state_store(request: Request) -> SqliteVMStateStore | None:
+def get_vm_state_store(request: Request) -> VMStateStore | None:
     """Return the VM state store, or None if not configured."""
     return request.app.state.vm_state_store

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -34,7 +34,9 @@ from tanren_api.services import (
 )
 from tanren_api.settings import APISettings
 from tanren_api.state import APIStateStore
+from tanren_core.adapters.event_reader import SqliteEventReader
 from tanren_core.adapters.null_emitter import NullEventEmitter
+from tanren_core.adapters.postgres_pool import is_postgres_url
 from tanren_core.adapters.sqlite_emitter import SqliteEventEmitter
 from tanren_core.builder import build_ssh_execution_environment
 from tanren_core.config import Config, load_config_env
@@ -66,8 +68,23 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         db = settings.events_db
         if db is None and app.state.config is not None:
             db = app.state.config.events_db
-        if db:
+
+        app.state.pg_pool = None
+        app.state.event_reader = None
+        if db and is_postgres_url(db):
+            from tanren_core.adapters.postgres_emitter import PostgresEventEmitter  # noqa: PLC0415
+            from tanren_core.adapters.postgres_event_reader import (  # noqa: PLC0415
+                PostgresEventReader,
+            )
+            from tanren_core.adapters.postgres_pool import create_postgres_pool  # noqa: PLC0415
+
+            pg_pool = await create_postgres_pool(db)
+            app.state.pg_pool = pg_pool
+            app.state.emitter = PostgresEventEmitter(pg_pool)
+            app.state.event_reader = PostgresEventReader(pg_pool)
+        elif db:
             app.state.emitter = SqliteEventEmitter(db)
+            app.state.event_reader = SqliteEventReader(db)
         else:
             app.state.emitter = NullEventEmitter()
 
@@ -79,7 +96,10 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         if app.state.config and app.state.config.remote_config_path:
             try:
                 env, vm_store = await asyncio.to_thread(
-                    build_ssh_execution_environment, app.state.config, app.state.emitter
+                    build_ssh_execution_environment,
+                    app.state.config,
+                    app.state.emitter,
+                    pool=app.state.pg_pool,
                 )
                 app.state.execution_env = env
                 app.state.vm_state_store = vm_store
@@ -116,7 +136,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
                 execution_env=app.state.execution_env,
             ),
             config=config_svc,
-            events=EventsService(settings, app.state.config),
+            events=EventsService(settings, app.state.config, event_reader=app.state.event_reader),
         )
 
         yield
@@ -126,6 +146,8 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         if app.state.execution_env is not None:
             await app.state.execution_env.close()
         await app.state.emitter.close()
+        if app.state.pg_pool is not None:
+            await app.state.pg_pool.close()
 
     # Build middleware stack before creating app (order matters: outermost first)
     middleware_stack: list[Middleware] = [

--- a/services/tanren-api/src/tanren_api/routers/events.py
+++ b/services/tanren-api/src/tanren_api/routers/events.py
@@ -7,10 +7,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Request
 
-from tanren_api.dependencies import get_settings
+from tanren_api.dependencies import get_event_reader, get_settings
 from tanren_api.models import PaginatedEvents
 from tanren_api.services import EventsService
 from tanren_api.settings import APISettings
+from tanren_core.adapters.event_reader import EventReader
 
 router = APIRouter(tags=["events"])
 
@@ -19,6 +20,7 @@ router = APIRouter(tags=["events"])
 async def list_events(
     request: Request,
     settings: Annotated[APISettings, Depends(get_settings)],
+    event_reader: Annotated[EventReader | None, Depends(get_event_reader)],
     workflow_id: Annotated[str | None, Query(description="Filter by workflow ID")] = None,
     event_type: Annotated[str | None, Query(description="Filter by event type")] = None,
     limit: Annotated[int, Query(ge=1, le=100, description="Page size")] = 50,
@@ -26,7 +28,7 @@ async def list_events(
 ) -> PaginatedEvents:
     """Query structured events with optional filters."""
     config = getattr(request.app.state, "config", None)
-    return await EventsService(settings, config).query(
+    return await EventsService(settings, config, event_reader=event_reader).query(
         workflow_id=workflow_id,
         event_type=event_type,
         limit=limit,

--- a/services/tanren-api/src/tanren_api/routers/vm.py
+++ b/services/tanren-api/src/tanren_api/routers/vm.py
@@ -18,8 +18,7 @@ from tanren_api.models import (
 )
 from tanren_api.services import VMService
 from tanren_api.state import APIStateStore
-from tanren_core.adapters.protocols import ExecutionEnvironment
-from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
+from tanren_core.adapters.protocols import ExecutionEnvironment, VMStateStore
 from tanren_core.config import Config
 
 router = APIRouter(tags=["vm"])
@@ -29,14 +28,14 @@ def _vm_service(
     store: APIStateStore,
     config: Config,
     execution_env: ExecutionEnvironment | None = None,
-    vm_state_store: SqliteVMStateStore | None = None,
+    vm_state_store: VMStateStore | None = None,
 ) -> VMService:
     return VMService(store, config, execution_env, vm_state_store)
 
 
 @router.get("/vm")
 async def list_vms(
-    vm_state_store: Annotated[SqliteVMStateStore | None, Depends(get_vm_state_store)],
+    vm_state_store: Annotated[VMStateStore | None, Depends(get_vm_state_store)],
     config: Annotated[Config, Depends(get_config)],
     store: Annotated[APIStateStore, Depends(get_api_store)],
 ) -> list[VMSummary]:
@@ -68,7 +67,7 @@ async def get_provision_status(
 @router.delete("/vm/{vm_id}")
 async def release_vm(
     vm_id: Annotated[str, Path(description="VM identifier")],
-    vm_state_store: Annotated[SqliteVMStateStore | None, Depends(get_vm_state_store)],
+    vm_state_store: Annotated[VMStateStore | None, Depends(get_vm_state_store)],
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
     config: Annotated[Config, Depends(get_config)],
     store: Annotated[APIStateStore, Depends(get_api_store)],

--- a/services/tanren-api/src/tanren_api/services/core.py
+++ b/services/tanren-api/src/tanren_api/services/core.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     from tanren_api.models import EventPayload
     from tanren_api.settings import APISettings
+    from tanren_core.adapters.event_reader import EventReader
     from tanren_core.config import Config
 
 logger = logging.getLogger(__name__)
@@ -63,10 +64,16 @@ class ConfigService:
 class EventsService:
     """Service for querying structured events."""
 
-    def __init__(self, settings: APISettings, config: Config | None = None) -> None:
-        """Initialize with settings and optional config for DB path fallback."""
+    def __init__(
+        self,
+        settings: APISettings,
+        config: Config | None = None,
+        event_reader: EventReader | None = None,
+    ) -> None:
+        """Initialize with settings, optional config, and optional event reader."""
         self._settings = settings
         self._config = config
+        self._event_reader = event_reader
 
     async def query(
         self,
@@ -77,22 +84,30 @@ class EventsService:
         offset: int = 0,
     ) -> PaginatedEvents:
         """Query structured events with optional filters."""
-        from tanren_core.adapters.event_reader import query_events  # noqa: PLC0415
+        if self._event_reader is not None:
+            result = await self._event_reader.query_events(
+                workflow_id=workflow_id,
+                event_type=event_type,
+                limit=limit,
+                offset=offset,
+            )
+        else:
+            from tanren_core.adapters.event_reader import query_events  # noqa: PLC0415
 
-        db_path = self._settings.events_db
-        if db_path is None and self._config is not None:
-            db_path = self._config.events_db
+            db_path = self._settings.events_db
+            if db_path is None and self._config is not None:
+                db_path = self._config.events_db
 
-        if not db_path:
-            return PaginatedEvents(events=[], total=0, limit=limit, offset=offset)
+            if not db_path:
+                return PaginatedEvents(events=[], total=0, limit=limit, offset=offset)
 
-        result = await query_events(
-            db_path,
-            workflow_id=workflow_id,
-            event_type=event_type,
-            limit=limit,
-            offset=offset,
-        )
+            result = await query_events(
+                db_path,
+                workflow_id=workflow_id,
+                event_type=event_type,
+                limit=limit,
+                offset=offset,
+            )
 
         events: list[EventPayload] = []
         skipped = 0

--- a/services/tanren-api/src/tanren_api/services/vm.py
+++ b/services/tanren-api/src/tanren_api/services/vm.py
@@ -21,9 +21,8 @@ from tanren_api.models import (
     VMSummary,
 )
 from tanren_api.state import APIStateStore, EnvironmentRecord
-from tanren_core.adapters.protocols import ExecutionEnvironment
+from tanren_core.adapters.protocols import ExecutionEnvironment, VMStateStore
 from tanren_core.adapters.remote_types import VMHandle, VMProvider, VMRequirements
-from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
 from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
 from tanren_core.remote_config import ProvisionerType, load_remote_config
@@ -62,7 +61,7 @@ class VMService:
         store: APIStateStore,
         config: Config | None = None,
         execution_env: ExecutionEnvironment | None = None,
-        vm_state_store: SqliteVMStateStore | None = None,
+        vm_state_store: VMStateStore | None = None,
     ) -> None:
         """Initialize with dependencies."""
         self._store = store

--- a/services/tanren-cli/src/tanren_cli/run_cli.py
+++ b/services/tanren-cli/src/tanren_cli/run_cli.py
@@ -12,13 +12,17 @@ import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Literal, cast
+
+if TYPE_CHECKING:
+    import asyncpg
 
 import typer
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from tanren_core.adapters.null_emitter import NullEventEmitter
+from tanren_core.adapters.postgres_pool import is_postgres_url
 from tanren_core.adapters.remote_types import VMHandle, WorkspacePath
 from tanren_core.adapters.ssh import SSHConfig, SSHConnection
 from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
@@ -82,11 +86,24 @@ def _require_remote_config(config: Config) -> None:
         raise typer.Exit(code=1)
 
 
-def _build_remote_execution_env(config: Config) -> SSHExecutionEnvironment:
+async def _build_remote_execution_env(
+    config: Config,
+) -> tuple[SSHExecutionEnvironment, asyncpg.Pool | None]:
+    """Build SSH execution environment, returning (env, pg_pool_or_none).
+
+    Returns:
+        Tuple of (SSHExecutionEnvironment, asyncpg.Pool | None).
+    """
     from tanren_core.builder import build_ssh_execution_environment  # noqa: PLC0415
 
-    env, _store = build_ssh_execution_environment(config, NullEventEmitter())
-    return env
+    pool = None
+    if config.events_db and is_postgres_url(config.events_db):
+        from tanren_core.adapters.postgres_pool import create_postgres_pool  # noqa: PLC0415
+
+        pool = await create_postgres_pool(config.events_db)
+
+    env, _store = build_ssh_execution_environment(config, NullEventEmitter(), pool=pool)
+    return env, pool
 
 
 def _handle_dir(config: Config) -> Path:
@@ -324,7 +341,7 @@ def run_provision(
     async def _run() -> None:
         config = _load_config()
         _require_remote_config(config)
-        env = _build_remote_execution_env(config)
+        env, pg_pool = await _build_remote_execution_env(config)
         try:
             workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
             tool = _resolve_agent_tool(config, Phase.DO_TASK)
@@ -385,6 +402,8 @@ def run_provision(
             typer.echo(f"handle_file: {path}")
         finally:
             await env.close()
+            if pg_pool is not None:
+                await pg_pool.close()
 
     asyncio.run(_run())
 
@@ -404,7 +423,7 @@ def run_execute(
     async def _run() -> None:
         config = _load_config()
         _require_remote_config(config)
-        env = _build_remote_execution_env(config)
+        env, pg_pool = await _build_remote_execution_env(config)
         try:
             persisted, _ = _load_handle(config, handle)
             if persisted.project != project:
@@ -461,6 +480,8 @@ def run_execute(
                     typer.echo(stderr_tail)
         finally:
             await env.close()
+            if pg_pool is not None:
+                await pg_pool.close()
 
     asyncio.run(_run())
 
@@ -474,7 +495,7 @@ def run_teardown(
     async def _run() -> None:
         config = _load_config()
         _require_remote_config(config)
-        env = _build_remote_execution_env(config)
+        env, pg_pool = await _build_remote_execution_env(config)
         try:
             persisted, handle_path = _load_handle(config, handle)
 
@@ -497,6 +518,8 @@ def run_teardown(
                 typer.echo(f"estimated_cost: {estimated_cost:.4f}")
         finally:
             await env.close()
+            if pg_pool is not None:
+                await pg_pool.close()
 
     asyncio.run(_run())
 
@@ -517,7 +540,7 @@ def run_full(
     async def _run() -> None:
         config = _load_config()
         _require_remote_config(config)
-        env = _build_remote_execution_env(config)
+        env, pg_pool = await _build_remote_execution_env(config)
         try:
             workflow_id = f"run-{project}-{uuid.uuid4().hex[:10]}"
             provision_tool = _resolve_agent_tool(config, Phase.DO_TASK)
@@ -621,6 +644,8 @@ def run_full(
                 raise typer.Exit(code=1)
         finally:
             await env.close()
+            if pg_pool is not None:
+                await pg_pool.close()
 
     asyncio.run(_run())
 

--- a/services/tanren-cli/src/tanren_cli/vm_cli.py
+++ b/services/tanren-cli/src/tanren_cli/vm_cli.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncpg
 
 import typer
 import yaml
 from dotenv import dotenv_values
 
 from tanren_core.adapters.manual_vm import ManualProvisionerSettings
+from tanren_core.adapters.postgres_pool import is_postgres_url
+from tanren_core.adapters.protocols import VMStateStore
 from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
 from tanren_core.adapters.ssh import SSHConfig, SSHConnection
 from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
@@ -38,14 +44,21 @@ def _load_config() -> Config:
         raise typer.Exit(code=1) from exc
 
 
-def _get_state_store(config: Config) -> SqliteVMStateStore:
-    """Create a VMStateStore from Config.data_dir.
+async def _get_state_store(config: Config) -> tuple[VMStateStore, asyncpg.Pool | None]:
+    """Create a VMStateStore from Config, returning (store, pool_or_none).
 
     Returns:
-        SqliteVMStateStore backed by the config data directory.
+        Tuple of (VMStateStore, asyncpg.Pool | None).
     """
+    if config.events_db and is_postgres_url(config.events_db):
+        from tanren_core.adapters.postgres_pool import create_postgres_pool  # noqa: PLC0415
+        from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore  # noqa: PLC0415
+
+        pool = await create_postgres_pool(config.events_db)
+        return PostgresVMStateStore(pool), pool
+
     db_path = f"{config.data_dir}/vm-state.db"
-    return SqliteVMStateStore(db_path)
+    return SqliteVMStateStore(db_path), None
 
 
 @vm_app.command("list")
@@ -54,7 +67,7 @@ def vm_list() -> None:
 
     async def _run() -> None:
         config = _load_config()
-        store = _get_state_store(config)
+        store, pool = await _get_state_store(config)
         try:
             assignments = await store.get_active_assignments()
             if not assignments:
@@ -72,6 +85,8 @@ def vm_list() -> None:
                 )
         finally:
             await store.close()
+            if pool is not None:
+                await pool.close()
 
     asyncio.run(_run())
 
@@ -82,7 +97,7 @@ def vm_release(vm_id: str = typer.Argument(...)) -> None:
 
     async def _run() -> None:
         config = _load_config()
-        store = _get_state_store(config)
+        store, pool = await _get_state_store(config)
         try:
             assignment = await store.get_assignment(vm_id)
             if assignment is None:
@@ -92,6 +107,8 @@ def vm_release(vm_id: str = typer.Argument(...)) -> None:
             typer.echo(f"Released VM {vm_id} (was assigned to {assignment.workflow_id})")
         finally:
             await store.close()
+            if pool is not None:
+                await pool.close()
 
     asyncio.run(_run())
 
@@ -102,7 +119,7 @@ def vm_recover() -> None:
 
     async def _run() -> None:
         config = _load_config()
-        store = _get_state_store(config)
+        store, pool = await _get_state_store(config)
         try:
             assignments = await store.get_active_assignments()
             if not assignments:
@@ -144,6 +161,8 @@ def vm_recover() -> None:
                     await conn.close()
         finally:
             await store.close()
+            if pool is not None:
+                await pool.close()
 
     asyncio.run(_run())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,4 @@ def pytest_addoption(parser):
     parser.addoption("--ssh-host", action="store", default=None)
     parser.addoption("--ssh-key", action="store", default=None)
     parser.addoption("--ssh-user", action="store", default="root")
+    parser.addoption("--postgres-url", action="store", default=None)

--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -1,0 +1,130 @@
+"""Integration tests for Postgres backend (requires --postgres-url)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tanren_core.adapters.events import DispatchReceived
+from tanren_core.adapters.postgres_emitter import PostgresEventEmitter
+from tanren_core.adapters.postgres_event_reader import PostgresEventReader
+from tanren_core.adapters.postgres_pool import create_postgres_pool, ensure_schema
+from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.fixture
+def postgres_url(request):
+    url = request.config.getoption("--postgres-url")
+    if url is None:
+        pytest.skip("--postgres-url not provided")  # type: ignore[invalid-argument-type,too-many-positional-arguments]
+    return url
+
+
+@pytest.fixture
+async def pg_pool(postgres_url):
+    pool = await create_postgres_pool(postgres_url)
+    yield pool
+    # Clean up tables
+    async with pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS events")
+        await conn.execute("DROP TABLE IF EXISTS vm_assignments")
+    await pool.close()
+
+
+class TestEmitAndQueryRoundtrip:
+    async def test_emit_and_query_roundtrip(self, pg_pool):
+        emitter = PostgresEventEmitter(pg_pool)
+        reader = PostgresEventReader(pg_pool)
+
+        event = DispatchReceived(
+            timestamp="2026-01-01T00:00:00Z",
+            workflow_id="wf-roundtrip",
+            phase="do-task",
+            project="test-proj",
+            cli="claude",
+        )
+        await emitter.emit(event)
+
+        result = await reader.query_events(workflow_id="wf-roundtrip")
+        assert result.total == 1
+        assert len(result.events) == 1
+        assert result.events[0].workflow_id == "wf-roundtrip"
+        assert result.events[0].event_type == "DispatchReceived"
+        assert result.events[0].payload["type"] == "dispatch_received"
+
+
+class TestVMStateLifecycle:
+    async def test_vm_state_lifecycle(self, pg_pool):
+        store = PostgresVMStateStore(pg_pool)
+
+        # Record assignment
+        await store.record_assignment("vm-pg-1", "wf-1", "proj", "spec", "10.0.0.1")
+
+        # Get active
+        active = await store.get_active_assignments()
+        assert len(active) == 1
+        assert active[0].vm_id == "vm-pg-1"
+
+        # Get by id
+        assignment = await store.get_assignment("vm-pg-1")
+        assert assignment is not None
+        assert assignment.host == "10.0.0.1"
+
+        # Release
+        await store.record_release("vm-pg-1")
+
+        # Verify empty
+        active = await store.get_active_assignments()
+        assert len(active) == 0
+
+        # Get by id returns None after release
+        assignment = await store.get_assignment("vm-pg-1")
+        assert assignment is None
+
+
+class TestSchemaIdempotent:
+    async def test_schema_idempotent(self, pg_pool):
+        # ensure_schema is called during pool creation, calling it again should be fine
+        await ensure_schema(pg_pool)
+        await ensure_schema(pg_pool)
+
+        # Tables should still be usable
+        emitter = PostgresEventEmitter(pg_pool)
+        event = DispatchReceived(
+            timestamp="2026-01-01T00:00:00Z",
+            workflow_id="wf-idempotent",
+            phase="do-task",
+            project="test-proj",
+            cli="claude",
+        )
+        await emitter.emit(event)
+
+
+class TestPoolSharedAcrossAdapters:
+    async def test_pool_shared_across_adapters(self, pg_pool):
+        emitter = PostgresEventEmitter(pg_pool)
+        reader = PostgresEventReader(pg_pool)
+        store = PostgresVMStateStore(pg_pool)
+
+        # All share the same pool
+        assert emitter._pool is pg_pool
+        assert reader._pool is pg_pool
+        assert store._pool is pg_pool
+
+        # All work with the same pool
+        event = DispatchReceived(
+            timestamp="2026-01-01T00:00:00Z",
+            workflow_id="wf-shared",
+            phase="do-task",
+            project="test-proj",
+            cli="claude",
+        )
+        await emitter.emit(event)
+        await store.record_assignment("vm-shared", "wf-shared", "proj", "spec", "10.0.0.2")
+
+        result = await reader.query_events(workflow_id="wf-shared")
+        assert result.total >= 1
+
+        active = await store.get_active_assignments()
+        assert any(a.vm_id == "vm-shared" for a in active)

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -107,6 +107,7 @@ def app(api_settings, tmp_path, mock_execution_env, mock_vm_state_store):
     application.state.api_store = APIStateStore()
     application.state.execution_env = mock_execution_env
     application.state.vm_state_store = mock_vm_state_store
+    application.state.event_reader = None
     return application
 
 

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
 import aiosqlite
 import pytest
 
+from tanren_core.adapters.event_reader import EventQueryResult, EventRow
 from tanren_core.adapters.sqlite_emitter import _SCHEMA  # noqa: PLC2701
 
 
@@ -215,3 +217,44 @@ class TestEvents:
         assert data["skipped"] == 2
         assert len(data["events"]) == 1
         assert data["events"][0]["type"] == "dispatch_received"
+
+
+@pytest.mark.api
+class TestEventsWithInjectedReader:
+    async def test_events_uses_injected_event_reader(self, client, auth_headers, app):
+        """Regression: /events endpoint must use event_reader from app state.
+
+        Without this, Postgres DSNs would be treated as SQLite paths and silently
+        return empty results.
+        """
+        mock_reader = AsyncMock()
+        mock_reader.query_events = AsyncMock(
+            return_value=EventQueryResult(
+                events=[
+                    EventRow(
+                        id=1,
+                        timestamp="2026-01-01T00:00:00Z",
+                        workflow_id="wf-pg",
+                        event_type="DispatchReceived",
+                        payload={
+                            "type": "dispatch_received",
+                            "timestamp": "2026-01-01T00:00:00Z",
+                            "workflow_id": "wf-pg",
+                            "phase": "do-task",
+                            "project": "p",
+                            "cli": "claude",
+                        },
+                    )
+                ],
+                total=1,
+                skipped=0,
+            )
+        )
+        app.state.event_reader = mock_reader
+
+        resp = await client.get("/api/v1/events", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["events"][0]["workflow_id"] == "wf-pg"
+        mock_reader.query_events.assert_awaited_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -247,6 +247,18 @@ class TestConfig:
         config = Config.from_env()
         assert config.events_db is None
 
+    def test_postgres_url_not_path_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_EVENTS_DB", "postgresql://host/db")
+        config = Config.from_env()
+        assert config.events_db == "postgresql://host/db"
+
+    def test_uppercase_postgres_url_not_path_expanded(self, monkeypatch):
+        _set_all_required(monkeypatch)
+        monkeypatch.setenv("WM_EVENTS_DB", "POSTGRESQL://host/db")
+        config = Config.from_env()
+        assert config.events_db == "POSTGRESQL://host/db"
+
 
 # ---------------------------------------------------------------------------
 # ConfigSource protocol check

--- a/tests/unit/test_event_reader.py
+++ b/tests/unit/test_event_reader.py
@@ -7,7 +7,7 @@ import json
 import aiosqlite
 import pytest
 
-from tanren_core.adapters.event_reader import query_events
+from tanren_core.adapters.event_reader import EventReader, SqliteEventReader, query_events
 from tanren_core.adapters.sqlite_emitter import _SCHEMA  # noqa: PLC2701
 
 
@@ -325,3 +325,63 @@ class TestQueryEvents:
         assert result.events == []
         assert result.total == 2
         assert result.skipped == 2
+
+
+class TestSqliteEventReader:
+    async def test_sqlite_event_reader_class(self, tmp_path):
+        """Verify SqliteEventReader works the same as standalone function."""
+        db = tmp_path / "events.db"
+        await _setup_db(
+            db,
+            [
+                (
+                    "2026-01-01T00:00:00Z",
+                    "wf-1",
+                    "DispatchReceived",
+                    {
+                        "type": "dispatch_received",
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "workflow_id": "wf-1",
+                        "phase": "do-task",
+                        "project": "p",
+                        "cli": "claude",
+                    },
+                ),
+            ],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events()
+        assert result.total == 1
+        assert len(result.events) == 1
+        assert result.events[0].workflow_id == "wf-1"
+
+    async def test_backward_compat_query_events(self, tmp_path):
+        """Verify standalone function still works."""
+        db = tmp_path / "events.db"
+        await _setup_db(
+            db,
+            [
+                (
+                    "2026-01-01T00:00:00Z",
+                    "wf-1",
+                    "DispatchReceived",
+                    {
+                        "type": "dispatch_received",
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "workflow_id": "wf-1",
+                        "phase": "do-task",
+                        "project": "p",
+                        "cli": "claude",
+                    },
+                ),
+            ],
+        )
+
+        result = await query_events(db)
+        assert result.total == 1
+
+    def test_event_reader_protocol_conformance(self, tmp_path):
+        db = tmp_path / "events.db"
+        reader = SqliteEventReader(db)
+        assert isinstance(reader, EventReader)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -308,3 +308,55 @@ class TestRecoverVmState:
         await manager._recover_vm_state()
 
         store.record_release.assert_awaited_once_with("vm-1")
+
+
+class TestInitPostgres:
+    @pytest.mark.asyncio
+    async def test_injected_execution_env_survives_postgres_init(self, tmp_path: Path, monkeypatch):
+        """Regression: _init_postgres must not overwrite an injected execution_env.
+
+        When execution_env is explicitly provided (e.g. in tests), _init_postgres
+        should still create the pool and emitter but must not rebuild the
+        execution environment.
+        """
+        from unittest.mock import MagicMock, patch  # noqa: PLC0415
+
+        remote_cfg = tmp_path / "remote.yml"
+        remote_cfg.write_text(
+            "provisioner:\n"
+            "  type: manual\n"
+            "  settings:\n"
+            "    vms:\n"
+            "      - vm_id: vm-1\n"
+            "        host: 10.0.0.1\n"
+        )
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(tmp_path / "github"),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            remote_config_path=str(remote_cfg),
+            events_db="postgresql://localhost/tanren",
+            roles_config_path=str(tmp_path / "roles.yml"),
+        )
+
+        mock_env = AsyncMock()
+        manager = WorkerManager(config=config, execution_env=mock_env)
+
+        # _pg_dsn should be set because events_db is a Postgres URL
+        assert manager._pg_dsn == "postgresql://localhost/tanren"
+
+        mock_pool = MagicMock()
+        mock_pool.close = AsyncMock()
+        mock_create_pool = AsyncMock(return_value=mock_pool)
+
+        with patch(
+            "tanren_core.adapters.postgres_pool.create_postgres_pool",
+            mock_create_pool,
+        ):
+            await manager._init_postgres()
+
+        # Pool and emitter should be set
+        assert manager._pg_pool is mock_pool
+        # Execution env must NOT have been replaced
+        assert manager.get_execution_environment() is mock_env

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -121,7 +121,7 @@ class TestWorkerManagerInit:
             _FakeSSHExecutionEnvironment,
         )
         monkeypatch.setattr(
-            "tanren_core.builder.SqliteVMStateStore",
+            "tanren_core.adapters.sqlite_vm_state.SqliteVMStateStore",
             lambda _: object(),
         )
         monkeypatch.setattr(

--- a/tests/unit/test_postgres_emitter.py
+++ b/tests/unit/test_postgres_emitter.py
@@ -29,7 +29,7 @@ class TestPostgresEventEmitter:
         call_args = pool.execute.call_args
         sql = call_args[0][0]
         assert "INSERT INTO events" in sql
-        assert "$1" in sql
+        assert "$4::jsonb" in sql
         # Verify positional params
         assert call_args[0][1] == "2026-01-01T00:00:00Z"
         assert call_args[0][2] == "wf-1"

--- a/tests/unit/test_postgres_emitter.py
+++ b/tests/unit/test_postgres_emitter.py
@@ -1,0 +1,70 @@
+"""Tests for the Postgres event emitter."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from tanren_core.adapters.events import DispatchReceived
+from tanren_core.adapters.postgres_emitter import PostgresEventEmitter
+from tanren_core.adapters.protocols import EventEmitter
+
+
+class TestPostgresEventEmitter:
+    async def test_emit_inserts_row(self):
+        pool = MagicMock()
+        pool.execute = AsyncMock()
+        emitter = PostgresEventEmitter(pool)
+
+        event = DispatchReceived(
+            timestamp="2026-01-01T00:00:00Z",
+            workflow_id="wf-1",
+            phase="do-task",
+            project="p",
+            cli="claude",
+        )
+        await emitter.emit(event)
+
+        pool.execute.assert_awaited_once()
+        call_args = pool.execute.call_args
+        sql = call_args[0][0]
+        assert "INSERT INTO events" in sql
+        assert "$1" in sql
+        # Verify positional params
+        assert call_args[0][1] == "2026-01-01T00:00:00Z"
+        assert call_args[0][2] == "wf-1"
+        assert call_args[0][3] == "DispatchReceived"
+
+    async def test_emit_serializes_payload(self):
+        pool = MagicMock()
+        pool.execute = AsyncMock()
+        emitter = PostgresEventEmitter(pool)
+
+        event = DispatchReceived(
+            timestamp="2026-01-01T00:00:00Z",
+            workflow_id="wf-1",
+            phase="do-task",
+            project="p",
+            cli="claude",
+        )
+        await emitter.emit(event)
+
+        call_args = pool.execute.call_args
+        payload_str = call_args[0][4]
+        payload = json.loads(payload_str)
+        assert payload["workflow_id"] == "wf-1"
+        assert payload["type"] == "dispatch_received"
+
+    async def test_close_is_noop(self):
+        pool = MagicMock()
+        pool.close = AsyncMock()
+        emitter = PostgresEventEmitter(pool)
+
+        await emitter.close()
+
+        pool.close.assert_not_awaited()
+
+    def test_protocol_conformance(self):
+        pool = MagicMock()
+        emitter = PostgresEventEmitter(pool)
+        assert isinstance(emitter, EventEmitter)

--- a/tests/unit/test_postgres_event_reader.py
+++ b/tests/unit/test_postgres_event_reader.py
@@ -67,6 +67,48 @@ class TestPostgresEventReader:
         assert 10 in fetch_args  # limit
         assert 20 in fetch_args  # offset
 
+    async def test_query_decodes_string_payload(self):
+        """Regression: string payloads must be decoded, not skipped.
+
+        asyncpg may return JSONB values as strings depending on codec config.
+        The reader must json.loads() them instead of treating them as invalid.
+        """
+        pool = _mock_pool()
+        row = {
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "workflow_id": "wf-1",
+            "event_type": "DispatchReceived",
+            "payload": '{"type": "dispatch_received", "workflow_id": "wf-1"}',
+        }
+        pool.fetchval = AsyncMock(return_value=1)
+        pool.fetch = AsyncMock(return_value=[row])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events()
+
+        assert len(result.events) == 1
+        assert result.skipped == 0
+        assert result.events[0].payload["type"] == "dispatch_received"
+
+    async def test_query_skips_malformed_string_payload(self):
+        pool = _mock_pool()
+        row = {
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "workflow_id": "wf-1",
+            "event_type": "Bad",
+            "payload": "not valid json {{",
+        }
+        pool.fetchval = AsyncMock(return_value=1)
+        pool.fetch = AsyncMock(return_value=[row])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events()
+
+        assert len(result.events) == 0
+        assert result.skipped == 1
+
     async def test_query_skips_non_dict_payload(self):
         pool = _mock_pool()
         row_good = {
@@ -81,7 +123,7 @@ class TestPostgresEventReader:
             "timestamp": "2026-01-01T00:00:01Z",
             "workflow_id": "wf-1",
             "event_type": "Bad",
-            "payload": "not a dict",
+            "payload": 42,
         }
         pool.fetchval = AsyncMock(return_value=2)
         pool.fetch = AsyncMock(return_value=[row_good, row_bad])

--- a/tests/unit/test_postgres_event_reader.py
+++ b/tests/unit/test_postgres_event_reader.py
@@ -1,0 +1,98 @@
+"""Tests for the Postgres event reader."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from tanren_core.adapters.event_reader import EventReader
+from tanren_core.adapters.postgres_event_reader import PostgresEventReader
+
+
+def _mock_pool():
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=0)
+    pool.fetch = AsyncMock(return_value=[])
+    return pool
+
+
+class TestPostgresEventReader:
+    async def test_query_no_filters(self):
+        pool = _mock_pool()
+        pool.fetchval = AsyncMock(return_value=0)
+        pool.fetch = AsyncMock(return_value=[])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events()
+
+        assert result.total == 0
+        assert result.events == []
+        pool.fetchval.assert_awaited_once()
+        pool.fetch.assert_awaited_once()
+
+    async def test_query_with_filters(self):
+        pool = _mock_pool()
+        row = {
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "workflow_id": "wf-1",
+            "event_type": "DispatchReceived",
+            "payload": {"type": "dispatch_received", "workflow_id": "wf-1"},
+        }
+        pool.fetchval = AsyncMock(return_value=1)
+        pool.fetch = AsyncMock(return_value=[row])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events(workflow_id="wf-1", event_type="DispatchReceived")
+
+        assert result.total == 1
+        assert len(result.events) == 1
+        assert result.events[0].workflow_id == "wf-1"
+
+        # Verify WHERE clause includes both filters
+        fetch_sql = pool.fetch.call_args[0][0]
+        assert "workflow_id = $1" in fetch_sql
+        assert "event_type = $2" in fetch_sql
+
+    async def test_query_pagination(self):
+        pool = _mock_pool()
+        pool.fetchval = AsyncMock(return_value=100)
+        pool.fetch = AsyncMock(return_value=[])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events(limit=10, offset=20)
+
+        assert result.total == 100
+        # Verify LIMIT and OFFSET params
+        fetch_args = pool.fetch.call_args[0]
+        assert 10 in fetch_args  # limit
+        assert 20 in fetch_args  # offset
+
+    async def test_query_skips_non_dict_payload(self):
+        pool = _mock_pool()
+        row_good = {
+            "id": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "workflow_id": "wf-1",
+            "event_type": "DispatchReceived",
+            "payload": {"type": "dispatch_received"},
+        }
+        row_bad = {
+            "id": 2,
+            "timestamp": "2026-01-01T00:00:01Z",
+            "workflow_id": "wf-1",
+            "event_type": "Bad",
+            "payload": "not a dict",
+        }
+        pool.fetchval = AsyncMock(return_value=2)
+        pool.fetch = AsyncMock(return_value=[row_good, row_bad])
+        reader = PostgresEventReader(pool)
+
+        result = await reader.query_events()
+
+        assert len(result.events) == 1
+        assert result.skipped == 1
+
+    def test_protocol_conformance(self):
+        pool = _mock_pool()
+        reader = PostgresEventReader(pool)
+        assert isinstance(reader, EventReader)

--- a/tests/unit/test_postgres_pool.py
+++ b/tests/unit/test_postgres_pool.py
@@ -1,0 +1,55 @@
+"""Tests for the Postgres pool factory and URL detection."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tanren_core.adapters.postgres_pool import create_postgres_pool, is_postgres_url
+
+
+class TestIsPostgresUrl:
+    def test_postgresql_scheme(self):
+        assert is_postgres_url("postgresql://localhost/db") is True
+
+    def test_postgres_scheme(self):
+        assert is_postgres_url("postgres://localhost/db") is True
+
+    def test_sqlite_path(self):
+        assert is_postgres_url("/data/events.db") is False
+
+    def test_none(self):
+        assert is_postgres_url(None) is False
+
+    def test_empty_string(self):
+        assert is_postgres_url("") is False
+
+    def test_relative_path(self):
+        assert is_postgres_url("events.db") is False
+
+
+class TestCreatePool:
+    @patch("tanren_core.adapters.postgres_pool.ensure_schema", new_callable=AsyncMock)
+    @patch("tanren_core.adapters.postgres_pool.asyncpg.create_pool", new_callable=AsyncMock)
+    async def test_create_pool_calls_ensure_schema(self, mock_create_pool, mock_ensure_schema):
+        mock_pool = MagicMock()
+        mock_create_pool.return_value = mock_pool
+
+        result = await create_postgres_pool("postgresql://localhost/db")
+
+        assert result is mock_pool
+        mock_create_pool.assert_awaited_once_with(
+            "postgresql://localhost/db", min_size=2, max_size=10
+        )
+        mock_ensure_schema.assert_awaited_once_with(mock_pool)
+
+    @patch("tanren_core.adapters.postgres_pool.ensure_schema", new_callable=AsyncMock)
+    @patch("tanren_core.adapters.postgres_pool.asyncpg.create_pool", new_callable=AsyncMock)
+    async def test_create_pool_custom_sizes(self, mock_create_pool, mock_ensure_schema):
+        mock_pool = MagicMock()
+        mock_create_pool.return_value = mock_pool
+
+        await create_postgres_pool("postgresql://localhost/db", min_size=1, max_size=5)
+
+        mock_create_pool.assert_awaited_once_with(
+            "postgresql://localhost/db", min_size=1, max_size=5
+        )

--- a/tests/unit/test_postgres_pool.py
+++ b/tests/unit/test_postgres_pool.py
@@ -26,6 +26,12 @@ class TestIsPostgresUrl:
     def test_relative_path(self):
         assert is_postgres_url("events.db") is False
 
+    def test_uppercase_postgresql_scheme(self):
+        assert is_postgres_url("POSTGRESQL://localhost/db") is True
+
+    def test_mixed_case_postgres_scheme(self):
+        assert is_postgres_url("Postgres://localhost/db") is True
+
 
 class TestCreatePool:
     @patch("tanren_core.adapters.postgres_pool.ensure_schema", new_callable=AsyncMock)

--- a/tests/unit/test_postgres_vm_state.py
+++ b/tests/unit/test_postgres_vm_state.py
@@ -1,0 +1,118 @@
+"""Tests for the Postgres VM state store."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from tanren_core.adapters.postgres_vm_state import PostgresVMStateStore
+from tanren_core.adapters.protocols import VMStateStore
+from tanren_core.adapters.remote_types import VMAssignment
+
+
+def _mock_pool():
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.fetch = AsyncMock(return_value=[])
+    pool.fetchrow = AsyncMock(return_value=None)
+    return pool
+
+
+class TestRecordAssignment:
+    async def test_record_assignment(self):
+        pool = _mock_pool()
+        store = PostgresVMStateStore(pool)
+
+        await store.record_assignment("vm-1", "wf-1", "proj", "spec", "1.2.3.4")
+
+        pool.execute.assert_awaited_once()
+        sql = pool.execute.call_args[0][0]
+        assert "INSERT INTO vm_assignments" in sql
+        assert "ON CONFLICT" in sql
+
+
+class TestRecordRelease:
+    async def test_record_release(self):
+        pool = _mock_pool()
+        store = PostgresVMStateStore(pool)
+
+        await store.record_release("vm-1")
+
+        pool.execute.assert_awaited_once()
+        sql = pool.execute.call_args[0][0]
+        assert "UPDATE vm_assignments" in sql
+        assert "released_at" in sql
+
+
+class TestGetActiveAssignments:
+    async def test_get_active_assignments_empty(self):
+        pool = _mock_pool()
+        store = PostgresVMStateStore(pool)
+
+        result = await store.get_active_assignments()
+
+        assert result == []
+        pool.fetch.assert_awaited_once()
+
+    async def test_get_active_assignments_with_rows(self):
+        pool = _mock_pool()
+        row = {
+            "vm_id": "vm-1",
+            "workflow_id": "wf-1",
+            "project": "proj",
+            "spec": "spec",
+            "host": "1.2.3.4",
+            "assigned_at": "2026-01-01T00:00:00Z",
+        }
+        pool.fetch = AsyncMock(return_value=[row])
+        store = PostgresVMStateStore(pool)
+
+        result = await store.get_active_assignments()
+
+        assert len(result) == 1
+        assert isinstance(result[0], VMAssignment)
+        assert result[0].vm_id == "vm-1"
+        assert result[0].host == "1.2.3.4"
+
+
+class TestGetAssignment:
+    async def test_get_assignment_not_found(self):
+        pool = _mock_pool()
+        store = PostgresVMStateStore(pool)
+
+        result = await store.get_assignment("vm-99")
+
+        assert result is None
+
+    async def test_get_assignment_found(self):
+        pool = _mock_pool()
+        row = {
+            "vm_id": "vm-1",
+            "workflow_id": "wf-1",
+            "project": "proj",
+            "spec": "spec",
+            "host": "1.2.3.4",
+            "assigned_at": "2026-01-01T00:00:00Z",
+        }
+        pool.fetchrow = AsyncMock(return_value=row)
+        store = PostgresVMStateStore(pool)
+
+        result = await store.get_assignment("vm-1")
+
+        assert result is not None
+        assert result.vm_id == "vm-1"
+
+
+class TestCloseAndProtocol:
+    async def test_close_is_noop(self):
+        pool = _mock_pool()
+        pool.close = AsyncMock()
+        store = PostgresVMStateStore(pool)
+
+        await store.close()
+
+        pool.close.assert_not_awaited()
+
+    def test_protocol_conformance(self):
+        pool = _mock_pool()
+        store = PostgresVMStateStore(pool)
+        assert isinstance(store, VMStateStore)

--- a/tests/unit/test_run_cli.py
+++ b/tests/unit/test_run_cli.py
@@ -6,7 +6,7 @@ import json
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import typer
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 from tanren_cli.run_cli import (
     PersistedRunHandle,
     PersistedSSHDefaults,
+    _build_remote_execution_env,  # noqa: PLC2701
     _load_handle,  # noqa: PLC2701
     _save_handle,  # noqa: PLC2701
     run,
@@ -116,7 +117,9 @@ def test_run_provision_prints_and_saves_handle(tmp_path: Path, monkeypatch):
     env.ssh_defaults = SSHConfig(host="", user="root", key_path="~/.ssh/id_rsa", port=22)
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
 
     result = CliRunner().invoke(
         run,
@@ -145,7 +148,9 @@ def test_run_execute_loads_handle_and_prints_result(tmp_path: Path, monkeypatch)
     )
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._resolve_agent_tool",
         lambda config, phase: AgentTool(cli=Cli.CLAUDE),
@@ -177,7 +182,9 @@ def test_run_teardown_removes_handle_and_calls_teardown(tmp_path: Path, monkeypa
     env = AsyncMock()
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
 
     result = CliRunner().invoke(run, ["teardown", "--handle", "env-123"])
 
@@ -202,7 +209,9 @@ def test_run_full_executes_in_order(tmp_path: Path, monkeypatch):
     env.ssh_defaults = SSHConfig(host="", user="root", key_path="~/.ssh/id_rsa", port=22)
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._resolve_agent_tool",
         lambda config, phase: AgentTool(cli=Cli.CLAUDE),
@@ -253,7 +262,9 @@ def test_run_full_teardown_runs_even_on_execute_failure(tmp_path: Path, monkeypa
     env.ssh_defaults = SSHConfig(host="", user="root", key_path="~/.ssh/id_rsa", port=22)
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._resolve_agent_tool",
         lambda config, phase: AgentTool(cli=Cli.CLAUDE),
@@ -302,7 +313,9 @@ def test_run_full_exits_nonzero_for_blocked(tmp_path: Path, monkeypatch):
     env.ssh_defaults = SSHConfig(host="", user="root", key_path="~/.ssh/id_rsa", port=22)
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._resolve_agent_tool",
         lambda config, phase: AgentTool(cli=Cli.CLAUDE),
@@ -369,7 +382,9 @@ def test_run_execute_rejects_legacy_handle_schema(tmp_path: Path, monkeypatch):
 
     env = AsyncMock()
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._resolve_agent_tool",
         lambda config, phase: AgentTool(cli=Cli.CLAUDE),
@@ -413,7 +428,9 @@ def test_run_execute_gate_uses_profile_gate_cmd_when_missing_flag(tmp_path: Path
     )
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
 
     result = CliRunner().invoke(
         run,
@@ -442,7 +459,9 @@ def test_run_execute_gate_rejects_blank_gate_cmd(tmp_path: Path, monkeypatch):
     env = AsyncMock()
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
 
     result = CliRunner().invoke(
         run,
@@ -510,7 +529,9 @@ def test_run_full_teardown_runs_even_when_handle_save_fails(tmp_path: Path, monk
     env.ssh_defaults = SSHConfig(host="", user="root", key_path="~/.ssh/id_rsa", port=22)
 
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
     monkeypatch.setattr(
         "tanren_cli.run_cli._save_handle",
         lambda _config, _persisted: (_ for _ in ()).throw(OSError("disk full")),
@@ -571,7 +592,9 @@ def test_teardown_retains_external_handle_file(tmp_path: Path, monkeypatch):
 
     env = AsyncMock()
     monkeypatch.setattr("tanren_cli.run_cli._load_config", lambda: config)
-    monkeypatch.setattr("tanren_cli.run_cli._build_remote_execution_env", lambda cfg: env)
+    monkeypatch.setattr(
+        "tanren_cli.run_cli._build_remote_execution_env", AsyncMock(return_value=(env, None))
+    )
 
     result = CliRunner().invoke(run, ["teardown", "--handle", str(external_file)])
 
@@ -672,3 +695,52 @@ def test_persisted_handle_rejects_invalid_host_key_policy(tmp_path: Path, capsys
     assert exc_info.value.exit_code == 1
     captured = capsys.readouterr()
     assert "Run handle schema has changed" in captured.err
+
+
+class TestBuildRemoteEnvPostgres:
+    async def test_passes_pool_when_postgres_configured(self, tmp_path, monkeypatch):
+        """Regression: _build_remote_execution_env must create a pool for Postgres DSNs.
+
+        Without this, VM assignments would be written to SQLite while other callers
+        (vm_cli, manager, API) read from Postgres, splitting state.
+        """
+        config = _config(tmp_path)
+        monkeypatch.setattr(config, "events_db", "postgresql://localhost/tanren")
+
+        mock_pool = MagicMock()
+        mock_create_pool = AsyncMock(return_value=mock_pool)
+        mock_build = MagicMock(return_value=(MagicMock(), MagicMock()))
+
+        with (
+            patch(
+                "tanren_core.adapters.postgres_pool.create_postgres_pool",
+                mock_create_pool,
+            ),
+            patch(
+                "tanren_core.builder.build_ssh_execution_environment",
+                mock_build,
+            ),
+        ):
+            _env, pool = await _build_remote_execution_env(config)
+
+        mock_create_pool.assert_awaited_once_with("postgresql://localhost/tanren")
+        _, kwargs = mock_build.call_args
+        assert kwargs["pool"] is mock_pool
+        assert pool is mock_pool
+
+    async def test_no_pool_when_sqlite_configured(self, tmp_path, monkeypatch):
+        """When events_db is a SQLite path, no pool should be created."""
+        config = _config(tmp_path)
+        monkeypatch.setattr(config, "events_db", str(tmp_path / "events.db"))
+
+        mock_build = MagicMock(return_value=(MagicMock(), MagicMock()))
+
+        with patch(
+            "tanren_core.builder.build_ssh_execution_environment",
+            mock_build,
+        ):
+            _env, pool = await _build_remote_execution_env(config)
+
+        _, kwargs = mock_build.call_args
+        assert kwargs["pool"] is None
+        assert pool is None

--- a/tests/unit/test_vm_cli.py
+++ b/tests/unit/test_vm_cli.py
@@ -57,7 +57,11 @@ class TestVmList:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
@@ -74,7 +78,11 @@ class TestVmList:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
@@ -88,7 +96,11 @@ class TestVmList:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["list"])
@@ -110,7 +122,11 @@ class TestVmRelease:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["release", "vm-001"])
@@ -126,7 +142,11 @@ class TestVmRelease:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["release", "vm-unknown"])
@@ -142,7 +162,11 @@ class TestVmRecover:
 
         with (
             patch("tanren_cli.vm_cli._load_config", return_value=_mock_config()),
-            patch("tanren_cli.vm_cli._get_state_store", return_value=store),
+            patch(
+                "tanren_cli.vm_cli._get_state_store",
+                new_callable=AsyncMock,
+                return_value=(store, None),
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(vm, ["recover"])

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,30 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1471,6 +1495,7 @@ version = "0.1.1"
 source = { editable = "packages/tanren-core" }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "asyncpg" },
     { name = "paramiko" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1488,6 +1513,7 @@ hetzner = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20,<1" },
+    { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "google-cloud-compute", marker = "extra == 'gcp'", specifier = ">=1.20.0,<2" },
     { name = "hcloud", marker = "extra == 'hetzner'", specifier = ">=2.4.0,<3" },
     { name = "paramiko", specifier = ">=3.0,<4" },


### PR DESCRIPTION
## Summary
- Add `asyncpg`-based adapters (`PostgresEventEmitter`, `PostgresVMStateStore`, `PostgresEventReader`) as drop-in alternatives to the existing SQLite implementations
- URL-based backend detection: if `events_db` starts with `postgresql://`, all adapters use Postgres via a shared `asyncpg.Pool`
- Refactor `EventReader` into a protocol with `SqliteEventReader` + `PostgresEventReader` implementations
- Wire Postgres support through manager, builder, API lifespan, CLI, and config layers
- Update type annotations from concrete `SqliteVMStateStore` to `VMStateStore` protocol across API dependencies, routers, and services

Closes #32

## Test plan
- [x] Unit tests for all new adapters (mocked asyncpg pool): `test_postgres_pool.py`, `test_postgres_emitter.py`, `test_postgres_vm_state.py`, `test_postgres_event_reader.py`
- [x] Updated `test_event_reader.py` with `SqliteEventReader` class tests and protocol conformance
- [x] Updated `test_vm_cli.py` and `test_manager.py` for the new async `_get_state_store` signature and lazy imports
- [x] Integration tests gated behind `--postgres-url` pytest option and `postgres` marker
- [x] `make check` passes (format, lint, type, unit, integration, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)