### PR TITLE
feat: add GitHubIssueSource adapter with GraphQL API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ unit:
 
 integration:
 	uv run pytest tests/integration -q --tb=short --timeout=30 \
-		-m "not ssh and not local_env and not hetzner and not gcp and not postgres" \
+		-m "not ssh and not local_env and not hetzner and not gcp and not postgres and not github" \
 		--cov=packages --cov=services --cov-fail-under=75
 
 docs-check:

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gcp = ["google-cloud-compute>=1.20.0, <2"]
+github = ["httpx>=0.27, <1"]
 hetzner = ["hcloud>=2.4.0, <3"]
 
 [build-system]

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -41,6 +41,10 @@ try:  # noqa: SIM105, RUF067
 except ImportError:  # google-cloud-compute not installed
     pass
 try:  # noqa: SIM105, RUF067
+    from tanren_core.adapters.github_issue import GitHubIssueSettings, GitHubIssueSource
+except ImportError:  # httpx not installed
+    pass
+try:  # noqa: SIM105, RUF067
     from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 except ImportError:  # hcloud not installed
     pass
@@ -127,6 +131,8 @@ __all__ = [
     "GCPProvisionerSettings",
     "GCPVMProvisioner",
     "GitAuthConfig",
+    "GitHubIssueSettings",
+    "GitHubIssueSource",
     "GitPostflightRunner",
     "GitPreflightRunner",
     "GitWorkspaceManager",

--- a/packages/tanren-core/src/tanren_core/adapters/github_issue.py
+++ b/packages/tanren-core/src/tanren_core/adapters/github_issue.py
@@ -1,0 +1,396 @@
+"""GitHub issue source adapter using GraphQL API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import types
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, cast
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from tanren_core.adapters.issue_types import Issue, IssueSummary
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+
+def _import_httpx() -> types.ModuleType:
+    """Import httpx at runtime.
+
+    Returns:
+        The httpx module.
+
+    Raises:
+        ImportError: If httpx is not installed.
+    """
+    try:
+        import httpx as _httpx  # noqa: PLC0415
+
+        return _httpx
+    except ImportError:
+        raise ImportError(
+            "httpx is required for the GitHub issue adapter. "
+            "Install it with: uv sync --extra github"
+        ) from None
+
+
+class GitHubIssueSettings(BaseModel):
+    """Configuration for GitHub issue source."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    token_env: str = Field(
+        default="GITHUB_TOKEN",
+        description="Environment variable name containing the GitHub token",
+    )
+    owner: str = Field(..., description="Repository owner (user or org)")
+    repo: str = Field(..., description="Repository name")
+    api_url: str = Field(
+        default=_GITHUB_GRAPHQL_URL,
+        description="GitHub GraphQL API endpoint (override for GitHub Enterprise)",
+    )
+
+    @classmethod
+    def from_settings(cls, settings: Mapping[str, JsonValue]) -> GitHubIssueSettings:
+        """Parse from tanren.yml issue_source.settings.
+
+        Returns:
+            Validated GitHubIssueSettings.
+        """
+        return cls.model_validate(settings)
+
+
+_GET_ISSUE_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      id
+      number
+      title
+      body
+      state
+      url
+      labels(first: 20) { nodes { name } }
+      milestone { title }
+      trackedInIssues(first: 10) { nodes { number title } }
+      trackedIssues(first: 10) { nodes { number title } }
+    }
+  }
+}
+"""
+
+_LIST_ISSUES_QUERY = """
+query($owner: String!, $repo: String!, $labels: [String!], $states: [IssueState!]) {
+  repository(owner: $owner, name: $repo) {
+    issues(first: 50, labels: $labels, states: $states,
+           orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        state
+        url
+        labels(first: 10) { nodes { name } }
+      }
+    }
+  }
+}
+"""
+
+_ADD_COMMENT_MUTATION = """
+mutation($issueId: ID!, $body: String!) {
+  addComment(input: { subjectId: $issueId, body: $body }) {
+    commentEdge { node { id } }
+  }
+}
+"""
+
+_CLOSE_ISSUE_MUTATION = """
+mutation($issueId: ID!, $stateReason: IssueClosedStateReason) {
+  closeIssue(input: { issueId: $issueId, stateReason: $stateReason }) {
+    issue { number state }
+  }
+}
+"""
+
+_REOPEN_ISSUE_MUTATION = """
+mutation($issueId: ID!) {
+  reopenIssue(input: { issueId: $issueId }) {
+    issue { number state }
+  }
+}
+"""
+
+_CLOSE_STATUSES = frozenset({"closed", "merged", "done", "completed"})
+_OPEN_STATUSES = frozenset({"open", "reopened"})
+
+type _JsonDict = dict[str, object]
+
+
+def _as_dict(val: object) -> _JsonDict:
+    """Cast a JSON value known to be a dict to ``dict[str, object]``.
+
+    Call only after confirming ``isinstance(val, dict)``.
+
+    Returns:
+        The value cast to ``dict[str, object]``.
+    """
+    return cast(_JsonDict, val)
+
+
+class GitHubIssueSource:
+    """Fetch and update GitHub issues via GraphQL API."""
+
+    def __init__(self, settings: GitHubIssueSettings) -> None:
+        """Initialize with GitHub issue settings.
+
+        Args:
+            settings: Validated GitHub issue settings.
+
+        Raises:
+            ValueError: If the token environment variable is not set.
+        """
+        token = os.environ.get(settings.token_env)
+        if not token:
+            raise ValueError(f"Missing GitHub token in environment variable: {settings.token_env}")
+        httpx_mod = _import_httpx()
+        self._client: httpx.Client = httpx_mod.Client(
+            base_url=settings.api_url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30.0,
+        )
+        self._owner = settings.owner
+        self._repo = settings.repo
+
+    def _execute(self, query: str, variables: dict[str, object]) -> dict[str, object]:
+        """Execute a GraphQL query/mutation.
+
+        Args:
+            query: GraphQL query or mutation string.
+            variables: Variables for the query.
+
+        Returns:
+            The ``data`` dict from the GraphQL response.
+
+        Raises:
+            RuntimeError: If the response contains GraphQL errors.
+        """
+        payload: dict[str, object] = {"query": query, "variables": variables}
+        response = self._client.post("", json=payload)
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict):
+            raise RuntimeError("Unexpected GraphQL response format")
+        if "errors" in body:
+            errors = body["errors"]
+            raise RuntimeError(f"GraphQL errors: {errors}")
+        data = body.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("Missing 'data' in GraphQL response")
+        return data
+
+    @staticmethod
+    def _build_issue(data: dict[str, object]) -> Issue:
+        """Map a GraphQL issue node to an Issue model.
+
+        Args:
+            data: The issue node from a GraphQL response.
+
+        Returns:
+            An Issue model instance.
+        """
+        node_id = str(data.get("id", ""))
+        number = data.get("number", 0)
+        title = str(data.get("title", ""))
+        body = str(data.get("body", ""))
+        state = str(data.get("state", ""))
+        url = str(data.get("url", ""))
+
+        labels_data = data.get("labels")
+        label_names: list[str] = []
+        if isinstance(labels_data, dict):
+            nodes = _as_dict(labels_data).get("nodes")
+            if isinstance(nodes, list):
+                for node in nodes:
+                    if isinstance(node, dict):
+                        name = _as_dict(node).get("name")
+                        if isinstance(name, str):
+                            label_names.append(name)
+
+        milestone_title = ""
+        milestone_data = data.get("milestone")
+        if isinstance(milestone_data, dict):
+            mt = _as_dict(milestone_data).get("title")
+            if isinstance(mt, str):
+                milestone_title = mt
+
+        blocked_by_numbers: list[str] = []
+        tracked_in = data.get("trackedInIssues")
+        if isinstance(tracked_in, dict):
+            nodes = _as_dict(tracked_in).get("nodes")
+            if isinstance(nodes, list):
+                for node in nodes:
+                    if isinstance(node, dict):
+                        n = _as_dict(node).get("number")
+                        if n is not None:
+                            blocked_by_numbers.append(str(n))
+
+        blocking_numbers: list[str] = []
+        tracked = data.get("trackedIssues")
+        if isinstance(tracked, dict):
+            nodes = _as_dict(tracked).get("nodes")
+            if isinstance(nodes, list):
+                for node in nodes:
+                    if isinstance(node, dict):
+                        n = _as_dict(node).get("number")
+                        if n is not None:
+                            blocking_numbers.append(str(n))
+
+        metadata: dict[str, str] = {"node_id": node_id}
+        if milestone_title:
+            metadata["milestone"] = milestone_title
+        if blocked_by_numbers:
+            metadata["blocked_by"] = ",".join(blocked_by_numbers)
+        if blocking_numbers:
+            metadata["blocking"] = ",".join(blocking_numbers)
+
+        return Issue(
+            id=str(number),
+            title=title,
+            body=body,
+            status=state,
+            labels=tuple(label_names),
+            url=url,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _build_summary(data: dict[str, object]) -> IssueSummary:
+        """Map a GraphQL issue node to an IssueSummary model.
+
+        Args:
+            data: The issue node from a GraphQL response.
+
+        Returns:
+            An IssueSummary model instance.
+        """
+        number = data.get("number", 0)
+        title = str(data.get("title", ""))
+        state = str(data.get("state", ""))
+        url = str(data.get("url", ""))
+        return IssueSummary(id=str(number), title=title, status=state, url=url)
+
+    async def get_issue(self, issue_id: str) -> Issue:
+        """Fetch full issue detail by ID.
+
+        Args:
+            issue_id: Numeric GitHub issue number as a string.
+
+        Returns:
+            The Issue model for the requested issue.
+
+        Raises:
+            ValueError: If issue_id is not numeric or the issue is not found.
+        """
+        if not issue_id.isdigit():
+            raise ValueError(f"GitHub issue IDs must be numeric, got: {issue_id!r}")
+        variables: dict[str, object] = {
+            "owner": self._owner,
+            "repo": self._repo,
+            "number": int(issue_id),
+        }
+        data = await asyncio.to_thread(self._execute, _GET_ISSUE_QUERY, variables)
+        repo = data.get("repository")
+        if not isinstance(repo, dict):
+            raise ValueError(f"Issue {issue_id} not found")
+        issue_data = _as_dict(repo).get("issue")
+        if not isinstance(issue_data, dict):
+            raise ValueError(f"Issue {issue_id} not found")
+        return self._build_issue(_as_dict(issue_data))
+
+    async def list_issues(
+        self, *, project: str | None = None, status: str | None = None
+    ) -> list[IssueSummary]:
+        """List issues, optionally filtered by status.
+
+        Args:
+            project: Ignored for GitHub (repo-scoped via settings).
+            status: Filter by status: ``"open"`` or ``"closed"``. None returns all.
+
+        Returns:
+            List of IssueSummary instances.
+        """
+        variables: dict[str, object] = {
+            "owner": self._owner,
+            "repo": self._repo,
+        }
+        if status is not None:
+            normalized = status.strip().upper()
+            if normalized in ("OPEN", "CLOSED"):
+                variables["states"] = [normalized]
+            else:
+                variables["states"] = [status.strip().upper()]
+
+        data = await asyncio.to_thread(self._execute, _LIST_ISSUES_QUERY, variables)
+        repo = data.get("repository")
+        if not isinstance(repo, dict):
+            return []
+        issues_data = _as_dict(repo).get("issues")
+        if not isinstance(issues_data, dict):
+            return []
+        nodes = _as_dict(issues_data).get("nodes")
+        if not isinstance(nodes, list):
+            return []
+        summaries: list[IssueSummary] = []
+        for node in nodes:
+            if isinstance(node, dict):
+                summaries.append(self._build_summary(_as_dict(node)))
+        return summaries
+
+    async def update_status(self, issue_id: str, status: str) -> None:
+        """Transition an issue to a new status.
+
+        GitHub only supports OPEN and CLOSED states. Granular statuses are
+        logged as warnings without raising.
+
+        Args:
+            issue_id: Numeric GitHub issue number as a string.
+            status: Target status string.
+        """
+        normalized = status.strip().lower()
+        issue = await self.get_issue(issue_id)
+        node_id = issue.metadata.get("node_id", "")
+
+        if normalized in _CLOSE_STATUSES:
+            variables: dict[str, object] = {
+                "issueId": node_id,
+                "stateReason": "COMPLETED",
+            }
+            await asyncio.to_thread(self._execute, _CLOSE_ISSUE_MUTATION, variables)
+        elif normalized in _OPEN_STATUSES:
+            reopen_vars: dict[str, object] = {"issueId": node_id}
+            await asyncio.to_thread(self._execute, _REOPEN_ISSUE_MUTATION, reopen_vars)
+        else:
+            logger.warning(
+                "GitHub does not support granular status %r for issue %s; skipping",
+                status,
+                issue_id,
+            )
+
+    async def add_comment(self, issue_id: str, body: str) -> None:
+        """Append a comment to an issue.
+
+        Args:
+            issue_id: Numeric GitHub issue number as a string.
+            body: Comment body text.
+        """
+        issue = await self.get_issue(issue_id)
+        node_id = issue.metadata.get("node_id", "")
+        variables: dict[str, object] = {"issueId": node_id, "body": body}
+        await asyncio.to_thread(self._execute, _ADD_COMMENT_MUTATION, variables)

--- a/packages/tanren-core/src/tanren_core/adapters/github_issue.py
+++ b/packages/tanren-core/src/tanren_core/adapters/github_issue.py
@@ -161,10 +161,10 @@ class GitHubIssueSource:
             raise ValueError(f"Missing GitHub token in environment variable: {settings.token_env}")
         httpx_mod = _import_httpx()
         self._client: httpx.Client = httpx_mod.Client(
-            base_url=settings.api_url,
             headers={"Authorization": f"Bearer {token}"},
             timeout=30.0,
         )
+        self._api_url = settings.api_url
         self._owner = settings.owner
         self._repo = settings.repo
 
@@ -182,7 +182,7 @@ class GitHubIssueSource:
             RuntimeError: If the response contains GraphQL errors.
         """
         payload: dict[str, object] = {"query": query, "variables": variables}
