### PR TITLE
feat: add dispatch checkpointing and resume for failure recovery

### DIFF
--- a/packages/tanren-core/src/tanren_core/config.py
+++ b/packages/tanren-core/src/tanren_core/config.py
@@ -198,6 +198,11 @@ class Config(BaseModel):
         description="Command for @ccusage/opencode",
     )
 
+    @property
+    def checkpoints_dir(self) -> str:
+        """Directory for dispatch checkpoint files, derived from data_dir."""
+        return str(Path(self.data_dir) / "checkpoints")
+
     @classmethod
     def from_env(cls, sources: Sequence[ConfigSource] = ()) -> Config:
         """Load configuration from sources and environment variables.

--- a/packages/tanren-core/src/tanren_core/ipc.py
+++ b/packages/tanren-core/src/tanren_core/ipc.py
@@ -10,7 +10,7 @@ import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from tanren_core.schemas import Dispatch, Nudge, ProgressState, Result, TaskState
+from tanren_core.schemas import Checkpoint, Dispatch, Nudge, ProgressState, Result, TaskState
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -147,3 +147,61 @@ async def init_progress_from_plan(plan_md_path: Path, spec_id: str) -> ProgressS
         return ProgressState(spec_id=spec_id, created_at=now, updated_at=now, tasks=tasks)
 
     return await asyncio.to_thread(_parse)
+
+
+async def write_checkpoint(checkpoints_dir: Path, checkpoint: Checkpoint) -> Path:
+    """Write a checkpoint file atomically, overwriting any existing for this workflow.
+
+    File naming: {workflow_id}.json (one active checkpoint per workflow).
+
+    Returns:
+        Path to the written checkpoint file.
+    """
+    path = checkpoints_dir / f"{checkpoint.workflow_id}.json"
+    await atomic_write(path, checkpoint.model_dump_json(indent=2))
+    return path
+
+
+async def read_checkpoint(checkpoints_dir: Path, workflow_id: str) -> Checkpoint | None:
+    """Read a checkpoint for a workflow, returning None if not found.
+
+    Returns:
+        Checkpoint if found, None otherwise.
+    """
+    path = checkpoints_dir / f"{workflow_id}.json"
+    if not path.exists():
+        return None
+
+    def _read() -> Checkpoint:
+        return Checkpoint.model_validate_json(path.read_text())
+
+    return await asyncio.to_thread(_read)
+
+
+async def delete_checkpoint(checkpoints_dir: Path, workflow_id: str) -> None:
+    """Delete a checkpoint after successful result write."""
+    path = checkpoints_dir / f"{workflow_id}.json"
+    await delete_file(path)
+
+
+async def list_checkpoints(checkpoints_dir: Path) -> list[Checkpoint]:
+    """List all active checkpoints for resume discovery.
+
+    Returns:
+        List of Checkpoint instances, sorted by filename.
+    """
+
+    def _list() -> list[Checkpoint]:
+        if not checkpoints_dir.exists():
+            return []
+        results: list[Checkpoint] = []
+        for entry in sorted(checkpoints_dir.iterdir()):
+            if entry.suffix != ".json":
+                continue
+            try:
+                results.append(Checkpoint.model_validate_json(entry.read_text()))
+            except Exception:  # noqa: S112 — skip corrupt checkpoints
+                continue
+        return results
+
+    return await asyncio.to_thread(_list)

--- a/packages/tanren-core/src/tanren_core/ipc.py
+++ b/packages/tanren-core/src/tanren_core/ipc.py
@@ -149,6 +149,20 @@ async def init_progress_from_plan(plan_md_path: Path, spec_id: str) -> ProgressS
     return await asyncio.to_thread(_parse)
 
 
+def _safe_checkpoint_path(checkpoints_dir: Path, workflow_id: str) -> Path:
+    """Build a checkpoint file path, rejecting path separators in workflow_id.
+
+    Returns:
+        Safe path within checkpoints_dir.
+
+    Raises:
+        ValueError: If workflow_id contains path separators.
+    """
+    if "/" in workflow_id or "\\" in workflow_id:
+        raise ValueError(f"Invalid workflow_id (contains path separator): {workflow_id}")
+    return checkpoints_dir / f"{workflow_id}.json"
+
+
 async def write_checkpoint(checkpoints_dir: Path, checkpoint: Checkpoint) -> Path:
     """Write a checkpoint file atomically, overwriting any existing for this workflow.
 
@@ -157,7 +171,7 @@ async def write_checkpoint(checkpoints_dir: Path, checkpoint: Checkpoint) -> Pat
     Returns:
         Path to the written checkpoint file.
     """
-    path = checkpoints_dir / f"{checkpoint.workflow_id}.json"
+    path = _safe_checkpoint_path(checkpoints_dir, checkpoint.workflow_id)
     await atomic_write(path, checkpoint.model_dump_json(indent=2))
     return path
 
@@ -168,7 +182,7 @@ async def read_checkpoint(checkpoints_dir: Path, workflow_id: str) -> Checkpoint
     Returns:
         Checkpoint if found, None otherwise.
     """
-    path = checkpoints_dir / f"{workflow_id}.json"
+    path = _safe_checkpoint_path(checkpoints_dir, workflow_id)
     if not path.exists():
         return None
 
@@ -180,7 +194,7 @@ async def read_checkpoint(checkpoints_dir: Path, workflow_id: str) -> Checkpoint
 
 async def delete_checkpoint(checkpoints_dir: Path, workflow_id: str) -> None:
     """Delete a checkpoint after successful result write."""
-    path = checkpoints_dir / f"{workflow_id}.json"
+    path = _safe_checkpoint_path(checkpoints_dir, workflow_id)
     await delete_file(path)
 
 

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -251,11 +251,13 @@ class WorkerManager:
         # Startup recovery: clean stale heartbeats
         await self._heartbeat.cleanup_stale()
 
-        # Startup recovery: check active VM assignments
-        await self._recover_vm_state()
-
-        # Startup recovery: resume stale checkpoints
+        # Startup recovery: resume checkpoints BEFORE releasing stale VMs,
+        # because checkpoints may reference VMs that are still active.
         await self._recover_checkpoints()
+
+        # Startup recovery: release any remaining stale VM assignments
+        # not covered by checkpoints.
+        await self._recover_vm_state()
 
         self._started_at = datetime.now(UTC).isoformat()
 
@@ -721,7 +723,10 @@ class WorkerManager:
 
         # 4. Write result
         await self._write_result_and_nudge(result, dispatch.workflow_id)
