### PR TITLE
refactor: make all commands agent-agnostic

### DIFF
--- a/commands/audit-spec.md
+++ b/commands/audit-spec.md
@@ -2,7 +2,7 @@
 
 Bird's-eye audit of the full implementation after all tasks and demo pass. Score rubrics, check non-negotiables, verify standards adherence, detect regressions. Fully autonomous — no user interaction.
 
-**Suggested model:** Strong reasoner, different from do-task (e.g., Codex high reasoning via headless CLI). Deep review — quality matters more than speed.
+**Suggested model:** Strong reasoner, different from do-task. Autonomous — no user interaction. Deep review — quality matters more than speed.
 
 ## Important Guidelines
 

--- a/commands/audit-task.md
+++ b/commands/audit-task.md
@@ -2,7 +2,7 @@
 
 Audit the most recently completed task. Lightweight, focused, fast. Fully autonomous — no user interaction.
 
-**Suggested model:** Different model from do-task for independence (e.g., Codex medium reasoning via headless CLI).
+**Suggested model:** Different model from do-task for independence. Autonomous — no user interaction.
 
 ## Important Guidelines
 
@@ -99,7 +99,7 @@ Write your findings to `audit-findings.json` in the spec folder:
 Severity levels:
 - `fix`: Must be fixed — becomes a new task for do-task
 - `note`: Informational only — logged but not actionable
-- `question`: Needs human input — will be escalated to the messaging platform
+- `question`: Needs human input — will be escalated to the user
 
 If the task passes, write `{"signal": "pass", "findings": []}`.
 

--- a/commands/discover-standards.md
+++ b/commands/discover-standards.md
@@ -4,7 +4,7 @@ Extract tribal knowledge from your codebase into concise, documented standards.
 
 ## Important Guidelines
 
-- **Always use AskUserQuestion tool** when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - **Write concise standards** — Use minimal words. Standards must be scannable by AI agents without bloating context windows.
 - **Offer suggestions** — Present options the user can confirm, choose between, or correct. Don't make them think harder than necessary.
 
@@ -21,7 +21,7 @@ If no area was specified:
    - **Frontend areas:** UI components, styling/CSS, state management, forms, routing
    - **Backend areas:** API routes, database/models, authentication, background jobs
    - **Cross-cutting:** Error handling, validation, testing, naming conventions, file structure
-3. Use AskUserQuestion to present the areas:
+3. Present the areas to the user:
 
 ```
 I've identified these areas in your codebase:
@@ -47,7 +47,7 @@ Once an area is determined:
    - **Tribal** — Things a new developer wouldn't know without being told
    - **Consistent** — Patterns repeated across multiple files
 
-3. Use AskUserQuestion to present findings and let user select:
+3. Present findings to the user and let them select:
 
 ```
 I analyzed [area] and found these potential standards worth documenting:
@@ -71,7 +71,7 @@ Wait for user selection before proceeding.
 
 **IMPORTANT:** For each selected standard, you MUST complete this full loop before moving to the next standard:
 
-1. **Ask 1-2 clarifying questions** about the "why" behind the pattern. Use your AskUserQuestion tool for this.
+1. **Ask 1-2 clarifying questions** about the "why" behind the pattern.
 2. **Wait for user response**
 3. **Draft the standard** incorporating their answer
 4. **Confirm with user** before creating the file