-        response = self._client.post("", json=payload)
+        response = self._client.post(self._api_url, json=payload)
         response.raise_for_status()
         body = response.json()
         if not isinstance(body, dict):
@@ -335,7 +335,10 @@ class GitHubIssueSource:
             if normalized in ("OPEN", "CLOSED"):
                 variables["states"] = [normalized]
             else:
-                variables["states"] = [status.strip().upper()]
+                logger.warning(
+                    "Unsupported GitHub issue status %r; returning all issues without state filter",
+                    status,
+                )
 
         data = await asyncio.to_thread(self._execute, _LIST_ISSUES_QUERY, variables)
         repo = data.get("repository")

--- a/packages/tanren-core/src/tanren_core/env/environment_schema.py
+++ b/packages/tanren-core/src/tanren_core/env/environment_schema.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Mapping
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 
 
 class EnvironmentProfileType(StrEnum):
@@ -86,3 +86,31 @@ def parse_environment_profiles(data: Mapping[str, object]) -> dict[str, Environm
         profiles["default"] = EnvironmentProfile(name="default")
 
     return profiles
+
+
+class IssueSourceType(StrEnum):
+    """Supported issue source backends."""
+
+    GITHUB = "github"
+    LINEAR = "linear"
+
+
+class IssueSourceConfig(BaseModel):
+    """Issue source configuration from tanren.yml."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    type: IssueSourceType = Field(default=IssueSourceType.GITHUB)
+    settings: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+def parse_issue_source(data: Mapping[str, object]) -> IssueSourceConfig | None:
+    """Parse 'issue_source' section of tanren.yml.
+
+    Returns:
+        IssueSourceConfig if present, None otherwise.
+    """
+    raw = data.get("issue_source")
+    if isinstance(raw, dict):
+        return IssueSourceConfig.model_validate(raw)
+    return None

--- a/packages/tanren-core/src/tanren_core/env/schema.py
+++ b/packages/tanren-core/src/tanren_core/env/schema.py
@@ -57,6 +57,7 @@ class TanrenConfig(BaseModel):
     env: EnvBlock | None = Field(default=None)
     # Consumed by runtime environment selection logic outside env tooling.
     environment: dict[str, object] | None = Field(default=None)
+    issue_source: dict[str, object] | None = Field(default=None)
 
     @model_validator(mode="before")
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.14"
 [project.optional-dependencies]
 hetzner = ["tanren-core[hetzner]"]
 gcp = ["tanren-core[gcp]"]
+github = ["tanren-core[github]"]
 
 [tool.uv]
 managed = true
@@ -76,12 +77,13 @@ markers = [
     "hetzner: requires Hetzner API token and provisions real VMs",
     "gcp: requires GCP credentials and provisions real VMs",
     "postgres: requires a real Postgres database",
+    "github: requires GitHub token and accesses real GitHub API",
 ]
 
 # ===== COVERAGE =====
 [tool.coverage.run]
 source = ["packages", "services"]
-omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py"]
+omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py", "*/adapters/github_issue.py"]
 
 [tool.coverage.report]
 fail_under = 80
@@ -98,6 +100,7 @@ exclude_lines = [
 [dependency-groups]
 dev = [
     "tanren-core[gcp]",
+    "tanren-core[github]",
     "tanren-core[hetzner]",
     "tanren-cli",
     "tanren-api",

--- a/tests/integration/test_github_issue_integration.py
+++ b/tests/integration/test_github_issue_integration.py
@@ -1,0 +1,39 @@
+"""Integration tests for GitHub issue source — requires real token.
+
+Run with:
+    uv run pytest tests/integration/test_github_issue_integration.py -v --timeout=60
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tanren_core.adapters.github_issue import GitHubIssueSettings, GitHubIssueSource
+
+pytestmark = pytest.mark.github
+
+
+@pytest.fixture()
+def source():
+    """Create a GitHubIssueSource using real GitHub credentials."""
+    if not os.environ.get("GITHUB_TOKEN"):
+        raise pytest.skip.Exception("GITHUB_TOKEN not set")
+
+    settings = GitHubIssueSettings(owner="trevorWieland", repo="tanren")
+    return GitHubIssueSource(settings)
+
+
+class TestGitHubIssueSourceIntegration:
+    async def test_get_issue(self, source):
+        """Fetch a real GitHub issue."""
+        issue = await source.get_issue("14")
+        assert issue.id == "14"
+        assert issue.title
+        assert issue.url
+
+    async def test_list_issues(self, source):
+        """List issues from a real repo."""
+        summaries = await source.list_issues(status="open")
+        assert isinstance(summaries, list)

--- a/tests/unit/test_environment_schema.py
+++ b/tests/unit/test_environment_schema.py
@@ -5,9 +5,12 @@ import pytest
 from tanren_core.env.environment_schema import (
     EnvironmentProfile,
     EnvironmentProfileType,
+    IssueSourceConfig,
+    IssueSourceType,
     McpServerConfig,
     ResourceRequirements,
     parse_environment_profiles,
+    parse_issue_source,
 )
 
 
@@ -186,3 +189,52 @@ class TestEnvironmentProfileMcp:
             mcp={"my-server": McpServerConfig(url="https://example.com/sse")},
         )
         assert "my-server" in p.mcp