-        await delete_checkpoint(self._checkpoints_dir, dispatch.workflow_id)
+
+        # Only delete checkpoint on success so failures can be resumed
+        if result.outcome != Outcome.ERROR:
+            await delete_checkpoint(self._checkpoints_dir, dispatch.workflow_id)
 
     async def _provision_phase(self, dispatch: Dispatch) -> EnvironmentHandle:
         """Phase 1: Provision execution environment.
@@ -996,14 +1001,16 @@ class WorkerManager:
             checkpoint.failure_count += 1
             checkpoint.updated_at = datetime.now(UTC).isoformat()
             await write_checkpoint(self._checkpoints_dir, checkpoint)
+            # Do NOT teardown on failure — keep VM alive for next resume attempt
             raise
 
-        finally:
-            if handle is not None:
-                await self._execution_env.teardown(handle)
+        # Teardown only on success — VM stays alive if resume fails
+        if handle is not None:
+            await self._execution_env.teardown(handle)
 
-        # Clean up checkpoint on success
-        await delete_checkpoint(self._checkpoints_dir, workflow_id)
+        # Clean up checkpoint only when a result was produced and written
+        if result is not None:
+            await delete_checkpoint(self._checkpoints_dir, workflow_id)
         return result
 
     async def _reconstruct_handle_for_resume(

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         WorktreeManager,
     )
     from tanren_core.adapters.protocols import VMProvisioner as VMProvisionerProtocol
+    from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 
 
 from tanren_core.adapters import (
@@ -52,11 +53,12 @@ from tanren_core.adapters import (
 from tanren_core.adapters.local_environment import LocalExecutionEnvironment
 from tanren_core.adapters.manual_vm import ManualProvisionerSettings, ManualVMProvisioner
 from tanren_core.adapters.postgres_pool import is_postgres_url
-from tanren_core.adapters.remote_types import VMHandle, VMProvider
+from tanren_core.adapters.remote_types import VMHandle, VMProvider, WorkspacePath
 from tanren_core.adapters.sqlite_vm_state import SqliteVMStateStore
 from tanren_core.adapters.types import (
     EnvironmentHandle,
     LocalEnvironmentRuntime,
+    PhaseResult,
     ProvisionError,
     RemoteEnvironmentRuntime,
 )
@@ -68,14 +70,20 @@ from tanren_core.config import Config
 from tanren_core.heartbeat import HeartbeatWriter
 from tanren_core.ipc import (
     atomic_write,
+    delete_checkpoint,
     delete_file,
+    list_checkpoints,
+    read_checkpoint,
     scan_dispatch_dir,
+    write_checkpoint,
     write_nudge,
     write_result,
 )
 from tanren_core.queues import DispatchRouter
 from tanren_core.remote_config import ProvisionerType, load_remote_config
 from tanren_core.schemas import (
+    Checkpoint,
+    CheckpointStage,
     Cli,
     Dispatch,
     FindingSeverity,
@@ -159,6 +167,8 @@ class WorkerManager:
         self._results_dir = Path(self._config.ipc_dir) / "results"
         self._in_progress_dir = Path(self._config.ipc_dir) / "in-progress"
         self._input_dir = Path(self._config.ipc_dir) / "input"
+        self._checkpoints_dir = Path(self._config.checkpoints_dir)
+        self._checkpoints_dir.mkdir(parents=True, exist_ok=True)
         self._heartbeat = HeartbeatWriter(self._in_progress_dir, self._config.heartbeat_interval)
         self._router = DispatchRouter(
             handler=self._handle_dispatch,
@@ -243,6 +253,9 @@ class WorkerManager:
 
         # Startup recovery: check active VM assignments
         await self._recover_vm_state()
+
+        # Startup recovery: resume stale checkpoints
+        await self._recover_checkpoints()
 
         self._started_at = datetime.now(UTC).isoformat()
 
@@ -620,24 +633,30 @@ class WorkerManager:
         dispatch_stem: str,
         worktree_path: Path,
     ) -> None:
-        """Handle agent/gate phases: provision, execute, report."""
+        """Handle agent/gate phases: provision, execute, post-process, write result.
+
+        Writes progressive checkpoints at each phase boundary so that
+        partially completed dispatches can be resumed after a crash.
+        """
         start = time.monotonic()
+        now = datetime.now(UTC).isoformat()
+
+        # Write initial checkpoint (DISPATCHED)
+        checkpoint = Checkpoint(
+            workflow_id=dispatch.workflow_id,
+            stage=CheckpointStage.DISPATCHED,
+            dispatch_json=dispatch.model_dump_json(),
+            worktree_path=str(worktree_path),
+            dispatch_stem=dispatch_stem,
+            created_at=now,
+            updated_at=now,
+        )
+        await write_checkpoint(self._checkpoints_dir, checkpoint)
 
         # 1. Provision
         try:
-            handle = await self._execution_env.provision(dispatch, self._config)
-
-            await self._emitter.emit(
-                PreflightCompleted(
-                    timestamp=datetime.now(UTC).isoformat(),
-                    workflow_id=dispatch.workflow_id,
-                    passed=True,
-                    repairs=self._preflight_repairs(handle),
-                )
-            )
-
+            handle = await self._provision_phase(dispatch)
         except ProvisionError as e:
-            # Emit PreflightCompleted(passed=False) if preflight ran
             await self._emitter.emit(
                 PreflightCompleted(
                     timestamp=datetime.now(UTC).isoformat(),
@@ -647,141 +666,33 @@ class WorkerManager:
                 )
             )
             await self._write_result_and_nudge(e.result, dispatch.workflow_id)
+            await delete_checkpoint(self._checkpoints_dir, dispatch.workflow_id)
             return
 
-        # 2. Execute
+        # Update checkpoint to PROVISIONED
+        checkpoint.stage = CheckpointStage.PROVISIONED
+        checkpoint.vm_id = self._extract_vm_id(handle)
+        checkpoint.environment_profile = dispatch.environment_profile
+        if handle.runtime.kind == "remote":
+            remote_rt = cast("RemoteEnvironmentRuntime", handle.runtime)
+            checkpoint.workspace_remote_path = remote_rt.workspace_path.path
+        checkpoint.updated_at = datetime.now(UTC).isoformat()
+        await write_checkpoint(self._checkpoints_dir, checkpoint)
+
+        # 2. Execute + 3. Post-process
         dispatch_start_utc = datetime.now(UTC)
         try:
-            phase_result = await self._execution_env.execute(
-                handle, dispatch, self._config, dispatch_stem=dispatch_stem
-            )
+            phase_result = await self._execute_phase(handle, dispatch, dispatch_stem)
 
-            duration = phase_result.duration_secs
-            spec_folder_path = worktree_path / dispatch.spec_folder
+            # Update checkpoint to EXECUTED
+            checkpoint.stage = CheckpointStage.EXECUTED
+            checkpoint.phase_result_json = phase_result.model_dump_json()
+            checkpoint.dispatch_start_utc = dispatch_start_utc.isoformat()
+            checkpoint.updated_at = datetime.now(UTC).isoformat()
+            await write_checkpoint(self._checkpoints_dir, checkpoint)
 
-            # 2b. Sync remote changes to local worktree for findings parsing
-            if self._config.remote_config_path:
-                await self._sync_remote_changes(worktree_path)
-
-            # 3. Build gate_output (gate phases only)
-            gate_output = None
-            if dispatch.phase == Phase.GATE:
-                gate_output = _build_gate_output(phase_result.stdout, phase_result.outcome)
-
-            # 4. Build tail_output
-            tail_output = None
-            is_agent_phase = dispatch.phase not in (
-                Phase.GATE,
-                Phase.SETUP,
-                Phase.CLEANUP,
-            )
-            if is_agent_phase or phase_result.outcome != Outcome.SUCCESS:
-                tail_output = build_tail_output(phase_result.stdout)
-
-            # 5. Apply postflight results
-            pushed: bool | None = None
-            integrity_repairs = None
-            spec_modified = False
-            if phase_result.postflight_result is not None:
-                postflight_result = phase_result.postflight_result
-
-                await self._emitter.emit(
-                    PostflightCompleted(
-                        timestamp=datetime.now(UTC).isoformat(),
-                        workflow_id=dispatch.workflow_id,
-                        phase=dispatch.phase.value,
-                        pushed=postflight_result.pushed,
-                        integrity_repairs=postflight_result.integrity_repairs,
-                    )
-                )
-
-                pushed = postflight_result.pushed
-                integrity_repairs = postflight_result.integrity_repairs
-                spec_modified = postflight_result.integrity_repairs.spec_reverted
-                if not postflight_result.pushed and postflight_result.push_error:
-                    if tail_output:
-                        tail_output += (
-                            f"\n\n--- git push failed ---\n{postflight_result.push_error}"
-                        )
-                    else:
-                        tail_output = f"git push failed: {postflight_result.push_error}"
-
-            # Capture execution-end timestamp before any post-processing
-            exec_end_utc = datetime.now(UTC)
-
-            # 6. Parse structured findings
-            new_tasks, findings_data = self._parse_findings(dispatch, spec_folder_path)
-
-            # 6b. Collect token usage (best-effort, 30s timeout)
-            token_usage_data = None
-            if dispatch.cli != Cli.BASH:
-                if isinstance(handle.runtime, RemoteEnvironmentRuntime):
-                    # Already collected inside SSHExecutionEnvironment.execute()
-                    if phase_result.token_usage is not None:
-                        token_usage_data = phase_result.token_usage.model_dump(mode="json")
-                else:
-                    # Local execution: collect here
-                    runner = LocalCommandRunner()
-                    usage = await collect_token_usage(
-                        dispatch.cli,
-                        str(worktree_path),
-                        dispatch_start_utc,
-                        exec_end_utc,
-                        self._config,
-                        runner,
-                    )
-                    if usage is not None:
-                        token_usage_data = usage.model_dump(mode="json")
-
-                if token_usage_data is not None:
-                    await self._emitter.emit(
-                        TokenUsageRecorded(
-                            timestamp=datetime.now(UTC).isoformat(),
-                            workflow_id=dispatch.workflow_id,
-                            phase=dispatch.phase.value,
-                            project=dispatch.project,
-                            cli=dispatch.cli.value,
-                            **{
-                                k: v
-                                for k, v in token_usage_data.items()
-                                if k not in ("provider", "project")
-                            },
-                        )
-                    )
-
-            # 7. Construct Result
-            result = Result(
-                workflow_id=dispatch.workflow_id,
-                phase=dispatch.phase,
-                outcome=phase_result.outcome,
-                signal=phase_result.signal,
-                exit_code=phase_result.exit_code,
-                duration_secs=duration,
-                gate_output=gate_output,
-                tail_output=tail_output,
-                stderr_tail=build_tail_output(phase_result.stderr),
-                unchecked_tasks=phase_result.unchecked_tasks,
-                plan_hash=phase_result.plan_hash,
-                spec_modified=spec_modified,
-                pushed=pushed,
-                integrity_repairs=integrity_repairs,
-                new_tasks=new_tasks,
-                findings=findings_data,
-                token_usage=token_usage_data,
-            )
-
-            # 8. Emit PhaseCompleted
-            await self._emitter.emit(
-                PhaseCompleted(
-                    timestamp=datetime.now(UTC).isoformat(),
-                    workflow_id=dispatch.workflow_id,
-                    phase=dispatch.phase.value,
-                    project=dispatch.project,
-                    outcome=phase_result.outcome.value,
-                    signal=phase_result.signal,
-                    duration_secs=duration,
-                    exit_code=phase_result.exit_code,
-                )
+            result = await self._post_process_phase(
+                dispatch, handle, phase_result, worktree_path, dispatch_start_utc
             )
 
         except Exception as e:
@@ -799,11 +710,405 @@ class WorkerManager:
                 plan_hash="00000000",
                 spec_modified=False,
             )
+            # Record error in checkpoint
+            checkpoint.last_error = str(e)
+            checkpoint.failure_count += 1
+            checkpoint.updated_at = datetime.now(UTC).isoformat()
+            await write_checkpoint(self._checkpoints_dir, checkpoint)
 
         finally:
             await self._execution_env.teardown(handle)
 
+        # 4. Write result
         await self._write_result_and_nudge(result, dispatch.workflow_id)
+        await delete_checkpoint(self._checkpoints_dir, dispatch.workflow_id)
+
+    async def _provision_phase(self, dispatch: Dispatch) -> EnvironmentHandle:
+        """Phase 1: Provision execution environment.
+
+        Returns:
+            EnvironmentHandle on success.
+        """
+        handle = await self._execution_env.provision(dispatch, self._config)
+
+        await self._emitter.emit(
+            PreflightCompleted(
+                timestamp=datetime.now(UTC).isoformat(),
+                workflow_id=dispatch.workflow_id,
+                passed=True,
+                repairs=self._preflight_repairs(handle),
+            )
+        )
+
+        return handle
+
+    async def _execute_phase(
+        self,
+        handle: EnvironmentHandle,
+        dispatch: Dispatch,
+        dispatch_stem: str,
+    ) -> PhaseResult:
+        """Phase 2: Execute agent/gate process.
+
+        Returns:
+            PhaseResult with outcome, signal, and metrics.
+        """
+        return await self._execution_env.execute(
+            handle, dispatch, self._config, dispatch_stem=dispatch_stem
+        )
+
+    async def _post_process_phase(
+        self,
+        dispatch: Dispatch,
+        handle: EnvironmentHandle,
+        phase_result: PhaseResult,
+        worktree_path: Path,
+        dispatch_start_utc: datetime,
+    ) -> Result:
+        """Phase 3: Post-process execution results and construct Result.
+
+        Handles remote sync, gate/tail output, postflight, findings,
+        token usage, and PhaseCompleted event emission.
+
+        Returns:
+            Fully constructed Result ready for writing.
+        """
+        duration = phase_result.duration_secs
+        spec_folder_path = worktree_path / dispatch.spec_folder
+
+        # Sync remote changes to local worktree for findings parsing
+        if self._config.remote_config_path:
+            await self._sync_remote_changes(worktree_path)
+
+        # Build gate_output (gate phases only)
+        gate_output = None
+        if dispatch.phase == Phase.GATE:
+            gate_output = _build_gate_output(phase_result.stdout, phase_result.outcome)
+
+        # Build tail_output
+        tail_output = None
+        is_agent_phase = dispatch.phase not in (
+            Phase.GATE,
+            Phase.SETUP,
+            Phase.CLEANUP,
+        )
+        if is_agent_phase or phase_result.outcome != Outcome.SUCCESS:
+            tail_output = build_tail_output(phase_result.stdout)
+
+        # Apply postflight results
+        pushed: bool | None = None
+        integrity_repairs = None
+        spec_modified = False
+        if phase_result.postflight_result is not None:
+            postflight_result = phase_result.postflight_result
+
+            await self._emitter.emit(
+                PostflightCompleted(
+                    timestamp=datetime.now(UTC).isoformat(),
+                    workflow_id=dispatch.workflow_id,
+                    phase=dispatch.phase.value,
+                    pushed=postflight_result.pushed,
+                    integrity_repairs=postflight_result.integrity_repairs,
+                )
+            )
+
+            pushed = postflight_result.pushed
+            integrity_repairs = postflight_result.integrity_repairs
+            spec_modified = postflight_result.integrity_repairs.spec_reverted
+            if not postflight_result.pushed and postflight_result.push_error:
+                if tail_output:
+                    tail_output += f"\n\n--- git push failed ---\n{postflight_result.push_error}"
+                else:
+                    tail_output = f"git push failed: {postflight_result.push_error}"
+
+        # Capture execution-end timestamp before any post-processing
+        exec_end_utc = datetime.now(UTC)
+
+        # Parse structured findings
+        new_tasks, findings_data = self._parse_findings(dispatch, spec_folder_path)
+
+        # Collect token usage (best-effort, 30s timeout)
+        token_usage_data = None
+        if dispatch.cli != Cli.BASH:
+            if isinstance(handle.runtime, RemoteEnvironmentRuntime):
+                # Already collected inside SSHExecutionEnvironment.execute()
+                if phase_result.token_usage is not None:
+                    token_usage_data = phase_result.token_usage.model_dump(mode="json")
+            else:
+                # Local execution: collect here
+                runner = LocalCommandRunner()
+                usage = await collect_token_usage(
+                    dispatch.cli,
+                    str(worktree_path),
+                    dispatch_start_utc,
+                    exec_end_utc,
+                    self._config,
+                    runner,
+                )
+                if usage is not None:
+                    token_usage_data = usage.model_dump(mode="json")
+
+            if token_usage_data is not None:
+                await self._emitter.emit(
+                    TokenUsageRecorded(
+                        timestamp=datetime.now(UTC).isoformat(),
+                        workflow_id=dispatch.workflow_id,
+                        phase=dispatch.phase.value,
+                        project=dispatch.project,
+                        cli=dispatch.cli.value,
+                        **{
+                            k: v
+                            for k, v in token_usage_data.items()
+                            if k not in ("provider", "project")
+                        },
+                    )
+                )
+
+        # Construct Result
+        result = Result(
+            workflow_id=dispatch.workflow_id,
+            phase=dispatch.phase,
+            outcome=phase_result.outcome,
+            signal=phase_result.signal,
+            exit_code=phase_result.exit_code,
+            duration_secs=duration,
+            gate_output=gate_output,
+            tail_output=tail_output,
+            stderr_tail=build_tail_output(phase_result.stderr),
+            unchecked_tasks=phase_result.unchecked_tasks,
+            plan_hash=phase_result.plan_hash,
+            spec_modified=spec_modified,
+            pushed=pushed,
+            integrity_repairs=integrity_repairs,
+            new_tasks=new_tasks,
+            findings=findings_data,
+            token_usage=token_usage_data,
+        )
+
+        # Emit PhaseCompleted
+        await self._emitter.emit(
+            PhaseCompleted(
+                timestamp=datetime.now(UTC).isoformat(),
+                workflow_id=dispatch.workflow_id,
+                phase=dispatch.phase.value,
+                project=dispatch.project,
+                outcome=phase_result.outcome.value,
+                signal=phase_result.signal,
+                duration_secs=duration,
+                exit_code=phase_result.exit_code,
+            )
+        )
+
+        return result
+
+    def _extract_vm_id(self, handle: EnvironmentHandle) -> str | None:
+        """Extract VM ID from handle if remote runtime.
+
+        Returns:
+            VM ID string, or None for local environments.
+        """
+        if handle.runtime.kind == "remote":
+            remote_rt = cast("RemoteEnvironmentRuntime", handle.runtime)
+            return remote_rt.vm_handle.vm_id
+        return None
+
+    async def resume_dispatch(self, workflow_id: str) -> Result | None:
+        """Resume a dispatch from its most recent checkpoint.
+
+        Returns:
+            Result if the dispatch completed, None if no checkpoint found.
+
+        Raises:
+            ValueError: If the checkpoint's VM is no longer available.
+        """
+        checkpoint = await read_checkpoint(self._checkpoints_dir, workflow_id)
+        if checkpoint is None:
+            return None
+
+        dispatch = Dispatch.model_validate_json(checkpoint.dispatch_json)
+        worktree_path = Path(checkpoint.worktree_path)
+
+        # Increment retry count
+        checkpoint.retry_count += 1
+        checkpoint.updated_at = datetime.now(UTC).isoformat()
+        await write_checkpoint(self._checkpoints_dir, checkpoint)
+
+        logger.info(
+            "Resuming dispatch %s from stage %s (attempt %d)",
+            workflow_id,
+            checkpoint.stage,
+            checkpoint.retry_count,
+        )
+
+        handle: EnvironmentHandle | None = None
+        phase_result: PhaseResult | None = None
+        result: Result | None = None
+
+        try:
+            if checkpoint.stage == CheckpointStage.DISPATCHED:
+                # Re-run from provision
+                handle = await self._provision_phase(dispatch)
+                checkpoint.stage = CheckpointStage.PROVISIONED
+                checkpoint.vm_id = self._extract_vm_id(handle)
+                checkpoint.environment_profile = dispatch.environment_profile
+                if handle.runtime.kind == "remote":
+                    remote_rt = cast("RemoteEnvironmentRuntime", handle.runtime)
+                    checkpoint.workspace_remote_path = remote_rt.workspace_path.path
+                checkpoint.updated_at = datetime.now(UTC).isoformat()
+                await write_checkpoint(self._checkpoints_dir, checkpoint)
+
+            if checkpoint.stage == CheckpointStage.PROVISIONED:
+                # Skip provision, run execute + post-process
+                if handle is None:
+                    handle = await self._reconstruct_handle_for_resume(checkpoint, dispatch)
+                phase_result = await self._execute_phase(handle, dispatch, checkpoint.dispatch_stem)
+                checkpoint.stage = CheckpointStage.EXECUTED
+                checkpoint.phase_result_json = phase_result.model_dump_json()
+                checkpoint.dispatch_start_utc = datetime.now(UTC).isoformat()
+                checkpoint.updated_at = datetime.now(UTC).isoformat()
+                await write_checkpoint(self._checkpoints_dir, checkpoint)
+
+            if checkpoint.stage == CheckpointStage.EXECUTED:
+                # Skip provision + execute, run post-process only
+                if handle is None:
+                    handle = await self._reconstruct_handle_for_resume(checkpoint, dispatch)
+                if phase_result is None and checkpoint.phase_result_json:
+                    phase_result = PhaseResult.model_validate_json(checkpoint.phase_result_json)
+                if phase_result is None:
+                    raise ValueError("No phase_result available for post-processing")
+                dispatch_start_utc = datetime.now(UTC)
+                if checkpoint.dispatch_start_utc:
+                    dispatch_start_utc = datetime.fromisoformat(checkpoint.dispatch_start_utc)
+                result = await self._post_process_phase(
+                    dispatch, handle, phase_result, worktree_path, dispatch_start_utc
+                )
+
+            if checkpoint.stage == CheckpointStage.POST_PROCESSED:
+                logger.warning("Checkpoint at POST_PROCESSED stage — retrying result write only")
+
+            # Write result if available
+            if result is not None:
+                await self._write_result_and_nudge(result, workflow_id)
+
+        except Exception as exc:
+            logger.exception("Resume failed for %s", workflow_id)
+            checkpoint.last_error = str(exc)
+            checkpoint.failure_count += 1
+            checkpoint.updated_at = datetime.now(UTC).isoformat()
+            await write_checkpoint(self._checkpoints_dir, checkpoint)
+            raise
+
+        finally:
+            if handle is not None:
+                await self._execution_env.teardown(handle)
+
+        # Clean up checkpoint on success
+        await delete_checkpoint(self._checkpoints_dir, workflow_id)
+        return result
+
+    async def _reconstruct_handle_for_resume(
+        self,
+        checkpoint: Checkpoint,
+        dispatch: Dispatch,
+    ) -> EnvironmentHandle:
+        """Reconstruct an EnvironmentHandle from checkpoint data for resume.
+
+        For remote environments, validates the VM is still active.
+
+        Returns:
+            Reconstructed EnvironmentHandle.
+
+        Raises:
+            ValueError: If the VM is no longer available.
+        """
+        worktree_path = Path(checkpoint.worktree_path)
+
+        if checkpoint.vm_id is not None:
+            # Remote environment — verify VM still exists
+            if not hasattr(self, "_remote_state_store"):
+                raise ValueError("No remote state store available for VM verification")
+
+            assignment = await self._remote_state_store.get_assignment(checkpoint.vm_id)
+            if assignment is None:
+                raise ValueError(
+                    f"VM {checkpoint.vm_id} is no longer active — cannot resume. "
+                    "Re-dispatch the workflow."
+                )
+
+            from tanren_core.adapters.ssh import (  # noqa: PLC0415 — deferred import for optional dependency
+                SSHConfig,
+                SSHConnection,
+            )
+
+            ssh_env = cast("SSHExecutionEnvironment", self._execution_env)
+            ssh_config = SSHConfig(
+                host=assignment.host,
+                user=ssh_env.ssh_defaults.user,
+                key_path=ssh_env.ssh_defaults.key_path,
+                port=ssh_env.ssh_defaults.port,
+                connect_timeout=ssh_env.ssh_defaults.connect_timeout,
+                host_key_policy=ssh_env.ssh_defaults.host_key_policy,
+            )
+            conn = SSHConnection(ssh_config)
+
+            workspace_path = WorkspacePath(
+                path=checkpoint.workspace_remote_path or f"/workspace/{dispatch.project}",
+                project=dispatch.project,
+                branch=dispatch.branch,
+            )
+
+            profile = ssh_env._resolve_profile(dispatch, self._config)
+
+            return EnvironmentHandle(
+                env_id=f"resume-{checkpoint.workflow_id}",
+                worktree_path=worktree_path,
+                branch=dispatch.branch,
+                project=dispatch.project,
+                runtime=RemoteEnvironmentRuntime(
+                    vm_handle=VMHandle(
+                        vm_id=checkpoint.vm_id,
+                        host=assignment.host,
+                        provider=ssh_env._provider,
+                        created_at=assignment.assigned_at,
+                    ),
+                    connection=conn,
+                    workspace_path=workspace_path,
+                    profile=profile,
+                    teardown_commands=profile.teardown,
+                    provision_start=time.monotonic(),
+                    workflow_id=dispatch.workflow_id,
+                ),
+            )
+
+        # Local environment — simple reconstruction
+        return EnvironmentHandle(
+            env_id=f"resume-{checkpoint.workflow_id}",
+            worktree_path=worktree_path,
+            branch=dispatch.branch,
+            project=dispatch.project,
+            runtime=LocalEnvironmentRuntime(),
+        )
+
+    async def _recover_checkpoints(self) -> None:
+        """Resume any checkpointed dispatches found at startup.
+
+        Best-effort: logs errors but does not crash the worker.
+        """
+        checkpoints = await list_checkpoints(self._checkpoints_dir)
+        if not checkpoints:
+            return
+
+        logger.info("Found %d checkpoint(s) to resume at startup", len(checkpoints))
+        for cp in checkpoints:
+            try:
+                await self.resume_dispatch(cp.workflow_id)
+                logger.info("Successfully resumed dispatch %s", cp.workflow_id)
+            except Exception:
+                logger.warning(
+                    "Failed to resume dispatch %s — checkpoint retained for manual retry",
+                    cp.workflow_id,
+                    exc_info=True,
+                )
 
     def _parse_findings(
         self, dispatch: Dispatch, spec_folder_path: Path

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -206,6 +206,12 @@ class WorkerManager:
         self._execution_env_injected = execution_env is not None
         if execution_env is not None:
             self._execution_env = execution_env
+            # When execution_env is injected but remote config exists,
+            # build the state store so resume can verify VM assignments.
+            if self._config.remote_config_path:
+                self._remote_state_store = SqliteVMStateStore(
+                    f"{self._config.data_dir}/vm-state.db"
+                )
         elif self._config.remote_config_path:
             self._execution_env = self._build_remote_env()
         else:
@@ -255,9 +261,13 @@ class WorkerManager:
         # because checkpoints may reference VMs that are still active.
         await self._recover_checkpoints()
 
+        # Collect VM IDs still owned by retained checkpoints (failed resumes)
+        # so _recover_vm_state skips them.
+        retained_vm_ids = await self._get_checkpoint_vm_ids()
+
         # Startup recovery: release any remaining stale VM assignments
         # not covered by checkpoints.
-        await self._recover_vm_state()
+        await self._recover_vm_state(skip_vm_ids=retained_vm_ids)
 
         self._started_at = datetime.now(UTC).isoformat()
 
@@ -380,8 +390,11 @@ class WorkerManager:
                 await self._remote_state_store.close()
             self._execution_env = self._build_remote_env(pool=pool)
 
-    async def _recover_vm_state(self) -> None:
+    async def _recover_vm_state(self, *, skip_vm_ids: frozenset[str] = frozenset()) -> None:
         """Startup recovery: release stale assignments via provider cleanup.
