### PR TITLE
feat: SecretProvider protocol + GCP Secret Manager adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync --locked
+        run: uv sync --locked --all-extras
 
       - name: Run verification
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.14

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
             suffix: -gcp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version from pyproject.toml
         id: version
@@ -61,7 +61,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/tanren-api
           tags: |
@@ -72,14 +72,14 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: services/tanren-api/Dockerfile

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gcp = ["google-cloud-compute>=1.20.0, <2"]
+gcp = ["google-cloud-compute>=1.20.0, <2", "google-cloud-secret-manager>=2.20.0, <3"]
 hetzner = ["hcloud>=2.4.0, <3"]
 
 [build-system]

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanren-core"
-version = "0.1.1"
+version = "0.2.0"
 description = "Core business logic for tanren"
 requires-python = ">=3.14"
 dependencies = [

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -15,6 +15,7 @@ from tanren_core.adapters.credentials import (
     providers_for_clis,
 )
 from tanren_core.adapters.dotenv_provisioner import DotenvEnvProvisioner
+from tanren_core.adapters.dotenv_secret_provider import DotenvSecretProvider
 from tanren_core.adapters.dotenv_validator import DotenvEnvValidator
 from tanren_core.adapters.events import (
     BootstrapCompleted,
@@ -36,6 +37,10 @@ from tanren_core.adapters.git_workspace import GitAuthConfig, GitWorkspaceManage
 from tanren_core.adapters.git_worktree import GitWorktreeManager
 from tanren_core.adapters.issue_types import Issue, IssueSummary
 
+try:  # noqa: SIM105, RUF067
+    from tanren_core.adapters.gcp_secret_manager import GCPSecretManagerProvider
+except ImportError:  # google-cloud-secret-manager not installed
+    pass
 try:  # noqa: SIM105, RUF067
     from tanren_core.adapters.gcp_vm import GCPProvisionerSettings, GCPVMProvisioner
 except ImportError:  # google-cloud-compute not installed
@@ -68,6 +73,7 @@ from tanren_core.adapters.protocols import (
     PreflightRunner,
     ProcessSpawner,
     RemoteConnection,
+    SecretProvider,
     VMStateStore,
     WorktreeManager,
 )
@@ -115,6 +121,7 @@ __all__ = [
     "DispatchReceived",
     "DotenvEnvProvisioner",
     "DotenvEnvValidator",
+    "DotenvSecretProvider",
     "EnvProvisioner",
     "EnvValidator",
     "EnvironmentBootstrapper",
@@ -125,6 +132,7 @@ __all__ = [
     "EventReader",
     "ExecutionEnvironment",
     "GCPProvisionerSettings",
+    "GCPSecretManagerProvider",
     "GCPVMProvisioner",
     "GitAuthConfig",
     "GitPostflightRunner",
@@ -164,6 +172,7 @@ __all__ = [
     "SSHConnection",
     "SSHExecutionEnvironment",
     "SecretBundle",
+    "SecretProvider",
     "SqliteEventEmitter",
     "SqliteEventReader",
     "SqliteVMStateStore",

--- a/packages/tanren-core/src/tanren_core/adapters/dotenv_secret_provider.py
+++ b/packages/tanren-core/src/tanren_core/adapters/dotenv_secret_provider.py
@@ -1,0 +1,70 @@
+"""Dotenv-backed SecretProvider — wraps existing secrets.env + secrets.d/*.env."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from tanren_core.env.secrets import DEFAULT_SECRETS_DIR
+
+
+class DotenvSecretProvider:
+    """Read secrets from dotenv files on disk.
+
+    Loads secrets.env and secrets.d/*.env on first access, caches in memory.
+    This is the backward-compatible default SecretProvider.
+    """
+
+    def __init__(self, secrets_dir: Path | None = None) -> None:
+        """Initialize with an optional secrets directory path."""
+        self._secrets_dir = secrets_dir or DEFAULT_SECRETS_DIR
+        self._cache: dict[str, str] | None = None
+
+    def _load(self) -> dict[str, str]:
+        """Load secrets from disk (cached after first call).
+
+        Returns:
+            Dict of secret key-value pairs.
+        """
+        if self._cache is not None:
+            return self._cache
+
+        merged: dict[str, str] = {}
+
+        secrets_path = self._secrets_dir / "secrets.env"
+        if secrets_path.exists():
+            values = dotenv_values(secrets_path)
+            for k, v in values.items():
+                if v is not None:
+                    merged[k] = v
+
+        secrets_d = self._secrets_dir / "secrets.d"
+        if secrets_d.is_dir():
+            for env_file in sorted(secrets_d.glob("*.env")):
+                values = dotenv_values(env_file)
+                for k, v in values.items():
+                    if v is not None:
+                        merged[k] = v
+
+        self._cache = merged
+        return merged
+
+    async def get_secret(self, secret_id: str, *, version: str = "latest") -> str | None:
+        """Look up a secret by key name in the dotenv files.
+
+        Returns:
+            The secret value, or None if the key is not found.
+        """
+        secrets = await asyncio.to_thread(self._load)
+        return secrets.get(secret_id)
+
+    async def list_secrets(self) -> list[str]:
+        """List all secret keys available in the dotenv files.
+
+        Returns:
+            List of secret key strings.
+        """
+        secrets = await asyncio.to_thread(self._load)
+        return list(secrets.keys())

--- a/packages/tanren-core/src/tanren_core/adapters/gcp_secret_manager.py
+++ b/packages/tanren-core/src/tanren_core/adapters/gcp_secret_manager.py
@@ -1,0 +1,90 @@
+"""GCP Secret Manager SecretProvider."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import types
+
+logger = logging.getLogger(__name__)
+
+
+def _import_secret_manager() -> types.ModuleType:
+    """Import and return the google.cloud.secretmanager module at runtime.
+
+    Returns:
+        The google.cloud.secretmanager module.
+
+    Raises:
+        ImportError: If the google-cloud-secret-manager package is not installed.
+    """
+    try:
+        import google.cloud.secretmanager as _sm  # noqa: PLC0415
+
+        return _sm
+    except ImportError:
+        raise ImportError(
+            "google-cloud-secret-manager is required for GCP secrets. "
+            "Install it with: uv sync --extra gcp"
+        ) from None
+
+
+class GCPSecretManagerProvider:
+    """Fetch secrets from GCP Secret Manager using Application Default Credentials.
+
+    Caches fetched secrets for the lifetime of the provider instance.
+    """
+
+    def __init__(self, project_id: str) -> None:
+        """Initialize with a GCP project ID."""
+        self._project_id = project_id
+        self._sm = _import_secret_manager()
+        self._client = self._sm.SecretManagerServiceClient()
+        self._cache: dict[str, str] = {}
+
+    async def get_secret(self, secret_id: str, *, version: str = "latest") -> str | None:
+        """Fetch a secret from GCP Secret Manager.
+
+        Returns:
+            The secret value as a string, or None if the secret is not found
+            or an error occurs.
+        """
+        cache_key = f"{secret_id}:{version}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        name = f"projects/{self._project_id}/secrets/{secret_id}/versions/{version}"
+        try:
+            response = await asyncio.to_thread(
+                self._client.access_secret_version,
+                request={"name": name},
+            )
+            value = response.payload.data.decode("UTF-8")
+            self._cache[cache_key] = value
+            return value
+        except Exception:
+            logger.warning(
+                "Failed to fetch secret %s from GCP Secret Manager",
+                secret_id,
+                exc_info=True,
+            )
+            return None
+
+    async def list_secrets(self) -> list[str]:
+        """List secret IDs in the GCP project.
+
+        Returns:
+            List of secret ID strings, or an empty list on error.
+        """
+        parent = f"projects/{self._project_id}"
+        try:
+            secrets = await asyncio.to_thread(
+                lambda: list(self._client.list_secrets(request={"parent": parent}))
+            )
+            return [s.name.rsplit("/", 1)[-1] for s in secrets]
+        except Exception:
+            logger.warning(
+                "Failed to list secrets from GCP Secret Manager",
+                exc_info=True,
+            )
+            return []

--- a/packages/tanren-core/src/tanren_core/adapters/protocols.py
+++ b/packages/tanren-core/src/tanren_core/adapters/protocols.py
@@ -33,6 +33,33 @@ from tanren_core.schemas import Dispatch
 
 
 @runtime_checkable
+class SecretProvider(Protocol):
+    """Fetch secrets from a backend (dotenv files, cloud secret managers, etc).
+
+    Implementations must be async. The provider is scoped to a single
+    dispatch lifetime and may cache fetched secrets internally.
+
+    Default implementation: DotenvSecretProvider.
+    """
+
+    async def get_secret(self, secret_id: str, *, version: str = "latest") -> str | None:
+        """Fetch a single secret value by ID.
+
+        Returns:
+            The secret value, or None if not found.
+        """
+        ...
+
+    async def list_secrets(self) -> list[str]:
+        """List available secret IDs.
+
+        Returns:
+            List of secret ID strings.
+        """
+        ...
+
+
+@runtime_checkable
 class WorktreeManager(Protocol):
     """Create, register, and clean up git worktrees.
 

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -658,6 +658,11 @@ class SSHExecutionEnvironment:
         try:
             tc = TanrenConfig.model_validate(data)
         except Exception:
+            logger.warning(
+                "Failed to parse tanren.yml for secret resolution in %s",
+                dispatch.project,
+                exc_info=True,
+            )
             return None
 
         has_sources = tc.env is not None and any(

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -663,12 +663,13 @@ class SSHExecutionEnvironment:
         has_sources = tc.env is not None and any(
             v.source for v in (*tc.env.required, *tc.env.optional)
         )
-        if tc.secrets is None and not has_sources:
+        if not has_sources:
             return None
 
         from tanren_core.env.secret_provider_factory import create_secret_provider  # noqa: PLC0415
 
-        provider = create_secret_provider(tc.secrets)
+        secrets_dir = self._secrets_dir()
+        provider = create_secret_provider(tc.secrets, secrets_dir=secrets_dir)
 
         result: dict[str, str] = {}
         if tc.env:
@@ -680,6 +681,17 @@ class SSHExecutionEnvironment:
                         result[var.key] = value
 
         return result or None
+
+    def _secrets_dir(self) -> Path:
+        """Derive the secrets directory from the SecretLoader config.
+
+        Respects the ``developer_secrets_path`` set via remote.yml so the
+        DotenvSecretProvider looks in the same location as SecretLoader.
+
+        Returns:
+            Path to the directory containing secrets files.
+        """
+        return Path(self._secret_loader._config.developer_secrets_path).expanduser().parent
 
     @staticmethod
     def _read_yaml(path: Path) -> object:

--- a/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ssh_environment.py
@@ -214,9 +214,10 @@ class SSHExecutionEnvironment:
             )
             workspace_path = await self._workspace_mgr.setup(conn, workspace_spec)
 
-            # 7a. Inject secrets
+            # 7a. Inject secrets (including cloud-fetched secrets)
             project_env = self._load_project_env(dispatch, config)
-            bundle = self._secret_loader.build_bundle(project_env)
+            cloud_secrets = await self._fetch_cloud_secrets(dispatch, config)
+            bundle = self._secret_loader.build_bundle(project_env, cloud_secrets=cloud_secrets)
             await self._workspace_mgr.inject_secrets(conn, workspace_path, bundle)
 
             # 7b. Inject MCP config
@@ -635,6 +636,60 @@ class SSHExecutionEnvironment:
             return {}
         values = dotenv_values(env_file)
         return {k: v for k, v in values.items() if v is not None}
+
+    async def _fetch_cloud_secrets(
+        self, dispatch: Dispatch, config: Config
+    ) -> dict[str, str] | None:
+        """Fetch cloud secrets for vars with ``source: "secret:X"`` in tanren.yml.
+
+        Returns:
+            Dict of fetched secrets, or None if no provider is configured.
+        """
+        tanren_yml = Path(config.github_dir) / dispatch.project / "tanren.yml"
+        if not tanren_yml.exists():
+            return None
+
+        data = await asyncio.to_thread(self._read_yaml, tanren_yml)
+        if not isinstance(data, dict):
+            return None
+
+        from tanren_core.env.schema import TanrenConfig  # noqa: PLC0415
+
+        try:
+            tc = TanrenConfig.model_validate(data)
+        except Exception:
+            return None
+
+        has_sources = tc.env is not None and any(
+            v.source for v in (*tc.env.required, *tc.env.optional)
+        )
+        if tc.secrets is None and not has_sources:
+            return None
+
+        from tanren_core.env.secret_provider_factory import create_secret_provider  # noqa: PLC0415
+
+        provider = create_secret_provider(tc.secrets)
+
+        result: dict[str, str] = {}
+        if tc.env:
+            for var in (*tc.env.required, *tc.env.optional):
+                if var.source and var.source.startswith("secret:"):
+                    secret_name = var.source[len("secret:") :]
+                    value = await provider.get_secret(secret_name)
+                    if value is not None:
+                        result[var.key] = value
+
+        return result or None
+
+    @staticmethod
+    def _read_yaml(path: Path) -> object:
+        """Read and parse a YAML file.
+
+        Returns:
+            Parsed YAML data.
+        """
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
 
     def _wrap_for_agent_user(self, command: str) -> str:
         """Wrap a shell command to run as the agent user via ``su -``.

--- a/packages/tanren-core/src/tanren_core/env/orchestrator.py
+++ b/packages/tanren-core/src/tanren_core/env/orchestrator.py
@@ -10,6 +10,7 @@ from tanren_core.env.loader import (
     parse_tanren_yml,
 )
 from tanren_core.env.schema import EnvBlock, OnMissing
+from tanren_core.env.secret_provider_factory import create_secret_provider
 from tanren_core.env.validator import EnvReport, validate_env
 
 logger = logging.getLogger(__name__)
@@ -49,8 +50,12 @@ async def load_and_validate_env(
     if daemon_mode and env_block.on_missing == OnMissing.PROMPT:
         env_block = env_block.model_copy(update={"on_missing": OnMissing.ERROR})
 
+    # Build secret provider from tanren.yml secrets config
+    secrets_config = config.secrets if config else None
+    secret_provider = create_secret_provider(secrets_config, secrets_dir=secrets_dir)
+
     merged_env, source_map = await asyncio.to_thread(load_env_layers, project_root, secrets_dir)
 
-    report = validate_env(env_block, merged_env, source_map)
+    report = await validate_env(env_block, merged_env, source_map, secret_provider=secret_provider)
 
     return report, merged_env

--- a/packages/tanren-core/src/tanren_core/env/orchestrator.py
+++ b/packages/tanren-core/src/tanren_core/env/orchestrator.py
@@ -50,9 +50,12 @@ async def load_and_validate_env(
     if daemon_mode and env_block.on_missing == OnMissing.PROMPT:
         env_block = env_block.model_copy(update={"on_missing": OnMissing.ERROR})
 
-    # Build secret provider from tanren.yml secrets config
-    secrets_config = config.secrets if config else None
-    secret_provider = create_secret_provider(secrets_config, secrets_dir=secrets_dir)
+    # Only build a secret provider if at least one var declares a source
+    secret_provider = None
+    has_sources = any(v.source for v in (*env_block.required, *env_block.optional))
+    if has_sources:
+        secrets_config = config.secrets if config else None
+        secret_provider = create_secret_provider(secrets_config, secrets_dir=secrets_dir)
 
     merged_env, source_map = await asyncio.to_thread(load_env_layers, project_root, secrets_dir)
 

--- a/packages/tanren-core/src/tanren_core/env/schema.py
+++ b/packages/tanren-core/src/tanren_core/env/schema.py
@@ -23,6 +23,10 @@ class RequiredEnvVar(BaseModel):
     description: str = Field(default="")
     pattern: str | None = Field(default=None, description="Regex for re.fullmatch()")
     hint: str = Field(default="")
+    source: str | None = Field(
+        default=None,
+        description="Secret source, e.g. 'secret:my-api-key' to resolve via SecretProvider",
+    )
 
 
 class OptionalEnvVar(BaseModel):
@@ -34,6 +38,26 @@ class OptionalEnvVar(BaseModel):
     description: str = Field(default="")
     pattern: str | None = Field(default=None)
     default: str | None = Field(default=None)
+    source: str | None = Field(
+        default=None,
+        description="Secret source, e.g. 'secret:my-api-key' to resolve via SecretProvider",
+    )
+
+
+class SecretsProviderType(StrEnum):
+    """Supported secret storage backends."""
+
+    DOTENV = "dotenv"
+    GCP = "gcp"
+
+
+class SecretsConfig(BaseModel):
+    """Configuration for the project's secret storage backend."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: SecretsProviderType = Field(default=SecretsProviderType.DOTENV)
+    settings: dict[str, str] = Field(default_factory=dict)
 
 
 class EnvBlock(BaseModel):
@@ -55,6 +79,7 @@ class TanrenConfig(BaseModel):
     profile: str = Field(...)
     installed: str = Field(...)
     env: EnvBlock | None = Field(default=None)
+    secrets: SecretsConfig | None = Field(default=None)
     # Consumed by runtime environment selection logic outside env tooling.
     environment: dict[str, object] | None = Field(default=None)
 

--- a/packages/tanren-core/src/tanren_core/env/secret_provider_factory.py
+++ b/packages/tanren-core/src/tanren_core/env/secret_provider_factory.py
@@ -1,0 +1,47 @@
+"""Create SecretProvider instances from tanren.yml SecretsConfig."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tanren_core.env.schema import SecretsConfig, SecretsProviderType
+
+if TYPE_CHECKING:
+    from tanren_core.adapters.protocols import SecretProvider
+
+
+def create_secret_provider(
+    config: SecretsConfig | None,
+    *,
+    secrets_dir: Path | None = None,
+) -> SecretProvider:
+    """Build a SecretProvider from the tanren.yml secrets config.
+
+    Returns:
+        DotenvSecretProvider when config is None or provider is "dotenv",
+        GCPSecretManagerProvider when provider is "gcp".
+
+    Raises:
+        ValueError: If the provider type is unsupported or required settings are missing.
+    """
+    if config is None or config.provider == SecretsProviderType.DOTENV:
+        from tanren_core.adapters.dotenv_secret_provider import (  # noqa: PLC0415
+            DotenvSecretProvider,
+        )
+
+        return DotenvSecretProvider(secrets_dir=secrets_dir)
+
+    if config.provider == SecretsProviderType.GCP:
+        from tanren_core.adapters.gcp_secret_manager import (  # noqa: PLC0415
+            GCPSecretManagerProvider,
+        )
+
+        project_id = config.settings.get("project_id")
+        if not project_id:
+            raise ValueError(
+                "secrets.settings.project_id is required when secrets.provider is 'gcp'"
+            )
+        return GCPSecretManagerProvider(project_id=project_id)
+
+    raise ValueError(f"Unsupported secrets provider: {config.provider}")

--- a/packages/tanren-core/src/tanren_core/env/validator.py
+++ b/packages/tanren-core/src/tanren_core/env/validator.py
@@ -1,12 +1,19 @@
 """Validate required/optional env vars against loaded layers."""
 
+from __future__ import annotations
+
+import os
 import re
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from tanren_core.env.loader import resolve_env_var
 from tanren_core.env.schema import EnvBlock
+
+if TYPE_CHECKING:
+    from tanren_core.adapters.protocols import SecretProvider
 
 
 class VarStatus(StrEnum):
@@ -43,10 +50,32 @@ class EnvReport(BaseModel):
     warnings: list[str] = Field(default_factory=list)
 
 
-def validate_env(
+async def _resolve_secret(
+    key: str,
+    source: str | None,
+    merged_env: dict[str, str],
+    source_map: dict[str, str],
+    secret_provider: SecretProvider | None,
+) -> None:
+    """Resolve a secret: source into merged_env if the var is not already set."""
+    if not source or not source.startswith("secret:") or secret_provider is None:
+        return
+    # Only fetch from provider if not already resolved from a higher-priority source
+    if key in merged_env or os.environ.get(key) is not None:
+        return
+    secret_name = source[len("secret:") :]
+    fetched = await secret_provider.get_secret(secret_name)
+    if fetched is not None:
+        merged_env[key] = fetched
+        source_map[key] = f"secret:{secret_name}"
+
+
+async def validate_env(
     env_block: EnvBlock,
     merged_env: dict[str, str],
     source_map: dict[str, str],
+    *,
+    secret_provider: SecretProvider | None = None,
 ) -> EnvReport:
     """Validate env vars against schema.
 
@@ -55,6 +84,10 @@ def validate_env(
 
     Optional vars: if absent, inject default into merged env (status=DEFAULTED).
     If present + pattern, validate.
+
+    When a secret_provider is given, vars with ``source: "secret:X"`` are
+    resolved from the provider before checking the normal env layers.
+    Priority: os.environ > dotenv layers > secret provider.
 
     Never logs full secret values -- redacted to first 4 chars + '...'.
 
@@ -67,6 +100,9 @@ def validate_env(
     all_pass = True
 
     for var in env_block.required:
+        # Resolve from secret provider if source declared and var not already set
+        await _resolve_secret(var.key, var.source, merged_env, source_map, secret_provider)
+
         value, source = resolve_env_var(var.key, merged_env, source_map)
 
         if value is None:
@@ -122,6 +158,9 @@ def validate_env(
         )
 
     for var in env_block.optional:
+        # Resolve from secret provider if source declared and var not already set
+        await _resolve_secret(var.key, var.source, merged_env, source_map, secret_provider)
+
         value, source = resolve_env_var(var.key, merged_env, source_map)
 
         if value is None:

--- a/packages/tanren-core/src/tanren_core/secrets.py
+++ b/packages/tanren-core/src/tanren_core/secrets.py
@@ -104,14 +104,25 @@ class SecretLoader:
                     result[key] = content
         return result
 
-    def build_bundle(self, project_secrets: dict[str, str] | None = None) -> SecretBundle:
+    def build_bundle(
+        self,
+        project_secrets: dict[str, str] | None = None,
+        cloud_secrets: dict[str, str] | None = None,
+    ) -> SecretBundle:
         """Build a SecretBundle from all secret sources.
+
+        Args:
+            project_secrets: Env vars from the project's .env file.
+            cloud_secrets: Secrets fetched from a cloud SecretProvider.
+                Merged into the developer scope (overrides dotenv values).
 
         Returns:
             SecretBundle combining developer, project, and infrastructure secrets.
         """
         developer = self.load_developer()
         developer.update(self.load_credential_files())
+        if cloud_secrets:
+            developer.update(cloud_secrets)
         return SecretBundle(
             developer=developer,
             project=project_secrets or {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanren-workspace"
-version = "0.1.1"
+version = "0.2.0"
 description = "Development lifecycle framework"
 requires-python = ">=3.14"
 

--- a/services/tanren-api/pyproject.toml
+++ b/services/tanren-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanren-api"
-version = "0.1.1"
+version = "0.2.0"
 description = "FastAPI HTTP API for tanren"
 requires-python = ">=3.14"
 dependencies = [

--- a/services/tanren-cli/pyproject.toml
+++ b/services/tanren-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanren-cli"
-version = "0.1.1"
+version = "0.2.0"
 description = "CLI for tanren"
 requires-python = ">=3.14"
 dependencies = [

--- a/services/tanren-cli/src/tanren_cli/env_cli.py
+++ b/services/tanren-cli/src/tanren_cli/env_cli.py
@@ -1,5 +1,6 @@
 """Typer subcommands for env and secret management."""
 
+import asyncio
 from pathlib import Path
 
 import typer
@@ -12,6 +13,7 @@ from tanren_core.env.loader import (
 )
 from tanren_core.env.reporter import format_report, format_report_json
 from tanren_core.env.schema import EnvBlock
+from tanren_core.env.secret_provider_factory import create_secret_provider
 from tanren_core.env.secrets import DEFAULT_SECRETS_DIR, list_secrets, set_secret
 from tanren_core.env.validator import validate_env
 
@@ -61,7 +63,11 @@ def check(
                 continue
 
         merged_env, source_map = load_env_layers(project_root)
-        report = validate_env(env_block, merged_env, source_map)
+        secrets_config = config.secrets if config else None
+        secret_provider = create_secret_provider(secrets_config)
+        report = asyncio.run(
+            validate_env(env_block, merged_env, source_map, secret_provider=secret_provider)
+        )
 
         if json_output:
             typer.echo(format_report_json(report))

--- a/services/tanren-cli/src/tanren_cli/env_cli.py
+++ b/services/tanren-cli/src/tanren_cli/env_cli.py
@@ -63,8 +63,11 @@ def check(
                 continue
 
         merged_env, source_map = load_env_layers(project_root)
-        secrets_config = config.secrets if config else None
-        secret_provider = create_secret_provider(secrets_config)
+        secret_provider = None
+        has_sources = any(v.source for v in (*env_block.required, *env_block.optional))
+        if has_sources:
+            secrets_config = config.secrets if config else None
+            secret_provider = create_secret_provider(secrets_config)
         report = asyncio.run(
             validate_env(env_block, merged_env, source_map, secret_provider=secret_provider)
         )

--- a/services/tanren-daemon/pyproject.toml
+++ b/services/tanren-daemon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tanren-daemon"
-version = "0.1.1"
+version = "0.2.0"
 description = "Worker manager polling daemon for tanren"
 requires-python = ">=3.14"
 dependencies = [

--- a/tests/integration/test_core_utils_integration.py
+++ b/tests/integration/test_core_utils_integration.py
@@ -29,8 +29,9 @@ from tanren_core.schemas import ProgressState
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
 class TestValidateEnv:
-    def test_validate_required_pattern_mismatch(self, monkeypatch) -> None:
+    async def test_validate_required_pattern_mismatch(self, monkeypatch) -> None:
         """Required var exists but doesn't match pattern -> PATTERN_MISMATCH."""
         monkeypatch.delenv("TEST_API_KEY_INTEG", raising=False)
         env_block = EnvBlock(
@@ -43,14 +44,14 @@ class TestValidateEnv:
         merged = {"TEST_API_KEY_INTEG": "wrong-prefix-value"}
         source_map = {"TEST_API_KEY_INTEG": ".env"}
 
-        report = validate_env(env_block, merged, source_map)
+        report = await validate_env(env_block, merged, source_map)
 
         assert not report.passed
         assert len(report.required_results) == 1
         assert report.required_results[0].status == VarStatus.PATTERN_MISMATCH
         assert report.required_results[0].key == "TEST_API_KEY_INTEG"
 
-    def test_validate_optional_missing_with_default(self, monkeypatch) -> None:
+    async def test_validate_optional_missing_with_default(self, monkeypatch) -> None:
         """Optional var missing, has default -> DEFAULTED status, default applied."""
         monkeypatch.delenv("OPT_LOG_LEVEL", raising=False)
         env_block = EnvBlock(
@@ -61,7 +62,7 @@ class TestValidateEnv:
         merged: dict[str, str] = {}
         source_map: dict[str, str] = {}
 
-        report = validate_env(env_block, merged, source_map)
+        report = await validate_env(env_block, merged, source_map)
 
         assert report.passed
         assert len(report.optional_results) == 1
@@ -70,7 +71,7 @@ class TestValidateEnv:
         assert merged["OPT_LOG_LEVEL"] == "INFO"
         assert source_map["OPT_LOG_LEVEL"] == "default"
 
-    def test_validate_optional_missing_no_default(self, monkeypatch) -> None:
+    async def test_validate_optional_missing_no_default(self, monkeypatch) -> None:
         """Optional var missing, no default -> MISSING but still passes."""
         monkeypatch.delenv("OPT_EXTRA_FLAG", raising=False)
         env_block = EnvBlock(
@@ -81,14 +82,14 @@ class TestValidateEnv:
         merged: dict[str, str] = {}
         source_map: dict[str, str] = {}
 
-        report = validate_env(env_block, merged, source_map)
+        report = await validate_env(env_block, merged, source_map)
 
         assert report.passed
         assert len(report.optional_results) == 1
         assert report.optional_results[0].status == VarStatus.MISSING
         assert "OPT_EXTRA_FLAG" not in merged
 
-    def test_validate_empty_required(self, monkeypatch) -> None:
+    async def test_validate_empty_required(self, monkeypatch) -> None:
         """Required var exists but empty string -> EMPTY status."""
         monkeypatch.delenv("EMPTY_REQ_VAR", raising=False)
         env_block = EnvBlock(
@@ -99,7 +100,7 @@ class TestValidateEnv:
         merged = {"EMPTY_REQ_VAR": ""}
         source_map = {"EMPTY_REQ_VAR": ".env"}
 
-        report = validate_env(env_block, merged, source_map)
+        report = await validate_env(env_block, merged, source_map)
 
         assert not report.passed
         assert len(report.required_results) == 1

--- a/tests/integration/test_env_integration.py
+++ b/tests/integration/test_env_integration.py
@@ -118,3 +118,32 @@ class TestLayeredPriority:
         report, env = await load_and_validate_env(tmp_path, secrets_dir=tmp_path / "secrets")
         assert report.passed
         assert env["MY_VAR"] == "from_real_env"
+
+    async def test_source_secret_resolved_from_dotenv_provider(self, tmp_path: Path, monkeypatch):
+        """source: secret:X resolves via DotenvSecretProvider."""
+        monkeypatch.delenv("MY_SECRET", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("MY_SECRET=resolved-from-secrets\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n    - key: MY_SECRET\n      source: 'secret:MY_SECRET'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        assert env["MY_SECRET"] == "resolved-from-secrets"
+
+    async def test_no_source_vars_skips_provider_init(self, tmp_path: Path):
+        """No vars with source -> provider not created (no crash even with gcp config)."""
+        (tmp_path / ".env").write_text("K=v\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "secrets:\n  provider: gcp\n  settings:\n    project_id: fake\n"
+            "env:\n  required:\n    - key: K\n"
+        )
+
+        # Should pass without importing google-cloud-secret-manager
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=tmp_path / "secrets")
+        assert report.passed
+        assert env["K"] == "v"

--- a/tests/integration/test_env_integration.py
+++ b/tests/integration/test_env_integration.py
@@ -1,10 +1,17 @@
 """Integration tests for full env validation flow."""
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from tanren_core.env import load_and_validate_env
+from tanren_core.env.loader import (
+    _check_permissions,  # noqa: PLC2701
+    discover_env_vars_from_dotenv_example,
+    load_env_layers,
+    resolve_env_var,
+)
 
 
 class TestFullFlow:
@@ -260,3 +267,99 @@ class TestLayeredPriority:
         report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
         assert report.passed
         assert env["MY_VAR"] == "from-dotenv-provider"
+
+
+class TestSecretsD:
+    def test_secrets_d_files_loaded_alphabetically(self, tmp_path: Path, monkeypatch):
+        """secrets.d/*.env files are loaded in alphabetical order (later wins)."""
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("")
+        sd_d = sd / "secrets.d"
+        sd_d.mkdir()
+        (sd_d / "01-first.env").write_text("VAR=first\n")
+        (sd_d / "02-second.env").write_text("VAR=second\n")
+
+        merged, source_map = load_env_layers(tmp_path, secrets_dir=sd)
+        assert merged["VAR"] == "second"
+        assert "02-second.env" in source_map["VAR"]
+
+
+class TestPermissionsWarning:
+    def test_world_readable_warning(self, tmp_path: Path, caplog):
+        """World-readable secrets file logs a warning."""
+        secret_file = tmp_path / "secrets.env"
+        secret_file.write_text("KEY=val\n")
+        secret_file.chmod(0o644)
+
+        with caplog.at_level(logging.WARNING, logger="tanren_core.env.loader"):
+            _check_permissions(secret_file)
+
+        assert any("world-readable" in r.message for r in caplog.records)
+
+    def test_secure_permissions_no_warning(self, tmp_path: Path, caplog):
+        """Properly secured file does not log a warning."""
+        secret_file = tmp_path / "secrets.env"
+        secret_file.write_text("KEY=val\n")
+        secret_file.chmod(0o600)
+
+        with caplog.at_level(logging.WARNING, logger="tanren_core.env.loader"):
+            _check_permissions(secret_file)
+
+        assert not any("world-readable" in r.message for r in caplog.records)
+
+
+class TestEnvExampleFallback:
+    def test_dotenv_example_keys_parsed(self, tmp_path: Path):
+        """.env.example fallback returns RequiredEnvVar list."""
+        (tmp_path / ".env.example").write_text("API_KEY=placeholder\nDB_URL=postgres://...\n")
+
+        result = discover_env_vars_from_dotenv_example(tmp_path)
+        keys = [v.key for v in result]
+        assert "API_KEY" in keys
+        assert "DB_URL" in keys
+
+    def test_missing_example_returns_empty(self, tmp_path: Path):
+        """No .env.example returns empty list."""
+        result = discover_env_vars_from_dotenv_example(tmp_path)
+        assert result == []
+
+
+class TestResolveEnvVar:
+    def test_resolve_from_merged(self):
+        merged = {"KEY": "val"}
+        source_map = {"KEY": "secrets.env"}
+        value, source = resolve_env_var("KEY", merged, source_map)
+        assert value == "val"
+        assert source == "secrets.env"
+
+    def test_resolve_from_os_environ(self, monkeypatch):
+        monkeypatch.setenv("ENV_KEY", "from-env")
+        value, source = resolve_env_var("ENV_KEY", {}, {})
+        assert value == "from-env"
+        assert source == "os.environ"
+
+    def test_missing_returns_none(self, monkeypatch):
+        monkeypatch.delenv("MISSING_XYZ", raising=False)
+        value, source = resolve_env_var("MISSING_XYZ", {}, {})
+        assert value is None
+        assert source is None
+
+
+class TestDaemonModeNonDaemon:
+    @pytest.mark.asyncio
+    async def test_non_daemon_mode_allows_prompt_policy(self, tmp_path: Path, monkeypatch):
+        """Non-daemon mode keeps on_missing=prompt (doesn't force error)."""
+        monkeypatch.delenv("MISSING_KEY_ABC", raising=False)
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  on_missing: prompt\n  required:\n    - key: MISSING_KEY_ABC\n"
+        )
+        # In non-daemon mode, prompt policy should be preserved.
+        # With prompt policy and a missing key, validate_env still reports
+        # MISSING — but the policy itself is not forced to error.
+        report, _ = await load_and_validate_env(
+            tmp_path, daemon_mode=False, secrets_dir=tmp_path / "secrets"
+        )
+        # Should still fail (key is missing), but the policy is PROMPT not ERROR
+        assert not report.passed

--- a/tests/integration/test_env_integration.py
+++ b/tests/integration/test_env_integration.py
@@ -134,6 +134,103 @@ class TestLayeredPriority:
         assert report.passed
         assert env["MY_SECRET"] == "resolved-from-secrets"
 
+    async def test_source_secret_from_secrets_d(self, tmp_path: Path, monkeypatch):
+        """source: secret:X resolves from secrets.d/*.env files."""
+        monkeypatch.delenv("DB_PASS", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("")
+        sd_d = sd / "secrets.d"
+        sd_d.mkdir()
+        (sd_d / "db.env").write_text("DB_PASS=s3cret\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n    - key: DB_PASS\n      source: 'secret:DB_PASS'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        assert env["DB_PASS"] == "s3cret"
+
+    async def test_source_secret_missing_fails(self, tmp_path: Path, monkeypatch):
+        """source: secret:X where the secret doesn't exist -> MISSING."""
+        monkeypatch.delenv("GONE", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n    - key: GONE\n      source: 'secret:GONE'\n"
+        )
+
+        report, _env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert not report.passed
+
+    async def test_source_secret_env_overrides(self, tmp_path: Path, monkeypatch):
+        """os.environ takes priority over secret provider."""
+        monkeypatch.setenv("MY_KEY", "from-env")
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("MY_KEY=from-provider\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n    - key: MY_KEY\n      source: 'secret:MY_KEY'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        assert env["MY_KEY"] == "from-env"
+
+    async def test_source_optional_resolved(self, tmp_path: Path, monkeypatch):
+        """Optional var with source: secret:X resolved from provider."""
+        monkeypatch.delenv("OPT_SECRET", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("OPT_SECRET=opt-val\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  optional:\n    - key: OPT_SECRET\n      source: 'secret:OPT_SECRET'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        assert env["OPT_SECRET"] == "opt-val"
+
+    async def test_source_with_pattern_validated(self, tmp_path: Path, monkeypatch):
+        """Resolved secret value is validated against pattern."""
+        monkeypatch.delenv("API_KEY", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("API_KEY=wrong-prefix\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n"
+            "    - key: API_KEY\n      source: 'secret:API_KEY'\n      pattern: '^sk-'\n"
+        )
+
+        report, _env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert not report.passed
+
+    async def test_mixed_source_and_normal_vars(self, tmp_path: Path, monkeypatch):
+        """Mix of source-backed and normal vars in the same env block."""
+        monkeypatch.setenv("NORMAL_VAR", "normal-val")
+        monkeypatch.delenv("SECRET_VAR", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("SECRET_VAR=secret-val\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "env:\n  required:\n"
+            "    - key: NORMAL_VAR\n"
+            "    - key: SECRET_VAR\n      source: 'secret:SECRET_VAR'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        # NORMAL_VAR is resolved from os.environ by the validator (not in merged dict)
+        # SECRET_VAR is injected into merged dict by the secret provider
+        assert env["SECRET_VAR"] == "secret-val"
+
     async def test_no_source_vars_skips_provider_init(self, tmp_path: Path):
         """No vars with source -> provider not created (no crash even with gcp config)."""
         (tmp_path / ".env").write_text("K=v\n")
@@ -147,3 +244,19 @@ class TestLayeredPriority:
         report, env = await load_and_validate_env(tmp_path, secrets_dir=tmp_path / "secrets")
         assert report.passed
         assert env["K"] == "v"
+
+    async def test_dotenv_provider_explicit_config(self, tmp_path: Path, monkeypatch):
+        """Explicit secrets.provider: dotenv works the same as default."""
+        monkeypatch.delenv("MY_VAR", raising=False)
+        sd = tmp_path / "secrets"
+        sd.mkdir()
+        (sd / "secrets.env").write_text("MY_VAR=from-dotenv-provider\n")
+        (tmp_path / "tanren.yml").write_text(
+            "version: 0.1.0\nprofile: default\ninstalled: 2026-01-01\n"
+            "secrets:\n  provider: dotenv\n"
+            "env:\n  required:\n    - key: MY_VAR\n      source: 'secret:MY_VAR'\n"
+        )
+
+        report, env = await load_and_validate_env(tmp_path, secrets_dir=sd)
+        assert report.passed
+        assert env["MY_VAR"] == "from-dotenv-provider"

--- a/tests/integration/test_event_reader_integration.py
+++ b/tests/integration/test_event_reader_integration.py
@@ -1,0 +1,169 @@
+"""Integration tests for SqliteEventReader with real SQLite databases."""
+
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tanren_core.adapters.event_reader import SqliteEventReader, query_events
+
+
+async def _create_events_db(db_path: Path, events: list[tuple]) -> None:
+    """Create a test events database with the given rows."""
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.execute(
+            "CREATE TABLE events ("
+            "  id INTEGER PRIMARY KEY,"
+            "  timestamp TEXT NOT NULL,"
+            "  workflow_id TEXT NOT NULL,"
+            "  event_type TEXT NOT NULL,"
+            "  payload TEXT"
+            ")"
+        )
+        await conn.executemany(
+            "INSERT INTO events (id, timestamp, workflow_id, event_type, payload) "
+            "VALUES (?, ?, ?, ?, ?)",
+            events,
+        )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+class TestSqliteEventReader:
+    async def test_query_all_events(self, tmp_path: Path):
+        """Query without filters returns all events."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [
+                (1, "2026-01-01T00:00:00", "wf-a-1-100", "DispatchReceived", '{"a": 1}'),
+                (2, "2026-01-01T01:00:00", "wf-a-1-100", "PhaseCompleted", '{"b": 2}'),
+            ],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events()
+        assert result.total == 2
+        assert len(result.events) == 2
+        assert result.skipped == 0
+
+    async def test_query_by_workflow_id(self, tmp_path: Path):
+        """Filter by workflow_id returns only matching events."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [
+                (1, "2026-01-01T00:00:00", "wf-a-1-100", "DispatchReceived", '{"a": 1}'),
+                (2, "2026-01-01T01:00:00", "wf-b-2-200", "DispatchReceived", '{"a": 2}'),
+                (3, "2026-01-01T02:00:00", "wf-a-1-100", "PhaseCompleted", '{"a": 3}'),
+            ],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events(workflow_id="wf-a-1-100")
+        assert result.total == 2
+        assert all(e.workflow_id == "wf-a-1-100" for e in result.events)
+
+    async def test_query_by_event_type(self, tmp_path: Path):
+        """Filter by event_type returns only matching events."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [
+                (1, "2026-01-01T00:00:00", "wf-a-1-100", "DispatchReceived", '{"a": 1}'),
+                (2, "2026-01-01T01:00:00", "wf-a-1-100", "PhaseCompleted", '{"b": 2}'),
+            ],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events(event_type="PhaseCompleted")
+        assert result.total == 1
+        assert result.events[0].event_type == "PhaseCompleted"
+
+    async def test_empty_database(self, tmp_path: Path):
+        """Empty database returns empty result."""
+        db = tmp_path / "events.db"
+        await _create_events_db(db, [])
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events()
+        assert result.total == 0
+        assert result.events == []
+
+    async def test_nonexistent_db(self, tmp_path: Path):
+        """Missing database file returns empty result (no error)."""
+        reader = SqliteEventReader(tmp_path / "nonexistent.db")
+        result = await reader.query_events()
+        assert result.total == 0
+        assert result.events == []
+        assert result.skipped == 0
+
+    async def test_pagination_limit(self, tmp_path: Path):
+        """Limit restricts returned events but total reflects all matches."""
+        db = tmp_path / "events.db"
+        events = [
+            (i, f"2026-01-01T{i:02d}:00:00", "wf-a-1-100", "E", json.dumps({"i": i}))
+            for i in range(1, 11)
+        ]
+        await _create_events_db(db, events)
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events(limit=3)
+        assert result.total == 10
+        assert len(result.events) == 3
+
+    async def test_pagination_offset(self, tmp_path: Path):
+        """Offset skips the first N events."""
+        db = tmp_path / "events.db"
+        events = [
+            (i, f"2026-01-01T{i:02d}:00:00", "wf-a-1-100", "E", json.dumps({"i": i}))
+            for i in range(1, 6)
+        ]
+        await _create_events_db(db, events)
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events(limit=2, offset=2)
+        assert result.total == 5
+        assert len(result.events) == 2
+
+    async def test_order_by_timestamp_desc(self, tmp_path: Path):
+        """Events are returned in descending timestamp order."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [
+                (1, "2026-01-01T01:00:00", "wf-a-1-100", "E", '{"a": 1}'),
+                (2, "2026-01-01T03:00:00", "wf-a-1-100", "E", '{"a": 2}'),
+                (3, "2026-01-01T02:00:00", "wf-a-1-100", "E", '{"a": 3}'),
+            ],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events()
+        timestamps = [e.timestamp for e in result.events]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    async def test_event_payload_parsed(self, tmp_path: Path):
+        """Payload JSON is parsed into a dict."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [(1, "2026-01-01T00:00:00", "wf-a-1-100", "E", '{"key": "value", "n": 42}')],
+        )
+
+        reader = SqliteEventReader(db)
+        result = await reader.query_events()
+        assert result.events[0].payload == {"key": "value", "n": 42}
+
+    async def test_backward_compat_wrapper(self, tmp_path: Path):
+        """Module-level query_events() delegates to SqliteEventReader."""
+        db = tmp_path / "events.db"
+        await _create_events_db(
+            db,
+            [(1, "2026-01-01T00:00:00", "wf-a-1-100", "E", '{"a": 1}')],
+        )
+
+        result = await query_events(db, workflow_id="wf-a-1-100")
+        assert result.total == 1
+        assert result.events[0].workflow_id == "wf-a-1-100"

--- a/tests/integration/test_gcp_provisioning.py
+++ b/tests/integration/test_gcp_provisioning.py
@@ -21,18 +21,12 @@ from tanren_core.adapters.ssh import SSHConfig, SSHConnection
 
 pytestmark = pytest.mark.gcp
 
-_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
-_skip_reason = "GOOGLE_CLOUD_PROJECT not set"
+_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
 
 
 @pytest.fixture()
 def provisioner():
     """Create a GCPVMProvisioner using real GCP credentials."""
-    if not _PROJECT:
-        raise pytest.skip.Exception(_skip_reason)
-    if not os.environ.get("GCP_SSH_PUBLIC_KEY"):
-        raise pytest.skip.Exception("GCP_SSH_PUBLIC_KEY not set")
-
     settings = GCPProvisionerSettings(
         project_id=_PROJECT,
         zone="us-central1-a",

--- a/tests/integration/test_gcp_secrets_integration.py
+++ b/tests/integration/test_gcp_secrets_integration.py
@@ -2,7 +2,7 @@
 
 Requires GOOGLE_CLOUD_PROJECT env var and Application Default Credentials.
 Run with:
-    uv run pytest tests/integration/test_gcp_secrets_integration.py -v --timeout=60
+    uv run pytest tests/integration/test_gcp_secrets_integration.py -v -m gcp --timeout=60
 """
 
 import os
@@ -11,15 +11,13 @@ import pytest
 
 pytestmark = pytest.mark.gcp
 
-_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
 _TEST_SECRET_NAME = os.environ.get("GCP_TEST_SECRET_NAME", "tanren-test-secret")
 
 
 @pytest.fixture()
 def provider():
     """Create a live GCP Secret Manager provider."""
-    if not _PROJECT:
-        pytest.skip("GOOGLE_CLOUD_PROJECT not set")  # type: ignore[invalid-argument-type,too-many-positional-arguments]
     from tanren_core.adapters.gcp_secret_manager import GCPSecretManagerProvider  # noqa: PLC0415
 
     return GCPSecretManagerProvider(project_id=_PROJECT)

--- a/tests/integration/test_gcp_secrets_integration.py
+++ b/tests/integration/test_gcp_secrets_integration.py
@@ -1,0 +1,41 @@
+"""Integration tests for GCP Secret Manager provider.
+
+Requires GOOGLE_CLOUD_PROJECT env var and Application Default Credentials.
+Run with:
+    uv run pytest tests/integration/test_gcp_secrets_integration.py -v --timeout=60
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.gcp
+
+_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+_TEST_SECRET_NAME = os.environ.get("GCP_TEST_SECRET_NAME", "tanren-test-secret")
+
+
+@pytest.fixture()
+def provider():
+    """Create a live GCP Secret Manager provider."""
+    if not _PROJECT:
+        pytest.skip("GOOGLE_CLOUD_PROJECT not set")  # type: ignore[invalid-argument-type,too-many-positional-arguments]
+    from tanren_core.adapters.gcp_secret_manager import GCPSecretManagerProvider  # noqa: PLC0415
+
+    return GCPSecretManagerProvider(project_id=_PROJECT)
+
+
+@pytest.mark.asyncio
+class TestGCPSecretManagerLive:
+    async def test_get_existing_secret(self, provider):
+        result = await provider.get_secret(_TEST_SECRET_NAME)
+        assert result is not None
+        assert len(result) > 0
+
+    async def test_get_nonexistent_returns_none(self, provider):
+        result = await provider.get_secret("tanren-nonexistent-secret-xyz-12345")
+        assert result is None
+
+    async def test_list_secrets(self, provider):
+        result = await provider.list_secrets()
+        assert isinstance(result, list)

--- a/tests/integration/test_hetzner_provisioning.py
+++ b/tests/integration/test_hetzner_provisioning.py
@@ -35,14 +35,11 @@ def _load_token() -> str | None:
 
 _TOKEN = _load_token()
 
-_skip_reason = "HETZNER_API_TOKEN not found in secrets.env"
-
 
 @pytest.fixture()
 def provisioner():
     """Create a HetznerVMProvisioner using developer secrets and real config values."""
-    if not _TOKEN:
-        raise pytest.skip.Exception(_skip_reason)
+    assert _TOKEN, "HETZNER_API_TOKEN not found in secrets.env (run with -m hetzner)"
 
     os.environ.setdefault("HETZNER_API_TOKEN", _TOKEN)
 

--- a/tests/integration/test_manager_edge_cases.py
+++ b/tests/integration/test_manager_edge_cases.py
@@ -1,0 +1,299 @@
+"""Integration tests for WorkerManager edge cases using mock adapters."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tanren_core.config import Config
+from tanren_core.manager import (
+    WorkerManager,
+    _build_gate_output,  # noqa: PLC2701
+    build_tail_output,
+)
+from tanren_core.schemas import Cli, Dispatch, Outcome, Phase
+
+
+def _make_config(tmp_path: Path) -> Config:
+    """Build a Config that points to tmp_path directories."""
+    ipc = tmp_path / "ipc"
+    data = tmp_path / "data"
+    github = tmp_path / "github"
+    for d in (ipc, data, github):
+        d.mkdir(parents=True, exist_ok=True)
+    return Config(
+        ipc_dir=str(ipc),
+        data_dir=str(data),
+        github_dir=str(github),
+        worktree_registry_path=str(tmp_path / "worktrees.json"),
+        roles_config_path=str(tmp_path / "roles.yml"),
+        poll_interval=0.1,
+        heartbeat_interval=60,
+        max_opencode=1,
+        max_codex=1,
+        max_gate=3,
+    )
+
+
+def _make_dispatch(
+    cli: Cli = Cli.OPENCODE,
+    phase: Phase = Phase.DO_TASK,
+    workflow_id: str = "wf-test-1-100",
+) -> Dispatch:
+    return Dispatch(
+        workflow_id=workflow_id,
+        phase=phase,
+        project="test",
+        spec_folder="specs/test",
+        branch="feature-1",
+        cli=cli,
+        timeout=60,
+    )
+
+
+class TestGateOutputBuilding:
+    def test_none_stdout(self):
+        assert _build_gate_output(None, Outcome.SUCCESS) is None
+
+    def test_empty_stdout(self):
+        assert _build_gate_output("", Outcome.SUCCESS) is None
+
+    def test_success_truncates_to_100_lines(self):
+        stdout = "\n".join(f"line {i}" for i in range(200))
+        result = _build_gate_output(stdout, Outcome.SUCCESS)
+        assert result is not None
+        assert len(result.split("\n")) == 100
+
+    def test_fail_truncates_to_300_lines(self):
+        stdout = "\n".join(f"line {i}" for i in range(500))
+        result = _build_gate_output(stdout, Outcome.FAIL)
+        assert result is not None
+        assert len(result.split("\n")) == 300
+
+    def test_short_output_unchanged(self):
+        stdout = "line 1\nline 2\nline 3"
+        result = _build_gate_output(stdout, Outcome.SUCCESS)
+        assert result == stdout
+
+
+class TestTailOutput:
+    def test_none_returns_none(self):
+        assert build_tail_output(None) is None
+
+    def test_empty_returns_none(self):
+        assert build_tail_output("") is None
+
+    def test_truncates_to_200_lines(self):
+        stdout = "\n".join(f"line {i}" for i in range(400))
+        result = build_tail_output(stdout)
+        assert result is not None
+        assert len(result.split("\n")) == 200
+
+    def test_short_output_unchanged(self):
+        stdout = "line 1\nline 2"
+        assert build_tail_output(stdout) == stdout
+
+
+class TestWorkerManagerInit:
+    def test_default_adapters(self, tmp_path: Path):
+        """WorkerManager initializes with default adapters when none injected."""
+        config = _make_config(tmp_path)
+        mgr = WorkerManager(config)
+        env = mgr.get_execution_environment()
+        assert env is not None
+
+    def test_injected_emitter(self, tmp_path: Path):
+        """Injected emitter is used instead of auto-configured one."""
+        config = _make_config(tmp_path)
+        mock_emitter = AsyncMock()
+        mgr = WorkerManager(config, emitter=mock_emitter)
+        assert mgr._emitter is mock_emitter
+
+    def test_sqlite_emitter_from_config(self, tmp_path: Path):
+        """SQLite emitter created when events_db is a file path."""
+        config = _make_config(tmp_path)
+        config.events_db = str(tmp_path / "events.db")
+        mgr = WorkerManager(config)
+        assert mgr._emitter is not None
+        assert mgr._pg_dsn is None
+
+    def test_null_emitter_when_no_events_db(self, tmp_path: Path):
+        """NullEventEmitter used when no events_db configured."""
+        config = _make_config(tmp_path)
+        config.events_db = None
+        mgr = WorkerManager(config)
+        # NullEventEmitter is the fallback
+        assert mgr._emitter is not None
+
+
+@pytest.mark.asyncio
+class TestWorkerManagerSetup:
+    async def test_handle_setup_success(self, tmp_path: Path):
+        """Setup phase creates worktree and writes result."""
+        config = _make_config(tmp_path)
+
+        mock_wt_mgr = MagicMock()
+        mock_wt_mgr.create = AsyncMock(return_value=tmp_path / "test-wt-1")
+        mock_wt_mgr.register = AsyncMock()
+        mock_env_provisioner = MagicMock()
+        mock_env_provisioner.provision = MagicMock(return_value=0)
+        mock_emitter = AsyncMock()
+        mock_emitter.emit = AsyncMock()
+        mock_emitter.close = AsyncMock()
+
+        mgr = WorkerManager(
+            config,
+            worktree_mgr=mock_wt_mgr,
+            env_provisioner=mock_env_provisioner,
+            emitter=mock_emitter,
+        )
+
+        dispatch = _make_dispatch(phase=Phase.SETUP)
+        result_dir = Path(config.ipc_dir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        input_dir = Path(config.ipc_dir) / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        await mgr._handle_setup(dispatch, 1, tmp_path / "test-wt-1")
+
+        mock_wt_mgr.create.assert_awaited_once()
+        mock_wt_mgr.register.assert_awaited_once()
+
+    async def test_handle_setup_error_writes_error_result(self, tmp_path: Path):
+        """Setup failure writes error result."""
+        config = _make_config(tmp_path)
+
+        mock_wt_mgr = MagicMock()
+        mock_wt_mgr.create = AsyncMock(side_effect=RuntimeError("branch conflict"))
+        mock_emitter = AsyncMock()
+        mock_emitter.emit = AsyncMock()
+        mock_emitter.close = AsyncMock()
+
+        mgr = WorkerManager(
+            config,
+            worktree_mgr=mock_wt_mgr,
+            emitter=mock_emitter,
+        )
+
+        dispatch = _make_dispatch(phase=Phase.SETUP)
+        result_dir = Path(config.ipc_dir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        input_dir = Path(config.ipc_dir) / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        # Should not raise
+        await mgr._handle_setup(dispatch, 1, tmp_path / "test-wt-1")
+
+        # Result file should be written
+        results = list(result_dir.glob("*.json"))
+        assert len(results) == 1
+
+
+@pytest.mark.asyncio
+class TestWorkerManagerCleanup:
+    async def test_handle_cleanup_success(self, tmp_path: Path):
+        """Cleanup phase calls worktree cleanup and writes result."""
+        config = _make_config(tmp_path)
+
+        mock_wt_mgr = MagicMock()
+        mock_wt_mgr.cleanup = AsyncMock()
+        mock_emitter = AsyncMock()
+        mock_emitter.emit = AsyncMock()
+        mock_emitter.close = AsyncMock()
+
+        mgr = WorkerManager(
+            config,
+            worktree_mgr=mock_wt_mgr,
+            emitter=mock_emitter,
+        )
+
+        dispatch = _make_dispatch(phase=Phase.CLEANUP)
+        result_dir = Path(config.ipc_dir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        input_dir = Path(config.ipc_dir) / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        await mgr._handle_cleanup(dispatch)
+        mock_wt_mgr.cleanup.assert_awaited_once()
+
+    async def test_handle_cleanup_error(self, tmp_path: Path):
+        """Cleanup failure writes error result (not raised)."""
+        config = _make_config(tmp_path)
+
+        mock_wt_mgr = MagicMock()
+        mock_wt_mgr.cleanup = AsyncMock(side_effect=RuntimeError("not found"))
+        mock_emitter = AsyncMock()
+        mock_emitter.emit = AsyncMock()
+        mock_emitter.close = AsyncMock()
+
+        mgr = WorkerManager(
+            config,
+            worktree_mgr=mock_wt_mgr,
+            emitter=mock_emitter,
+        )
+
+        dispatch = _make_dispatch(phase=Phase.CLEANUP)
+        result_dir = Path(config.ipc_dir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        input_dir = Path(config.ipc_dir) / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        await mgr._handle_cleanup(dispatch)
+
+        results = list(result_dir.glob("*.json"))
+        assert len(results) == 1
+
+
+@pytest.mark.asyncio
+class TestWorkerManagerDispatch:
+    async def test_unhandled_error_writes_error_result(self, tmp_path: Path):
+        """Unhandled exception in _handle_dispatch writes error result."""
+        config = _make_config(tmp_path)
+
+        mock_emitter = AsyncMock()
+        mock_emitter.emit = AsyncMock()
+        mock_emitter.close = AsyncMock()
+        mock_exec_env = AsyncMock()
+        mock_exec_env.provision = AsyncMock(side_effect=RuntimeError("unexpected"))
+        mock_exec_env.teardown = AsyncMock()
+
+        mgr = WorkerManager(
+            config,
+            execution_env=mock_exec_env,
+            emitter=mock_emitter,
+        )
+
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        result_dir = Path(config.ipc_dir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        input_dir = Path(config.ipc_dir) / "input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        await mgr._handle_dispatch(Path("/dispatch/1.json"), dispatch)
+
+        results = list(result_dir.glob("*.json"))
+        assert len(results) >= 1
+
+
+class TestParseFindings:
+    def test_no_findings_for_do_task(self, tmp_path: Path):
+        """do-task phase returns empty findings."""
+        config = _make_config(tmp_path)
+        mgr = WorkerManager(config)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        spec_folder = tmp_path / "specs" / "test"
+        spec_folder.mkdir(parents=True)
+
+        new_tasks, findings = mgr._parse_findings(dispatch, spec_folder)
+        assert new_tasks == []
+        assert findings == []
+
+
+class TestSignalShutdown:
+    def test_signal_sets_shutdown_event(self, tmp_path: Path):
+        """_signal_shutdown sets the shutdown event."""
+        config = _make_config(tmp_path)
+        mgr = WorkerManager(config)
+        assert not mgr._shutdown_event.is_set()
+        mgr._signal_shutdown()
+        assert mgr._shutdown_event.is_set()

--- a/tests/integration/test_manager_edge_cases.py
+++ b/tests/integration/test_manager_edge_cases.py
@@ -154,7 +154,7 @@ class TestWorkerManagerSetup:
         input_dir = Path(config.ipc_dir) / "input"
         input_dir.mkdir(parents=True, exist_ok=True)
 
-        await mgr._handle_setup(dispatch, 1, tmp_path / "test-wt-1")
+        await mgr._handle_setup(dispatch, "1", tmp_path / "test-wt-1")
 
         mock_wt_mgr.create.assert_awaited_once()
         mock_wt_mgr.register.assert_awaited_once()
@@ -182,7 +182,7 @@ class TestWorkerManagerSetup:
         input_dir.mkdir(parents=True, exist_ok=True)
 
         # Should not raise
-        await mgr._handle_setup(dispatch, 1, tmp_path / "test-wt-1")
+        await mgr._handle_setup(dispatch, "1", tmp_path / "test-wt-1")
 
         # Result file should be written
         results = list(result_dir.glob("*.json"))

--- a/tests/integration/test_postflight_edge_cases.py
+++ b/tests/integration/test_postflight_edge_cases.py
@@ -1,0 +1,241 @@
+"""Integration tests for postflight edge cases using real git repos."""
+
+import asyncio
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tanren_core.postflight import run_postflight
+
+
+@pytest.fixture
+def postflight_repo(tmp_path: Path) -> Path:
+    """Create a git repo suitable for postflight testing."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    for cmd in [
+        ["git", "-C", str(repo), "init"],
+        ["git", "-C", str(repo), "checkout", "-b", "test-branch"],
+        ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+    ]:
+        subprocess.run(cmd, capture_output=True, check=True)
+
+    (repo / "spec.md").write_text("# Spec\nOriginal content")
+    (repo / "plan.md").write_text("# Plan\nOriginal plan")
+    (repo / "Makefile").write_text("all:\n\techo ok")
+    (repo / "main.py").write_text("print('hello')")
+
+    for cmd in [
+        ["git", "-C", str(repo), "add", "-A"],
+        ["git", "-C", str(repo), "commit", "-m", "initial"],
+    ]:
+        subprocess.run(cmd, capture_output=True, check=True)
+
+    return repo
+
+
+def _md5(content: str) -> str:
+    return hashlib.md5(content.encode()).hexdigest()
+
+
+class TestPostflightNoChanges:
+    @pytest.mark.asyncio
+    async def test_no_file_changes_no_repairs(self, postflight_repo: Path):
+        """Postflight with no file changes results in no repairs."""
+        spec_content = "# Spec\nOriginal content"
+        plan_content = "# Plan\nOriginal plan"
+        hashes = {"spec.md": _md5(spec_content), "plan.md": _md5(plan_content)}
+        backups = {"spec.md": spec_content, "plan.md": plan_content}
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            hashes,
+            backups,
+            skip_push=True,
+        )
+
+        assert not result.integrity_repairs.spec_reverted
+        assert not result.integrity_repairs.plan_reverted
+        assert not result.integrity_repairs.branch_switched
+        assert not result.integrity_repairs.wip_committed
+
+
+class TestPostflightSpecRevert:
+    @pytest.mark.asyncio
+    async def test_spec_md_reverted(self, postflight_repo: Path):
+        """Unauthorized spec.md modification is reverted."""
+        original = "# Spec\nOriginal content"
+        hashes = {"spec.md": _md5(original)}
+        backups = {"spec.md": original}
+
+        # Agent modifies spec.md
+        (postflight_repo / "spec.md").write_text("# Spec\nModified by agent")
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            hashes,
+            backups,
+            skip_push=True,
+        )
+
+        assert result.integrity_repairs.spec_reverted
+        # Verify file was actually reverted
+        assert (postflight_repo / "spec.md").read_text() == original
+
+    @pytest.mark.asyncio
+    async def test_plan_md_reverted_in_impl_phase(self, postflight_repo: Path):
+        """plan.md is reverted during do-task (implementation phase)."""
+        original = "# Plan\nOriginal plan"
+        hashes = {"plan.md": _md5(original)}
+        backups = {"plan.md": original}
+
+        (postflight_repo / "plan.md").write_text("# Plan\nModified by agent")
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            hashes,
+            backups,
+            skip_push=True,
+        )
+
+        assert result.integrity_repairs.plan_reverted
+        assert (postflight_repo / "plan.md").read_text() == original
+
+    @pytest.mark.asyncio
+    async def test_plan_md_not_reverted_in_audit_phase(self, postflight_repo: Path):
+        """plan.md is NOT reverted during audit-task (audits may append fix items)."""
+        original = "# Plan\nOriginal plan"
+        hashes = {"plan.md": _md5(original)}
+        backups = {"plan.md": original}
+
+        modified = "# Plan\nModified by audit"
+        (postflight_repo / "plan.md").write_text(modified)
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "audit-task",
+            hashes,
+            backups,
+            skip_push=True,
+        )
+
+        assert not result.integrity_repairs.plan_reverted
+        # File should remain modified
+        assert (postflight_repo / "plan.md").read_text() == modified
+
+
+class TestPostflightSkipPush:
+    @pytest.mark.asyncio
+    async def test_skip_push_flag(self, postflight_repo: Path):
+        """skip_push=True prevents git push."""
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            {},
+            {},
+            skip_push=True,
+        )
+
+        assert not result.pushed
+        assert result.push_error is None
+
+
+class TestPostflightWarnOnly:
+    @pytest.mark.asyncio
+    async def test_makefile_modification_warns(self, postflight_repo: Path):
+        """Makefile modification is detected and flagged (not reverted)."""
+        original = "all:\n\techo ok"
+        hashes = {"Makefile": _md5(original)}
+
+        (postflight_repo / "Makefile").write_text("all:\n\techo modified")
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            hashes,
+            {},
+            skip_push=True,
+        )
+
+        assert result.integrity_repairs.makefile_modified
+        # Should NOT be reverted (warn-only)
+        assert (postflight_repo / "Makefile").read_text() == "all:\n\techo modified"
+
+
+class TestPostflightUncommittedWork:
+    @pytest.mark.asyncio
+    async def test_uncommitted_work_committed_as_wip(self, postflight_repo: Path):
+        """Uncommitted changes are committed as WIP."""
+        (postflight_repo / "new_file.py").write_text("# new file")
+
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            {},
+            {},
+            skip_push=True,
+        )
+
+        assert result.integrity_repairs.wip_committed
+
+        # Verify the WIP commit was made
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(postflight_repo),
+            "log",
+            "--oneline",
+            "-1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        assert "WIP" in stdout.decode()
+
+    @pytest.mark.asyncio
+    async def test_clean_tree_no_wip(self, postflight_repo: Path):
+        """Clean working tree does not create WIP commit."""
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            {},
+            {},
+            skip_push=True,
+        )
+
+        assert not result.integrity_repairs.wip_committed
+
+
+class TestPostflightMissingFile:
+    @pytest.mark.asyncio
+    async def test_missing_protected_file_skipped(self, postflight_repo: Path):
+        """If a protected file doesn't exist, it's silently skipped."""
+        hashes = {"nonexistent.md": "abc123"}
+        backups = {"nonexistent.md": "content"}
+
+        # Should not raise
+        result = await run_postflight(
+            postflight_repo,
+            "test-branch",
+            "do-task",
+            hashes,
+            backups,
+            skip_push=True,
+        )
+
+        assert not result.integrity_repairs.spec_reverted

--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -16,8 +16,7 @@ pytestmark = pytest.mark.postgres
 @pytest.fixture
 def postgres_url(request):
     url = request.config.getoption("--postgres-url")
-    if url is None:
-        pytest.skip("--postgres-url not provided")  # type: ignore[invalid-argument-type,too-many-positional-arguments]
+    assert url is not None, "--postgres-url not provided (run with -m postgres)"
     return url
 
 

--- a/tests/integration/test_process_spawning.py
+++ b/tests/integration/test_process_spawning.py
@@ -1,6 +1,5 @@
 """Integration test: real process spawning and timeout handling."""
 
-import shutil
 from pathlib import Path
 
 import pytest
@@ -143,7 +142,7 @@ class TestSpawnBashGate:
         assert result.exit_code == 1
 
 
-@pytest.mark.skipif(shutil.which("opencode") is None, reason="opencode CLI not installed")
+@pytest.mark.local_env
 class TestCliArgSmoke:
     """Smoke tests that invoke real CLI binaries to verify arg ordering.
 
@@ -212,7 +211,7 @@ class TestCliArgSmoke:
         assert "File not found" in result.stdout or result.exit_code != 0
 
 
-@pytest.mark.skipif(shutil.which("codex") is None, reason="codex CLI not installed")
+@pytest.mark.local_env
 class TestCodexCliArgSmoke:
     @pytest.mark.asyncio
     @pytest.mark.timeout(15)

--- a/tests/integration/test_queues_integration.py
+++ b/tests/integration/test_queues_integration.py
@@ -1,0 +1,156 @@
+"""Integration tests for DispatchRouter queue routing and consumers."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tanren_core.queues import DispatchRouter
+from tanren_core.schemas import Cli, Dispatch, Phase
+
+
+def _make_dispatch(cli: Cli, workflow_id: str = "wf-test-1-100") -> Dispatch:
+    return Dispatch(
+        workflow_id=workflow_id,
+        phase=Phase.DO_TASK,
+        project="test",
+        spec_folder="specs/test",
+        branch="feature-1",
+        cli=cli,
+        timeout=60,
+    )
+
+
+@pytest.mark.asyncio
+class TestDispatchRouterRouting:
+    async def test_route_impl_queue(self):
+        """OPENCODE and CLAUDE route to impl queue."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+
+        d1 = _make_dispatch(Cli.OPENCODE, "wf-test-1-100")
+        d2 = _make_dispatch(Cli.CLAUDE, "wf-test-2-200")
+        router.route(Path("/d/1.json"), d1)
+        router.route(Path("/d/2.json"), d2)
+
+        assert router._impl_queue.qsize() == 2
+        assert router._audit_queue.qsize() == 0
+        assert router._gate_queue.qsize() == 0
+
+    async def test_route_audit_queue(self):
+        """CODEX routes to audit queue."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+
+        d = _make_dispatch(Cli.CODEX)
+        router.route(Path("/d/1.json"), d)
+
+        assert router._audit_queue.qsize() == 1
+        assert router._impl_queue.qsize() == 0
+
+    async def test_route_gate_queue(self):
+        """BASH routes to gate queue."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+
+        d = _make_dispatch(Cli.BASH)
+        router.route(Path("/d/1.json"), d)
+
+        assert router._gate_queue.qsize() == 1
+
+    async def test_get_stats_idle(self):
+        """Stats show 0 active and 0 queued when idle."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+        active, queued = router.get_stats()
+        assert active == 0
+        assert queued == 0
+
+    async def test_get_stats_with_queued(self):
+        """Stats reflect queued dispatches."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+
+        router.route(Path("/d/1.json"), _make_dispatch(Cli.OPENCODE))
+        router.route(Path("/d/2.json"), _make_dispatch(Cli.CODEX))
+        router.route(Path("/d/3.json"), _make_dispatch(Cli.BASH))
+
+        _, queued = router.get_stats()
+        assert queued == 3
+
+
+@pytest.mark.asyncio
+class TestDispatchRouterConsumers:
+    async def test_consumer_processes_dispatch(self):
+        """Consumer calls handler and drains queue."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+
+        d = _make_dispatch(Cli.OPENCODE)
+        router.route(Path("/d/1.json"), d)
+
+        router.start_consumers()
+        # Give consumer time to process
+        await asyncio.sleep(0.05)
+        await router.stop()
+
+        handler.assert_awaited_once()
+        args = handler.call_args[0]
+        assert args[0] == Path("/d/1.json")
+        assert args[1].cli == Cli.OPENCODE
+
+    async def test_consumer_continues_after_handler_error(self):
+        """Consumer should not die when handler raises."""
+        call_count = 0
+
+        async def failing_then_ok(path: Path, dispatch: Dispatch) -> None:  # noqa: RUF029
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("boom")
+
+        router = DispatchRouter(failing_then_ok)
+
+        router.route(Path("/d/1.json"), _make_dispatch(Cli.OPENCODE, "wf-test-1-100"))
+        router.route(Path("/d/2.json"), _make_dispatch(Cli.OPENCODE, "wf-test-2-200"))
+
+        router.start_consumers()
+        await asyncio.sleep(0.1)
+        await router.stop()
+
+        assert call_count == 2
+
+    async def test_gate_parallel_consumer(self):
+        """Gate consumer allows concurrent dispatches up to semaphore limit."""
+        active_count = 0
+        max_active = 0
+
+        async def slow_handler(path: Path, dispatch: Dispatch) -> None:
+            nonlocal active_count, max_active
+            active_count += 1
+            max_active = max(max_active, active_count)
+            await asyncio.sleep(0.05)
+            active_count -= 1
+
+        router = DispatchRouter(slow_handler, max_gate=3)
+
+        for i in range(3):
+            router.route(Path(f"/d/{i}.json"), _make_dispatch(Cli.BASH, f"wf-test-{i}-100"))
+
+        router.start_consumers()
+        await asyncio.sleep(0.15)
+        await router.stop()
+
+        assert max_active >= 2  # At least some parallelism
+
+    async def test_stop_cancels_all_tasks(self):
+        """stop() cancels all consumer tasks."""
+        handler = AsyncMock()
+        router = DispatchRouter(handler)
+        tasks = router.start_consumers()
+        assert len(tasks) == 3
+
+        await router.stop()
+        assert all(t.done() for t in tasks)
+        assert len(router._tasks) == 0

--- a/tests/integration/test_roles_config_integration.py
+++ b/tests/integration/test_roles_config_integration.py
@@ -1,0 +1,165 @@
+"""Integration tests for roles_config YAML loading and parsing."""
+
+from pathlib import Path
+
+import pytest
+
+from tanren_core.roles import RoleMapping
+from tanren_core.roles_config import load_roles_config
+from tanren_core.schemas import AuthMode, Cli
+
+
+class TestLoadRolesConfig:
+    def test_full_roles_yml(self, tmp_path: Path):
+        """Load a complete roles.yml with all roles specified."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n"
+            "  default:\n"
+            "    cli: claude\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+            "  implementation:\n"
+            "    cli: opencode\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+            "  audit:\n"
+            "    cli: codex\n"
+            "    auth: api_key\n"
+            "    model: o3\n"
+        )
+        mapping = load_roles_config(cfg)
+        assert isinstance(mapping, RoleMapping)
+        assert mapping.default.cli == Cli.CLAUDE
+        assert mapping.default.model == "sonnet-4"
+        assert mapping.implementation is not None
+        assert mapping.implementation.cli == Cli.OPENCODE
+        assert mapping.audit is not None
+        assert mapping.audit.cli == Cli.CODEX
+
+    def test_minimal_roles_yml(self, tmp_path: Path):
+        """Only default agent — all other roles should be None."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n  default:\n    cli: claude\n    auth: api_key\n    model: sonnet-4\n"
+        )
+        mapping = load_roles_config(cfg)
+        assert mapping.default.cli == Cli.CLAUDE
+        assert mapping.conversation is None
+        assert mapping.implementation is None
+        assert mapping.audit is None
+        assert mapping.feedback is None
+        assert mapping.conflict_resolution is None
+
+    def test_required_clis(self, tmp_path: Path):
+        """required_clis() returns correct CLI set excluding bash."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n"
+            "  default:\n"
+            "    cli: claude\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+            "  audit:\n"
+            "    cli: codex\n"
+            "    auth: api_key\n"
+            "    model: o3\n"
+        )
+        mapping = load_roles_config(cfg)
+        clis = mapping.required_clis()
+        assert Cli.CLAUDE in clis
+        assert Cli.CODEX in clis
+        assert Cli.BASH not in clis
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Roles config not found"):
+            load_roles_config(tmp_path / "nonexistent.yml")
+
+    def test_malformed_yaml_not_mapping(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text("just a string\n")
+        with pytest.raises(ValueError, match="expected a mapping"):
+            load_roles_config(cfg)
+
+    def test_empty_yaml(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text("")
+        with pytest.raises(ValueError, match="expected a mapping"):
+            load_roles_config(cfg)
+
+    def test_missing_agents_section(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text("version: 1\n")
+        with pytest.raises(ValueError, match="missing required 'agents' section"):
+            load_roles_config(cfg)
+
+    def test_missing_default_agent(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n"
+            "  implementation:\n"
+            "    cli: opencode\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+        )
+        with pytest.raises(ValueError, match=r"agents\.default must be a mapping"):
+            load_roles_config(cfg)
+
+    def test_invalid_cli_value(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n  default:\n    cli: invalid_cli\n    auth: api_key\n    model: sonnet-4\n"
+        )
+        with pytest.raises(ValueError, match="Invalid CLI value"):
+            load_roles_config(cfg)
+
+    def test_missing_cli_field(self, tmp_path: Path):
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text("agents:\n  default:\n    auth: api_key\n    model: sonnet-4\n")
+        with pytest.raises(ValueError, match="missing required 'cli' field"):
+            load_roles_config(cfg)
+
+    def test_hyphenated_role_key(self, tmp_path: Path):
+        """conflict-resolution (hyphenated) maps to conflict_resolution."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n"
+            "  default:\n"
+            "    cli: claude\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+            "  conflict-resolution:\n"
+            "    cli: opencode\n"
+            "    auth: oauth\n"
+            "    model: opus-4\n"
+        )
+        mapping = load_roles_config(cfg)
+        assert mapping.conflict_resolution is not None
+        assert mapping.conflict_resolution.cli == Cli.OPENCODE
+        assert mapping.conflict_resolution.auth == AuthMode.OAUTH
+
+    def test_resolve_fallback_to_default(self, tmp_path: Path):
+        """resolve() falls back to default for unconfigured roles."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n  default:\n    cli: claude\n    auth: api_key\n    model: sonnet-4\n"
+        )
+        mapping = load_roles_config(cfg)
+        tool = mapping.resolve("implementation")
+        assert tool.cli == Cli.CLAUDE  # falls back to default
+
+    def test_optional_endpoint_and_cli_path(self, tmp_path: Path):
+        """endpoint and cli_path are optional fields."""
+        cfg = tmp_path / "roles.yml"
+        cfg.write_text(
+            "agents:\n"
+            "  default:\n"
+            "    cli: claude\n"
+            "    auth: api_key\n"
+            "    model: sonnet-4\n"
+            "    endpoint: https://api.example.com\n"
+            "    cli_path: /usr/local/bin/claude\n"
+        )
+        mapping = load_roles_config(cfg)
+        assert mapping.default.endpoint == "https://api.example.com"
+        assert mapping.default.cli_path == "/usr/local/bin/claude"

--- a/tests/integration/test_secret_provider_integration.py
+++ b/tests/integration/test_secret_provider_integration.py
@@ -1,0 +1,103 @@
+"""Integration tests for SecretProvider implementations with real file I/O."""
+
+from pathlib import Path
+
+import pytest
+
+from tanren_core.adapters.dotenv_secret_provider import DotenvSecretProvider
+from tanren_core.env.schema import SecretsConfig, SecretsProviderType
+from tanren_core.env.secret_provider_factory import create_secret_provider
+
+
+@pytest.mark.asyncio
+class TestDotenvSecretProviderIntegration:
+    """End-to-end tests for DotenvSecretProvider with real filesystem."""
+
+    async def test_get_from_secrets_env(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("API_KEY=sk-abc123\nDB_URL=postgres://localhost\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("API_KEY") == "sk-abc123"
+        assert await provider.get_secret("DB_URL") == "postgres://localhost"
+
+    async def test_get_missing_key_returns_none(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("OTHER=val\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("MISSING") is None
+
+    async def test_get_from_secrets_d_directory(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "api.env").write_text("GCP_KEY=gcp-value\n")
+        (sd / "db.env").write_text("DB_PASS=s3cret\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("GCP_KEY") == "gcp-value"
+        assert await provider.get_secret("DB_PASS") == "s3cret"
+
+    async def test_secrets_d_overrides_secrets_env(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("KEY=base\n")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "override.env").write_text("KEY=overridden\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("KEY") == "overridden"
+
+    async def test_secrets_d_alphabetical_order(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "a.env").write_text("KEY=from-a\n")
+        (sd / "b.env").write_text("KEY=from-b\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        # b.env loaded after a.env, so b wins
+        assert await provider.get_secret("KEY") == "from-b"
+
+    async def test_list_secrets_combined(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("A=1\nB=2\n")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "extra.env").write_text("C=3\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        result = await provider.list_secrets()
+        assert set(result) == {"A", "B", "C"}
+
+    async def test_empty_secrets_dir(self, tmp_path: Path):
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("X") is None
+        assert await provider.list_secrets() == []
+
+    async def test_caching_after_first_load(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("K=original\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("K") == "original"
+        # Modify file after first load
+        (tmp_path / "secrets.env").write_text("K=modified\n")
+        # Cached value returned
+        assert await provider.get_secret("K") == "original"
+
+
+@pytest.mark.asyncio
+class TestSecretProviderFactoryIntegration:
+    """Factory integration with real provider construction."""
+
+    async def test_none_config_creates_dotenv(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("KEY=val\n")
+        provider = create_secret_provider(None, secrets_dir=tmp_path)
+        assert isinstance(provider, DotenvSecretProvider)
+        assert await provider.get_secret("KEY") == "val"
+
+    async def test_explicit_dotenv_config(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("KEY=val\n")
+        config = SecretsConfig(provider=SecretsProviderType.DOTENV)
+        provider = create_secret_provider(config, secrets_dir=tmp_path)
+        assert await provider.get_secret("KEY") == "val"
+
+    def test_gcp_missing_project_id_raises(self):
+        config = SecretsConfig(provider=SecretsProviderType.GCP, settings={})
+        with pytest.raises(ValueError, match="project_id"):
+            create_secret_provider(config)
+
+    def test_gcp_empty_project_id_raises(self):
+        config = SecretsConfig(provider=SecretsProviderType.GCP, settings={"project_id": ""})
+        with pytest.raises(ValueError, match="project_id"):
+            create_secret_provider(config)

--- a/tests/integration/test_worktree_lifecycle.py
+++ b/tests/integration/test_worktree_lifecycle.py
@@ -6,12 +6,15 @@ from pathlib import Path
 
 import pytest
 
+from tanren_core.schemas import WorktreeEntry, WorktreeRegistry
 from tanren_core.worktree import (
+    check_isolation,
     cleanup_worktree,
     create_worktree,
     load_registry,
     register_worktree,
     remove_worktree,
+    save_registry,
 )
 
 
@@ -306,3 +309,157 @@ class TestWorktreeResilience:
         assert wt_path2.exists()
 
         await remove_worktree(wt_path2, github_dir / "test-project")
+
+
+class TestWorktreeRegistryEdgeCases:
+    @pytest.mark.asyncio
+    async def test_load_registry_missing_file(self, tmp_path: Path):
+        """Loading from a non-existent path returns empty registry."""
+        reg = await load_registry(tmp_path / "nonexistent.json")
+        assert reg.worktrees == {}
+
+    @pytest.mark.asyncio
+    async def test_load_registry_corrupted_file(self, tmp_path: Path):
+        """Corrupted JSON returns empty registry (graceful recovery)."""
+        bad_file = tmp_path / "worktrees.json"
+        bad_file.write_text("{invalid json!!!")
+        reg = await load_registry(bad_file)
+        assert reg.worktrees == {}
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_roundtrip(self, tmp_path: Path):
+        """Registry can be saved and loaded back."""
+
+        registry_path = tmp_path / "worktrees.json"
+        reg = WorktreeRegistry()
+        reg.worktrees["wf-test-1-100"] = WorktreeEntry(
+            project="test",
+            issue=1,
+            branch="feature-1",
+            path="/tmp/test-wt-1",
+            created_at="2026-01-01T00:00:00",
+        )
+        await save_registry(registry_path, reg)
+
+        loaded = await load_registry(registry_path)
+        assert "wf-test-1-100" in loaded.worktrees
+        assert loaded.worktrees["wf-test-1-100"].branch == "feature-1"
+
+
+class TestWorktreeIsolation:
+    @pytest.mark.asyncio
+    async def test_branch_conflict_detected(self, tmp_path: Path):
+        """Registering a branch already in use by another workflow raises."""
+
+        reg = WorktreeRegistry()
+        reg.worktrees["wf-existing-1-100"] = WorktreeEntry(
+            project="test",
+            issue=1,
+            branch="shared-branch",
+            path="/tmp/test-wt-1",
+            created_at="2026-01-01T00:00:00",
+        )
+
+        with pytest.raises(RuntimeError, match="Branch shared-branch already in use"):
+            await check_isolation(
+                reg,
+                "wf-new-2-200",
+                "shared-branch",
+                Path("/tmp/test-wt-2"),
+                str(tmp_path),
+            )
+
+    @pytest.mark.asyncio
+    async def test_path_conflict_detected(self, tmp_path: Path):
+        """Registering a path already in use by another workflow raises."""
+
+        reg = WorktreeRegistry()
+        reg.worktrees["wf-existing-1-100"] = WorktreeEntry(
+            project="test",
+            issue=1,
+            branch="branch-a",
+            path="/tmp/test-wt-1",
+            created_at="2026-01-01T00:00:00",
+        )
+
+        with pytest.raises(RuntimeError, match=r"Worktree path .* already in use"):
+            await check_isolation(
+                reg,
+                "wf-new-2-200",
+                "branch-b",
+                Path("/tmp/test-wt-1"),
+                str(tmp_path),
+            )
+
+    @pytest.mark.asyncio
+    async def test_main_copy_rejected(self, tmp_path: Path):
+        """Path without -wt- suffix is rejected as a main working copy."""
+        reg = WorktreeRegistry()
+        with pytest.raises(RuntimeError, match="appears to be a main working copy"):
+            await check_isolation(
+                reg,
+                "wf-test-1-100",
+                "feature-1",
+                Path("/tmp/test-project"),
+                str(tmp_path),
+            )
+
+    @pytest.mark.asyncio
+    async def test_same_workflow_skipped(self, tmp_path: Path):
+        """Re-registration of the same workflow_id is allowed (no conflict)."""
+
+        reg = WorktreeRegistry()
+        reg.worktrees["wf-test-1-100"] = WorktreeEntry(
+            project="test",
+            issue=1,
+            branch="feature-1",
+            path="/tmp/test-wt-1",
+            created_at="2026-01-01T00:00:00",
+        )
+
+        # Should not raise — same workflow re-registering
+        await check_isolation(
+            reg,
+            "wf-test-1-100",
+            "feature-1",
+            Path("/tmp/test-wt-1"),
+            str(tmp_path),
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_passes(self, tmp_path: Path):
+        """Empty registry has no conflicts."""
+        reg = WorktreeRegistry()
+        await check_isolation(
+            reg,
+            "wf-test-1-100",
+            "feature-1",
+            Path("/tmp/test-wt-1"),
+            str(tmp_path),
+        )
+
+    @pytest.mark.asyncio
+    async def test_wrong_branch_worktree_raises(self, tmp_path: Path):
+        """Existing worktree on wrong branch raises RuntimeError."""
+        github_dir = tmp_path
+        repo, branch = await _setup_git_repo(tmp_path)
+
+        # Create worktree on feature-123
+        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+
+        # Create another branch
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "branch",
+            "different-branch",
+            cwd=str(repo),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+
+        # Try to create worktree at same path but different branch
+        with pytest.raises(RuntimeError, match="exists on branch"):
+            await create_worktree("test-project", 123, "different-branch", str(github_dir))
+
+        await remove_worktree(wt_path, repo)

--- a/tests/integration/test_worktree_lifecycle.py
+++ b/tests/integration/test_worktree_lifecycle.py
@@ -334,7 +334,7 @@ class TestWorktreeRegistryEdgeCases:
         reg = WorktreeRegistry()
         reg.worktrees["wf-test-1-100"] = WorktreeEntry(
             project="test",
-            issue=1,
+            issue="1",
             branch="feature-1",
             path="/tmp/test-wt-1",
             created_at="2026-01-01T00:00:00",
@@ -354,7 +354,7 @@ class TestWorktreeIsolation:
         reg = WorktreeRegistry()
         reg.worktrees["wf-existing-1-100"] = WorktreeEntry(
             project="test",
-            issue=1,
+            issue="1",
             branch="shared-branch",
             path="/tmp/test-wt-1",
             created_at="2026-01-01T00:00:00",
@@ -376,7 +376,7 @@ class TestWorktreeIsolation:
         reg = WorktreeRegistry()
         reg.worktrees["wf-existing-1-100"] = WorktreeEntry(
             project="test",
-            issue=1,
+            issue="1",
             branch="branch-a",
             path="/tmp/test-wt-1",
             created_at="2026-01-01T00:00:00",
@@ -411,7 +411,7 @@ class TestWorktreeIsolation:
         reg = WorktreeRegistry()
         reg.worktrees["wf-test-1-100"] = WorktreeEntry(
             project="test",
-            issue=1,
+            issue="1",
             branch="feature-1",
             path="/tmp/test-wt-1",
             created_at="2026-01-01T00:00:00",
@@ -445,7 +445,7 @@ class TestWorktreeIsolation:
         repo, branch = await _setup_git_repo(tmp_path)
 
         # Create worktree on feature-123
-        wt_path = await create_worktree("test-project", 123, branch, str(github_dir))
+        wt_path = await create_worktree("test-project", "123", branch, str(github_dir))
 
         # Create another branch
         proc = await asyncio.create_subprocess_exec(
@@ -460,6 +460,6 @@ class TestWorktreeIsolation:
 
         # Try to create worktree at same path but different branch
         with pytest.raises(RuntimeError, match="exists on branch"):
-            await create_worktree("test-project", 123, "different-branch", str(github_dir))
+            await create_worktree("test-project", "123", "different-branch", str(github_dir))
 
         await remove_worktree(wt_path, repo)

--- a/tests/unit/api/test_vm.py
+++ b/tests/unit/api/test_vm.py
@@ -112,7 +112,7 @@ class TestVM:
             host="10.0.0.1",
             assigned_at="2026-01-01T00:00:00Z",
         )
-        mock_execution_env.release_vm = pytest.importorskip("unittest.mock").AsyncMock()
+        mock_execution_env.release_vm = AsyncMock()
 
         resp = await client.delete("/api/v1/vm/vm-1", headers=auth_headers)
         assert resp.status_code == 200

--- a/tests/unit/test_dotenv_secret_provider.py
+++ b/tests/unit/test_dotenv_secret_provider.py
@@ -1,0 +1,59 @@
+"""Tests for DotenvSecretProvider."""
+
+from pathlib import Path
+
+import pytest
+
+from tanren_core.adapters.dotenv_secret_provider import DotenvSecretProvider
+
+
+@pytest.mark.asyncio
+class TestDotenvSecretProvider:
+    async def test_get_from_secrets_env(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("API_KEY=sk-abc123\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("API_KEY") == "sk-abc123"
+
+    async def test_get_from_secrets_d(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "api.env").write_text("GCP_KEY=gcp-val\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("GCP_KEY") == "gcp-val"
+
+    async def test_secrets_d_overrides_secrets_env(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("K=from-base\n")
+        sd = tmp_path / "secrets.d"
+        sd.mkdir()
+        (sd / "override.env").write_text("K=from-d\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("K") == "from-d"
+
+    async def test_get_returns_none_for_missing_key(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("OTHER=val\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.get_secret("MISSING") is None
+
+    async def test_get_returns_none_for_missing_dir(self, tmp_path: Path):
+        provider = DotenvSecretProvider(secrets_dir=tmp_path / "nonexistent")
+        assert await provider.get_secret("X") is None
+
+    async def test_list_secrets(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("A=1\nB=2\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        result = await provider.list_secrets()
+        assert set(result) == {"A", "B"}
+
+    async def test_list_empty_dir(self, tmp_path: Path):
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        assert await provider.list_secrets() == []
+
+    async def test_caching(self, tmp_path: Path):
+        (tmp_path / "secrets.env").write_text("K=v\n")
+        provider = DotenvSecretProvider(secrets_dir=tmp_path)
+        await provider.get_secret("K")
+        # Modify file after cache
+        (tmp_path / "secrets.env").write_text("K=changed\n")
+        # Should still return cached value
+        assert await provider.get_secret("K") == "v"

--- a/tests/unit/test_env_schema.py
+++ b/tests/unit/test_env_schema.py
@@ -1,10 +1,15 @@
 """Tests for env schema models."""
 
+import pytest
+from pydantic import ValidationError
+
 from tanren_core.env.schema import (
     EnvBlock,
     OnMissing,
     OptionalEnvVar,
     RequiredEnvVar,
+    SecretsConfig,
+    SecretsProviderType,
     TanrenConfig,
 )
 
@@ -23,6 +28,7 @@ class TestRequiredEnvVar:
         assert not v.description
         assert v.pattern is None
         assert not v.hint
+        assert v.source is None
 
     def test_full(self):
         v = RequiredEnvVar(
@@ -34,6 +40,10 @@ class TestRequiredEnvVar:
         assert v.pattern == "^sk-"
         assert v.hint == "Get one at example.com"
 
+    def test_with_source(self):
+        v = RequiredEnvVar(key="K", source="secret:my-api-key")
+        assert v.source == "secret:my-api-key"
+
 
 class TestOptionalEnvVar:
     def test_with_default(self):
@@ -43,6 +53,11 @@ class TestOptionalEnvVar:
     def test_no_default(self):
         v = OptionalEnvVar(key="EXTRA")
         assert v.default is None
+        assert v.source is None
+
+    def test_with_source(self):
+        v = OptionalEnvVar(key="K", source="secret:opt-key")
+        assert v.source == "secret:opt-key"
 
 
 class TestEnvBlock:
@@ -63,10 +78,27 @@ class TestEnvBlock:
         assert len(block.optional) == 1
 
 
+class TestSecretsConfig:
+    def test_defaults(self):
+        c = SecretsConfig()
+        assert c.provider == SecretsProviderType.DOTENV
+        assert c.settings == {}
+
+    def test_gcp_provider(self):
+        c = SecretsConfig(provider=SecretsProviderType.GCP, settings={"project_id": "my-proj"})
+        assert c.provider == SecretsProviderType.GCP
+        assert c.settings["project_id"] == "my-proj"
+
+    def test_unknown_provider_rejected(self):
+        with pytest.raises(ValidationError):
+            SecretsConfig(provider="aws")  # type: ignore[arg-type]
+
+
 class TestTanrenConfig:
     def test_without_env(self):
         c = TanrenConfig(version="0.1.0", profile="python-uv", installed="2026-03-07")
         assert c.env is None
+        assert c.secrets is None
 
     def test_with_env(self):
         c = TanrenConfig(
@@ -77,3 +109,20 @@ class TestTanrenConfig:
         )
         assert c.env is not None
         assert len(c.env.required) == 1
+
+    def test_with_secrets(self):
+        c = TanrenConfig(
+            version="0.1.0",
+            profile="python-uv",
+            installed="2026-03-07",
+            secrets=SecretsConfig(
+                provider=SecretsProviderType.GCP,
+                settings={"project_id": "test"},
+            ),
+        )
+        assert c.secrets is not None
+        assert c.secrets.provider == SecretsProviderType.GCP
+
+    def test_secrets_defaults_to_none(self):
+        c = TanrenConfig(version="0.1.0", profile="python-uv", installed="2026-03-07")
+        assert c.secrets is None

--- a/tests/unit/test_env_validator.py
+++ b/tests/unit/test_env_validator.py
@@ -1,60 +1,63 @@
 """Tests for env validator module."""
 
+import pytest
+
 from tanren_core.env.schema import EnvBlock, OptionalEnvVar, RequiredEnvVar
 from tanren_core.env.validator import VarStatus, validate_env
 
 
+@pytest.mark.asyncio
 class TestValidateRequired:
-    def test_pass(self):
+    async def test_pass(self):
         block = EnvBlock(required=[RequiredEnvVar(key="API_KEY")])
         merged = {"API_KEY": "sk-abc123"}
         source = {"API_KEY": ".env"}
-        report = validate_env(block, merged, source)
+        report = await validate_env(block, merged, source)
         assert report.passed
         assert len(report.required_results) == 1
         assert report.required_results[0].status == VarStatus.PASS
 
-    def test_missing(self):
+    async def test_missing(self):
         block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", hint="get one")])
-        report = validate_env(block, {}, {})
+        report = await validate_env(block, {}, {})
         assert not report.passed
         assert report.required_results[0].status == VarStatus.MISSING
         assert report.required_results[0].hint == "get one"
 
-    def test_empty(self):
+    async def test_empty(self):
         block = EnvBlock(required=[RequiredEnvVar(key="API_KEY")])
-        report = validate_env(block, {"API_KEY": ""}, {"API_KEY": ".env"})
+        report = await validate_env(block, {"API_KEY": ""}, {"API_KEY": ".env"})
         assert not report.passed
         assert report.required_results[0].status == VarStatus.EMPTY
 
-    def test_pattern_match(self):
+    async def test_pattern_match(self):
         block = EnvBlock(required=[RequiredEnvVar(key="K", pattern="^sk-or-v1-")])
-        report = validate_env(block, {"K": "sk-or-v1-abc123"}, {"K": ".env"})
+        report = await validate_env(block, {"K": "sk-or-v1-abc123"}, {"K": ".env"})
         assert report.passed
         assert report.required_results[0].status == VarStatus.PASS
 
-    def test_pattern_mismatch(self):
+    async def test_pattern_mismatch(self):
         block = EnvBlock(required=[RequiredEnvVar(key="K", pattern="^sk-or-v1-")])
-        report = validate_env(block, {"K": "wrong-prefix"}, {"K": ".env"})
+        report = await validate_env(block, {"K": "wrong-prefix"}, {"K": ".env"})
         assert not report.passed
         assert report.required_results[0].status == VarStatus.PATTERN_MISMATCH
         # Value should be redacted in message
         assert "wron..." in report.required_results[0].message
 
-    def test_multiple_required_partial_fail(self):
+    async def test_multiple_required_partial_fail(self):
         block = EnvBlock(
             required=[
                 RequiredEnvVar(key="A"),
                 RequiredEnvVar(key="B"),
             ]
         )
-        report = validate_env(block, {"A": "val"}, {"A": ".env"})
+        report = await validate_env(block, {"A": "val"}, {"A": ".env"})
         assert not report.passed
         statuses = {r.key: r.status for r in report.required_results}
         assert statuses["A"] == VarStatus.PASS
         assert statuses["B"] == VarStatus.MISSING
 
-    def test_all_pass(self):
+    async def test_all_pass(self):
         block = EnvBlock(
             required=[
                 RequiredEnvVar(key="A"),
@@ -63,69 +66,153 @@ class TestValidateRequired:
         )
         merged = {"A": "1", "B": "2"}
         source = {"A": ".env", "B": ".env"}
-        report = validate_env(block, merged, source)
+        report = await validate_env(block, merged, source)
         assert report.passed
 
-    def test_from_os_environ(self, monkeypatch):
+    async def test_from_os_environ(self, monkeypatch):
         monkeypatch.setenv("API_KEY", "sk-live-123")
         block = EnvBlock(required=[RequiredEnvVar(key="API_KEY")])
-        report = validate_env(block, {}, {})
+        report = await validate_env(block, {}, {})
         assert report.passed
         assert report.required_results[0].source == "os.environ"
 
 
+@pytest.mark.asyncio
 class TestValidateOptional:
-    def test_present(self):
+    async def test_present(self):
         block = EnvBlock(optional=[OptionalEnvVar(key="LOG_LEVEL")])
-        report = validate_env(block, {"LOG_LEVEL": "DEBUG"}, {"LOG_LEVEL": ".env"})
+        report = await validate_env(block, {"LOG_LEVEL": "DEBUG"}, {"LOG_LEVEL": ".env"})
         assert report.passed
         assert report.optional_results[0].status == VarStatus.PASS
 
-    def test_missing_with_default(self):
+    async def test_missing_with_default(self):
         block = EnvBlock(optional=[OptionalEnvVar(key="LOG_LEVEL", default="INFO")])
         merged: dict[str, str] = {}
         source: dict[str, str] = {}
-        report = validate_env(block, merged, source)
+        report = await validate_env(block, merged, source)
         assert report.passed
         assert report.optional_results[0].status == VarStatus.DEFAULTED
         # Default should be injected into merged env
         assert merged["LOG_LEVEL"] == "INFO"
 
-    def test_missing_no_default(self):
+    async def test_missing_no_default(self):
         block = EnvBlock(optional=[OptionalEnvVar(key="EXTRA")])
-        report = validate_env(block, {}, {})
+        report = await validate_env(block, {}, {})
         assert report.passed  # optional missing is not a failure
         assert report.optional_results[0].status == VarStatus.MISSING
 
-    def test_pattern_mismatch_warning(self):
+    async def test_pattern_mismatch_warning(self):
         block = EnvBlock(optional=[OptionalEnvVar(key="URL", pattern="^https://")])
-        report = validate_env(block, {"URL": "http://bad"}, {"URL": ".env"})
+        report = await validate_env(block, {"URL": "http://bad"}, {"URL": ".env"})
         assert report.passed  # optional pattern mismatch is not a hard failure
         assert report.optional_results[0].status == VarStatus.PATTERN_MISMATCH
         assert len(report.warnings) == 1
 
-    def test_pattern_match(self):
+    async def test_pattern_match(self):
         block = EnvBlock(optional=[OptionalEnvVar(key="URL", pattern="^https://")])
-        report = validate_env(block, {"URL": "https://ok"}, {"URL": ".env"})
+        report = await validate_env(block, {"URL": "https://ok"}, {"URL": ".env"})
         assert report.optional_results[0].status == VarStatus.PASS
 
 
+@pytest.mark.asyncio
 class TestRedaction:
-    def test_short_value_fully_redacted(self):
+    async def test_short_value_fully_redacted(self):
         block = EnvBlock(required=[RequiredEnvVar(key="K", pattern="^abc$")])
-        report = validate_env(block, {"K": "xy"}, {"K": ".env"})
+        report = await validate_env(block, {"K": "xy"}, {"K": ".env"})
         assert "****" in report.required_results[0].message
 
-    def test_long_value_partially_redacted(self):
+    async def test_long_value_partially_redacted(self):
         block = EnvBlock(required=[RequiredEnvVar(key="K", pattern="^abc$")])
-        report = validate_env(block, {"K": "xyzzzzz"}, {"K": ".env"})
+        report = await validate_env(block, {"K": "xyzzzzz"}, {"K": ".env"})
         assert "xyzz..." in report.required_results[0].message
 
 
+@pytest.mark.asyncio
 class TestEmptyBlock:
-    def test_no_vars(self):
+    async def test_no_vars(self):
         block = EnvBlock()
-        report = validate_env(block, {}, {})
+        report = await validate_env(block, {}, {})
         assert report.passed
         assert report.required_results == []
         assert report.optional_results == []
+
+
+@pytest.mark.asyncio
+class TestSecretResolution:
+    """Tests for source: 'secret:X' resolution via SecretProvider."""
+
+    async def test_source_resolved_from_provider(self):
+        """Provider returns value for source: secret:X -> PASS."""
+        provider = _MockProvider({"my-api-key": "sk-resolved"})
+        block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", source="secret:my-api-key")])
+        merged: dict[str, str] = {}
+        source_map: dict[str, str] = {}
+        report = await validate_env(block, merged, source_map, secret_provider=provider)
+        assert report.passed
+        assert merged["API_KEY"] == "sk-resolved"
+        assert source_map["API_KEY"] == "secret:my-api-key"
+
+    async def test_source_missing_from_provider(self):
+        """Provider returns None, not in env -> MISSING."""
+        provider = _MockProvider({})
+        block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", source="secret:missing")])
+        report = await validate_env(block, {}, {}, secret_provider=provider)
+        assert not report.passed
+        assert report.required_results[0].status == VarStatus.MISSING
+
+    async def test_env_overrides_provider(self):
+        """Value already in merged_env -> provider not queried."""
+        provider = _MockProvider({"my-key": "from-provider"})
+        block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", source="secret:my-key")])
+        merged = {"API_KEY": "from-env"}
+        source_map = {"API_KEY": ".env"}
+        report = await validate_env(block, merged, source_map, secret_provider=provider)
+        assert report.passed
+        assert merged["API_KEY"] == "from-env"
+
+    async def test_no_provider_ignores_source(self):
+        """No provider passed -> source field ignored, falls back to env."""
+        block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", source="secret:my-key")])
+        report = await validate_env(block, {}, {})
+        assert not report.passed
+        assert report.required_results[0].status == VarStatus.MISSING
+
+    async def test_optional_source_resolved(self):
+        """Optional var with source -> resolved from provider."""
+        provider = _MockProvider({"opt-key": "opt-value"})
+        block = EnvBlock(optional=[OptionalEnvVar(key="OPT", source="secret:opt-key")])
+        merged: dict[str, str] = {}
+        report = await validate_env(block, merged, {}, secret_provider=provider)
+        assert report.passed
+        assert merged["OPT"] == "opt-value"
+        assert report.optional_results[0].status == VarStatus.PASS
+
+    async def test_source_value_validated_against_pattern(self):
+        """Resolved value fails pattern check -> PATTERN_MISMATCH."""
+        provider = _MockProvider({"my-key": "wrong-prefix-value"})
+        block = EnvBlock(required=[RequiredEnvVar(key="K", source="secret:my-key", pattern="^sk-")])
+        report = await validate_env(block, {}, {}, secret_provider=provider)
+        assert not report.passed
+        assert report.required_results[0].status == VarStatus.PATTERN_MISMATCH
+
+    async def test_os_environ_overrides_provider(self, monkeypatch):
+        """os.environ takes priority over secret provider."""
+        monkeypatch.setenv("API_KEY", "from-os-env")
+        provider = _MockProvider({"my-key": "from-provider"})
+        block = EnvBlock(required=[RequiredEnvVar(key="API_KEY", source="secret:my-key")])
+        report = await validate_env(block, {}, {}, secret_provider=provider)
+        assert report.passed
+        assert report.required_results[0].source == "os.environ"
+
+
+class _MockProvider:
+    """Simple mock SecretProvider for testing."""
+
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = secrets
+
+    async def get_secret(self, secret_id: str, *, version: str = "latest") -> str | None:
+        return self._secrets.get(secret_id)
+
+    async def list_secrets(self) -> list[str]:
+        return list(self._secrets.keys())

--- a/tests/unit/test_gcp_secret_manager.py
+++ b/tests/unit/test_gcp_secret_manager.py
@@ -1,0 +1,116 @@
+"""Tests for GCP Secret Manager SecretProvider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tanren_core.adapters.gcp_secret_manager import GCPSecretManagerProvider
+
+
+def _build_secretmanager_module(client):
+    """Build a fake google.cloud.secretmanager module."""
+    return SimpleNamespace(
+        SecretManagerServiceClient=Mock(return_value=client),
+    )
+
+
+def _make_provider(monkeypatch, client, **overrides):
+    """Create a GCPSecretManagerProvider with mocked SDK."""
+    mod = _build_secretmanager_module(client)
+    monkeypatch.setattr(
+        "tanren_core.adapters.gcp_secret_manager._import_secret_manager",
+        lambda: mod,
+    )
+    return GCPSecretManagerProvider(
+        project_id=overrides.get("project_id", "my-project"),
+    )
+
+
+@pytest.mark.asyncio
+class TestGCPSecretManagerProvider:
+    async def test_get_returns_value(self, monkeypatch):
+        response = SimpleNamespace(payload=SimpleNamespace(data=b"super-secret-value"))
+        client = Mock()
+        client.access_secret_version = Mock(return_value=response)
+
+        provider = _make_provider(monkeypatch, client)
+        value = await provider.get_secret("my-secret")
+
+        assert value == "super-secret-value"
+        client.access_secret_version.assert_called_once()
+        call_kwargs = client.access_secret_version.call_args.kwargs
+        assert "my-project" in call_kwargs["request"]["name"]
+        assert "my-secret" in call_kwargs["request"]["name"]
+        assert "latest" in call_kwargs["request"]["name"]
+
+    async def test_get_with_custom_version(self, monkeypatch):
+        response = SimpleNamespace(payload=SimpleNamespace(data=b"v3-value"))
+        client = Mock()
+        client.access_secret_version = Mock(return_value=response)
+
+        provider = _make_provider(monkeypatch, client)
+        value = await provider.get_secret("key", version="3")
+
+        assert value == "v3-value"
+        call_kwargs = client.access_secret_version.call_args.kwargs
+        assert "/versions/3" in call_kwargs["request"]["name"]
+
+    async def test_get_caches_result(self, monkeypatch):
+        response = SimpleNamespace(payload=SimpleNamespace(data=b"cached-value"))
+        client = Mock()
+        client.access_secret_version = Mock(return_value=response)
+
+        provider = _make_provider(monkeypatch, client)
+        v1 = await provider.get_secret("key")
+        v2 = await provider.get_secret("key")
+
+        assert v1 == v2 == "cached-value"
+        assert client.access_secret_version.call_count == 1
+
+    async def test_get_returns_none_on_error(self, monkeypatch):
+        client = Mock()
+        client.access_secret_version = Mock(side_effect=RuntimeError("API error"))
+
+        provider = _make_provider(monkeypatch, client)
+        value = await provider.get_secret("missing-secret")
+
+        assert value is None
+
+    async def test_list_secrets(self, monkeypatch):
+        secret1 = SimpleNamespace(name="projects/my-project/secrets/secret-a")
+        secret2 = SimpleNamespace(name="projects/my-project/secrets/secret-b")
+        client = Mock()
+        client.list_secrets = Mock(return_value=[secret1, secret2])
+
+        provider = _make_provider(monkeypatch, client)
+        result = await provider.list_secrets()
+
+        assert result == ["secret-a", "secret-b"]
+
+    async def test_list_secrets_returns_empty_on_error(self, monkeypatch):
+        client = Mock()
+        client.list_secrets = Mock(side_effect=RuntimeError("API error"))
+
+        provider = _make_provider(monkeypatch, client)
+        result = await provider.list_secrets()
+
+        assert result == []
+
+
+def test_import_error_clear_message(monkeypatch):
+    def _raise():
+        raise ImportError(
+            "google-cloud-secret-manager is required for GCP secrets. "
+            "Install it with: uv sync --extra gcp"
+        )
+
+    monkeypatch.setattr(
+        "tanren_core.adapters.gcp_secret_manager._import_secret_manager",
+        _raise,
+    )
+
+    with pytest.raises(ImportError, match="uv sync --extra gcp"):
+        GCPSecretManagerProvider(project_id="test")

--- a/tests/unit/test_gcp_vm.py
+++ b/tests/unit/test_gcp_vm.py
@@ -158,10 +158,10 @@ async def test_release_deletes_instance(monkeypatch):
 @pytest.mark.asyncio
 async def test_release_missing_instance_is_graceful(monkeypatch):
     monkeypatch.setenv("GCP_SSH_PUBLIC_KEY", "ssh-ed25519 AAAA testkey")
-    gae = pytest.importorskip("google.api_core.exceptions")
+    from google.api_core.exceptions import NotFound  # noqa: PLC0415
 
     client = Mock()
-    client.delete = Mock(side_effect=gae.NotFound("not found"))
+    client.delete = Mock(side_effect=NotFound("not found"))
 
     provisioner = _make_provisioner(monkeypatch, client)
 

--- a/tests/unit/test_protocols.py
+++ b/tests/unit/test_protocols.py
@@ -1,8 +1,11 @@
 """Verify each adapter class satisfies its protocol via isinstance checks."""
 
+from pathlib import Path
+
 from tanren_core.adapters import (
     DotenvEnvProvisioner,
     DotenvEnvValidator,
+    DotenvSecretProvider,
     GitPostflightRunner,
     GitPreflightRunner,
     GitWorktreeManager,
@@ -17,6 +20,7 @@ from tanren_core.adapters.protocols import (
     PostflightRunner,
     PreflightRunner,
     ProcessSpawner,
+    SecretProvider,
     WorktreeManager,
 )
 
@@ -45,3 +49,6 @@ class TestProtocolConformance:
 
     def test_sqlite_event_emitter(self):
         assert isinstance(SqliteEventEmitter("/tmp/test.db"), EventEmitter)
+
+    def test_dotenv_secret_provider(self, tmp_path: Path):
+        assert isinstance(DotenvSecretProvider(secrets_dir=tmp_path), SecretProvider)

--- a/tests/unit/test_secret_provider_factory.py
+++ b/tests/unit/test_secret_provider_factory.py
@@ -1,0 +1,30 @@
+"""Tests for secret provider factory."""
+
+from pathlib import Path
+
+import pytest
+
+from tanren_core.adapters.dotenv_secret_provider import DotenvSecretProvider
+from tanren_core.env.schema import SecretsConfig, SecretsProviderType
+from tanren_core.env.secret_provider_factory import create_secret_provider
+
+
+class TestCreateSecretProvider:
+    def test_none_config_returns_dotenv(self, tmp_path: Path):
+        provider = create_secret_provider(None, secrets_dir=tmp_path)
+        assert isinstance(provider, DotenvSecretProvider)
+
+    def test_dotenv_explicit(self, tmp_path: Path):
+        config = SecretsConfig(provider=SecretsProviderType.DOTENV)
+        provider = create_secret_provider(config, secrets_dir=tmp_path)
+        assert isinstance(provider, DotenvSecretProvider)
+
+    def test_gcp_missing_project_id_raises(self):
+        config = SecretsConfig(provider=SecretsProviderType.GCP, settings={})
+        with pytest.raises(ValueError, match="project_id"):
+            create_secret_provider(config)
+
+    def test_gcp_empty_project_id_raises(self):
+        config = SecretsConfig(provider=SecretsProviderType.GCP, settings={"project_id": ""})
+        with pytest.raises(ValueError, match="project_id"):
+            create_secret_provider(config)

--- a/uv.lock
+++ b/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "tanren-api"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "services/tanren-api" }
 dependencies = [
     { name = "fastapi" },
@@ -1512,7 +1512,7 @@ provides-extras = ["hetzner", "gcp"]
 
 [[package]]
 name = "tanren-cli"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "services/tanren-cli" }
 dependencies = [
     { name = "tanren-core" },
@@ -1527,7 +1527,7 @@ requires-dist = [
 
 [[package]]
 name = "tanren-core"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/tanren-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1563,7 +1563,7 @@ provides-extras = ["gcp", "hetzner"]
 
 [[package]]
 name = "tanren-daemon"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "services/tanren-daemon" }
 dependencies = [
     { name = "tanren-core" },
@@ -1574,7 +1574,7 @@ requires-dist = [{ name = "tanren-core", editable = "packages/tanren-core" }]
 
 [[package]]
 name = "tanren-workspace"
-version = "0.1.1"
+version = "0.2.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -533,6 +533,23 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-secret-manager"
+version = "2.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/a6c7144bc96df77376ae3fcc916fb639c40814c2e4bba2051d31dc136cd0/google_cloud_secret_manager-2.26.0.tar.gz", hash = "sha256:0d1d6f76327685a0ed78a4cf50f289e1bfbbe56026ed0affa98663b86d6d50d6", size = 277603, upload-time = "2025-12-18T00:29:31.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/30/a58739dd12cec0f7f761ed1efb518aed2250a407d4ed14c5a0eeee7eaaf9/google_cloud_secret_manager-2.26.0-py3-none-any.whl", hash = "sha256:940a5447a6ec9951446fd1a0f22c81a4303fde164cd747aae152c5f5c8e6723e", size = 223623, upload-time = "2025-12-18T00:29:29.311Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +559,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/1e/1011451679a983f2f5c6771a1682542ecb027776762ad031fd0d7129164b/grpc_google_iam_v1-0.14.3.tar.gz", hash = "sha256:879ac4ef33136c5491a6300e27575a9ec760f6cdf9a2518798c1b8977a5dc389", size = 23745, upload-time = "2025-10-15T21:14:53.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/bd/330a1bbdb1afe0b96311249e699b6dc9cfc17916394fd4503ac5aca2514b/grpc_google_iam_v1-0.14.3-py3-none-any.whl", hash = "sha256:7a7f697e017a067206a3dfef44e4c634a34d3dee135fe7d7a4613fe3e59217e6", size = 32690, upload-time = "2025-10-15T21:14:51.72Z" },
 ]
 
 [[package]]
@@ -1505,6 +1541,7 @@ dependencies = [
 [package.optional-dependencies]
 gcp = [
     { name = "google-cloud-compute" },
+    { name = "google-cloud-secret-manager" },
 ]
 hetzner = [
     { name = "hcloud" },
@@ -1515,6 +1552,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20,<1" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "google-cloud-compute", marker = "extra == 'gcp'", specifier = ">=1.20.0,<2" },
+    { name = "google-cloud-secret-manager", marker = "extra == 'gcp'", specifier = ">=2.20.0,<3" },
     { name = "hcloud", marker = "extra == 'hetzner'", specifier = ">=2.4.0,<3" },
     { name = "paramiko", specifier = ">=3.0,<4" },
     { name = "pydantic", specifier = ">=2,<3" },


### PR DESCRIPTION
## Summary

- Adds a `SecretProvider` protocol with two implementations: `DotenvSecretProvider` (backward-compatible default) and `GCPSecretManagerProvider` (fetches from GCP Secret Manager via ADC)
- New `source` field on env var declarations enables explicit mapping from env vars to cloud secrets (e.g., `source: "secret:my-api-key"`)
- New `secrets:` config block in `tanren.yml` selects the storage backend (`dotenv` or `gcp`)
- `validate_env()` is now async to support cloud secret resolution; priority preserved: os.environ > dotenv layers > SecretProvider
- Remote injection path fetches cloud secrets into `SecretBundle.developer` scope — `inject_secrets()` unchanged
- `google-cloud-secret-manager` added to the existing `gcp` optional dependency group

## Test plan

- [x] Unit tests for `DotenvSecretProvider` (file reading, caching, missing keys)
- [x] Unit tests for `GCPSecretManagerProvider` (mocked SDK, caching, error handling)
- [x] Unit tests for `create_secret_provider` factory (dotenv default, GCP validation, error cases)
- [x] Protocol conformance test (`isinstance` check for `DotenvSecretProvider`)
- [x] Schema tests for new `source` field and `SecretsConfig` model
- [x] Validator tests for `secret:` prefix resolution (7 new test cases covering provider resolution, env override, pattern validation, os.environ priority)
- [x] All 16 existing validator tests updated to async — behavior preserved
- [x] 4 integration tests updated to async
- [x] Integration test for live GCP (marked `gcp`, excluded from CI)
- [x] `make check` passes (format, lint, type, unit, integration, docs)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)