+
+
+class TestIssueSourceType:
+    def test_github_value(self):
+        assert IssueSourceType.GITHUB == "github"
+
+    def test_linear_value(self):
+        assert IssueSourceType.LINEAR == "linear"
+
+
+class TestIssueSourceConfig:
+    def test_default_type_is_github(self):
+        cfg = IssueSourceConfig()
+        assert cfg.type == IssueSourceType.GITHUB
+        assert cfg.settings == {}
+
+    def test_explicit_linear_type(self):
+        cfg = IssueSourceConfig(type=IssueSourceType.LINEAR, settings={"team": "ENG"})
+        assert cfg.type == IssueSourceType.LINEAR
+        assert cfg.settings == {"team": "ENG"}
+
+    def test_frozen(self):
+        cfg = IssueSourceConfig()
+        with pytest.raises(ValueError):
+            cfg.type = IssueSourceType.LINEAR
+
+    def test_extra_forbidden(self):
+        with pytest.raises(ValueError):
+            IssueSourceConfig(type=IssueSourceType.GITHUB, bogus="x")  # type: ignore[unknown-argument]
+
+
+class TestParseIssueSource:
+    def test_returns_none_when_absent(self):
+        assert parse_issue_source({}) is None
+
+    def test_parses_github_config(self):
+        data = {
+            "issue_source": {
+                "type": "github",
+                "settings": {"owner": "myorg", "repo": "myrepo"},
+            }
+        }
+        cfg = parse_issue_source(data)
+        assert cfg is not None
+        assert cfg.type == IssueSourceType.GITHUB
+        assert cfg.settings == {"owner": "myorg", "repo": "myrepo"}
+
+    def test_returns_none_for_non_dict(self):
+        assert parse_issue_source({"issue_source": "invalid"}) is None