+
+        Args:
+            skip_vm_ids: VM IDs to skip (owned by retained checkpoints).
 
         Raises:
             ValueError: If the provisioner type in remote.yml is unsupported.
@@ -452,6 +465,13 @@ class WorkerManager:
                 return
 
             for a in assignments:
+                if a.vm_id in skip_vm_ids:
+                    logger.info(
+                        "Skipping VM %s (%s) — owned by retained checkpoint",
+                        a.vm_id,
+                        a.host,
+                    )
+                    continue
                 stale_handle = VMHandle(
                     vm_id=a.vm_id,
                     host=a.host,
@@ -683,6 +703,7 @@ class WorkerManager:
 
         # 2. Execute + 3. Post-process
         dispatch_start_utc = datetime.now(UTC)
+        failed = False
         try:
             phase_result = await self._execute_phase(handle, dispatch, dispatch_stem)
 
@@ -698,6 +719,7 @@ class WorkerManager:
             )
 
         except Exception as e:
+            failed = True
             duration = int(time.monotonic() - start)
             result = Result(
                 workflow_id=dispatch.workflow_id,
@@ -712,20 +734,21 @@ class WorkerManager:
                 plan_hash="00000000",
                 spec_modified=False,
             )
-            # Record error in checkpoint
+            # Record error in checkpoint — keep checkpoint for resume
             checkpoint.last_error = str(e)
             checkpoint.failure_count += 1
             checkpoint.updated_at = datetime.now(UTC).isoformat()
             await write_checkpoint(self._checkpoints_dir, checkpoint)
 
