### PR TITLE
feat: add IssueSource protocol and generalize issue IDs to str

### DIFF
--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -34,6 +34,7 @@ from tanren_core.adapters.git_postflight import GitPostflightRunner
 from tanren_core.adapters.git_preflight import GitPreflightRunner
 from tanren_core.adapters.git_workspace import GitAuthConfig, GitWorkspaceManager
 from tanren_core.adapters.git_worktree import GitWorktreeManager
+from tanren_core.adapters.issue_types import Issue, IssueSummary
 
 try:  # noqa: SIM105, RUF067
     from tanren_core.adapters.gcp_vm import GCPProvisionerSettings, GCPVMProvisioner
@@ -62,6 +63,7 @@ from tanren_core.adapters.protocols import (
     EnvValidator,
     EventEmitter,
     ExecutionEnvironment,
+    IssueSource,
     PostflightRunner,
     PreflightRunner,
     ProcessSpawner,
@@ -131,6 +133,9 @@ __all__ = [
     "GitWorktreeManager",
     "HetznerProvisionerSettings",
     "HetznerVMProvisioner",
+    "Issue",
+    "IssueSource",
+    "IssueSummary",
     "LocalExecutionEnvironment",
     "ManualProvisionerSettings",
     "ManualVMConfig",

--- a/packages/tanren-core/src/tanren_core/adapters/git_worktree.py
+++ b/packages/tanren-core/src/tanren_core/adapters/git_worktree.py
@@ -14,7 +14,7 @@ from tanren_core.worktree import (
 class GitWorktreeManager:
     """Delegates to worktree module functions."""
 
-    async def create(self, project: str, issue: int, branch: str, github_dir: str) -> Path:
+    async def create(self, project: str, issue: str, branch: str, github_dir: str) -> Path:
         """Create a new git worktree for the given project and issue.
 
         Returns:
@@ -27,7 +27,7 @@ class GitWorktreeManager:
         registry_path: Path,
         workflow_id: str,
         project: str,
-        issue: int,
+        issue: str,
         branch: str,
         worktree_path: Path,
         github_dir: str,

--- a/packages/tanren-core/src/tanren_core/adapters/issue_types.py
+++ b/packages/tanren-core/src/tanren_core/adapters/issue_types.py
@@ -1,0 +1,30 @@
+"""Data types for issue tracker adapters."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Issue(BaseModel):
+    """Full issue detail from a tracker."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    id: str = Field(..., description="Issue identifier (e.g. '144' or 'PROJ-123')")
+    title: str = Field(..., description="Issue title")
+    body: str = Field(default="", description="Issue body / description")
+    status: str = Field(default="", description="Current status label")
+    labels: tuple[str, ...] = Field(default_factory=tuple, description="Attached labels")
+    url: str = Field(default="", description="Web URL for the issue")
+    metadata: dict[str, str] = Field(default_factory=dict, description="Provider-specific metadata")
+
+
+class IssueSummary(BaseModel):
+    """Lightweight issue summary for listings."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    id: str = Field(..., description="Issue identifier")
+    title: str = Field(..., description="Issue title")
+    status: str = Field(default="", description="Current status label")
+    url: str = Field(default="", description="Web URL for the issue")

--- a/packages/tanren-core/src/tanren_core/adapters/local_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/local_environment.py
@@ -68,7 +68,7 @@ class LocalExecutionEnvironment:
         Raises:
             ProvisionError: If environment validation or preflight checks fail.
         """
-        issue = _parse_issue(dispatch.workflow_id)
+        issue = _parse_issue(dispatch.workflow_id, project=dispatch.project)
         worktree_path = Path(config.github_dir) / f"{dispatch.project}-wt-{issue}"
         spec_folder_path = worktree_path / dispatch.spec_folder
 
@@ -274,10 +274,10 @@ class LocalExecutionEnvironment:
         pass
 
 
-def _parse_issue(workflow_id: str) -> int:
-    """Extract issue number from workflow_id.
+def _parse_issue(workflow_id: str, *, project: str | None = None) -> str:
+    """Extract issue identifier from workflow_id.
 
     Returns:
-        Issue number parsed from the workflow_id.
+        Issue identifier parsed from the workflow_id.
     """
-    return parse_issue_from_workflow_id(workflow_id)
+    return parse_issue_from_workflow_id(workflow_id, project=project)

--- a/packages/tanren-core/src/tanren_core/adapters/protocols.py
+++ b/packages/tanren-core/src/tanren_core/adapters/protocols.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from tanren_core.adapters.events import Event
+from tanren_core.adapters.issue_types import Issue, IssueSummary
 from tanren_core.adapters.remote_types import (
     BootstrapResult,
     RemoteResult,
@@ -43,7 +44,7 @@ class WorktreeManager(Protocol):
     Default implementation: GitWorktreeManager (git worktree add/remove).
     """
 
-    async def create(self, project: str, issue: int, branch: str, github_dir: str) -> Path:
+    async def create(self, project: str, issue: str, branch: str, github_dir: str) -> Path:
         """Create a new git worktree for the given project and issue."""
         ...
 
@@ -52,7 +53,7 @@ class WorktreeManager(Protocol):
         registry_path: Path,
         workflow_id: str,
         project: str,
-        issue: int,
+        issue: str,
         branch: str,
         worktree_path: Path,
         github_dir: str,
@@ -361,4 +362,32 @@ class VMStateStore(Protocol):
 
     async def close(self) -> None:
         """Close any resources held by the state store."""
+        ...
+
+
+@runtime_checkable
+class IssueSource(Protocol):
+    """Read and update issues from an external tracker.
+
+    Abstracts over GitHub Issues, Linear, Jira, etc. Implementations
+    translate between the tracker's native format and the Issue/IssueSummary
+    models.
+    """
+
+    async def get_issue(self, issue_id: str) -> Issue:
+        """Fetch full issue detail by ID."""
+        ...
+
+    async def list_issues(
+        self, *, project: str | None = None, status: str | None = None
+    ) -> list[IssueSummary]:
+        """List issues, optionally filtered by project and/or status."""
+        ...
+
+    async def update_status(self, issue_id: str, status: str) -> None:
+        """Transition an issue to a new status."""
+        ...
+
+    async def add_comment(self, issue_id: str, body: str) -> None:
+        """Append a comment to an issue."""
         ...

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -452,7 +452,7 @@ class WorkerManager:
     async def _handle_dispatch(self, path: Path, dispatch: Dispatch) -> None:
         """Handle a single dispatch through its full lifecycle."""
         dispatch_stem = path.stem
-        issue = parse_issue_from_workflow_id(dispatch.workflow_id)
+        issue = parse_issue_from_workflow_id(dispatch.workflow_id, project=dispatch.project)
         worktree_path = Path(self._config.github_dir) / f"{dispatch.project}-wt-{issue}"
 
         now = datetime.now(UTC).isoformat()
@@ -511,7 +511,7 @@ class WorkerManager:
             )
             await self._write_result_and_nudge(result, dispatch.workflow_id)
 
-    async def _handle_setup(self, dispatch: Dispatch, issue: int, worktree_path: Path) -> None:
+    async def _handle_setup(self, dispatch: Dispatch, issue: str, worktree_path: Path) -> None:
         """Handle setup phase: create worktree + register."""
         start = time.monotonic()
         try:

--- a/packages/tanren-core/src/tanren_core/schemas.py
+++ b/packages/tanren-core/src/tanren_core/schemas.py
@@ -281,7 +281,7 @@ class WorktreeEntry(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     project: str = Field(..., description="Project name")
-    issue: int = Field(..., description="GitHub issue number")
+    issue: str = Field(..., description="Issue identifier (e.g. '144' or 'PROJ-123')")
     branch: str = Field(..., description="Git branch name")
     path: str = Field(..., description="Absolute path to the worktree")
     created_at: str = Field(..., description="ISO 8601 creation timestamp")
@@ -298,19 +298,41 @@ class WorktreeRegistry(BaseModel):
     )
 
 
-def parse_issue_from_workflow_id(workflow_id: str) -> int:
-    """Extract issue number from workflow_id format: wf-{project}-{issue}-{epoch}.
+def parse_issue_from_workflow_id(workflow_id: str, *, project: str | None = None) -> str:
+    """Extract issue identifier from workflow_id format: wf-{project}-{issue}-{epoch}.
 
-    The project name may contain hyphens, so we match from the end:
-    the last segment is epoch (digits), second-to-last is issue (digits).
+    When *project* is provided the prefix ``wf-{project}-`` is stripped and
+    the last ``-``-separated segment (the epoch, which must be numeric) is
+    removed, leaving the issue id — which may itself contain hyphens (e.g.
+    ``PROJ-123``).
+
+    Without *project* the legacy regex heuristic is used: it assumes both the
+    issue and epoch segments are purely numeric and grabs the second-to-last
+    numeric group.
 
     Returns:
-        The issue number extracted from the workflow_id.
+        The issue identifier extracted from the workflow_id.
 
     Raises:
         ValueError: If the workflow_id does not match the expected format.
     """
+    if project is not None:
+        prefix = f"wf-{project}-"
+        if not workflow_id.startswith(prefix):
+            raise ValueError(f"Invalid workflow_id format: {workflow_id}")
+        remainder = workflow_id[len(prefix) :]
+        # remainder = "{issue}-{epoch}" — split on *last* hyphen
+        last_dash = remainder.rfind("-")
+        if last_dash < 1:
+            raise ValueError(f"Invalid workflow_id format: {workflow_id}")
+        issue_part = remainder[:last_dash]
+        epoch_part = remainder[last_dash + 1 :]
+        if not epoch_part.isdigit():
+            raise ValueError(f"Invalid workflow_id format: {workflow_id}")
+        return issue_part
+
+    # Legacy fallback: assume numeric issue
     match = re.match(r"^wf-(.+)-(\d+)-(\d+)$", workflow_id)
     if not match:
         raise ValueError(f"Invalid workflow_id format: {workflow_id}")
-    return int(match.group(2))
+    return match.group(2)

--- a/packages/tanren-core/src/tanren_core/schemas.py
+++ b/packages/tanren-core/src/tanren_core/schemas.py
@@ -329,6 +329,8 @@ def parse_issue_from_workflow_id(workflow_id: str, *, project: str | None = None
         epoch_part = remainder[last_dash + 1 :]
         if not epoch_part.isdigit():
             raise ValueError(f"Invalid workflow_id format: {workflow_id}")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", issue_part):
+            raise ValueError(f"Invalid issue segment in workflow_id: {workflow_id}")
         return issue_part
 
     # Legacy fallback: assume numeric issue

--- a/packages/tanren-core/src/tanren_core/worktree.py
+++ b/packages/tanren-core/src/tanren_core/worktree.py
@@ -105,7 +105,7 @@ async def _get_worktree_branch(worktree_path: Path) -> str:
 
 async def create_worktree(
     project: str,
-    issue: int,
+    issue: str,
     branch: str,
     github_dir: str,
 ) -> Path:
@@ -287,7 +287,7 @@ async def register_worktree(
     registry_path: Path,
     workflow_id: str,
     project: str,
-    issue: int,
+    issue: str,
     branch: str,
     worktree_path: Path,
     github_dir: str,

--- a/services/tanren-api/openapi.json
+++ b/services/tanren-api/openapi.json
@@ -1348,11 +1348,12 @@
             "description": "Shell command for gate phases"
           },
           "issue": {
-            "type": "integer",
-            "minimum": 0.0,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$",
             "title": "Issue",
-            "description": "GitHub issue number (0 = API-originated)",
-            "default": 0
+            "description": "Issue identifier ('0' = API-originated)",
+            "default": "0"
           }
         },
         "additionalProperties": false,

--- a/services/tanren-api/src/tanren_api/mcp_server.py
+++ b/services/tanren-api/src/tanren_api/mcp_server.py
@@ -116,7 +116,7 @@ async def dispatch_create(
     timeout: int = 1800,
     context: str | None = None,
     gate_cmd: str | None = None,
-    issue: int = 0,
+    issue: str = "0",
 ) -> dict[str, Any]:
     """Create a new dispatch."""
     from tanren_api.models import DispatchRequest  # noqa: PLC0415

--- a/services/tanren-api/src/tanren_api/models.py
+++ b/services/tanren-api/src/tanren_api/models.py
@@ -83,7 +83,12 @@ class DispatchRequest(BaseModel):
     environment_profile: str = Field(default="default", description="Environment profile name")
     context: str | None = Field(default=None, description="Extra context for the agent")
     gate_cmd: str | None = Field(default=None, description="Shell command for gate phases")
-    issue: str = Field(default="0", description="Issue identifier ('0' = API-originated)")
+    issue: str = Field(
+        default="0",
+        min_length=1,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_-]*$",
+        description="Issue identifier ('0' = API-originated)",
+    )
 
 
 class ProvisionRequest(BaseModel):

--- a/services/tanren-api/src/tanren_api/models.py
+++ b/services/tanren-api/src/tanren_api/models.py
@@ -83,7 +83,7 @@ class DispatchRequest(BaseModel):
     environment_profile: str = Field(default="default", description="Environment profile name")
     context: str | None = Field(default=None, description="Extra context for the agent")
     gate_cmd: str | None = Field(default=None, description="Shell command for gate phases")
-    issue: int = Field(default=0, ge=0, description="GitHub issue number (0 = API-originated)")
+    issue: str = Field(default="0", description="Issue identifier ('0' = API-originated)")
 
 
 class ProvisionRequest(BaseModel):

--- a/services/tanren-api/src/tanren_api/services/dispatch.py
+++ b/services/tanren-api/src/tanren_api/services/dispatch.py
@@ -66,7 +66,7 @@ class DispatchService:
         """Accept a new dispatch request."""
         config = self._require_config()
         epoch = time.time_ns()
-        issue = body.issue if body.issue != 0 else epoch
+        issue = body.issue if body.issue != "0" else str(epoch)
         workflow_id = f"wf-{body.project}-{issue}-{epoch}"
 
         dispatch = Dispatch(

--- a/tests/integration/test_worktree_lifecycle.py
+++ b/tests/integration/test_worktree_lifecycle.py
@@ -95,7 +95,7 @@ class TestWorktreeBranchSwitch:
         assert stdout.decode().strip() == branch
 
         # create_worktree should succeed by switching main repo to default branch
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
         assert wt_path.exists()
 
         # Verify main repo switched to default branch
@@ -121,7 +121,7 @@ class TestWorktreeLifecycle:
         repo, branch = await _setup_git_repo(tmp_path)
 
         # Create worktree
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
         assert wt_path.exists()
         assert wt_path.name == "test-project-wt-123"
 
@@ -134,13 +134,13 @@ class TestWorktreeLifecycle:
         """Register a worktree, then clean it up via cleanup_worktree."""
         github_dir = tmp_path
         _repo, branch = await _setup_git_repo(tmp_path)
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
 
         registry_path = tmp_path / "worktrees.json"
         workflow_id = "wf-test-project-123-1000"
 
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path, str(github_dir)
         )
 
         # Verify registered
@@ -169,7 +169,7 @@ class TestWorktreeResilience:
         (stale_path / "leftover.txt").write_text("stale")
 
         # create_worktree should remove stale dir and succeed
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
         assert wt_path.exists()
         assert not (wt_path / "leftover.txt").exists()
 
@@ -181,11 +181,11 @@ class TestWorktreeResilience:
         github_dir = tmp_path
         _repo, branch = await _setup_git_repo(tmp_path)
 
-        wt_path1 = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path1 = await create_worktree("test-project", "123", branch, str(github_dir))
         assert wt_path1.exists()
 
         # Second call with same params should return same path
-        wt_path2 = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path2 = await create_worktree("test-project", "123", branch, str(github_dir))
         assert wt_path2 == wt_path1
 
         await remove_worktree(wt_path1, github_dir / "test-project")
@@ -195,18 +195,18 @@ class TestWorktreeResilience:
         """Re-registering same workflow_id should succeed (overwrite)."""
         github_dir = tmp_path
         _repo, branch = await _setup_git_repo(tmp_path)
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
 
         registry_path = tmp_path / "worktrees.json"
         workflow_id = "wf-test-project-123-1000"
 
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path, str(github_dir)
         )
 
         # Register again — should succeed
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path, str(github_dir)
         )
 
         reg = await load_registry(registry_path)
@@ -219,13 +219,13 @@ class TestWorktreeResilience:
         """Cleanup should succeed even if worktree directory was already deleted."""
         github_dir = tmp_path
         _repo, branch = await _setup_git_repo(tmp_path)
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
 
         registry_path = tmp_path / "worktrees.json"
         workflow_id = "wf-test-project-123-1000"
 
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path, str(github_dir)
         )
 
         # Manually delete the directory
