### PR TITLE
fix: stage README.md in version bump, add Docker Hub push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml packages/tanren-core/pyproject.toml services/*/pyproject.toml uv.lock
+          git add pyproject.toml packages/tanren-core/pyproject.toml services/*/pyproject.toml uv.lock README.md
           git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
           git pull --rebase https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git master
           git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git HEAD:master
@@ -118,11 +118,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Summary
- **Hotfix**: The `bump_version.py` script updates the version badge in `README.md`, but the release workflow's `git add` didn't include it — leaving unstaged changes that blocked `git pull --rebase` (failed run: #23554072109)
- **Feature**: Adds Docker Hub as a second push target alongside GHCR (requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets)

## Test plan
- [ ] Merge and verify the version bump job succeeds (README.md staged correctly)
- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repo before or after merge
- [ ] Verify images appear on both GHCR and Docker Hub after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)