-        finally:
+        # Teardown only on success — preserve VM for resume on failure
+        if not failed:
             await self._execution_env.teardown(handle)
 
         # 4. Write result
         await self._write_result_and_nudge(result, dispatch.workflow_id)
 
         # Only delete checkpoint on success so failures can be resumed
-        if result.outcome != Outcome.ERROR:
+        if not failed:
             await delete_checkpoint(self._checkpoints_dir, dispatch.workflow_id)
 
     async def _provision_phase(self, dispatch: Dispatch) -> EnvironmentHandle:
@@ -1087,13 +1110,17 @@ class WorkerManager:
                 ),
             )
 
-        # Local environment — simple reconstruction
+        # Local environment — re-run env validation to rebuild task_env
+        env_report, task_env = await self._env_validator.load_and_validate(worktree_path)
         return EnvironmentHandle(
             env_id=f"resume-{checkpoint.workflow_id}",
             worktree_path=worktree_path,
             branch=dispatch.branch,
             project=dispatch.project,
-            runtime=LocalEnvironmentRuntime(),
+            runtime=LocalEnvironmentRuntime(
+                task_env=task_env,
+                env_report=env_report,
+            ),
         )
 
     async def _recover_checkpoints(self) -> None:
@@ -1116,6 +1143,15 @@ class WorkerManager:
                     cp.workflow_id,
                     exc_info=True,
                 )
+
+    async def _get_checkpoint_vm_ids(self) -> frozenset[str]:
+        """Collect VM IDs referenced by active checkpoints.
+
+        Returns:
+            Set of VM IDs that should not be released by stale VM cleanup.
+        """
+        checkpoints = await list_checkpoints(self._checkpoints_dir)
+        return frozenset(cp.vm_id for cp in checkpoints if cp.vm_id is not None)
 
     def _parse_findings(
         self, dispatch: Dispatch, spec_folder_path: Path

--- a/packages/tanren-core/src/tanren_core/manager.py
+++ b/packages/tanren-core/src/tanren_core/manager.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         PostflightRunner,
         PreflightRunner,
         ProcessSpawner,
+        VMStateStore,
         WorktreeManager,
     )
     from tanren_core.adapters.protocols import VMProvisioner as VMProvisionerProtocol
@@ -159,6 +160,7 @@ class WorkerManager:
         env_validator: EnvValidator | None = None,
         env_provisioner: EnvProvisioner | None = None,
         emitter: EventEmitter | None = None,
+        vm_state_store: VMStateStore | None = None,
     ) -> None:
         """Initialize with optional config and adapter overrides."""
         self._config = config or Config.from_env()
@@ -207,9 +209,11 @@ class WorkerManager:
         if execution_env is not None:
             self._execution_env = execution_env
             # When execution_env is injected but remote config exists,
-            # build the state store so resume can verify VM assignments.
+            # wire the VM state store so resume can verify VM assignments.
+            # Prefer the caller-supplied store (which matches the provisioning backend);
+            # fall back to Sqlite if none was provided.
             if self._config.remote_config_path:
-                self._remote_state_store = SqliteVMStateStore(
+                self._remote_state_store = vm_state_store or SqliteVMStateStore(
                     f"{self._config.data_dir}/vm-state.db"
                 )
         elif self._config.remote_config_path:
@@ -718,6 +722,13 @@ class WorkerManager:
                 dispatch, handle, phase_result, worktree_path, dispatch_start_utc
             )
 
+            # Update checkpoint to POST_PROCESSED — crash between here and
+            # _write_result_and_nudge will resume at result-write only,
+            # avoiding duplicate event emissions from post-processing.
+            checkpoint.stage = CheckpointStage.POST_PROCESSED
+            checkpoint.updated_at = datetime.now(UTC).isoformat()
+            await write_checkpoint(self._checkpoints_dir, checkpoint)
+
         except Exception as e:
             failed = True
             duration = int(time.monotonic() - start)
@@ -1010,13 +1021,24 @@ class WorkerManager:
                 result = await self._post_process_phase(
                     dispatch, handle, phase_result, worktree_path, dispatch_start_utc
                 )
+                checkpoint.stage = CheckpointStage.POST_PROCESSED
+                checkpoint.updated_at = datetime.now(UTC).isoformat()
+                await write_checkpoint(self._checkpoints_dir, checkpoint)
 
             if checkpoint.stage == CheckpointStage.POST_PROCESSED:
-                logger.warning("Checkpoint at POST_PROCESSED stage — retrying result write only")
+                logger.info("Checkpoint at POST_PROCESSED stage — writing result only")
 
             # Write result if available
             if result is not None:
                 await self._write_result_and_nudge(result, workflow_id)
+
+        except ProvisionError as e:
+            # Provision failed with a terminal result — write it and clean up,
+            # matching the handling in _handle_work_phase.
+            logger.warning("Resume provision failed for %s: %s", workflow_id, e)
+            await self._write_result_and_nudge(e.result, workflow_id)
+            await delete_checkpoint(self._checkpoints_dir, workflow_id)
+            return e.result
 
         except Exception as exc:
             logger.exception("Resume failed for %s", workflow_id)

--- a/packages/tanren-core/src/tanren_core/schemas.py
+++ b/packages/tanren-core/src/tanren_core/schemas.py
@@ -48,6 +48,15 @@ class Outcome(StrEnum):
     TIMEOUT = "timeout"
 
 
+class CheckpointStage(StrEnum):
+    """Stage within the dispatch lifecycle for crash-resilient checkpointing."""
+
+    DISPATCHED = "dispatched"
+    PROVISIONED = "provisioned"
+    EXECUTED = "executed"
+    POST_PROCESSED = "post_processed"
+
+
 class TaskStatus(StrEnum):
     """Progress tracking status for individual tasks."""
 
@@ -296,6 +305,42 @@ class WorktreeRegistry(BaseModel):
         default_factory=dict,
         description="Map of workflow_id to worktree entry",
     )
+
+
+class Checkpoint(BaseModel):
+    """Persistent snapshot of dispatch progress for crash-resilient resumption.
+
+    One checkpoint file per workflow, overwritten progressively as stages advance.
+    Deleted after successful result write.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str = Field(..., description="Matches the dispatch's workflow_id")
+    stage: CheckpointStage = Field(..., description="Last completed stage")
+    dispatch_json: str = Field(..., description="Serialized Dispatch JSON for replay")
+    worktree_path: str = Field(..., description="Absolute path to the worktree")
+    dispatch_stem: str = Field(default="", description="Original dispatch filename stem")
+    created_at: str = Field(..., description="ISO 8601 timestamp of first creation")
+    updated_at: str = Field(..., description="ISO 8601 timestamp of last update")
+
+    # Provision state (populated after PROVISIONED)
+    vm_id: str | None = Field(default=None, description="VM identifier for remote environments")
+    environment_profile: str | None = Field(default=None, description="Environment profile name")
+    workspace_remote_path: str | None = Field(
+        default=None, description="Remote workspace path on the VM"
+    )
+
+    # Execution state (populated after EXECUTED)
+    phase_result_json: str | None = Field(default=None, description="Serialized PhaseResult JSON")
+    dispatch_start_utc: str | None = Field(
+        default=None, description="ISO 8601 timestamp of execution start"
+    )
+
+    # Failure tracking
+    retry_count: int = Field(default=0, ge=0, description="Resume attempts so far")
+    last_error: str | None = Field(default=None, description="Last failure reason")
+    failure_count: int = Field(default=0, ge=0, description="Total failures across resume attempts")
 
 
 def parse_issue_from_workflow_id(workflow_id: str, *, project: str | None = None) -> str:

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -147,6 +147,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
                 store=app.state.api_store,
                 config=app.state.config,
                 execution_env=app.state.execution_env,
+                vm_state_store=app.state.vm_state_store,
             ),
             config=config_svc,
             events=EventsService(settings, app.state.config, event_reader=app.state.event_reader),

--- a/services/tanren-api/src/tanren_api/mcp_server.py
+++ b/services/tanren-api/src/tanren_api/mcp_server.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from fastmcp import FastMCP
 
 from tanren_api.models import (
+    CheckpointSummary,
     ConfigResponse,
     DispatchAccepted,
     DispatchCancelled,
@@ -23,6 +24,7 @@ from tanren_api.models import (
     MetricsVMsResponse,
     PaginatedEvents,
     ReadinessResponse,
+    ResumeAccepted,
     RunEnvironment,
     RunExecuteAccepted,
     RunStatus,
@@ -580,3 +582,37 @@ async def metrics_vms(
     """
     assert _metrics_svc is not None
     return await _metrics_svc.vms(since=since, until=until, project=project)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / resume tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description=(
+        "Resume a checkpointed dispatch that was interrupted. "
+        "The dispatch picks up from the last completed phase."
+    ),
+)
+async def resume_dispatch(workflow_id: str) -> ResumeAccepted:
+    """Resume a checkpointed dispatch.
+
+    Returns:
+        ResumeAccepted confirmation.
+    """
+    assert _run_svc is not None
+    return await _run_svc.resume(workflow_id)
+
+
+@mcp.tool(
+    description="List all active dispatch checkpoints with their stage and retry count.",
+)
+async def list_checkpoints() -> list[CheckpointSummary]:
+    """List active checkpoints.
+
+    Returns:
+        List of CheckpointSummary instances.
+    """
+    assert _run_svc is not None
+    return await _run_svc.get_checkpoints()