@@ -255,9 +255,9 @@ class TestWorktreeResilience:
         workflow_id = "wf-test-project-123-1000"
 
         # Initial setup
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path, str(github_dir)
         )
 
         # Cleanup (simulates halt)
@@ -265,9 +265,9 @@ class TestWorktreeResilience:
         assert not wt_path.exists()
 
         # Re-setup (simulates resume)
-        wt_path2 = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path2 = await create_worktree("test-project", "123", branch, str(github_dir))
         await register_worktree(
-            registry_path, workflow_id, "test-project", 123, branch, wt_path2, str(github_dir)
+            registry_path, workflow_id, "test-project", "123", branch, wt_path2, str(github_dir)
         )
 
         # Verify

--- a/tests/integration/test_worktree_lifecycle.py
+++ b/tests/integration/test_worktree_lifecycle.py
@@ -156,6 +156,36 @@ class TestWorktreeLifecycle:
         assert not wt_path.exists()
 
 
+class TestWorktreeHyphenatedIssue:
+    @pytest.mark.asyncio
+    async def test_create_register_cleanup_with_hyphenated_issue(self, tmp_path: Path):
+        """Full lifecycle with a Linear-style hyphenated issue ID (PROJ-123)."""
+        github_dir = tmp_path
+        _repo, branch = await _setup_git_repo(tmp_path)
+
+        issue = "PROJ-123"
+        wt_path = await create_worktree("test-project", issue, branch, str(github_dir))
+        assert wt_path.exists()
+        assert wt_path.name == "test-project-wt-PROJ-123"
+
+        registry_path = tmp_path / "worktrees.json"
+        workflow_id = "wf-test-project-PROJ-123-1000"
+
+        await register_worktree(
+            registry_path, workflow_id, "test-project", issue, branch, wt_path, str(github_dir)
+        )
+
+        reg = await load_registry(registry_path)
+        assert workflow_id in reg.worktrees
+        assert reg.worktrees[workflow_id].issue == issue
+
+        await cleanup_worktree(workflow_id, registry_path, str(github_dir))
+
+        reg = await load_registry(registry_path)
+        assert workflow_id not in reg.worktrees
+        assert not wt_path.exists()
+
+
 class TestWorktreeResilience:
     @pytest.mark.asyncio
     async def test_create_with_stale_directory(self, tmp_path: Path):

