### PR TITLE
feat: add Linear issue source adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ unit:
 
 integration:
 	uv run pytest tests/integration -q --tb=short --timeout=30 \
-		-m "not ssh and not local_env and not hetzner and not gcp and not postgres and not github" \
+		-m "not ssh and not local_env and not hetzner and not gcp and not postgres and not github and not linear" \
 		--cov=packages --cov=services --cov-fail-under=75
 
 docs-check:

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 gcp = ["google-cloud-compute>=1.20.0, <2"]
 github = ["httpx>=0.27, <1"]
 hetzner = ["hcloud>=2.4.0, <3"]
+linear = ["httpx>=0.27, <1"]
 
 [build-system]
 requires = ["uv-build>=0.1.0"]

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -45,6 +45,10 @@ try:  # noqa: SIM105, RUF067
 except ImportError:  # httpx not installed
     pass
 try:  # noqa: SIM105, RUF067
+    from tanren_core.adapters.linear_issue import LinearIssueSettings, LinearIssueSource
+except ImportError:  # httpx not installed
+    pass
+try:  # noqa: SIM105, RUF067
     from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 except ImportError:  # hcloud not installed
     pass
@@ -142,6 +146,8 @@ __all__ = [
     "Issue",
     "IssueSource",
     "IssueSummary",
+    "LinearIssueSettings",
+    "LinearIssueSource",
     "LocalExecutionEnvironment",
     "ManualProvisionerSettings",
     "ManualVMConfig",

--- a/packages/tanren-core/src/tanren_core/adapters/linear_issue.py
+++ b/packages/tanren-core/src/tanren_core/adapters/linear_issue.py
@@ -322,9 +322,11 @@ class LinearIssueSource:
         if not isinstance(issue_data, dict):
             raise ValueError(f"Issue {issue_id} not found")
         issue = self._build_issue(_as_dict(issue_data))
-        # Cache team ID from the first successful fetch.
-        if self._team_id is None:
-            self._team_id = issue.metadata.get("team_id", "")
+        # Cache or update team ID based on the fetched issue.
+        team_id = issue.metadata.get("team_id", "")
+        if team_id and team_id != self._team_id:
+            self._team_id = team_id
+            self._state_cache.clear()
         return issue
 
     async def list_issues(
@@ -379,6 +381,8 @@ class LinearIssueSource:
             )
             return
 
+        # Ensure team context is available for state resolution.
+        await self.get_issue(issue_id)
         state_id = await asyncio.to_thread(self._resolve_state_id, target_name)
         if state_id is None:
             logger.warning(

--- a/packages/tanren-core/src/tanren_core/adapters/linear_issue.py
+++ b/packages/tanren-core/src/tanren_core/adapters/linear_issue.py
@@ -1,0 +1,442 @@
+"""Linear issue source adapter using GraphQL API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import types
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, cast
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from tanren_core.adapters.issue_types import Issue, IssueSummary
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+
+
+def _import_httpx() -> types.ModuleType:
+    """Import httpx at runtime.
+
+    Returns:
+        The httpx module.
+
+    Raises:
+        ImportError: If httpx is not installed.
+    """
+    try:
+        import httpx as _httpx  # noqa: PLC0415
+
+        return _httpx
+    except ImportError:
+        raise ImportError(
+            "httpx is required for the Linear issue adapter. "
+            "Install it with: uv sync --extra linear"
+        ) from None
+
+
+class LinearIssueSettings(BaseModel):
+    """Configuration for Linear issue source."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    api_key_env: str = Field(
+        default="LINEAR_API_KEY",
+        description="Environment variable name containing the Linear API key",
+    )
+    team_key: str = Field(
+        ...,
+        description="Linear team key prefix (e.g. 'PROJ' for PROJ-123 identifiers)",
+    )
+    api_url: str = Field(
+        default=_LINEAR_GRAPHQL_URL,
+        description="Linear GraphQL API endpoint",
+    )
+    status_mapping: dict[str, str] = Field(
+        default_factory=lambda: {
+            "draft": "Backlog",
+            "shaped": "Todo",
+            "executing": "In Progress",
+            "validating": "In Review",
+            "review": "In Review",
+            "merged": "Done",
+        },
+        description="Map of tanren lifecycle states to Linear workflow state names",
+    )
+
+    @classmethod
+    def from_settings(cls, settings: Mapping[str, JsonValue]) -> LinearIssueSettings:
+        """Parse from tanren.yml issue_source.settings.
+
+        Returns:
+            Validated LinearIssueSettings.
+        """
+        return cls.model_validate(settings)
+
+
+_GET_ISSUE_QUERY = """
+query($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    description
+    state { id name type }
+    labels(first: 20) { nodes { name } }
+    url
+    team { id key }
+  }
+}
+"""
+
+_LIST_ISSUES_QUERY = """
+query($teamKey: String, $stateName: String) {
+  issues(filter: {
+    team: { key: { eq: $teamKey } }
+    state: { name: { eq: $stateName } }
+  }) {
+    nodes {
+      identifier
+      title
+      state { name }
+      url
+    }
+  }
+}
+"""
+
+_LIST_ISSUES_NO_STATUS_QUERY = """
+query($teamKey: String) {
+  issues(filter: {
+    team: { key: { eq: $teamKey } }
+  }) {
+    nodes {
+      identifier
+      title
+      state { name }
+      url
+    }
+  }
+}
+"""
+
+_GET_TEAM_STATES_QUERY = """
+query($teamId: String!) {
+  team(id: $teamId) {
+    states {
+      nodes {
+        id
+        name
+        type
+      }
+    }
+  }
+}
+"""
+
+_UPDATE_ISSUE_MUTATION = """
+mutation($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue { state { name } }
+  }
+}
+"""
+
+_CREATE_COMMENT_MUTATION = """
+mutation($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+  }
+}
+"""
+
+type _JsonDict = dict[str, object]
+
+
+def _as_dict(val: object) -> _JsonDict:
+    """Cast a JSON value known to be a dict to ``dict[str, object]``.
+
+    Call only after confirming ``isinstance(val, dict)``.
+
+    Returns:
+        The value cast to ``dict[str, object]``.
+    """
+    return cast(_JsonDict, val)
+
+
+class LinearIssueSource:
+    """Fetch and update Linear issues via GraphQL API."""
+
+    def __init__(self, settings: LinearIssueSettings) -> None:
+        """Initialize with Linear issue settings.
+
+        Args:
+            settings: Validated Linear issue settings.
+
+        Raises:
+            ValueError: If the API key environment variable is not set.
+        """
+        api_key = os.environ.get(settings.api_key_env)
+        if not api_key:
+            raise ValueError(
+                f"Missing Linear API key in environment variable: {settings.api_key_env}"
+            )
+        httpx_mod = _import_httpx()
+        self._client: httpx.Client = httpx_mod.Client(
+            headers={"Authorization": api_key, "Content-Type": "application/json"},
+            timeout=30.0,
+        )
+        self._settings = settings
+        self._api_url = settings.api_url
+        self._state_cache: dict[str, str] = {}
+        self._team_id: str | None = None
+
+    def _execute(self, query: str, variables: dict[str, object]) -> dict[str, object]:
+        """Execute a GraphQL query/mutation.
+
+        Args:
+            query: GraphQL query or mutation string.
+            variables: Variables for the query.
+
+        Returns:
+            The ``data`` dict from the GraphQL response.
+
+        Raises:
+            RuntimeError: If the response contains GraphQL errors.
+        """
+        payload: dict[str, object] = {"query": query, "variables": variables}
+        response = self._client.post(self._api_url, json=payload)
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict):
+            raise RuntimeError("Unexpected GraphQL response format")
+        if "errors" in body:
+            errors = body["errors"]
+            raise RuntimeError(f"GraphQL errors: {errors}")
+        data = body.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("Missing 'data' in GraphQL response")
+        return data
+
+    @staticmethod
+    def _build_issue(data: dict[str, object]) -> Issue:
+        """Map a GraphQL issue node to an Issue model.
+
+        Args:
+            data: The issue node from a GraphQL response.
+
+        Returns:
+            An Issue model instance.
+        """
+        linear_id = str(data.get("id", ""))
+        identifier = str(data.get("identifier", ""))
+        title = str(data.get("title", ""))
+        description = str(data.get("description") or "")
+        url = str(data.get("url", ""))
+
+        state_data = data.get("state")
+        status = ""
+        state_type = ""
+        if isinstance(state_data, dict):
+            s = _as_dict(state_data)
+            status = str(s.get("name", ""))
+            state_type = str(s.get("type", ""))
+
+        labels_data = data.get("labels")
+        label_names: list[str] = []
+        if isinstance(labels_data, dict):
+            nodes = _as_dict(labels_data).get("nodes")
+            if isinstance(nodes, list):
+                for node in nodes:
+                    if isinstance(node, dict):
+                        name = _as_dict(node).get("name")
+                        if isinstance(name, str):
+                            label_names.append(name)
+
+        team_data = data.get("team")
+        team_key = ""
+        team_id = ""
+        if isinstance(team_data, dict):
+            t = _as_dict(team_data)
+            team_key = str(t.get("key", ""))
+            team_id = str(t.get("id", ""))
+
+        metadata: dict[str, str] = {
+            "linear_id": linear_id,
+            "team_key": team_key,
+            "team_id": team_id,
+            "state_type": state_type,
+        }
+
+        return Issue(
+            id=identifier,
+            title=title,
+            body=description,
+            status=status,
+            labels=tuple(label_names),
+            url=url,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _build_summary(data: dict[str, object]) -> IssueSummary:
+        """Map a GraphQL issue node to an IssueSummary model.
+
+        Args:
+            data: The issue node from a GraphQL response.
+
+        Returns:
+            An IssueSummary model instance.
+        """
+        identifier = str(data.get("identifier", ""))
+        title = str(data.get("title", ""))
+        url = str(data.get("url", ""))
+        state_data = data.get("state")
+        status = ""
+        if isinstance(state_data, dict):
+            status = str(_as_dict(state_data).get("name", ""))
+        return IssueSummary(id=identifier, title=title, status=status, url=url)
+
+    async def get_issue(self, issue_id: str) -> Issue:
+        """Fetch full issue detail by ID.
+
+        Args:
+            issue_id: Linear issue identifier (e.g. ``"PROJ-123"``).
+
+        Returns:
+            The Issue model for the requested issue.
+
+        Raises:
+            ValueError: If the issue is not found.
+        """
+        variables: dict[str, object] = {"id": issue_id}
+        data = await asyncio.to_thread(self._execute, _GET_ISSUE_QUERY, variables)
+        issue_data = data.get("issue")
+        if not isinstance(issue_data, dict):
+            raise ValueError(f"Issue {issue_id} not found")
+        issue = self._build_issue(_as_dict(issue_data))
+        # Cache team ID from the first successful fetch.
+        if self._team_id is None:
+            self._team_id = issue.metadata.get("team_id", "")
+        return issue
+
+    async def list_issues(
+        self, *, project: str | None = None, status: str | None = None
+    ) -> list[IssueSummary]:
+        """List issues, optionally filtered by status.
+
+        Args:
+            project: Override team key filter. Defaults to ``settings.team_key``.
+            status: Filter by Linear workflow state name. None returns all.
+
+        Returns:
+            List of IssueSummary instances.
+        """
+        team_key = project if project is not None else self._settings.team_key
+        if status is not None:
+            variables: dict[str, object] = {"teamKey": team_key, "stateName": status}
+            data = await asyncio.to_thread(self._execute, _LIST_ISSUES_QUERY, variables)
+        else:
+            variables = {"teamKey": team_key}
+            data = await asyncio.to_thread(self._execute, _LIST_ISSUES_NO_STATUS_QUERY, variables)
+        issues_data = data.get("issues")
+        if not isinstance(issues_data, dict):
+            return []
+        nodes = _as_dict(issues_data).get("nodes")
+        if not isinstance(nodes, list):
+            return []
+        summaries: list[IssueSummary] = []
+        for node in nodes:
+            if isinstance(node, dict):
+                summaries.append(self._build_summary(_as_dict(node)))
+        return summaries
+
+    async def update_status(self, issue_id: str, status: str) -> None:
+        """Transition an issue to a new status.
+
+        Maps tanren lifecycle status to a Linear workflow state name via
+        ``settings.status_mapping``, then resolves the state name to a UUID
+        for the ``issueUpdate`` mutation.
+
+        Args:
+            issue_id: Linear issue identifier (e.g. ``"PROJ-123"``).
+            status: Tanren lifecycle status string.
+        """
+        normalized = status.strip().lower()
+        target_name = self._settings.status_mapping.get(normalized)
+        if target_name is None:
+            logger.warning(
+                "No Linear status mapping for tanren status %r; skipping update for %s",
+                status,
+                issue_id,
+            )
+            return
+
+        state_id = await asyncio.to_thread(self._resolve_state_id, target_name)
+        if state_id is None:
+            logger.warning(
+                "Linear workflow state %r not found for team; skipping update for %s",
+                target_name,
+                issue_id,
+            )
+            return
+
+        variables: dict[str, object] = {"id": issue_id, "stateId": state_id}
+        await asyncio.to_thread(self._execute, _UPDATE_ISSUE_MUTATION, variables)
+
+    async def add_comment(self, issue_id: str, body: str) -> None:
+        """Append a comment to an issue.
+
+        Resolves the internal UUID via ``get_issue`` because Linear's
+        ``commentCreate`` mutation requires the UUID, not the identifier.
+
+        Args:
+            issue_id: Linear issue identifier (e.g. ``"PROJ-123"``).
+            body: Comment body text.
+        """
+        issue = await self.get_issue(issue_id)
+        linear_id = issue.metadata.get("linear_id", "")
+        variables: dict[str, object] = {"issueId": linear_id, "body": body}
+        await asyncio.to_thread(self._execute, _CREATE_COMMENT_MUTATION, variables)
+
+    def _resolve_state_id(self, state_name: str) -> str | None:
+        """Resolve a workflow state name to its UUID.
+
+        Fetches and caches team workflow states on first call.
+
+        Args:
+            state_name: Linear workflow state name (e.g. ``"In Progress"``).
+
+        Returns:
+            The state UUID, or None if not found.
+        """
+        if not self._state_cache:
+            if not self._team_id:
+                logger.warning(
+                    "Cannot resolve state %r: team ID not yet known (call get_issue first)",
+                    state_name,
+                )
+                return None
+            variables: dict[str, object] = {"teamId": self._team_id}
+            data = self._execute(_GET_TEAM_STATES_QUERY, variables)
+            team_data = data.get("team")
+            if isinstance(team_data, dict):
+                states_data = _as_dict(team_data).get("states")
+                if isinstance(states_data, dict):
+                    nodes = _as_dict(states_data).get("nodes")
+                    if isinstance(nodes, list):
+                        for node in nodes:
+                            if isinstance(node, dict):
+                                n = _as_dict(node)
+                                name = n.get("name")
+                                sid = n.get("id")
+                                if isinstance(name, str) and isinstance(sid, str):
+                                    self._state_cache[name.lower()] = sid
+        return self._state_cache.get(state_name.lower())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.14"
 hetzner = ["tanren-core[hetzner]"]
 gcp = ["tanren-core[gcp]"]
 github = ["tanren-core[github]"]
+linear = ["tanren-core[linear]"]
 
 [tool.uv]
 managed = true
@@ -78,12 +79,13 @@ markers = [
     "gcp: requires GCP credentials and provisions real VMs",
     "postgres: requires a real Postgres database",
     "github: requires GitHub token and accesses real GitHub API",
+    "linear: requires Linear API token and accesses real Linear API",
 ]
 
 # ===== COVERAGE =====
 [tool.coverage.run]
 source = ["packages", "services"]
-omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py", "*/adapters/github_issue.py"]
+omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py", "*/adapters/github_issue.py", "*/adapters/linear_issue.py"]
 
 [tool.coverage.report]
 fail_under = 80
@@ -102,6 +104,7 @@ dev = [
     "tanren-core[gcp]",
     "tanren-core[github]",
     "tanren-core[hetzner]",
+    "tanren-core[linear]",
     "tanren-cli",
     "tanren-api",
     "tanren-daemon",

--- a/tests/integration/test_linear_integration.py
+++ b/tests/integration/test_linear_integration.py
@@ -30,10 +30,6 @@ def source():
 
 
 class TestLinearIssueSourceIntegration:
-    async def test_get_issue(self, source):
-        """Fetch a real Linear issue."""
-        ...
-
     async def test_list_issues(self, source):
         """List issues from a real Linear team."""
         summaries = await source.list_issues()

--- a/tests/integration/test_linear_integration.py
+++ b/tests/integration/test_linear_integration.py
@@ -1,0 +1,40 @@
+"""Integration tests for Linear issue source -- requires real token.
+
+Run with:
+    uv run pytest tests/integration/test_linear_integration.py -v --timeout=60
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tanren_core.adapters.linear_issue import LinearIssueSettings, LinearIssueSource
+
+pytestmark = pytest.mark.linear
+
+
+@pytest.fixture()
+def source():
+    """Create a LinearIssueSource using real Linear credentials."""
+    if not os.environ.get("LINEAR_API_KEY"):
+        raise pytest.skip.Exception("LINEAR_API_KEY not set")
+
+    team_key = os.environ.get("LINEAR_TEAM_KEY", "")
+    if not team_key:
+        raise pytest.skip.Exception("LINEAR_TEAM_KEY not set")
+
+    settings = LinearIssueSettings(team_key=team_key)
+    return LinearIssueSource(settings)
+
+
+class TestLinearIssueSourceIntegration:
+    async def test_get_issue(self, source):
+        """Fetch a real Linear issue."""
+        ...
+
+    async def test_list_issues(self, source):
+        """List issues from a real Linear team."""
+        summaries = await source.list_issues()
+        assert isinstance(summaries, list)

--- a/tests/unit/test_linear_issue.py
+++ b/tests/unit/test_linear_issue.py
@@ -1,0 +1,413 @@
+"""Tests for Linear issue source adapter."""
+
+from __future__ import annotations
+
+import logging
+import types
+from unittest.mock import Mock
+
+import pytest
+
+from tanren_core.adapters.issue_types import Issue, IssueSummary
+from tanren_core.adapters.linear_issue import LinearIssueSettings, LinearIssueSource
+
+
+class _FakeResponse:
+    def __init__(self, data, status_code=200):
+        self.status_code = status_code
+        self._json = data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _settings(**overrides: object) -> LinearIssueSettings:
+    defaults: dict[str, object] = {"team_key": "PROJ"}
+    defaults.update(overrides)
+    return LinearIssueSettings.model_validate(defaults)
+
+
+def _make_source(monkeypatch, mock_client, **settings_kw):
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_test_key")
+    httpx_mod = types.SimpleNamespace(Client=Mock(return_value=mock_client))
+    monkeypatch.setattr(
+        "tanren_core.adapters.linear_issue._import_httpx",
+        lambda: httpx_mod,
+    )
+    return LinearIssueSource(_settings(**settings_kw))
+
+
+def _issue_graphql_response(
+    *,
+    linear_id="uuid-abc-123",
+    identifier="PROJ-42",
+    title="Test issue",
+    description="Issue body",
+    state_name="In Progress",
+    state_type="started",
+    state_id="state-uuid-1",
+    labels=None,
+    url="https://linear.app/proj/issue/PROJ-42",
+    team_id="team-uuid",
+    team_key="PROJ",
+):
+    return {
+        "data": {
+            "issue": {
+                "id": linear_id,
+                "identifier": identifier,
+                "title": title,
+                "description": description,
+                "state": {"id": state_id, "name": state_name, "type": state_type},
+                "labels": {"nodes": [{"name": n} for n in (labels or [])]},
+                "url": url,
+                "team": {"id": team_id, "key": team_key},
+            }
+        }
+    }
+
+
+def _list_issues_graphql_response(issues=None):
+    if issues is None:
+        issues = [
+            {
+                "identifier": "PROJ-1",
+                "title": "First",
+                "state": {"name": "Todo"},
+                "url": "https://linear.app/proj/issue/PROJ-1",
+            },
+            {
+                "identifier": "PROJ-2",
+                "title": "Second",
+                "state": {"name": "Done"},
+                "url": "https://linear.app/proj/issue/PROJ-2",
+            },
+        ]
+    return {"data": {"issues": {"nodes": issues}}}
+
+
+def _team_states_response(states=None):
+    if states is None:
+        states = [
+            {"id": "state-backlog", "name": "Backlog", "type": "backlog"},
+            {"id": "state-todo", "name": "Todo", "type": "unstarted"},
+            {"id": "state-inprog", "name": "In Progress", "type": "started"},
+            {"id": "state-done", "name": "Done", "type": "completed"},
+            {"id": "state-cancelled", "name": "Cancelled", "type": "cancelled"},
+        ]
+    return {"data": {"team": {"states": {"nodes": states}}}}
+
+
+class TestLinearIssueSettings:
+    def test_from_settings(self):
+        raw = {"team_key": "ENG", "api_key_env": "MY_LINEAR_KEY"}
+        settings = LinearIssueSettings.from_settings(raw)
+        assert settings.team_key == "ENG"
+        assert settings.api_key_env == "MY_LINEAR_KEY"
+
+    def test_defaults(self):
+        settings = _settings()
+        assert settings.api_key_env == "LINEAR_API_KEY"
+        assert settings.api_url == "https://api.linear.app/graphql"
+        assert "executing" in settings.status_mapping
+        assert settings.status_mapping["executing"] == "In Progress"
+
+    def test_custom_status_mapping(self):
+        mapping = {"todo": "Backlog", "done": "Complete"}
+        settings = _settings(status_mapping=mapping)
+        assert settings.status_mapping == mapping
+
+    def test_custom_api_url(self):
+        settings = _settings(api_url="https://linear.corp.com/graphql")
+        assert settings.api_url == "https://linear.corp.com/graphql"
+
+
+class TestLinearIssueSourceInit:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+        httpx_mod = types.SimpleNamespace(Client=Mock())
+        monkeypatch.setattr(
+            "tanren_core.adapters.linear_issue._import_httpx",
+            lambda: httpx_mod,
+        )
+        with pytest.raises(ValueError, match="Missing Linear API key"):
+            LinearIssueSource(_settings())
+
+    def test_missing_httpx_raises(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_API_KEY", "lin_test")
+
+        def _raise():
+            raise ImportError(
+                "httpx is required for the Linear issue adapter. "
+                "Install it with: uv sync --extra linear"
+            )
+
+        monkeypatch.setattr(
+            "tanren_core.adapters.linear_issue._import_httpx",
+            _raise,
+        )
+        with pytest.raises(ImportError, match="uv sync --extra linear"):
+            LinearIssueSource(_settings())
+
+
+class TestGetIssue:
+    async def test_returns_issue_model(self, monkeypatch):
+        response_data = _issue_graphql_response(
+            linear_id="uuid-abc-123",
+            identifier="PROJ-42",
+            title="Test issue",
+            description="Issue body",
+            state_name="In Progress",
+            state_type="started",
+            labels=["bug", "priority"],
+            team_id="team-uuid",
+            team_key="PROJ",
+        )
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        issue = await source.get_issue("PROJ-42")
+
+        assert isinstance(issue, Issue)
+        assert issue.id == "PROJ-42"
+        assert issue.title == "Test issue"
+        assert issue.body == "Issue body"
+        assert issue.status == "In Progress"
+        assert issue.labels == ("bug", "priority")
+        assert issue.url == "https://linear.app/proj/issue/PROJ-42"
+        assert issue.metadata["linear_id"] == "uuid-abc-123"
+        assert issue.metadata["team_key"] == "PROJ"
+        assert issue.metadata["team_id"] == "team-uuid"
+        assert issue.metadata["state_type"] == "started"
+
+    async def test_not_found_raises(self, monkeypatch):
+        response_data = {"data": {"issue": None}}
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        with pytest.raises(ValueError, match="not found"):
+            await source.get_issue("PROJ-999")
+
+    async def test_caches_team_id(self, monkeypatch):
+        response_data = _issue_graphql_response(team_id="team-uuid-42")
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        assert source._team_id is None
+        await source.get_issue("PROJ-42")
+        assert source._team_id == "team-uuid-42"
+
+
+class TestListIssues:
+    async def test_returns_summaries(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        summaries = await source.list_issues()
+
+        assert len(summaries) == 2
+        assert all(isinstance(s, IssueSummary) for s in summaries)
+        assert summaries[0].id == "PROJ-1"
+        assert summaries[0].title == "First"
+        assert summaries[0].status == "Todo"
+        assert summaries[1].id == "PROJ-2"
+        assert summaries[1].status == "Done"
+
+    async def test_team_key_filter(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        await source.list_issues()
+
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert json_body["variables"]["teamKey"] == "PROJ"
+
+    async def test_status_filter(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        await source.list_issues(status="In Progress")
+
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert json_body["variables"]["stateName"] == "In Progress"
+
+    async def test_project_overrides_team_key(self, monkeypatch):
+        response_data = _list_issues_graphql_response()
+        client = Mock()
+        client.post = Mock(return_value=_FakeResponse(response_data))
+        source = _make_source(monkeypatch, client)
+
+        await source.list_issues(project="OTHER")
+
+        call_kwargs = client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert json_body["variables"]["teamKey"] == "OTHER"
+
+
+class TestUpdateStatus:
+    async def test_maps_tanren_status_to_linear_state(self, monkeypatch):
+        get_response = _issue_graphql_response(team_id="team-uuid")
+        states_response = _team_states_response()
+        update_response = {
+            "data": {"issueUpdate": {"success": True, "issue": {"state": {"name": "In Progress"}}}}
+        }
+
+        def _side_effect(*_args, **kwargs):
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "issueUpdate" in query:
+                return _FakeResponse(update_response)
+            if "states" in query:
+                return _FakeResponse(states_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        # Populate _team_id first.
+        await source.get_issue("PROJ-42")
+        await source.update_status("PROJ-42", "executing")
+
+        # Verify the update mutation was called with the correct state UUID.
+        last_call = client.post.call_args_list[-1]
+        json_body = last_call.kwargs["json"]
+        assert json_body["variables"]["stateId"] == "state-inprog"
+        assert json_body["variables"]["id"] == "PROJ-42"
+
+    async def test_caches_workflow_states(self, monkeypatch):
+        get_response = _issue_graphql_response(team_id="team-uuid")
+        states_response = _team_states_response()
+        update_response = {
+            "data": {"issueUpdate": {"success": True, "issue": {"state": {"name": "Done"}}}}
+        }
+
+        states_call_count = 0
+
+        def _side_effect(*_args, **kwargs):
+            nonlocal states_call_count
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "issueUpdate" in query:
+                return _FakeResponse(update_response)
+            if "states" in query:
+                states_call_count += 1
+                return _FakeResponse(states_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.get_issue("PROJ-42")
+        await source.update_status("PROJ-42", "executing")
+        await source.update_status("PROJ-42", "merged")
+
+        # Team states should be fetched only once.
+        assert states_call_count == 1
+
+    async def test_unmapped_status_warns(self, monkeypatch, caplog):
+        client = Mock()
+        source = _make_source(monkeypatch, client)
+
+        with caplog.at_level(logging.WARNING):
+            await source.update_status("PROJ-42", "unknown_status")
+
+        assert "no linear status mapping" in caplog.text.lower() or "unknown_status" in caplog.text
+        # No GraphQL calls should have been made.
+        client.post.assert_not_called()
+
+    async def test_state_name_not_found_warns(self, monkeypatch, caplog):
+        get_response = _issue_graphql_response(team_id="team-uuid")
+        states_response = _team_states_response(
+            states=[
+                {"id": "state-only", "name": "OnlyState", "type": "started"},
+            ]
+        )
+
+        def _side_effect(*_args, **kwargs):
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "states" in query:
+                return _FakeResponse(states_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(
+            monkeypatch,
+            client,
+            status_mapping={"executing": "Nonexistent State"},
+        )
+
+        await source.get_issue("PROJ-42")
+
+        with caplog.at_level(logging.WARNING):
+            await source.update_status("PROJ-42", "executing")
+
+        assert "not found" in caplog.text.lower() or "Nonexistent State" in caplog.text
+
+
+class TestAddComment:
+    async def test_resolves_uuid_and_posts(self, monkeypatch):
+        get_response = _issue_graphql_response(linear_id="uuid-abc-123")
+        comment_response = {"data": {"commentCreate": {"success": True}}}
+        call_count = 0
+
+        def _side_effect(*_args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "commentCreate" in query:
+                return _FakeResponse(comment_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.add_comment("PROJ-42", "Test comment")
+
+        assert call_count == 2  # get_issue + commentCreate
+
+    async def test_comment_uses_linear_id_not_identifier(self, monkeypatch):
+        get_response = _issue_graphql_response(
+            linear_id="uuid-internal-42",
+            identifier="PROJ-42",
+        )
+        comment_response = {"data": {"commentCreate": {"success": True}}}
+
+        def _side_effect(*_args, **kwargs):
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "commentCreate" in query:
+                return _FakeResponse(comment_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        await source.add_comment("PROJ-42", "Test comment")
+
+        # Verify the comment mutation used the UUID, not the identifier.
+        last_call = client.post.call_args_list[-1]
+        json_body = last_call.kwargs["json"]
+        assert json_body["variables"]["issueId"] == "uuid-internal-42"
+        assert json_body["variables"]["body"] == "Test comment"

--- a/tests/unit/test_linear_issue.py
+++ b/tests/unit/test_linear_issue.py
@@ -280,8 +280,6 @@ class TestUpdateStatus:
         client.post = Mock(side_effect=_side_effect)
         source = _make_source(monkeypatch, client)
 
-        # Populate _team_id first.
-        await source.get_issue("PROJ-42")
         await source.update_status("PROJ-42", "executing")
 
         # Verify the update mutation was called with the correct state UUID.
@@ -289,6 +287,36 @@ class TestUpdateStatus:
         json_body = last_call.kwargs["json"]
         assert json_body["variables"]["stateId"] == "state-inprog"
         assert json_body["variables"]["id"] == "PROJ-42"
+
+    async def test_works_without_prior_get_issue(self, monkeypatch):
+        """update_status resolves team context automatically."""
+        get_response = _issue_graphql_response(team_id="team-uuid")
+        states_response = _team_states_response()
+        update_response = {
+            "data": {"issueUpdate": {"success": True, "issue": {"state": {"name": "Done"}}}}
+        }
+
+        def _side_effect(*_args, **kwargs):
+            json_body = kwargs.get("json", {})
+            query = json_body.get("query", "")
+            if "issueUpdate" in query:
+                return _FakeResponse(update_response)
+            if "states" in query:
+                return _FakeResponse(states_response)
+            return _FakeResponse(get_response)
+
+        client = Mock()
+        client.post = Mock(side_effect=_side_effect)
+        source = _make_source(monkeypatch, client)
+
+        assert source._team_id is None
+        await source.update_status("PROJ-42", "merged")
+
+        # team_id should now be populated from the internal get_issue call.
+        assert source._team_id == "team-uuid"
+        last_call = client.post.call_args_list[-1]
+        json_body = last_call.kwargs["json"]
+        assert json_body["variables"]["stateId"] == "state-done"
 
     async def test_caches_workflow_states(self, monkeypatch):
         get_response = _issue_graphql_response(team_id="team-uuid")
@@ -314,7 +342,6 @@ class TestUpdateStatus:
         client.post = Mock(side_effect=_side_effect)
         source = _make_source(monkeypatch, client)
 
-        await source.get_issue("PROJ-42")
         await source.update_status("PROJ-42", "executing")
         await source.update_status("PROJ-42", "merged")
 
@@ -354,8 +381,6 @@ class TestUpdateStatus:
             client,
             status_mapping={"executing": "Nonexistent State"},
         )
-
-        await source.get_issue("PROJ-42")
 
         with caplog.at_level(logging.WARNING):
             await source.update_status("PROJ-42", "executing")

--- a/uv.lock
+++ b/uv.lock
@@ -1512,6 +1512,9 @@ github = [
 hetzner = [
     { name = "hcloud" },
 ]
+linear = [
+    { name = "httpx" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1520,12 +1523,13 @@ requires-dist = [
     { name = "google-cloud-compute", marker = "extra == 'gcp'", specifier = ">=1.20.0,<2" },
     { name = "hcloud", marker = "extra == 'hetzner'", specifier = ">=2.4.0,<3" },
     { name = "httpx", marker = "extra == 'github'", specifier = ">=0.27,<1" },
+    { name = "httpx", marker = "extra == 'linear'", specifier = ">=0.27,<1" },
     { name = "paramiko", specifier = ">=3.0,<4" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
 ]
-provides-extras = ["gcp", "github", "hetzner"]
+provides-extras = ["gcp", "github", "hetzner", "linear"]
 
 [[package]]
 name = "tanren-daemon"
@@ -1553,6 +1557,9 @@ github = [
 hetzner = [
     { name = "tanren-core", extra = ["hetzner"] },
 ]
+linear = [
+    { name = "tanren-core", extra = ["linear"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1565,7 +1572,7 @@ dev = [
     { name = "ruff" },
     { name = "tanren-api" },
     { name = "tanren-cli" },
-    { name = "tanren-core", extra = ["gcp", "github", "hetzner"] },
+    { name = "tanren-core", extra = ["gcp", "github", "hetzner", "linear"] },
     { name = "tanren-daemon" },
     { name = "ty" },
 ]
@@ -1575,8 +1582,9 @@ requires-dist = [
     { name = "tanren-core", extras = ["gcp"], marker = "extra == 'gcp'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["github"], marker = "extra == 'github'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["hetzner"], marker = "extra == 'hetzner'", editable = "packages/tanren-core" },
+    { name = "tanren-core", extras = ["linear"], marker = "extra == 'linear'", editable = "packages/tanren-core" },
 ]
-provides-extras = ["hetzner", "gcp", "github"]
+provides-extras = ["hetzner", "gcp", "github", "linear"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1592,6 +1600,7 @@ dev = [
     { name = "tanren-core", extras = ["gcp"], editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["github"], editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["hetzner"], editable = "packages/tanren-core" },
+    { name = "tanren-core", extras = ["linear"], editable = "packages/tanren-core" },
     { name = "tanren-daemon", editable = "services/tanren-daemon" },
     { name = "ty", specifier = ">=0.0.1a13,<1" },
 ]


### PR DESCRIPTION
## Summary
- Add `LinearIssueSource` implementing `IssueSource` protocol via Linear GraphQL API
- Add `LinearIssueSettings` with configurable status mapping (tanren lifecycle → Linear workflow states)
- Workflow state resolution with caching (state name → UUID lookup via team states query)
- Uses `httpx` as optional dependency (same as GitHub adapter)
- `commentCreate` resolves identifier → UUID automatically (Linear requirement)

## Test plan
- [x] Unit tests for LinearIssueSource (get_issue, list_issues, update_status, add_comment)
- [x] Unit tests for settings parsing, status mapping, caching, error cases
- [x] Integration test stub (marked `linear`, excluded from CI)
- [x] `make check` passes (format, lint, type, unit 80%+, integration 75%+)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)