--- a/services/tanren-api/src/tanren_api/models.py
+++ b/services/tanren-api/src/tanren_api/models.py
@@ -462,3 +462,54 @@ class PaginatedEvents(BaseModel):
     skipped: int = Field(
         default=0, ge=0, description="Events skipped due to parse errors in this page"
     )
+
+
+# ---------------------------------------------------------------------------
+# Response models — checkpoint
+# ---------------------------------------------------------------------------
+
+
+class CheckpointSummary(BaseModel):
+    """Summary of an active dispatch checkpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str = Field(..., description="Workflow identifier")
+    stage: str = Field(..., description="Last completed checkpoint stage")
+    retry_count: int = Field(..., ge=0, description="Resume attempts so far")
+    vm_id: str | None = Field(default=None, description="VM identifier if remote")
+    last_error: str | None = Field(default=None, description="Last failure reason")
+    failure_count: int = Field(..., ge=0, description="Total failure count")
+    created_at: str = Field(..., description="ISO 8601 creation timestamp")
+    updated_at: str = Field(..., description="ISO 8601 last update timestamp")
+
+
+class CheckpointDetail(BaseModel):
+    """Detailed checkpoint information including dispatch and state data."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str = Field(..., description="Workflow identifier")
+    stage: str = Field(..., description="Last completed checkpoint stage")
+    dispatch_json: str = Field(..., description="Serialized Dispatch JSON")
+    worktree_path: str = Field(..., description="Absolute path to the worktree")
+    dispatch_stem: str = Field(default="", description="Original dispatch filename stem")
+    vm_id: str | None = Field(default=None, description="VM identifier if remote")
+    environment_profile: str | None = Field(default=None, description="Environment profile name")
+    workspace_remote_path: str | None = Field(default=None, description="Remote workspace path")
+    phase_result_json: str | None = Field(default=None, description="Serialized PhaseResult JSON")
+    dispatch_start_utc: str | None = Field(default=None, description="Execution start timestamp")
+    retry_count: int = Field(..., ge=0, description="Resume attempts so far")
+    last_error: str | None = Field(default=None, description="Last failure reason")
+    failure_count: int = Field(..., ge=0, description="Total failure count")
+    created_at: str = Field(..., description="ISO 8601 creation timestamp")
+    updated_at: str = Field(..., description="ISO 8601 last update timestamp")
+
+
+class ResumeAccepted(BaseModel):
+    """Confirmation that a checkpoint resume has been initiated."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str = Field(..., description="Workflow being resumed")
+    status: str = Field(default="resuming", description="Current resume status")

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -8,9 +8,12 @@ from fastapi import APIRouter, Depends, Path
 
 from tanren_api.dependencies import get_api_store, get_config, get_execution_env
 from tanren_api.models import (
+    CheckpointDetail,
+    CheckpointSummary,
     DispatchAccepted,
     ExecuteRequest,
     ProvisionRequest,
+    ResumeAccepted,
     RunEnvironment,
     RunExecuteAccepted,
     RunFullRequest,
@@ -109,3 +112,45 @@ async def run_status(
         RunStatus: Current status of the environment.
     """
     return await _run_service(store).status(env_id)
+
+
+@router.post("/run/{workflow_id}/resume")
+async def resume_dispatch(
+    workflow_id: Annotated[str, Path(description="Workflow ID to resume")],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
+    execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
+    config: Annotated[Config, Depends(get_config)],
+) -> ResumeAccepted:
+    """Resume a checkpointed dispatch.
+
+    Returns:
+        ResumeAccepted confirmation.
+    """
+    return await _run_service(store, config, execution_env).resume(workflow_id)
+
+
+@router.get("/run/checkpoints")
+async def get_checkpoints(
+    store: Annotated[APIStateStore, Depends(get_api_store)],
+    config: Annotated[Config, Depends(get_config)],
+) -> list[CheckpointSummary]:
+    """List all active checkpoints.
+
+    Returns:
+        List of CheckpointSummary instances.
+    """
+    return await _run_service(store, config).get_checkpoints()
+
+
+@router.get("/run/{workflow_id}/checkpoint")
+async def get_checkpoint(
+    workflow_id: Annotated[str, Path(description="Workflow ID")],
+    store: Annotated[APIStateStore, Depends(get_api_store)],
+    config: Annotated[Config, Depends(get_config)],
+) -> CheckpointDetail:
+    """Get checkpoint details for a specific workflow.
+
+    Returns:
+        CheckpointDetail for the workflow.
+    """
+    return await _run_service(store, config).get_checkpoint(workflow_id)

--- a/services/tanren-api/src/tanren_api/routers/run.py
+++ b/services/tanren-api/src/tanren_api/routers/run.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path
 
-from tanren_api.dependencies import get_api_store, get_config, get_execution_env
+from tanren_api.dependencies import get_api_store, get_config, get_execution_env, get_vm_state_store
 from tanren_api.models import (
     CheckpointDetail,
     CheckpointSummary,
@@ -22,7 +22,7 @@ from tanren_api.models import (
 )
 from tanren_api.services import RunService
 from tanren_api.state import APIStateStore
-from tanren_core.adapters.protocols import ExecutionEnvironment
+from tanren_core.adapters.protocols import ExecutionEnvironment, VMStateStore
 from tanren_core.config import Config
 
 router = APIRouter(tags=["run"])
@@ -32,13 +32,14 @@ def _run_service(
     store: APIStateStore,
     config: Config | None = None,
     execution_env: ExecutionEnvironment | None = None,
+    vm_state_store: VMStateStore | None = None,
 ) -> RunService:
     """Build a RunService with the given dependencies.
 
     Returns:
         RunService: Configured service instance.
     """
-    return RunService(store, config, execution_env)
+    return RunService(store, config, execution_env, vm_state_store=vm_state_store)
 
 
 @router.post("/run/provision")
@@ -119,6 +120,7 @@ async def resume_dispatch(
     workflow_id: Annotated[str, Path(description="Workflow ID to resume")],
     store: Annotated[APIStateStore, Depends(get_api_store)],
     execution_env: Annotated[ExecutionEnvironment | None, Depends(get_execution_env)],
+    vm_state_store: Annotated[VMStateStore | None, Depends(get_vm_state_store)],
     config: Annotated[Config, Depends(get_config)],
 ) -> ResumeAccepted:
     """Resume a checkpointed dispatch.
@@ -126,7 +128,7 @@ async def resume_dispatch(
     Returns:
         ResumeAccepted confirmation.
     """
-    return await _run_service(store, config, execution_env).resume(workflow_id)
+    return await _run_service(store, config, execution_env, vm_state_store).resume(workflow_id)
 
 
 @router.get("/run/checkpoints")

--- a/services/tanren-api/src/tanren_api/services/run.py
+++ b/services/tanren-api/src/tanren_api/services/run.py
@@ -471,7 +471,7 @@ class RunService:
         )
 
     async def resume(self, workflow_id: str) -> ResumeAccepted:
-        """Resume a checkpointed dispatch (non-blocking background task).
+        """Resume a checkpointed dispatch in a background task.
 
         Returns:
             ResumeAccepted with the workflow_id.
@@ -480,10 +480,24 @@ class RunService:
             NotFoundError: If no checkpoint exists for the workflow.
         """
         config = self._require_config()
+        execution_env = self._require_execution_env()
         checkpoints_dir = Path(config.checkpoints_dir)
         checkpoint = await read_checkpoint(checkpoints_dir, workflow_id)
         if checkpoint is None:
             raise NotFoundError(f"No checkpoint found for workflow: {workflow_id}")
+
+        async def _resume_background() -> None:
+            from tanren_core.manager import (  # noqa: PLC0415 — heavy import
+                WorkerManager,
+            )
+
+            manager = WorkerManager(config=config, execution_env=execution_env)
+            try:
+                await manager.resume_dispatch(workflow_id)
+            except Exception:
+                logger.exception("Background resume failed for %s", workflow_id)
+
+        _task = asyncio.create_task(_resume_background())  # noqa: RUF006 — fire-and-forget background task
 
         return ResumeAccepted(workflow_id=workflow_id)
 

--- a/services/tanren-api/src/tanren_api/services/run.py
+++ b/services/tanren-api/src/tanren_api/services/run.py
@@ -26,7 +26,7 @@ from tanren_api.models import (
     RunTeardownAccepted,
 )
 from tanren_api.state import APIStateStore, DispatchRecord, EnvironmentRecord
-from tanren_core.adapters.protocols import ExecutionEnvironment
+from tanren_core.adapters.protocols import ExecutionEnvironment, VMStateStore
 from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
 from tanren_core.ipc import list_checkpoints as list_checkpoints_ipc
@@ -36,6 +36,9 @@ from tanren_core.roles_config import load_roles_config
 from tanren_core.schemas import Dispatch, Outcome, Phase
 
 logger = logging.getLogger(__name__)
+
+# Strong references to fire-and-forget resume tasks to prevent GC.
+_resume_tasks: set[asyncio.Task[None]] = set()
 
 _EXECUTE_FROM = frozenset({RunEnvironmentStatus.PROVISIONED, RunEnvironmentStatus.COMPLETED})
 _TEARDOWN_FROM = frozenset({
@@ -64,11 +67,13 @@ class RunService:
         store: APIStateStore,
         config: Config | None = None,
         execution_env: ExecutionEnvironment | None = None,
+        vm_state_store: VMStateStore | None = None,
     ) -> None:
         """Initialize with dependencies."""
         self._store = store
         self._config = config
         self._execution_env = execution_env
+        self._vm_state_store = vm_state_store
 
     def _require_config(self) -> Config:
         """Return config or raise if unavailable.
@@ -473,6 +478,9 @@ class RunService:
     async def resume(self, workflow_id: str) -> ResumeAccepted:
         """Resume a checkpointed dispatch in a background task.
 
+        Works for both local and remote checkpoints. Local deployments
+        (no remote execution env) construct a local WorkerManager from config.
+
         Returns:
             ResumeAccepted with the workflow_id.
 
@@ -480,24 +488,34 @@ class RunService:
             NotFoundError: If no checkpoint exists for the workflow.
         """
         config = self._require_config()
-        execution_env = self._require_execution_env()
         checkpoints_dir = Path(config.checkpoints_dir)
         checkpoint = await read_checkpoint(checkpoints_dir, workflow_id)
         if checkpoint is None:
             raise NotFoundError(f"No checkpoint found for workflow: {workflow_id}")
+
+        # Capture references for the background closure
+        execution_env = self._execution_env  # may be None for local deployments
+        vm_state_store = self._vm_state_store
 
         async def _resume_background() -> None:
             from tanren_core.manager import (  # noqa: PLC0415 — heavy import
                 WorkerManager,
             )
 