--- a/tests/unit/api/test_dispatch.py
+++ b/tests/unit/api/test_dispatch.py
@@ -192,7 +192,7 @@ class TestDispatch:
                     "branch": "main",
                     "spec_folder": "specs/test",
                     "cli": "claude",
-                    "issue": 1,
+                    "issue": "1",
                 },
                 headers=auth_headers,
             )
@@ -200,7 +200,7 @@ class TestDispatch:
         assert len(ids) == 3
 
     async def test_synthetic_issue_does_not_wrap(self, client, auth_headers):
-        """Synthetic issue ID (when issue=0) is a full nanosecond timestamp, not modulo-wrapped."""
+        """Synthetic issue ID (issue='0') uses a full nanosecond timestamp."""
         resp = await client.post(
             "/api/v1/dispatch",
             json={
@@ -209,7 +209,7 @@ class TestDispatch:
                 "branch": "main",
                 "spec_folder": "specs/test",
                 "cli": "claude",
-                "issue": 0,
+                "issue": "0",
             },
             headers=auth_headers,
         )

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -25,8 +25,8 @@ class TestGitWorktreeManager:
     async def test_create_delegates(self, mock_create):
         mock_create.return_value = Path("/tmp/project-wt-1")
         mgr = GitWorktreeManager()
-        result = await mgr.create("project", 1, "feat-1", "/home/github")
-        mock_create.assert_awaited_once_with("project", 1, "feat-1", "/home/github")
+        result = await mgr.create("project", "1", "feat-1", "/home/github")
+        mock_create.assert_awaited_once_with("project", "1", "feat-1", "/home/github")
         assert result == Path("/tmp/project-wt-1")
 
     @pytest.mark.asyncio