--- a/tests/unit/test_github_issue.py
+++ b/tests/unit/test_github_issue.py
@@ -234,6 +234,20 @@ class TestListIssues:
         json_body = call_kwargs["json"]
         assert "states" not in json_body["variables"]
 
+    async def test_unsupported_status_warns_and_omits_filter(self, monkeypatch, caplog):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        with caplog.at_level(logging.WARNING):
+            await source.list_issues(status="in_progress")
+
+        assert "unsupported" in caplog.text.lower() or "in_progress" in caplog.text
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert "states" not in json_body["variables"]
+
 
 class TestUpdateStatus:
     async def test_closes_issue(self, monkeypatch):

--- a/tests/unit/test_github_issue.py
+++ b/tests/unit/test_github_issue.py
@@ -1,0 +1,316 @@
+"""Tests for GitHub issue source adapter."""
+
+from __future__ import annotations
+
+import logging
+import types
+from unittest.mock import Mock
+
+import pytest
+
+from tanren_core.adapters.github_issue import GitHubIssueSettings, GitHubIssueSource
+from tanren_core.adapters.issue_types import Issue, IssueSummary
+
+
+class _FakeResponse:
+    def __init__(self, data, status_code=200):
+        self.status_code = status_code
+        self._json = data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _settings(**overrides):
+    defaults = {"owner": "testorg", "repo": "testrepo"}
+    defaults.update(overrides)
+    return GitHubIssueSettings(**defaults)
+
+
+def _make_source(monkeypatch, mock_client, **settings_kw):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test_token")
+    httpx_mod = types.SimpleNamespace(Client=Mock(return_value=mock_client))
+    monkeypatch.setattr(
+        "tanren_core.adapters.github_issue._import_httpx",
+        lambda: httpx_mod,
+    )
+    return GitHubIssueSource(_settings(**settings_kw))
+
+
+def _issue_graphql_response(
+    *,
+    number=42,
+    node_id="I_kwDOtest",
+    title="Test issue",
+    body="Issue body",
+    state="OPEN",
+    url="https://github.com/testorg/testrepo/issues/42",
+    labels=None,
+    milestone=None,
+    tracked_in=None,
+    tracked=None,
+):
+    return {
+        "data": {
+            "repository": {
+                "issue": {
+                    "id": node_id,
+                    "number": number,
+                    "title": title,
+                    "body": body,
+                    "state": state,
+                    "url": url,
+                    "labels": {"nodes": [{"name": n} for n in (labels or [])]},
+                    "milestone": {"title": milestone} if milestone else None,
+                    "trackedInIssues": {
+                        "nodes": [{"number": n, "title": f"#{n}"} for n in (tracked_in or [])]
+                    },
+                    "trackedIssues": {
+                        "nodes": [{"number": n, "title": f"#{n}"} for n in (tracked or [])]
+                    },
+                }
+            }
+        }
+    }
+
+
+def _list_issues_graphql_response(issues=None):
+    if issues is None:
+        issues = [
+            {
+                "number": 1,
+                "title": "First",
+                "state": "OPEN",
+                "url": "https://example.com/1",
+                "labels": {"nodes": []},
+            },
+            {
+                "number": 2,
+                "title": "Second",
+                "state": "CLOSED",
+                "url": "https://example.com/2",
+                "labels": {"nodes": []},
+            },
+        ]
+    return {"data": {"repository": {"issues": {"nodes": issues}}}}
+
+
+class TestGitHubIssueSettings:
+    def test_from_settings(self):
+        raw = {"owner": "myorg", "repo": "myrepo", "token_env": "MY_TOKEN"}
+        settings = GitHubIssueSettings.from_settings(raw)
+        assert settings.owner == "myorg"
+        assert settings.repo == "myrepo"
+        assert settings.token_env == "MY_TOKEN"
+
+    def test_defaults(self):
+        settings = _settings()
+        assert settings.token_env == "GITHUB_TOKEN"
+        assert settings.api_url == "https://api.github.com/graphql"
+
+    def test_github_enterprise_url(self):
+        settings = _settings(api_url="https://github.corp.com/api/graphql")
+        assert settings.api_url == "https://github.corp.com/api/graphql"
+
+
+class TestGitHubIssueSourceInit:
+    def test_missing_token_raises(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        httpx_mod = types.SimpleNamespace(Client=Mock())
+        monkeypatch.setattr(
+            "tanren_core.adapters.github_issue._import_httpx",
+            lambda: httpx_mod,
+        )
+        with pytest.raises(ValueError, match="Missing GitHub token"):
+            GitHubIssueSource(_settings())
+
+    def test_missing_httpx_raises(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        def _raise():
+            raise ImportError(
+                "httpx is required for the GitHub issue adapter. "
+                "Install it with: uv sync --extra github"
+            )
+
+        monkeypatch.setattr(
+            "tanren_core.adapters.github_issue._import_httpx",
+            _raise,
+        )
+        with pytest.raises(ImportError, match="uv sync --extra github"):
+            GitHubIssueSource(_settings())
+
+
+class TestGetIssue:
+    async def test_returns_issue_model(self, monkeypatch):
+        response_data = _issue_graphql_response(
+            number=42,
+            node_id="I_kwDOtest42",
+            title="Test issue",
+            body="Issue body",
+            state="OPEN",
+            labels=["bug", "priority"],
+            milestone="v1.0",
+            tracked_in=[10, 20],
+            tracked=[30],
+        )
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        issue = await source.get_issue("42")
+
+        assert isinstance(issue, Issue)
+        assert issue.id == "42"
+        assert issue.title == "Test issue"
+        assert issue.body == "Issue body"
+        assert issue.status == "OPEN"
+        assert issue.labels == ("bug", "priority")
+        assert issue.url == "https://github.com/testorg/testrepo/issues/42"
+        assert issue.metadata["node_id"] == "I_kwDOtest42"
+        assert issue.metadata["milestone"] == "v1.0"
+        assert issue.metadata["blocked_by"] == "10,20"
+        assert issue.metadata["blocking"] == "30"
+
+    async def test_not_found_raises(self, monkeypatch):
+        response_data = {"data": {"repository": {"issue": None}}}
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        with pytest.raises(ValueError, match="not found"):
+            await source.get_issue("999")
+
+    async def test_non_numeric_id_raises(self, monkeypatch):
+        client = Mock()
+        source = _make_source(monkeypatch, client)
+
+        with pytest.raises(ValueError, match="numeric"):
+            await source.get_issue("PROJ-123")
+
+
+class TestListIssues:
+    async def test_returns_summaries(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        summaries = await source.list_issues()
+
+        assert len(summaries) == 2
+        assert all(isinstance(s, IssueSummary) for s in summaries)
+        assert summaries[0].id == "1"
+        assert summaries[0].title == "First"
+        assert summaries[0].status == "OPEN"
+        assert summaries[1].id == "2"
+        assert summaries[1].status == "CLOSED"
+
+    async def test_status_filter(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        await source.list_issues(status="open")
+
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert json_body["variables"]["states"] == ["OPEN"]
+
+    async def test_defaults(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        await source.list_issues()
+
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert "states" not in json_body["variables"]
+
+
+class TestUpdateStatus:
+    async def test_closes_issue(self, monkeypatch):
+        get_response = _issue_graphql_response(number=42, node_id="I_node42")
+        close_response = {"data": {"closeIssue": {"issue": {"number": 42, "state": "CLOSED"}}}}
+        call_count = 0
+
+        def _side_effect(*_args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "closeIssue" in query:
+                return _FakeResponse(close_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.update_status("42", "closed")
+
+        assert call_count == 2  # get_issue + closeIssue
+
+    async def test_reopens_issue(self, monkeypatch):
+        get_response = _issue_graphql_response(number=42, node_id="I_node42", state="CLOSED")
+        reopen_response = {"data": {"reopenIssue": {"issue": {"number": 42, "state": "OPEN"}}}}
+
+        def _side_effect(*_args, **kwargs):
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "reopenIssue" in query:
+                return _FakeResponse(reopen_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.update_status("42", "open")
+
+    async def test_unmappable_warns(self, monkeypatch, caplog):
+        get_response = _issue_graphql_response(number=42, node_id="I_node42")
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(get_response))
+        source = _make_source(monkeypatch, client)
+
+        with caplog.at_level(logging.WARNING):
+            await source.update_status("42", "executing")
+
+        assert "granular status" in caplog.text.lower() or "executing" in caplog.text
+
+
+class TestAddComment:
+    async def test_resolves_node_id_and_posts(self, monkeypatch):
+        get_response = _issue_graphql_response(number=42, node_id="I_node42")
+        comment_response = {"data": {"addComment": {"commentEdge": {"node": {"id": "IC_abc"}}}}}
+        call_count = 0
+
+        def _side_effect(*_args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "addComment" in query:
+                return _FakeResponse(comment_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.add_comment("42", "Test comment")
+
+        assert call_count == 2
+        # Verify the comment mutation was called with the correct node_id
+        last_call = client.post.call_args_list[-1]
+        json_body = last_call.kwargs["json"]
+        assert json_body["variables"]["issueId"] == "I_node42"
+        assert json_body["variables"]["body"] == "Test comment"

--- a/uv.lock
+++ b/uv.lock
@@ -1506,6 +1506,9 @@ dependencies = [
 gcp = [
     { name = "google-cloud-compute" },
 ]
+github = [
+    { name = "httpx" },
+]
 hetzner = [
     { name = "hcloud" },
 ]
@@ -1516,12 +1519,13 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "google-cloud-compute", marker = "extra == 'gcp'", specifier = ">=1.20.0,<2" },
     { name = "hcloud", marker = "extra == 'hetzner'", specifier = ">=2.4.0,<3" },
+    { name = "httpx", marker = "extra == 'github'", specifier = ">=0.27,<1" },
     { name = "paramiko", specifier = ">=3.0,<4" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
 ]
-provides-extras = ["gcp", "hetzner"]
+provides-extras = ["gcp", "github", "hetzner"]
 
 [[package]]
 name = "tanren-daemon"
@@ -1543,6 +1547,9 @@ source = { virtual = "." }
 gcp = [
     { name = "tanren-core", extra = ["gcp"] },
 ]
+github = [
+    { name = "tanren-core", extra = ["github"] },
+]
 hetzner = [
     { name = "tanren-core", extra = ["hetzner"] },
 ]
@@ -1558,7 +1565,7 @@ dev = [
     { name = "ruff" },
     { name = "tanren-api" },
     { name = "tanren-cli" },
-    { name = "tanren-core", extra = ["gcp", "hetzner"] },
+    { name = "tanren-core", extra = ["gcp", "github", "hetzner"] },
     { name = "tanren-daemon" },
     { name = "ty" },
 ]
@@ -1566,9 +1573,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "tanren-core", extras = ["gcp"], marker = "extra == 'gcp'", editable = "packages/tanren-core" },
+    { name = "tanren-core", extras = ["github"], marker = "extra == 'github'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["hetzner"], marker = "extra == 'hetzner'", editable = "packages/tanren-core" },
 ]
-provides-extras = ["hetzner", "gcp"]
+provides-extras = ["hetzner", "gcp", "github"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1582,6 +1590,7 @@ dev = [
     { name = "tanren-api", editable = "services/tanren-api" },
     { name = "tanren-cli", editable = "services/tanren-cli" },
     { name = "tanren-core", extras = ["gcp"], editable = "packages/tanren-core" },
+    { name = "tanren-core", extras = ["github"], editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["hetzner"], editable = "packages/tanren-core" },
     { name = "tanren-daemon", editable = "services/tanren-daemon" },
     { name = "ty", specifier = ">=0.0.1a13,<1" },


### PR DESCRIPTION
## Summary
- Add `GitHubIssueSource` implementing `IssueSource` protocol via GitHub GraphQL API
- Add `GitHubIssueSettings` Pydantic model with owner/repo/token config
- Add `issue_source` config section to tanren.yml schema (`type: github` or `type: linear`)
- Add `IssueSourceConfig` and `parse_issue_source()` to environment schema
- Uses `httpx` as optional dependency for GraphQL (no `gh` CLI dependency)
- Supports: get issue, list issues, close/reopen, add comment, blockedBy metadata extraction
- Supports GitHub Enterprise via configurable `api_url`

## Test plan
- [x] Unit tests for GitHubIssueSource (get_issue, list_issues, update_status, add_comment)
- [x] Unit tests for settings parsing, error cases, GitHub Enterprise URL
- [x] Unit tests for IssueSourceConfig in environment schema
- [x] Integration test stub (marked `github`, excluded from CI)
- [x] `make check` passes (format, lint, type, unit 80%+, integration 75%+)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)