-            manager = WorkerManager(config=config, execution_env=execution_env)
+            manager = WorkerManager(
+                config=config,
+                execution_env=execution_env,
+                vm_state_store=vm_state_store,
+            )
             try:
                 await manager.resume_dispatch(workflow_id)
             except Exception:
                 logger.exception("Background resume failed for %s", workflow_id)
 
-        _task = asyncio.create_task(_resume_background())  # noqa: RUF006 — fire-and-forget background task
+        task = asyncio.create_task(_resume_background())
+        # Keep a strong reference so asyncio doesn't GC the task before completion.
+        _resume_tasks.add(task)
+        task.add_done_callback(_resume_tasks.discard)
 
         return ResumeAccepted(workflow_id=workflow_id)
 

--- a/services/tanren-api/src/tanren_api/services/run.py
+++ b/services/tanren-api/src/tanren_api/services/run.py
@@ -7,13 +7,17 @@ import contextlib
 import logging
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
 from tanren_api.errors import ConflictError, NotFoundError, ServiceError
 from tanren_api.models import (
+    CheckpointDetail,
+    CheckpointSummary,
     DispatchAccepted,
     DispatchRunStatus,
     ExecuteRequest,
     ProvisionRequest,
+    ResumeAccepted,
     RunEnvironment,
     RunEnvironmentStatus,
     RunExecuteAccepted,
@@ -25,6 +29,8 @@ from tanren_api.state import APIStateStore, DispatchRecord, EnvironmentRecord
 from tanren_core.adapters.protocols import ExecutionEnvironment
 from tanren_core.adapters.types import EnvironmentHandle, RemoteEnvironmentRuntime
 from tanren_core.config import Config
+from tanren_core.ipc import list_checkpoints as list_checkpoints_ipc
+from tanren_core.ipc import read_checkpoint
 from tanren_core.roles import RoleName
 from tanren_core.roles_config import load_roles_config
 from tanren_core.schemas import Dispatch, Outcome, Phase
@@ -462,4 +468,76 @@ class RunService:
             duration_secs=duration_secs,
             vm_id=record.vm_id or None,
             host=record.host or None,
+        )
+
+    async def resume(self, workflow_id: str) -> ResumeAccepted:
+        """Resume a checkpointed dispatch (non-blocking background task).
+
+        Returns:
+            ResumeAccepted with the workflow_id.
+
+        Raises:
+            NotFoundError: If no checkpoint exists for the workflow.
+        """
+        config = self._require_config()
+        checkpoints_dir = Path(config.checkpoints_dir)
+        checkpoint = await read_checkpoint(checkpoints_dir, workflow_id)
+        if checkpoint is None:
+            raise NotFoundError(f"No checkpoint found for workflow: {workflow_id}")
+
+        return ResumeAccepted(workflow_id=workflow_id)
+
+    async def get_checkpoints(self) -> list[CheckpointSummary]:
+        """List all active checkpoints.
+
+        Returns:
+            List of CheckpointSummary instances.
+        """
+        config = self._require_config()
+        checkpoints_dir = Path(config.checkpoints_dir)
+        checkpoints = await list_checkpoints_ipc(checkpoints_dir)
+        return [
+            CheckpointSummary(
+                workflow_id=cp.workflow_id,
+                stage=cp.stage.value,
+                retry_count=cp.retry_count,
+                vm_id=cp.vm_id,
+                last_error=cp.last_error,
+                failure_count=cp.failure_count,
+                created_at=cp.created_at,
+                updated_at=cp.updated_at,
+            )
+            for cp in checkpoints
+        ]
+
+    async def get_checkpoint(self, workflow_id: str) -> CheckpointDetail:
+        """Get checkpoint details for a workflow.
+
+        Returns:
+            CheckpointDetail for the workflow.
+
+        Raises:
+            NotFoundError: If no checkpoint exists for the workflow.
+        """
+        config = self._require_config()
+        checkpoints_dir = Path(config.checkpoints_dir)
+        cp = await read_checkpoint(checkpoints_dir, workflow_id)
+        if cp is None:
+            raise NotFoundError(f"No checkpoint found for workflow: {workflow_id}")
+        return CheckpointDetail(
+            workflow_id=cp.workflow_id,
+            stage=cp.stage.value,
+            dispatch_json=cp.dispatch_json,
+            worktree_path=cp.worktree_path,
+            dispatch_stem=cp.dispatch_stem,
+            vm_id=cp.vm_id,
+            environment_profile=cp.environment_profile,
+            workspace_remote_path=cp.workspace_remote_path,
+            phase_result_json=cp.phase_result_json,
+            dispatch_start_utc=cp.dispatch_start_utc,
+            retry_count=cp.retry_count,
+            last_error=cp.last_error,
+            failure_count=cp.failure_count,
+            created_at=cp.created_at,
+            updated_at=cp.updated_at,
         )

--- a/services/tanren-cli/src/tanren_cli/run_cli.py
+++ b/services/tanren-cli/src/tanren_cli/run_cli.py
@@ -8,6 +8,7 @@ Reference docs:
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 import uuid
 from datetime import UTC, datetime
@@ -35,6 +36,7 @@ from tanren_core.env.environment_schema import (
     parse_environment_profiles,
 )
 from tanren_core.env.gates import resolve_gate_cmd
+from tanren_core.ipc import list_checkpoints as list_checkpoints_io
 from tanren_core.manager import build_tail_output
 from tanren_core.roles import AgentTool, AuthMode, RoleName
 from tanren_core.roles_config import load_roles_config
@@ -654,6 +656,54 @@ def run_full(
             await env.close()
             if pg_pool is not None:
                 await pg_pool.close()
+
+    asyncio.run(_run())
+
+
+@run_app.command("resume")
+def run_resume(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID to resume from checkpoint")],
+) -> None:
+    """Resume a dispatch from its most recent checkpoint."""
+
+    async def _run() -> None:
+        config = _load_config()
+        from tanren_core.manager import WorkerManager  # noqa: PLC0415 — heavy import
+
+        manager = WorkerManager(config)
+        result = await manager.resume_dispatch(workflow_id)
+        if result is None:
+            typer.echo(f"No checkpoint found for {workflow_id}", err=True)
+            raise typer.Exit(code=1)
+        typer.echo(f"outcome: {result.outcome.value}")
+        typer.echo(f"signal: {result.signal}")
+        typer.echo(f"exit_code: {result.exit_code}")
+        typer.echo(f"duration_secs: {result.duration_secs}")
+
+    asyncio.run(_run())
+
+
+@run_app.command("checkpoints")
+def run_checkpoints(
+    as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+) -> None:
+    """List all active checkpoints."""
+
+    async def _run() -> None:
+        config = _load_config()
+        checkpoints_dir = Path(config.checkpoints_dir)
+        entries = await list_checkpoints_io(checkpoints_dir)
+        if as_json:
+            typer.echo(json.dumps([e.model_dump(mode="json") for e in entries], indent=2))
+        else:
+            if not entries:
+                typer.echo("No active checkpoints.")
+                return
+            for entry in entries:
+                typer.echo(
+                    f"{entry.workflow_id}  stage={entry.stage}  "
+                    f"retries={entry.retry_count}  updated={entry.updated_at}"
+                )
 
     asyncio.run(_run())
 

--- a/tests/integration/test_checkpoint_lifecycle.py
+++ b/tests/integration/test_checkpoint_lifecycle.py
@@ -1,0 +1,243 @@
+"""Integration tests for checkpoint lifecycle."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tanren_core.adapters.null_emitter import NullEventEmitter
+from tanren_core.adapters.types import (
+    EnvironmentHandle,
+    LocalEnvironmentRuntime,
+    PhaseResult,
+)
+from tanren_core.config import Config
+from tanren_core.ipc import list_checkpoints, read_checkpoint, write_checkpoint
+from tanren_core.manager import WorkerManager
+from tanren_core.schemas import (
+    Checkpoint,
+    CheckpointStage,
+    Cli,
+    Dispatch,
+    Outcome,
+    Phase,
+    Result,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(tmp_path: Path) -> Config:
+    return Config(
+        ipc_dir=str(tmp_path / "ipc"),
+        github_dir=str(tmp_path / "github"),
+        data_dir=str(tmp_path / "data"),
+        worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+        roles_config_path=str(tmp_path / "roles.yml"),
+    )
+
+
+def _dispatch() -> Dispatch:
+    return Dispatch(
+        workflow_id="wf-test-1-1000",
+        phase=Phase.DO_TASK,
+        project="test",
+        spec_folder="specs/test",
+        branch="main",
+        cli=Cli.CLAUDE,
+        timeout=1800,
+    )
+
+
+def _checkpoint(stage: CheckpointStage = CheckpointStage.DISPATCHED) -> Checkpoint:
+    return Checkpoint(
+        workflow_id="wf-test-1-1000",
+        stage=stage,
+        dispatch_json=_dispatch().model_dump_json(),
+        worktree_path="/tmp/worktree",
+        dispatch_stem="1000-abc123",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+def _handle() -> EnvironmentHandle:
+    from pathlib import Path as _Path
+
+    return EnvironmentHandle(
+        env_id="env-1",
+        worktree_path=_Path("/tmp/worktree"),
+        branch="main",
+        project="test",
+        runtime=LocalEnvironmentRuntime(),
+    )
+
+
+def _phase_result() -> PhaseResult:
+    return PhaseResult(
+        outcome=Outcome.SUCCESS,
+        signal="complete",
+        exit_code=0,
+        stdout="done",
+        duration_secs=10,
+        preflight_passed=True,
+    )
+
+
+def _result() -> Result:
+    return Result(
+        workflow_id="wf-test-1-1000",
+        phase=Phase.DO_TASK,
+        outcome=Outcome.SUCCESS,
+        signal="complete",
+        exit_code=0,
+        duration_secs=10,
+        gate_output=None,
+        tail_output=None,
+        unchecked_tasks=0,
+        plan_hash="00000000",
+        spec_modified=False,
+    )
+
+
+def _manager(tmp_path: Path) -> WorkerManager:
+    from pathlib import Path as _Path
+
+    config = _config(tmp_path)
+    _Path(config.checkpoints_dir).mkdir(parents=True, exist_ok=True)
+    return WorkerManager(
+        config=config,
+        execution_env=AsyncMock(),
+        emitter=NullEventEmitter(),
+    )
+
+
+class TestCheckpointLifecycle:
+    async def test_resume_full_lifecycle_deletes_checkpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Resume from DISPATCHED, complete all phases, checkpoint deleted."""
+        manager = _manager(tmp_path)
+        cp = _checkpoint(CheckpointStage.DISPATCHED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        loaded = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert loaded is not None
+        assert loaded.stage == CheckpointStage.DISPATCHED
+
+        monkeypatch.setattr(manager, "_provision_phase", AsyncMock(return_value=_handle()))
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(return_value=_phase_result()))
+        monkeypatch.setattr(manager, "_post_process_phase", AsyncMock(return_value=_result()))
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        result = await manager.resume_dispatch("wf-test-1-1000")
+        assert result is not None
+        assert result.outcome == Outcome.SUCCESS
+
+        loaded = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert loaded is None
+
+    async def test_resume_from_provisioned_skips_provision(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Resume from PROVISIONED skips provision, still completes."""
+        manager = _manager(tmp_path)
+        cp = _checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        mock_provision = AsyncMock()
+        mock_execute = AsyncMock(return_value=_phase_result())
+        mock_postprocess = AsyncMock(return_value=_result())
+
+        monkeypatch.setattr(manager, "_provision_phase", mock_provision)
+        monkeypatch.setattr(manager, "_execute_phase", mock_execute)
+        monkeypatch.setattr(manager, "_post_process_phase", mock_postprocess)
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=_handle())
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        result = await manager.resume_dispatch("wf-test-1-1000")
+        assert result is not None
+
+        mock_provision.assert_not_awaited()
+        mock_execute.assert_awaited_once()
+        mock_postprocess.assert_awaited_once()
+
+        assert await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000") is None
+
+    async def test_failure_preserves_checkpoint_with_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Failure during resume preserves checkpoint with error info."""
+        manager = _manager(tmp_path)
+        cp = _checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=_handle())
+        )
+        monkeypatch.setattr(
+            manager, "_execute_phase", AsyncMock(side_effect=RuntimeError("network timeout"))
+        )
+
+        with pytest.raises(RuntimeError, match="network timeout"):
+            await manager.resume_dispatch("wf-test-1-1000")
+
+        updated = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert updated is not None
+        assert updated.last_error == "network timeout"
+        assert updated.failure_count == 1
+        assert updated.retry_count == 1
+
+    async def test_retry_after_failure_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """After a failed resume, a second resume succeeds and deletes checkpoint."""
+        manager = _manager(tmp_path)
+        cp = _checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        # First attempt: fail
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=_handle())
+        )
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(side_effect=RuntimeError("oops")))
+
+        with pytest.raises(RuntimeError):
+            await manager.resume_dispatch("wf-test-1-1000")
+
+        updated = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert updated is not None
+        assert updated.failure_count == 1
+
+        # Second attempt: succeed
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(return_value=_phase_result()))
+        monkeypatch.setattr(manager, "_post_process_phase", AsyncMock(return_value=_result()))
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        result = await manager.resume_dispatch("wf-test-1-1000")
+        assert result is not None
+        assert result.outcome == Outcome.SUCCESS
+
+        assert await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000") is None
+
+    async def test_multiple_checkpoints_listed(self, tmp_path: Path):
+        """Multiple checkpoints can be listed."""
+        manager = _manager(tmp_path)
+        for i in range(3):
+            cp = Checkpoint(
+                workflow_id=f"wf-test-{i}-1000",
+                stage=CheckpointStage.PROVISIONED,
+                dispatch_json=_dispatch().model_dump_json(),
+                worktree_path="/tmp/worktree",
+                created_at="2026-01-01T00:00:00+00:00",
+                updated_at="2026-01-01T00:00:00+00:00",
+            )
+            await write_checkpoint(manager._checkpoints_dir, cp)
+
+        entries = await list_checkpoints(manager._checkpoints_dir)
+        assert len(entries) == 3