@@ -94,7 +94,7 @@ For each standard (after completing Step 3's Q&A):
 
 2. Check if a related standard file already exists — append to it if so
 
-3. Draft the content and use AskUserQuestion to confirm:
+3. Draft the content and ask the user to confirm:
 
 ```
 Here's the draft for api/response-format.md:
@@ -125,7 +125,7 @@ Create this file? (yes / edit: [your changes] / skip)
 After all standards are created:
 
 1. Scan `tanren/standards/` for all `.md` files
-2. For each new file without an index entry, use AskUserQuestion:
+2. For each new file without an index entry, ask the user:
 
 ```
 New standard needs an index entry:
@@ -148,7 +148,7 @@ Alphabetize by folder, then by filename.
 
 ### Step 6: Offer to Continue
 
-Use AskUserQuestion:
+Ask the user:
 
 ```
 Standards created for [area]:

--- a/commands/do-task.md
+++ b/commands/do-task.md
@@ -2,7 +2,7 @@
 
 Pick up the next unchecked task from the plan, implement it, verify it, and commit it. One task per invocation. Fully autonomous — no user interaction.
 
-**Suggested model:** Fast, capable implementer (e.g., Sonnet via headless CLI). Cost-efficiency matters — this runs many times.
+**Suggested model:** Fast, capable implementer. Autonomous — no user interaction. Cost-efficiency matters — this runs many times.
 
 ## Important Guidelines
 

--- a/commands/handle-feedback.md
+++ b/commands/handle-feedback.md
@@ -2,12 +2,12 @@
 
 Pull PR review comments and automated analysis feedback, evaluate their correctness, and route valid feedback into the spec workflow as tasks. Interactive — the user validates the triage before any actions are taken.
 
-**Suggested model:** Strong reasoner with good judgment (e.g., Opus via TUI). Evaluating whether a reviewer is correct requires deep technical reasoning and the user must approve the triage.
+**Suggested model:** Strong reasoner with good judgment. Interactive — requires user dialogue. Evaluating whether a reviewer is correct requires deep technical reasoning and the user must approve the triage.
 
 ## Important Guidelines
 
 - Human-in-the-loop — the user approves the triage before any changes or replies are posted
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - Never blindly accept feedback — verify every claim against the actual code
 - Never blindly reject feedback — incorrect dismissals erode reviewer trust
 - Never modify spec.md
@@ -171,7 +171,7 @@ N. **[CI: {make_target}] {test_name or rule}** at `{file:line}`
 - [list of duplicates referencing which item they duplicate]
 ```
 
-Use AskUserQuestion to let the user:
+Ask the user to:
 - Override any classification (e.g., promote "invalid" to "valid-actionable" if they disagree)
 - Edit draft replies before posting
 - Choose which actions to take

--- a/commands/index-standards.md
+++ b/commands/index-standards.md
@@ -39,7 +39,7 @@ Compare the file scan with the existing index:
 For each new standard file that needs an index entry:
 
 1. Read the file to understand its content
-2. Use AskUserQuestion to propose a description:
+2. Propose a description to the user:
 
 ```
 New standard needs indexing:

--- a/commands/inject-standards.md
+++ b/commands/inject-standards.md
@@ -42,7 +42,7 @@ Before injecting standards, determine which scenario we're in. Read the current 
 - If conversation clearly mentions creating a skill, editing `.claude/skills/`, or building a reusable procedure → **Creating a Skill**
 - Otherwise → **Ask to confirm** (do not assume)
 
-**If neither skill nor plan is clearly detected**, use AskUserQuestion to confirm:
+**If neither skill nor plan is clearly detected**, ask the user to confirm:
 
 ```
 I'll inject the relevant standards. How should I format them?
@@ -75,7 +75,7 @@ Look at the current conversation to understand what the user is working on:
 
 ### Step 4: Match and Suggest
 
-Match index descriptions against the context. Use AskUserQuestion to present suggestions:
+Match index descriptions against the context. Present suggestions to the user:
 
 ```
 Based on your task, these standards may be relevant:
@@ -123,7 +123,7 @@ I've read the following standards as they are relevant to what we're working on:
 
 #### Scenario: Creating a Skill
 
-First, use AskUserQuestion to determine how to include the standards:
+First, ask the user how to include the standards:
 
 ```
 How should these standards be included in your skill?
@@ -176,7 +176,7 @@ These standards cover:
 
 #### Scenario: Shaping/Planning
 
-First, use AskUserQuestion to determine how to include the standards:
+First, ask the user how to include the standards:
 
 ```
 How should these standards be included in your plan?

--- a/commands/investigate.md
+++ b/commands/investigate.md
@@ -2,7 +2,7 @@
 
 Read-only root cause analysis for persistent failures. Diagnose the problem — do NOT fix it. Fully autonomous — no user interaction.
 
-**Suggested model:** Capable reasoner for diagnosis (e.g., Codex medium reasoning via headless CLI).
+**Suggested model:** Capable reasoner for diagnosis. Autonomous — no user interaction.
 
 ## Important Guidelines
 

--- a/commands/plan-product.md
+++ b/commands/plan-product.md
@@ -4,7 +4,7 @@ Establish foundational product documentation through an interactive conversation
 
 ## Important Guidelines
 
-- **Always use AskUserQuestion tool** when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - **Keep it lightweight** — gather enough to create useful docs without over-documenting
 - **One question at a time** — don't overwhelm with multiple questions
 
@@ -17,7 +17,7 @@ Check if `tanren/product/` exists and contains any of these files:
 - `roadmap.md`
 - `tech-stack.md`
 
-**If any files exist**, use AskUserQuestion:
+**If any files exist**, ask the user:
 
 ```
 I found existing product documentation:
@@ -40,7 +40,7 @@ If option 3, stop here.
 
 ### Step 2: Gather Product Vision (for mission.md)
 
-Use AskUserQuestion:
+Ask the user:
 
 ```
 Let's define your product's mission.
@@ -50,7 +50,7 @@ Let's define your product's mission.
 (Describe the core problem or pain point you're addressing)
 ```
 
-After they respond, use AskUserQuestion:
+After they respond, ask the user:
 
 ```
 **Who is this product for?**
@@ -58,7 +58,7 @@ After they respond, use AskUserQuestion:
 (Describe your target users or audience)
 ```
 
-After they respond, use AskUserQuestion:
+After they respond, ask the user:
 
 ```
 **What makes your solution unique?**
@@ -68,7 +68,7 @@ After they respond, use AskUserQuestion:
 
 ### Step 3: Gather Roadmap (for roadmap.md)
 
-Use AskUserQuestion:
+Ask the user:
 
 ```
 Now let's outline your development roadmap.
@@ -78,7 +78,7 @@ Now let's outline your development roadmap.
 (List the core features needed for the first usable version)
 ```
 
-After they respond, use AskUserQuestion:
+After they respond, ask the user:
 
 ```
 **What features are planned for after launch?**
@@ -90,7 +90,7 @@ After they respond, use AskUserQuestion:
 
 First, check if `tanren/standards/global/tech-stack.md` exists.
 
-**If the tech-stack standard exists**, read it and use AskUserQuestion:
+**If the tech-stack standard exists**, read it and ask the user:
 
 ```
 I found a tech stack standard in your standards:
@@ -108,7 +108,7 @@ Does this project use the same tech stack, or does it differ?
 If they choose option 1, use the standard's content for tech-stack.md.
 If they choose option 2, proceed to ask them to specify (see below).
 
-**If no tech-stack standard exists** (or they chose option 2 above), use AskUserQuestion:
+**If no tech-stack standard exists** (or they chose option 2 above), ask the user:
 
 ```
 **What technologies does this project use?**

--- a/commands/plan-product.md
+++ b/commands/plan-product.md
@@ -4,7 +4,7 @@ Establish foundational product documentation through an interactive conversation
 
 ## Important Guidelines
 
-- When asking the user a question, present numbered options and wait for their response before proceeding.
+- When asking the user to choose between alternatives, present numbered options and wait for their response before proceeding.
 - **Keep it lightweight** — gather enough to create useful docs without over-documenting
 - **One question at a time** — don't overwhelm with multiple questions
 

--- a/commands/resolve-blockers.md
+++ b/commands/resolve-blockers.md
@@ -2,12 +2,12 @@
 
 Investigate blockers that halted the orchestrator, propose solutions, and reconcile the spec artifacts after the user chooses a path forward. Interactive — the user makes decisions, the agent investigates and executes.
 
-**Suggested model:** Strong reasoner with good interactive skills (e.g., Opus via TUI). Needs to understand architectural constraints and present options clearly.
+**Suggested model:** Strong reasoner with good interactive skills. Interactive — requires user dialogue. Needs to understand architectural constraints and present options clearly.
 
 ## Important Guidelines
 
 - Human-in-the-loop — investigate and present options, but the user decides
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - Never modify spec.md without explicit user approval (and even then, present the exact diff first)
 - Signposts must include evidence — verify every claim before trusting it
 - Changes must be committed with clear "Resolve blockers" messages
@@ -95,7 +95,7 @@ For each blocker, present 2-3 resolution strategies ranked by recommendation:
 - Why: [when this makes sense]
 ```
 
-Use AskUserQuestion to let the user pick an option per blocker. Group related blockers if they share a root cause.
+Present options to the user and let them pick an option per blocker. Group related blockers if they share a root cause.
 
 ### Step 4: Reconcile Artifacts
 

--- a/commands/run-demo.md
+++ b/commands/run-demo.md
@@ -2,7 +2,7 @@
 
 Execute the demo plan and validate it works. If it fails, investigate and route issues back to the task loop. Fully autonomous — no user interaction.
 
-**Suggested model:** Capable implementer with good debugging skills (e.g., Sonnet via headless CLI).
+**Suggested model:** Capable implementer with good debugging skills. Autonomous — no user interaction.
 
 ## Important Guidelines
 

--- a/commands/shape-spec.md
+++ b/commands/shape-spec.md
@@ -2,11 +2,11 @@
 
 Plan the work with the user. Produce all spec artifacts and push. This is the only command where the user and agent collaborate interactively on what to build.
 
-**Suggested model:** Strong planner with good communication skills (e.g., Opus via TUI).
+**Suggested model:** Strong planner with good communication skills. Interactive — requires user dialogue.
 
 ## Important Guidelines
 
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - Offer suggestions — present options the user can confirm or adjust
 - Keep it lightweight — this is shaping, not exhaustive documentation
 - Prefer GitHub issues as the source of truth for spec id, title, status, and dependencies
@@ -25,7 +25,7 @@ If the user provided an issue number, URL, or spec id:
 1. Fetch the issue via `gh issue view` to get title, body, labels, milestone, and relationships.
 2. Extract `spec_id`, `version` (from `version:*` label), and dependencies (blocked-by relationships).
 
-If no issue was provided, use AskUserQuestion:
+If no issue was provided, ask the user:
 
 ```
 Do you want me to create a new spec issue on GitHub before shaping?
@@ -43,7 +43,7 @@ If picking the next best issue:
 python3 tanren/scripts/list-candidates.py
 ```
 
-2. Present the candidates to the user with AskUserQuestion. Do NOT do any additional research, exploration, or codebase analysis at this point — just show the script output and let the user pick.
+2. Present the candidates to the user and wait for their choice. Do NOT do any additional research, exploration, or codebase analysis at this point — just show the script output and let the user pick.
 3. Once chosen, fetch the full issue with `gh issue view <number>`.
 
 If using an existing issue:
@@ -113,7 +113,7 @@ Any product goals or constraints this spec should align with?
 
 ### Step 6: Standards
 
-Read `tanren/standards/index.yml` and propose relevant standards. Confirm with AskUserQuestion.
+Read `tanren/standards/index.yml` and propose relevant standards. Confirm with the user.
 
 ### Step 7: Non-Negotiables
 
@@ -171,9 +171,9 @@ Before finalizing the demo steps, assess and **verify** the execution environmen
 
 **Why this matters:** The `run-demo` agent runs autonomously and cannot ask questions. If the environment section is vague (e.g., "local model server running" without a URL), the agent will guess — and guess wrong. Every detail the agent would need to connect to a service must be captured here, during shaping, while the user is present.
 
-Also probe for available agent CLIs: claude, codex, opencode, and other agent CLIs that the orchestrator will need.
+Also probe for available agent CLIs installed on the system that the orchestrator will need.
 
-Ask using AskUserQuestion:
+Ask the user:
 
 ```
 For the autonomous demo runner, what's available in the execution environment?
@@ -223,7 +223,7 @@ The classification is written into demo.md and becomes binding for `run-demo`. T
 
 #### 9b: Finalize Demo Plan
 
-Propose the demo and confirm with AskUserQuestion:
+Propose the demo and confirm with the user:
 
 ```
 Here's my proposed demo for this feature:

--- a/commands/sync-roadmap.md
+++ b/commands/sync-roadmap.md
@@ -2,12 +2,12 @@
 
 Sync `tanren/product/roadmap.md` with GitHub issues labeled `type:spec`. Use GitHub as the source of truth for spec ids. Interactive — the user approves all conflict resolutions and new issue/entry creation before any changes are made.
 
-**Suggested model:** Strong reasoner with good judgment (e.g., Opus via TUI). Conflict resolution and dependency alignment require cross-referencing multiple sources and the user must approve actions.
+**Suggested model:** Strong reasoner with good judgment. Interactive — requires user dialogue. Conflict resolution and dependency alignment require cross-referencing multiple sources and the user must approve actions.
 
 ## Important Guidelines
 
 - Human-in-the-loop — the user approves all sync actions before execution
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - Prefer GitHub issues for spec id allocation and dependency relationships
 - Ask on conflicts — never overwrite silently
 - Never modify spec.md files
@@ -64,7 +64,7 @@ For each `spec_id`, determine:
 
 ### Step 3: Resolve Conflicts (Ask)
 
-For each conflict, use AskUserQuestion with a recommended default:
+For each conflict, present options to the user with a recommended default:
 
 ```
 Conflict for sX.Y.ZZ — {field}:

--- a/commands/triage-audits.md
+++ b/commands/triage-audits.md
@@ -2,12 +2,12 @@
 
 Load standards audit reports, analyze violations across all standards, group findings by root cause, and create GitHub issues for the most impactful fixes. Interactive — the user approves the triage before any issues are created.
 
-**Suggested model:** Strong reasoner with good judgment (e.g., Opus via TUI). Grouping violations by root cause requires cross-standard analysis and the user must approve the triage.
+**Suggested model:** Strong reasoner with good judgment. Interactive — requires user dialogue. Grouping violations by root cause requires cross-standard analysis and the user must approve the triage.
 
 ## Important Guidelines
 
 - Human-in-the-loop — the user approves the triage before any issues are created
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - Group by root cause / natural fix scope, not per-standard
 - Priority is a function of score, importance, and violation count
 - Every created issue must be actionable with clear scope
@@ -131,7 +131,7 @@ For each proposed issue group:
 **Proposed labels:** type:spec, status:planned, {category labels}
 ```
 
-Use AskUserQuestion to let the user:
+Ask the user to:
 - Approve or skip each issue group
 - Adjust titles, labels, or scope
 - Split or merge groups

--- a/commands/walk-spec.md
+++ b/commands/walk-spec.md
@@ -2,13 +2,13 @@
 
 The human validation checkpoint. The agent does the inspection work — reads the spec, reads the audit, reads the code — then walks the user through an interactive demo of the feature before submitting a PR.
 
-**Suggested model:** Strong communicator (e.g., Opus via TUI). Needs excellent interactive skills for the demo walkthrough.
+**Suggested model:** Strong communicator. Interactive — requires user dialogue. Needs excellent interactive skills for the demo walkthrough.
 
 ## Important Guidelines
 
 - Human-in-the-loop — the user validates; the agent investigates and presents
 - Do NOT ask the user generic yes/no checklist questions. Instead, read the code yourself, summarize what you found, and ask the user to confirm specific behaviors.
-- Always use AskUserQuestion tool when asking the user anything. In TUI: use AskUserQuestion. Via the messaging platform: use send_message with numbered options and wait for reply.
+- When asking the user a question, present numbered options and wait for their response before proceeding.
 - If the demo fails during the walkthrough, stop and discuss with the user — do not silently fix
 
 ## Prerequisites

--- a/docs/methodology/system.md
+++ b/docs/methodology/system.md
@@ -51,3 +51,18 @@ conventions templates used to seed persistent product context.
 
 Role independence is deliberate: implementation and audit should use different
 model families when possible to reduce self-agreement bias.
+
+## Agent Agnosticism
+
+Commands describe **capabilities needed**, not tools or models by name.
+
+- `**Suggested model:**` lines describe the reasoning profile (strong planner,
+  fast implementer, independent auditor) and execution mode (interactive vs
+  autonomous) — never a specific model name or provider.
+- User interaction is described as behavior ("ask the user", "present options",
+  "wait for response") — never as a specific tool invocation.
+- CLI references use generic terms ("agent CLI", "installed CLIs") — never
+  specific product names.
+
+This ensures commands work identically across Claude Code, Codex CLI, OpenCode,
+Aider, and any future agent runtime.


### PR DESCRIPTION
## Summary
- Remove specific model name suggestions (Opus, Sonnet, Codex) from all 11 commands that had them — replaced with capability descriptions + execution mode hints (Interactive/Autonomous)
- Replace `AskUserQuestion` tool references (28+ occurrences across 10 files) with generic behavioral descriptions ("ask the user", "present options", "wait for response")
- Remove interface-specific references (TUI, headless CLI, messaging platform) from boilerplate and model suggestion lines
- Replace CLI name references (claude, codex, opencode) with generic "agent CLIs installed on the system" language
- Document the agent-agnosticism principle in `docs/methodology/system.md`

## Test plan
- [x] `grep -rni` for model names, AskUserQuestion, TUI in commands/ returns zero hits
- [x] All 15 command files preserve their existing structure and instruction flow
- [x] `docs/methodology/system.md` includes new Agent Agnosticism section
- [x] `make check` passes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)