@@ -35,9 +35,9 @@ class TestGitWorktreeManager:
         mgr = GitWorktreeManager()
         reg_path = Path("/tmp/worktrees.json")
         wt_path = Path("/tmp/project-wt-1")
-        await mgr.register(reg_path, "wf-1", "project", 1, "feat-1", wt_path, "/home/github")
+        await mgr.register(reg_path, "wf-1", "project", "1", "feat-1", wt_path, "/home/github")
         mock_register.assert_awaited_once_with(
-            reg_path, "wf-1", "project", 1, "feat-1", wt_path, "/home/github"
+            reg_path, "wf-1", "project", "1", "feat-1", wt_path, "/home/github"
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_issue_types.py
+++ b/tests/unit/test_issue_types.py
@@ -1,0 +1,56 @@
+"""Tests for issue data models."""
+
+import pytest
+from pydantic import ValidationError
+
+from tanren_core.adapters.issue_types import Issue, IssueSummary
+
+
+class TestIssue:
+    def test_minimal(self):
+        issue = Issue(id="144", title="Fix login bug")
+        assert issue.id == "144"
+        assert issue.title == "Fix login bug"
+        assert not issue.body
+        assert not issue.status
+        assert issue.labels == ()
+        assert not issue.url
+        assert issue.metadata == {}
+
+    def test_full(self):
+        issue = Issue(
+            id="PROJ-123",
+            title="Add feature X",
+            body="Detailed description",
+            status="in_progress",
+            labels=("bug", "urgent"),
+            url="https://linear.app/proj/PROJ-123",
+            metadata={"priority": "high"},
+        )
+        assert issue.id == "PROJ-123"
+        assert issue.labels == ("bug", "urgent")
+        assert issue.metadata == {"priority": "high"}
+
+    def test_frozen(self):
+        issue = Issue(id="1", title="Test")
+        with pytest.raises(ValidationError):
+            issue.title = "Changed"
+
+
+class TestIssueSummary:
+    def test_minimal(self):
+        s = IssueSummary(id="42", title="Quick fix")
+        assert s.id == "42"
+        assert s.title == "Quick fix"
+        assert not s.status
+        assert not s.url
+
+    def test_full(self):
+        s = IssueSummary(
+            id="PROJ-99",
+            title="Upgrade deps",
+            status="todo",
+            url="https://example.com/PROJ-99",
+        )
+        assert s.status == "todo"
+        assert s.url == "https://example.com/PROJ-99"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -249,22 +249,22 @@ class TestWorktreeRegistry:
     def test_registry_with_entry(self):
         entry = WorktreeEntry(
             project="rentl",
-            issue=144,
+            issue="144",
             branch="s0146-slug",
             path="/home/trevor/github/rentl-wt-144",
             created_at="2026-03-07T15:01:00Z",
         )
         r = WorktreeRegistry(worktrees={"wf-rentl-144-1741359600": entry})
         assert "wf-rentl-144-1741359600" in r.worktrees
-        assert r.worktrees["wf-rentl-144-1741359600"].issue == 144
+        assert r.worktrees["wf-rentl-144-1741359600"].issue == "144"
 
 
 class TestParseIssueFromWorkflowId:
     def test_simple(self):
-        assert parse_issue_from_workflow_id("wf-rentl-144-1741359600") == 144
+        assert parse_issue_from_workflow_id("wf-rentl-144-1741359600") == "144"
 
     def test_hyphenated_project(self):
-        assert parse_issue_from_workflow_id("wf-unicorn-armada-3-1741359600") == 3
+        assert parse_issue_from_workflow_id("wf-unicorn-armada-3-1741359600") == "3"
 
     def test_invalid_format(self):
         with pytest.raises(ValueError, match="Invalid workflow_id format"):
@@ -273,6 +273,23 @@ class TestParseIssueFromWorkflowId:
     def test_missing_prefix(self):
         with pytest.raises(ValueError):
             parse_issue_from_workflow_id("rentl-144-1741359600")
+
+    def test_project_context_numeric(self):
+        assert parse_issue_from_workflow_id("wf-rentl-144-1741359600", project="rentl") == "144"
+
+    def test_project_context_hyphenated_issue(self):
+        assert (
+            parse_issue_from_workflow_id("wf-myapp-PROJ-123-1741359600", project="myapp")
+            == "PROJ-123"
+        )
+
+    def test_project_context_wrong_project(self):
+        with pytest.raises(ValueError, match="Invalid workflow_id format"):
+            parse_issue_from_workflow_id("wf-rentl-144-1741359600", project="other")
+
+    def test_project_context_no_epoch(self):
+        with pytest.raises(ValueError, match="Invalid workflow_id format"):
+            parse_issue_from_workflow_id("wf-rentl-144", project="rentl")
 
 
 class TestTaskStatus:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -291,6 +291,14 @@ class TestParseIssueFromWorkflowId:
         with pytest.raises(ValueError, match="Invalid workflow_id format"):
             parse_issue_from_workflow_id("wf-rentl-144", project="rentl")
 
+    def test_project_context_rejects_path_traversal(self):
+        with pytest.raises(ValueError, match="Invalid issue segment"):
+            parse_issue_from_workflow_id("wf-myproj-../../tmp-123", project="myproj")
+
+    def test_project_context_rejects_slash(self):
+        with pytest.raises(ValueError, match="Invalid issue segment"):
+            parse_issue_from_workflow_id("wf-myproj-foo/bar-123", project="myproj")
+
 
 class TestTaskStatus:
     def test_all_values(self):

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -84,7 +84,7 @@ class TestLoadRegistry:
             worktrees={
                 "wf-rentl-144-1741359600": WorktreeEntry(
                     project="rentl",
-                    issue=144,
+                    issue="144",
                     branch="s0146-slug",
                     path="/home/trevor/github/rentl-wt-144",
                     created_at="2026-03-07T15:01:00Z",
@@ -118,7 +118,7 @@ class TestSaveRegistry:
             worktrees={
                 "wf-test-1-1000": WorktreeEntry(
                     project="test",
-                    issue=1,
+                    issue="1",
                     branch="feat-1",
                     path="/tmp/test-wt-1",
                     created_at="2026-01-01T00:00:00Z",
@@ -143,7 +143,7 @@ class TestCheckIsolation:
             worktrees={
                 "wf-existing-1-1000": WorktreeEntry(
                     project="test",
-                    issue=1,
+                    issue="1",
                     branch="shared-branch",
                     path="/tmp/test-wt-1",
                     created_at="2026-01-01T00:00:00Z",
@@ -160,7 +160,7 @@ class TestCheckIsolation:
             worktrees={
                 "wf-existing-1-1000": WorktreeEntry(
                     project="test",
-                    issue=1,
+                    issue="1",
                     branch="branch-a",
                     path="/tmp/test-wt-1",
                     created_at="2026-01-01T00:00:00Z",
@@ -185,7 +185,7 @@ class TestCheckIsolation:
             worktrees={
                 "wf-test-1-1000": WorktreeEntry(
                     project="test",
-                    issue=1,
+                    issue="1",
                     branch="feat-1",
                     path="/tmp/test-wt-1",
                     created_at="2026-01-01T00:00:00Z",
@@ -203,7 +203,7 @@ class TestCheckIsolation:
             worktrees={
                 "wf-test-1-1000": WorktreeEntry(
                     project="test",
-                    issue=1,
+                    issue="1",
                     branch="feat-1",
                     path="/tmp/test-wt-1",
                     created_at="2026-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary

- **Generalize `issue: int` → `issue: str`** across the entire codebase (schemas, protocols, adapters, manager, API models, tests) to support non-numeric issue identifiers like Linear's `PROJ-123` format
- **Add `IssueSource` protocol** (`protocols.py`) with `get_issue`, `list_issues`, `update_status`, and `add_comment` methods for pluggable issue tracker integration
- **Add `Issue` and `IssueSummary` data models** (`issue_types.py`) following the frozen Pydantic model pattern used by `remote_types.py`
- **Improve `parse_issue_from_workflow_id()`** with an optional `project` parameter for context-aware parsing that correctly handles hyphenated issue IDs

Closes #28

## Test plan

- [x] `make format` — passes
- [x] `make check` — all gates pass (format, lint, type, unit 80%+, integration 75%+, docs)
- [x] New unit tests for `Issue` and `IssueSummary` models (construction, defaults, frozen immutability)
- [x] New test cases for `parse_issue_from_workflow_id` with `project` parameter (hyphenated issues, wrong project, missing epoch)
- [x] All existing tests updated from `int` to `str` issue values

🤖 Generated with [Claude Code](https://claude.com/claude-code)