--- a/tests/integration/test_manager_integration.py
+++ b/tests/integration/test_manager_integration.py
@@ -446,8 +446,11 @@ class TestWorkPhaseDetails:
         assert result_data["tail_output"] == "git push failed: auth denied"
 
     @pytest.mark.asyncio
-    async def test_execute_exception_writes_error_result_and_calls_teardown(self, tmp_path: Path):
-        """If execute() raises, an error result is written and teardown is still called."""
+    async def test_execute_exception_writes_error_result_and_preserves_checkpoint(
+        self, tmp_path: Path
+    ):
+        """If execute() raises, an error result is written, teardown is skipped
+        (VM preserved for resume), and the checkpoint is retained."""
         exec_env = AsyncMock()
         worktree_path = tmp_path / "github" / "demo-wt-42"
         worktree_path.mkdir(parents=True)
@@ -470,11 +473,17 @@ class TestWorkPhaseDetails:
 
         await manager._handle_dispatch(dispatch_path, dispatch)
 
-        exec_env.teardown.assert_awaited_once()
+        # Teardown is NOT called — VM preserved for checkpoint resume
+        exec_env.teardown.assert_not_awaited()
+
         result_files = list((tmp_path / "ipc" / "results").iterdir())
         result_data = json.loads(result_files[0].read_text())
         assert result_data["outcome"] == "error"
         assert "execute crashed" in result_data["tail_output"]
+
+        # Checkpoint should be retained for resume
+        checkpoint_files = list(manager._checkpoints_dir.iterdir())
+        assert len(checkpoint_files) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_mcp.py
+++ b/tests/unit/api/test_mcp.py
@@ -99,6 +99,8 @@ class TestMCPToolRegistration:
             "dispatch_create",
             "dispatch_get_status",
             "dispatch_cancel",
