### PR TITLE
docs: repo branding and style sweep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,21 @@ make ci
 If your changes touch SSH or local environment flows, also run the relevant
 integration target (`make integration-ssh` or `make integration-local`).
 
+## Tooling
+
+| Tool | Purpose | Config |
+|------|---------|--------|
+| [ruff](https://docs.astral.sh/ruff/) | Formatting and linting | `pyproject.toml [tool.ruff]` |
+| [ty](https://docs.astral.sh/ty/) | Type checking | `pyproject.toml [tool.ty]` |
+| [pytest](https://docs.pytest.org/) | Testing | `pyproject.toml [tool.pytest.ini_options]` |
+| [uv](https://docs.astral.sh/uv/) | Package and environment management | `pyproject.toml [tool.uv]` |
+| make | Task runner | `Makefile` |
+
+Test markers: `ssh`, `local_env`, `api`, `hetzner`, `gcp`, `postgres`,
+`github`, `linear`. Run a specific marker with `uv run pytest -m <marker>`.
+
+Coverage thresholds: 80% for unit tests, 75% for integration tests.
+
 ## Repository Areas
 
 - `packages/tanren-core/`: core library

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Trevor Wieland
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,150 @@
+<!-- Replace assets/logo.png with the real tanren logo -->
+![tanren](assets/logo.png)
+
 # tanren
 
 Opinionated orchestration engine for agentic software development.
 
-Tanren decides **what work happens and in what order** (issue intake, spec
-lifecycle, orchestration, gates, feedback). Agent runtimes decide **how each
-role executes** (CLI/model/auth/tooling).
+[![CI](https://github.com/trevorWieland/tanren/actions/workflows/ci.yml/badge.svg)](https://github.com/trevorWieland/tanren/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![Python](https://img.shields.io/badge/python-%3E%3D3.14-blue)](https://python.org)
+[![Version](https://img.shields.io/badge/version-0.2.4-green)](https://github.com/trevorWieland/tanren/releases)
+
+## What is tanren?
+
+Tanren decides **what work happens and in what order** -- issue intake, spec
+lifecycle, orchestration, gates, feedback. Agent runtimes decide **how each
+role executes** -- CLI selection, model routing, authentication, tooling. This
+separation lets you swap agents, models, and coordinators without changing
+workflow logic.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Coordinator
+        DASH[Dashboard / Chat]
+        COORD[Coordinator CLI]
+    end
+
+    subgraph "Tanren &lpar;this repo&rpar;"
+        API[HTTP API]
+        MCP[MCP Server]
+        CLI[tanren CLI]
+        IPC[File-based IPC]
+
+        WM[WorkerManager]
+
+        LOCAL[Local Environment]
+        SSH[SSH Environment]
+    end
+
+    subgraph Agent Runtimes
+        AGENT_CLI[Agent CLIs]
+        GATES[Bash Gates]
+    end
+
+    DASH --> API
+    DASH --> MCP
+    COORD --> IPC
+
+    API --> WM
+    MCP --> WM
+    CLI --> WM
+    IPC --> WM
+
+    WM --> LOCAL
+    WM --> SSH
+
+    LOCAL --> AGENT_CLI
+    LOCAL --> GATES
+    SSH --> AGENT_CLI
+    SSH --> GATES
+```
+
+**Three-layer model**: Coordinators (identity, authorization, developer UX)
+sit above tanren. Tanren manages workflow state, dispatch routing, and
+environment lifecycle. Agent runtimes (opencode, codex, claude, aider) sit
+below and handle role-specific execution.
+
+## Quick Start
+
+### Run with Docker
+
+```bash
+docker run -d --name tanren-api \
+  -p 8000:8000 \
+  ghcr.io/trevorwieland/tanren-api:latest
+```
+
+Health check: `curl http://localhost:8000/api/v1/health`
+
+### Run with the CLI
+
+```bash
+git clone https://github.com/trevorWieland/tanren.git
+cd tanren
+uv sync
+```
+
+Validate your environment:
+
+```bash
+tanren env check
+```
+
+Run a full lifecycle:
+
+```bash
+tanren run full \
+  --project my-project \
+  --branch main \
+  --spec-path tanren/specs/s0001 \
+  --phase do-task
+```
+
+### Install methodology into a project
+
+```bash
+cd /path/to/your-project
+/path/to/tanren/scripts/install.sh --profile python-uv
+```
+
+This installs commands, standards, product templates, and helper scripts.
+Then bootstrap project knowledge (run once per project, via your agent):
+
+1. `plan-product`
+2. `discover-standards`
+3. `inject-standards`
+4. `index-standards`
+
+See [docs/getting-started/bootstrap.md](docs/getting-started/bootstrap.md)
+for the full bootstrap flow.
+
+## Features
+
+- **Spec lifecycle orchestration** -- shape, implement, audit, gate, and
+  feedback phases with automatic retries and dependency tracking
+- **Multi-agent dispatch** -- routes work to opencode, codex, claude, or
+  bash based on role configuration
+- **Local and remote execution** -- run agents locally via subprocess or on
+  remote VMs over SSH (Hetzner, GCP)
+- **Methodology system** -- reusable commands, coding standards profiles, and
+  product context templates installed into target projects
+- **Multiple entry points** -- HTTP API, MCP server, CLI, and file-based IPC
+  for flexible coordinator integration
+- **Gate checks** -- automated validation between phases with configurable
+  per-phase gate commands
+- **Event tracking** -- structured event emission to SQLite or Postgres for
+  observability and metering
 
 ## What Tanren Is
 
 Tanren has two coupled halves:
 
-1. **Execution framework** (`packages/tanren-core/`, `services/`): dispatch routing, environment
-   provisioning, retries, lifecycle handling, and result emission.
+1. **Execution framework** (`packages/tanren-core/`, `services/`): dispatch
+   routing, environment provisioning, retries, lifecycle handling, and result
+   emission.
 2. **Methodology system** (`commands/`, `profiles/`, `templates/`):
    reusable agent instructions, standards, and product context.
 
@@ -20,35 +153,6 @@ Tanren has two coupled halves:
 - Not a model router or model chooser
 - Not tied to one coordinator UX (dashboard/CLI/chat can all sit above tanren)
 - Not a vendor-locked hosted platform
-
-## The Three Layers
-
-```
-Coordinator -> Tanren -> Agent Runtime
-```
-
-- **Coordinator**: identity, authorization, developer interface, reporting
-- **Tanren**: workflow state machine and orchestration policy
-- **Agent runtime**: role mapping to CLI/model/auth configuration
-
-## Quick Start
-
-### Install Tanren into a Project
-
-```bash
-cd your-project
-~/github/tanren/scripts/install.sh --profile python-uv
-```
-
-Installs commands, standards, product templates, and helper scripts.
-
-### Run Worker Manager
-
-```bash
-export WM_IPC_DIR=~/data/ipc/main
-export WM_GITHUB_DIR=~/github
-uv run worker-manager
-```
 
 ## Repository Structure
 
@@ -68,57 +172,31 @@ tanren/
 └── scripts/         # install and utility scripts
 ```
 
-## Commands
+## Configuration
 
-`shape-spec`, `do-task`, `audit-task`, `run-demo`, `audit-spec`, `walk-spec`,
-`handle-feedback`, `resolve-blockers`, `investigate`, `plan-product`,
-`discover-standards`, `inject-standards`, `index-standards`, `triage-audits`,
-`sync-roadmap`
-
-## Profiles
-
-- `default`: minimal language-agnostic standards
-- `python-uv`: strict Python + uv standards (typing/testing/architecture)
-
-## Configuration Scopes
-
-- **Developer-scoped**: local auth/secrets/preferences (never committed)
-- **Project-scoped**: repo config (`tanren.yml`, standards, product docs)
+- **Developer-scoped**: local auth, secrets, preferences (never committed)
+- **Project-scoped**: `tanren.yml`, standards, product docs (committed per-repo)
 - **Organization-scoped**: runtime policy and infrastructure config
-
-## Execution Environments
-
-The `ExecutionEnvironment` abstraction supports local and remote lifecycle:
-`provision() -> execute() -> get_access_info() -> teardown()`
-
-See `docs/ADAPTERS.md` for protocol details.
-
-## Docker
-
-The `tanren-api` image is published to GHCR as a single all-inclusive image.
-Adapter selection (Hetzner, GCP, GitHub, Linear) is a runtime config decision —
-all optional deps are included by default (~20-30 MB overhead).
-
-On merge to master the release workflow auto-bumps the patch version and
-publishes with tags: `latest`, `{version}`, `sha-{short}`.
-
-```bash
-# Build locally
-make docker           # tanren-api:latest (all adapters)
-make docker-slim      # tanren-api:slim   (no optional adapters)
-```
 
 ## Documentation
 
-- `docs/README.md` - documentation index
-- `docs/architecture/overview.md` - architecture and boundaries
-- `docs/workflow/spec-lifecycle.md` - lifecycle and orchestration rules
-- `docs/getting-started/bootstrap.md` - install/bootstrap flow
-- `docs/operations/security-secrets.md` - security and secret handling
-- `docs/operations/observability.md` - events and metering
-- `docs/interfaces.md` - CLI/library/IPC interaction surfaces
-- `docs/design-principles.md` - architectural principles
-- `docs/roadmap.md` - date-stamped roadmap
-- `protocol/README.md` + `protocol/PROTOCOL.md` - protocol overview and full spec
-- `docs/worker-manager-README.md` - runtime behavior and operations
-- `docs/ADAPTERS.md` - adapter architecture and extension points
+- [docs/README.md](docs/README.md) - documentation index
+- [docs/architecture/overview.md](docs/architecture/overview.md) - architecture and boundaries
+- [docs/workflow/spec-lifecycle.md](docs/workflow/spec-lifecycle.md) - lifecycle and orchestration rules
+- [docs/getting-started/bootstrap.md](docs/getting-started/bootstrap.md) - install/bootstrap flow
+- [docs/operations/security-secrets.md](docs/operations/security-secrets.md) - security and secret handling
+- [docs/operations/observability.md](docs/operations/observability.md) - events and metering
+- [docs/interfaces.md](docs/interfaces.md) - CLI/library/IPC interaction surfaces
+- [docs/design-principles.md](docs/design-principles.md) - architectural principles
+- [docs/roadmap.md](docs/roadmap.md) - date-stamped roadmap
+- [protocol/README.md](protocol/README.md) + [protocol/PROTOCOL.md](protocol/PROTOCOL.md) - protocol overview and full spec
+- [docs/worker-manager-README.md](docs/worker-manager-README.md) - runtime behavior and operations
+- [docs/ADAPTERS.md](docs/ADAPTERS.md) - adapter architecture and extension points
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) for full text.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,4 @@
+# Assets
+
+Place the tanren logo at `logo.png` in this directory. The root README
+references `assets/logo.png`.

--- a/docs/hld-migration-map.md
+++ b/docs/hld-migration-map.md
@@ -7,11 +7,11 @@ repo docs before deletion.
 |---|---|
 | What Tanren Is | [`architecture/overview.md#what-tanren-is`](architecture/overview.md#what-tanren-is) |
 | Why Tanren / raw agents / plan mode / cloud platforms | [`architecture/overview.md`](architecture/overview.md) + [`../README.md#what-tanren-is-not`](../README.md#what-tanren-is-not) |
-| Three-Layer Model | [`../README.md#the-three-layers`](../README.md#the-three-layers) + [`architecture/overview.md#three-layer-model`](architecture/overview.md#three-layer-model) |
+| Three-Layer Model | [`../README.md#architecture`](../README.md#architecture) + [`architecture/overview.md#three-layer-model`](architecture/overview.md#three-layer-model) |
 | Coordinator / Tanren / Agent Runtime boundaries | [`architecture/overview.md#three-layer-model`](architecture/overview.md#three-layer-model) |
 | Methodology System | [`methodology/system.md`](methodology/system.md) |
-| Command files inventory | [`../README.md#commands`](../README.md#commands) + [`methodology/system.md#command-files`](methodology/system.md#command-files) |
-| Standards profiles | [`../README.md#profiles`](../README.md#profiles) + [`methodology/system.md#standards-profiles`](methodology/system.md#standards-profiles) |
+| Command files inventory | [`methodology/system.md#command-files`](methodology/system.md#command-files) |
+| Standards profiles | [`methodology/system.md#standards-profiles`](methodology/system.md#standards-profiles) |
 | Product templates | [`methodology/system.md#product-templates`](methodology/system.md#product-templates) |
 | Dual nature in practice | [`architecture/overview.md#what-tanren-is`](architecture/overview.md#what-tanren-is) |
 | Bootstrapping a project | [`../README.md#quick-start`](../README.md#quick-start) + [`getting-started/bootstrap.md`](getting-started/bootstrap.md) |
@@ -26,14 +26,14 @@ repo docs before deletion.
 | Spec lifecycle states | [`workflow/spec-lifecycle.md#core-lifecycle`](workflow/spec-lifecycle.md#core-lifecycle) |
 | run-demo computer-use expectations | [`workflow/spec-lifecycle.md#run-demo-expectations`](workflow/spec-lifecycle.md#run-demo-expectations) |
 | Agent roles and role separation rationale | [`methodology/system.md#agent-roles`](methodology/system.md#agent-roles) + [`methodology/system.md#role-separation`](methodology/system.md#role-separation) |
-| Execution environment lifecycle | [`../README.md#execution-environments`](../README.md#execution-environments) |
+| Execution environment lifecycle | [`ADAPTERS.md`](ADAPTERS.md) |
 | Sub-adapter decomposition | [`ADAPTERS.md`](ADAPTERS.md) |
 | Agent-proof remote design | [`ADAPTERS.md`](ADAPTERS.md) |
 | Environment profiles and debug handoff | [`ADAPTERS.md#sshexecutionenvironment`](ADAPTERS.md#sshexecutionenvironment) |
 | Pluggable integrations overview | [`architecture/overview.md#opinionated-core-vs-pluggable-integrations`](architecture/overview.md#opinionated-core-vs-pluggable-integrations) |
 | Current adapters | [`ADAPTERS.md`](ADAPTERS.md) + [`roadmap.md`](roadmap.md) |
-| Secret scoping (developer/project/infrastructure) | [`../README.md#configuration-scopes`](../README.md#configuration-scopes) + [`operations/security-secrets.md#secret-scopes`](operations/security-secrets.md#secret-scopes) |
-| Configuration scopes | [`../README.md#configuration-scopes`](../README.md#configuration-scopes) + [`operations/security-secrets.md#configuration-scopes`](operations/security-secrets.md#configuration-scopes) |
+| Secret scoping (developer/project/infrastructure) | [`../README.md#configuration`](../README.md#configuration) + [`operations/security-secrets.md#secret-scopes`](operations/security-secrets.md#secret-scopes) |
+| Configuration scopes | [`../README.md#configuration`](../README.md#configuration) + [`operations/security-secrets.md#configuration-scopes`](operations/security-secrets.md#configuration-scopes) |
 | Interaction methodologies (CLI/library/IPC/HTTP API) | [`interfaces.md`](interfaces.md) + [`../protocol/README.md`](../protocol/README.md) |
 | Metering and observability | [`ADAPTERS.md#eventemitter`](ADAPTERS.md#eventemitter) + [`operations/observability.md`](operations/observability.md) |
 | Security model | [`operations/security-secrets.md#security-controls`](operations/security-secrets.md#security-controls) |

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -3,6 +3,7 @@ name = "tanren-core"
 version = "0.2.4"
 description = "Core business logic for tanren"
 requires-python = ">=3.14"
+license = "Apache-2.0"
 dependencies = [
     "pydantic>=2, <3",
     "python-dotenv>=1.0, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "tanren-workspace"
 version = "0.2.4"
 description = "Development lifecycle framework"
 requires-python = ">=3.14"
+license = "Apache-2.0"
 
 [project.optional-dependencies]
 hetzner = ["tanren-core[hetzner]"]

--- a/services/tanren-api/pyproject.toml
+++ b/services/tanren-api/pyproject.toml
@@ -3,6 +3,7 @@ name = "tanren-api"
 version = "0.2.4"
 description = "FastAPI HTTP API for tanren"
 requires-python = ">=3.14"
+license = "Apache-2.0"
 dependencies = [
     "tanren-core",
     "fastapi>=0.128.0, <1",

--- a/services/tanren-cli/pyproject.toml
+++ b/services/tanren-cli/pyproject.toml
@@ -3,6 +3,7 @@ name = "tanren-cli"
 version = "0.2.4"
 description = "CLI for tanren"
 requires-python = ">=3.14"
+license = "Apache-2.0"
 dependencies = [
     "tanren-core",
     "typer>=0.12, <1",

--- a/services/tanren-daemon/pyproject.toml
+++ b/services/tanren-daemon/pyproject.toml
@@ -3,6 +3,7 @@ name = "tanren-daemon"
 version = "0.2.4"
 description = "Worker manager polling daemon for tanren"
 requires-python = ">=3.14"
+license = "Apache-2.0"
 dependencies = [
     "tanren-core",
 ]


### PR DESCRIPTION
## Summary

- Add Apache 2.0 `LICENSE` file and `license = "Apache-2.0"` to all 5 `pyproject.toml` files
- Create `assets/` directory with logo placeholder (swap `assets/logo.png` with real image)
- Overhaul `README.md`: badges (CI, license, Python, version), Mermaid architecture diagram, rewritten quick start (Docker / CLI / methodology install), features list, condensed config section
- Add tooling section to `CONTRIBUTING.md` (ruff, ty, pytest, uv, make, test markers, coverage thresholds)
- Fix 6 broken anchors in `docs/hld-migration-map.md` caused by removed/renamed README sections

## Manual follow-ups after merge

- [ ] Replace `assets/logo.png` with real tanren logo
- [ ] Set repo description and topics (`orchestration`, `agentic`, `developer-tools`, `python`)
- [ ] Upload social preview image (Settings > Social preview)
- [ ] Verify Mermaid diagram renders correctly on GitHub

## Test plan

- [x] `make format-check` passes
- [x] `make lint-check` passes
- [x] `make docs-check` passes (84 files, 0 errors)
- [ ] Mermaid diagram renders on GitHub
- [ ] Badges display correctly
- [ ] LICENSE recognized by GitHub (shows in repo sidebar)

Closes #50