+            "resume_dispatch",
+            "list_checkpoints",
             # VM
             "vm_list",
             "vm_provision",

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -1,0 +1,164 @@
+"""Tests for checkpoint schema and I/O."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from tanren_core.ipc import (
+    delete_checkpoint,
+    list_checkpoints,
+    read_checkpoint,
+    write_checkpoint,
+)
+from tanren_core.schemas import (
+    Checkpoint,
+    CheckpointStage,
+    Cli,
+    Dispatch,
+    Phase,
+)
+
+
+def _make_dispatch() -> Dispatch:
+    return Dispatch(
+        workflow_id="wf-test-1-1000",
+        phase=Phase.DO_TASK,
+        project="test",
+        spec_folder="specs/test",
+        branch="main",
+        cli=Cli.CLAUDE,
+        timeout=1800,
+    )
+
+
+def _make_checkpoint(workflow_id: str = "wf-test-1-1000") -> Checkpoint:
+    return Checkpoint(
+        workflow_id=workflow_id,
+        stage=CheckpointStage.DISPATCHED,
+        dispatch_json=_make_dispatch().model_dump_json(),
+        worktree_path="/tmp/worktree",
+        dispatch_stem="1000-abc123",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+class TestCheckpointModel:
+    def test_roundtrip_serialization(self):
+        cp = _make_checkpoint()
+        json_str = cp.model_dump_json()
+        cp2 = Checkpoint.model_validate_json(json_str)
+        assert cp == cp2
+
+    def test_stage_enum_values(self):
+        assert CheckpointStage.DISPATCHED == "dispatched"
+        assert CheckpointStage.PROVISIONED == "provisioned"
+        assert CheckpointStage.EXECUTED == "executed"
+        assert CheckpointStage.POST_PROCESSED == "post_processed"
+
+    def test_extra_forbid_rejects_unknown(self):
+        data = _make_checkpoint().model_dump()
+        data["unknown_field"] = "bad"
+        with pytest.raises(ValidationError):
+            Checkpoint.model_validate(data)
+
+    def test_dispatch_preserved_in_json(self):
+        cp = _make_checkpoint()
+        dispatch = Dispatch.model_validate_json(cp.dispatch_json)
+        assert dispatch.workflow_id == "wf-test-1-1000"
+        assert dispatch.phase == Phase.DO_TASK
+
+    def test_default_failure_fields(self):
+        cp = _make_checkpoint()
+        assert cp.retry_count == 0
+        assert cp.failure_count == 0
+        assert cp.last_error is None
+        assert cp.vm_id is None
+        assert cp.phase_result_json is None
+
+
+class TestCheckpointIO:
+    async def test_write_and_read(self, tmp_path: Path):
+        cp = _make_checkpoint()
+        path = await write_checkpoint(tmp_path, cp)
+        assert path.exists()
+        assert path.name == "wf-test-1-1000.json"
+
+        loaded = await read_checkpoint(tmp_path, "wf-test-1-1000")
+        assert loaded is not None
+        assert loaded == cp
+
+    async def test_write_overwrites_same_workflow(self, tmp_path: Path):
+        cp = _make_checkpoint()
+        await write_checkpoint(tmp_path, cp)
+
+        cp.stage = CheckpointStage.PROVISIONED
+        cp.updated_at = "2026-01-01T01:00:00+00:00"
+        await write_checkpoint(tmp_path, cp)
+
+        loaded = await read_checkpoint(tmp_path, "wf-test-1-1000")
+        assert loaded is not None
+        assert loaded.stage == CheckpointStage.PROVISIONED
+
+        # Only one file should exist
+        all_checkpoints = await list_checkpoints(tmp_path)
+        assert len(all_checkpoints) == 1
+
+    async def test_read_nonexistent_returns_none(self, tmp_path: Path):
+        result = await read_checkpoint(tmp_path, "nonexistent")
+        assert result is None
+
+    async def test_delete_checkpoint(self, tmp_path: Path):
+        cp = _make_checkpoint()
+        await write_checkpoint(tmp_path, cp)
+        await delete_checkpoint(tmp_path, "wf-test-1-1000")
+        result = await read_checkpoint(tmp_path, "wf-test-1-1000")
+        assert result is None
+
+    async def test_delete_nonexistent_no_error(self, tmp_path: Path):
+        # Should not raise
+        await delete_checkpoint(tmp_path, "nonexistent")
+
+    async def test_list_empty_dir(self, tmp_path: Path):
+        result = await list_checkpoints(tmp_path)
+        assert result == []
+
+    async def test_list_nonexistent_dir(self, tmp_path: Path):
+        result = await list_checkpoints(tmp_path / "nonexistent")
+        assert result == []
+
+    async def test_list_multiple(self, tmp_path: Path):
+        for i in range(3):
+            cp = _make_checkpoint(f"wf-test-{i}-1000")
+            await write_checkpoint(tmp_path, cp)
+        result = await list_checkpoints(tmp_path)
+        assert len(result) == 3
+
+    async def test_list_skips_invalid_json(self, tmp_path: Path):
+        cp = _make_checkpoint()
+        await write_checkpoint(tmp_path, cp)
+        # Write corrupt file
+        (tmp_path / "corrupt.json").write_text("not json")
+        result = await list_checkpoints(tmp_path)
+        assert len(result) == 1
+        assert result[0].workflow_id == "wf-test-1-1000"
+
+
+class TestCheckpointConfig:
+    def test_checkpoints_dir_derived_from_data_dir(self, tmp_path: Path):
+        from tanren_core.config import Config
+
+        config = Config(
+            ipc_dir=str(tmp_path / "ipc"),
+            github_dir=str(tmp_path / "github"),
+            data_dir=str(tmp_path / "data"),
+            worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+            roles_config_path=str(tmp_path / "roles.yml"),
+        )
+        assert config.checkpoints_dir == str(tmp_path / "data" / "checkpoints")

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -1,0 +1,329 @@
+"""Tests for dispatch resume logic."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tanren_core.adapters.null_emitter import NullEventEmitter
+from tanren_core.adapters.types import (
+    EnvironmentHandle,
+    LocalEnvironmentRuntime,
+    PhaseResult,
+)
+from tanren_core.config import Config
+from tanren_core.ipc import read_checkpoint, write_checkpoint
+from tanren_core.manager import WorkerManager
+from tanren_core.schemas import (
+    Checkpoint,
+    CheckpointStage,
+    Cli,
+    Dispatch,
+    Outcome,
+    Phase,
+    Result,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_config(tmp_path: Path) -> Config:
+    return Config(
+        ipc_dir=str(tmp_path / "ipc"),
+        github_dir=str(tmp_path / "github"),
+        data_dir=str(tmp_path / "data"),
+        worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+        roles_config_path=str(tmp_path / "roles.yml"),
+    )
+
+
+def _make_dispatch() -> Dispatch:
+    return Dispatch(
+        workflow_id="wf-test-1-1000",
+        phase=Phase.DO_TASK,
+        project="test",
+        spec_folder="specs/test",
+        branch="main",
+        cli=Cli.CLAUDE,
+        timeout=1800,
+    )
+
+
+def _make_checkpoint(
+    stage: CheckpointStage = CheckpointStage.DISPATCHED,
+) -> Checkpoint:
+    return Checkpoint(
+        workflow_id="wf-test-1-1000",
+        stage=stage,
+        dispatch_json=_make_dispatch().model_dump_json(),
+        worktree_path="/tmp/worktree",
+        dispatch_stem="1000-abc123",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+def _make_handle() -> EnvironmentHandle:
+    from pathlib import Path as _Path
+
+    return EnvironmentHandle(
+        env_id="env-1",
+        worktree_path=_Path("/tmp/worktree"),
+        branch="main",
+        project="test",
+        runtime=LocalEnvironmentRuntime(),
+    )
+
+
+def _make_phase_result() -> PhaseResult:
+    return PhaseResult(
+        outcome=Outcome.SUCCESS,
+        signal="complete",
+        exit_code=0,
+        stdout="done",
+        duration_secs=10,
+        preflight_passed=True,
+    )
+
+
+def _make_result() -> Result:
+    return Result(
+        workflow_id="wf-test-1-1000",
+        phase=Phase.DO_TASK,
+        outcome=Outcome.SUCCESS,
+        signal="complete",
+        exit_code=0,
+        duration_secs=10,
+        gate_output=None,
+        tail_output=None,
+        unchecked_tasks=0,
+        plan_hash="00000000",
+        spec_modified=False,
+    )
+
+
+def _make_manager(tmp_path: Path) -> WorkerManager:
+    from pathlib import Path as _Path
+
+    config = _make_config(tmp_path)
+    _Path(config.checkpoints_dir).mkdir(parents=True, exist_ok=True)
+    execution_env = AsyncMock()
+    execution_env.provision = AsyncMock(return_value=_make_handle())
+    execution_env.execute = AsyncMock(return_value=_make_phase_result())
+    execution_env.teardown = AsyncMock()
+    return WorkerManager(
+        config=config,
+        execution_env=execution_env,
+        emitter=NullEventEmitter(),
+    )
+
+
+class TestResumeDispatch:
+    async def test_resume_nonexistent_returns_none(self, tmp_path: Path):
+        manager = _make_manager(tmp_path)
+        result = await manager.resume_dispatch("nonexistent")
+        assert result is None
+
+    async def test_resume_from_dispatched_runs_all_phases(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.DISPATCHED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        phase_result = _make_phase_result()
+        result = _make_result()
+        mock_provision = AsyncMock(return_value=handle)
+        mock_execute = AsyncMock(return_value=phase_result)
+        mock_postprocess = AsyncMock(return_value=result)
+        mock_write = AsyncMock()
+
+        monkeypatch.setattr(manager, "_provision_phase", mock_provision)
+        monkeypatch.setattr(manager, "_execute_phase", mock_execute)
+        monkeypatch.setattr(manager, "_post_process_phase", mock_postprocess)
+        monkeypatch.setattr(manager, "_write_result_and_nudge", mock_write)
+
+        returned = await manager.resume_dispatch("wf-test-1-1000")
+        assert returned is not None
+        assert returned.outcome == Outcome.SUCCESS
+
+        mock_provision.assert_awaited_once()
+        mock_execute.assert_awaited_once()
+        mock_postprocess.assert_awaited_once()
+        mock_write.assert_awaited_once()
+
+    async def test_resume_from_provisioned_skips_provision(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        phase_result = _make_phase_result()
+        result = _make_result()
+        mock_provision = AsyncMock(return_value=handle)
+        mock_execute = AsyncMock(return_value=phase_result)
+        mock_postprocess = AsyncMock(return_value=result)
+
+        monkeypatch.setattr(manager, "_provision_phase", mock_provision)
+        monkeypatch.setattr(manager, "_execute_phase", mock_execute)
+        monkeypatch.setattr(manager, "_post_process_phase", mock_postprocess)
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        returned = await manager.resume_dispatch("wf-test-1-1000")
+        assert returned is not None
+
+        mock_provision.assert_not_awaited()
+        mock_execute.assert_awaited_once()
+        mock_postprocess.assert_awaited_once()
+
+    async def test_resume_from_executed_skips_execute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.EXECUTED)
+        cp.phase_result_json = _make_phase_result().model_dump_json()
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        result = _make_result()
+        mock_provision = AsyncMock(return_value=handle)
+        mock_execute = AsyncMock()
+        mock_postprocess = AsyncMock(return_value=result)
+
+        monkeypatch.setattr(manager, "_provision_phase", mock_provision)
+        monkeypatch.setattr(manager, "_execute_phase", mock_execute)
+        monkeypatch.setattr(manager, "_post_process_phase", mock_postprocess)
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        returned = await manager.resume_dispatch("wf-test-1-1000")
+        assert returned is not None
+
+        mock_provision.assert_not_awaited()
+        mock_execute.assert_not_awaited()
+        mock_postprocess.assert_awaited_once()
+
+    async def test_resume_increments_retry_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        cp.retry_count = 2
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        phase_result = _make_phase_result()
+        result = _make_result()
+        mock_execute = AsyncMock(return_value=phase_result)
+
+        monkeypatch.setattr(manager, "_provision_phase", AsyncMock())
+        monkeypatch.setattr(manager, "_execute_phase", mock_execute)
+        monkeypatch.setattr(manager, "_post_process_phase", AsyncMock(return_value=result))
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        await manager.resume_dispatch("wf-test-1-1000")
+        mock_execute.assert_awaited_once()
+
+    async def test_resume_stores_error_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(side_effect=ValueError("VM gone"))
+        )
+
+        with pytest.raises(ValueError, match="VM gone"):
+            await manager.resume_dispatch("wf-test-1-1000")
+
+        updated = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert updated is not None
+        assert updated.last_error == "VM gone"
+        assert updated.failure_count == 1
+
+    async def test_resume_teardown_always_called(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(side_effect=RuntimeError("boom")))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await manager.resume_dispatch("wf-test-1-1000")
+
+        teardown_mock: AsyncMock = manager._execution_env.teardown  # type: ignore[assignment]
+        teardown_mock.assert_awaited_once_with(handle)
+
+    async def test_resume_checkpoint_deleted_on_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        phase_result = _make_phase_result()
+        result = _make_result()
+
+        monkeypatch.setattr(manager, "_provision_phase", AsyncMock())
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(return_value=phase_result))
+        monkeypatch.setattr(manager, "_post_process_phase", AsyncMock(return_value=result))
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        await manager.resume_dispatch("wf-test-1-1000")
+
+        loaded = await read_checkpoint(manager._checkpoints_dir, "wf-test-1-1000")
+        assert loaded is None
+
+
+class TestReconstructHandle:
+    async def test_local_reconstruction(self, tmp_path: Path):
+        from pathlib import Path as _Path
+
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        dispatch = _make_dispatch()
+
+        handle = await manager._reconstruct_handle_for_resume(cp, dispatch)
+        assert handle.runtime.kind == "local"
+        assert handle.worktree_path == _Path("/tmp/worktree")
+        assert handle.branch == "main"
+        assert handle.project == "test"
+
+    async def test_remote_vm_released_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        cp.vm_id = "vm-gone"
+        dispatch = _make_dispatch()
+
+        store = AsyncMock()
+        store.get_assignment = AsyncMock(return_value=None)
+        manager._remote_state_store = store  # dynamically set in remote mode
+
+        with pytest.raises(ValueError, match="no longer active"):
+            await manager._reconstruct_handle_for_resume(cp, dispatch)

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -257,9 +257,10 @@ class TestResumeDispatch:
         assert updated.last_error == "VM gone"
         assert updated.failure_count == 1
 
-    async def test_resume_teardown_always_called(
+    async def test_resume_skips_teardown_on_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        """On failure, VM is preserved for retry — teardown is NOT called."""
         manager = _make_manager(tmp_path)
         cp = _make_checkpoint(CheckpointStage.PROVISIONED)
         await write_checkpoint(manager._checkpoints_dir, cp)
@@ -272,6 +273,31 @@ class TestResumeDispatch:
 
         with pytest.raises(RuntimeError, match="boom"):
             await manager.resume_dispatch("wf-test-1-1000")
+
+        teardown_mock: AsyncMock = manager._execution_env.teardown  # type: ignore[assignment]
+        teardown_mock.assert_not_awaited()
+
+    async def test_resume_teardown_called_on_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """On success, teardown is called to release the VM."""
+        manager = _make_manager(tmp_path)
+        cp = _make_checkpoint(CheckpointStage.PROVISIONED)
+        await write_checkpoint(manager._checkpoints_dir, cp)
+
+        handle = _make_handle()
+        phase_result = _make_phase_result()
+        result = _make_result()
+
+        monkeypatch.setattr(manager, "_provision_phase", AsyncMock())
+        monkeypatch.setattr(manager, "_execute_phase", AsyncMock(return_value=phase_result))
+        monkeypatch.setattr(manager, "_post_process_phase", AsyncMock(return_value=result))
+        monkeypatch.setattr(
+            manager, "_reconstruct_handle_for_resume", AsyncMock(return_value=handle)
+        )
+        monkeypatch.setattr(manager, "_write_result_and_nudge", AsyncMock())
+
+        await manager.resume_dispatch("wf-test-1-1000")
 
         teardown_mock: AsyncMock = manager._execution_env.teardown  # type: ignore[assignment]
         teardown_mock.assert_awaited_once_with(handle)


### PR DESCRIPTION
## Summary
- Add `Checkpoint` and `CheckpointStage` models for persistent dispatch state
- Write progressive checkpoints at 4 boundaries: DISPATCHED → PROVISIONED → EXECUTED → (delete on success)
- Refactor `_handle_work_phase()` into composable sub-methods (`_provision_phase`, `_execute_phase`, `_post_process_phase`) for targeted resume
- Add `WorkerManager.resume_dispatch()` that reads checkpoint and jumps to the right phase
- Handle remote resume: check VM still exists via VMStateStore, reconnect SSH
- Add CLI: `tanren run resume <workflow_id>`, `tanren run checkpoints`
- Add API: `POST /run/{id}/resume`, `GET /run/checkpoints`, `GET /run/{id}/checkpoint`
- Add MCP tools: `resume_dispatch`, `list_checkpoints`
- Checkpoints deleted after successful result write (no accumulation)
- Automatic checkpoint recovery on worker startup

## Test plan
- [x] Unit tests for checkpoint I/O (write, read, delete, list, overwrite)
- [x] Unit tests for checkpoint model (roundtrip, validation, enum values)
- [x] Unit tests for resume logic (resume from each stage, error cases, VM gone)
- [x] Unit tests for handle reconstruction (local + remote VM released)
- [x] Integration tests for full checkpoint lifecycle (create → fail → resume → complete → delete)
- [x] Updated MCP tool registration test
- [x] `make check` passes (format, lint, type, unit 85%, integration 75%, docs)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)