### PR TITLE
feat: Docker execution environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ unit:
 
 integration:
 	uv run pytest tests/integration -q --tb=short --timeout=30 \
-		-m "not ssh and not local_env and not hetzner and not gcp and not postgres and not github and not linear" \
+		-m "not ssh and not local_env and not hetzner and not gcp and not postgres and not github and not linear and not docker" \
 		--cov=packages --cov=services --cov-fail-under=75
 
 docs-check:

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -18,11 +18,13 @@ gcp = ["google-cloud-compute>=1.20.0, <2", "google-cloud-secret-manager>=2.20.0,
 github = ["httpx>=0.27, <1"]
 hetzner = ["hcloud>=2.4.0, <3"]
 linear = ["httpx>=0.27, <1"]
+docker = ["aiodocker>=0.23, <1"]
 all = [
     "google-cloud-compute>=1.20.0, <2",
     "google-cloud-secret-manager>=2.20.0, <3",
     "httpx>=0.27, <1",
     "hcloud>=2.4.0, <3",
+    "aiodocker>=0.23, <1",
 ]
 
 [build-system]

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -57,11 +57,8 @@ try:  # noqa: SIM105, RUF067 — optional dependency try/except
     from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 except ImportError:  # hcloud not installed
     pass
-try:  # noqa: RUF067 — optional dependency try/except
-    from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
-    from tanren_core.adapters.docker_environment import DockerExecutionEnvironment
-except ImportError:  # aiodocker not installed
-    pass
+from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
+from tanren_core.adapters.docker_environment import DockerExecutionEnvironment
 from tanren_core.adapters.local_environment import LocalExecutionEnvironment
 from tanren_core.adapters.manual_vm import (
     ManualProvisionerSettings,

--- a/packages/tanren-core/src/tanren_core/adapters/__init__.py
+++ b/packages/tanren-core/src/tanren_core/adapters/__init__.py
@@ -57,6 +57,11 @@ try:  # noqa: SIM105, RUF067 — optional dependency try/except
     from tanren_core.adapters.hetzner_vm import HetznerProvisionerSettings, HetznerVMProvisioner
 except ImportError:  # hcloud not installed
     pass
+try:  # noqa: RUF067 — optional dependency try/except
+    from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
+    from tanren_core.adapters.docker_environment import DockerExecutionEnvironment
+except ImportError:  # aiodocker not installed
+    pass
 from tanren_core.adapters.local_environment import LocalExecutionEnvironment
 from tanren_core.adapters.manual_vm import (
     ManualProvisionerSettings,
@@ -125,6 +130,9 @@ __all__ = [
     "CodexCredentialProvider",
     "CredentialProvider",
     "DispatchReceived",
+    "DockerConfig",
+    "DockerConnection",
+    "DockerExecutionEnvironment",
     "DotenvEnvProvisioner",
     "DotenvEnvValidator",
     "DotenvSecretProvider",

--- a/packages/tanren-core/src/tanren_core/adapters/docker_connection.py
+++ b/packages/tanren-core/src/tanren_core/adapters/docker_connection.py
@@ -1,0 +1,388 @@
+"""Docker container connection — execute commands and transfer files via docker exec."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import logging
+import shlex
+from typing import TYPE_CHECKING, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tanren_core.adapters.remote_types import RemoteResult
+
+if TYPE_CHECKING:
+    import collections.abc
+
+    import aiodocker
+    from aiodocker.types import JSONObject
+
+logger = logging.getLogger(__name__)
+
+
+class DockerConfig(BaseModel):
+    """Configuration for creating Docker containers."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    image: str = Field(default="ubuntu:24.04", description="Docker image to use for containers")
+    socket_url: str | None = Field(
+        default=None, description="Docker daemon socket URL (None for default)"
+    )
+    network: str | None = Field(
+        default=None, description="Docker network to attach the container to"
+    )
+    extra_volumes: tuple[str, ...] = Field(
+        default=(), description="Additional bind-mount volume specs (host:container format)"
+    )
+    extra_env: dict[str, str] = Field(
+        default_factory=dict, description="Extra environment variables for the container"
+    )
+    api_version: str = Field(default="v1.45", description="Docker API version string")
+
+
+class DockerConnection:
+    """Execute commands inside a Docker container via aiodocker exec.
+
+    Implements the ``RemoteConnection`` protocol. All I/O goes through
+    ``docker exec`` so the connection survives workspace mutations inside
+    the container.
+    """
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def __init__(self, *, container_id: str, socket_url: str | None = None) -> None:
+        """Initialize with a container ID and optional Docker socket URL.
+
+        Args:
+            container_id: ID (or name) of the running container.
+            socket_url: Docker daemon socket URL, ``None`` for the default.
+        """
+        self._container_id = container_id
+        self._socket_url = socket_url
+        self._docker: aiodocker.Docker | None = None
+
+    @property
+    def container_id(self) -> str:
+        """Return the Docker container ID."""
+        return self._container_id
+
+    def _ensure_client(self) -> aiodocker.Docker:
+        """Return the cached aiodocker client, creating one on first call.
+
+        Returns:
+            An ``aiodocker.Docker`` client instance.
+
+        Raises:
+            ConnectionError: If the client cannot be created.
+        """
+        if self._docker is not None:
+            return self._docker
+
+        try:
+            import aiodocker as _aiodocker  # noqa: PLC0415 — optional dep
+
+            self._docker = _aiodocker.Docker(url=self._socket_url)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to create Docker client (url={self._socket_url}): {exc}"
+            ) from exc
+
+        return self._docker
+
+    # ------------------------------------------------------------------
+    # Factory class-methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def create_and_start(
+        cls,
+        config: DockerConfig,
+        *,
+        name: str,
+        labels: dict[str, str] | None = None,
+        cpu_limit: float | None = None,
+        memory_limit_bytes: int | None = None,
+    ) -> DockerConnection:
+        """Create a new container from *config*, start it, and return a connection.
+
+        Args:
+            config: Docker container configuration.
+            name: Container name.
+            labels: Optional labels to attach to the container.
+            cpu_limit: CPU limit in cores (e.g. ``1.5`` = 1.5 cores).
+            memory_limit_bytes: Hard memory limit in bytes.
+
+        Returns:
+            A ``DockerConnection`` connected to the newly started container.
+
+        Raises:
+            ConnectionError: If the Docker client cannot be created.
+        """
+        import aiodocker as _aiodocker  # noqa: PLC0415 — optional dep
+
+        try:
+            docker = _aiodocker.Docker(url=config.socket_url)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to create Docker client (url={config.socket_url}): {exc}"
+            ) from exc
+
+        # Best-effort image pull — the image may already exist locally.
+        try:
+            await docker.images.pull(config.image)
+        except Exception:
+            logger.warning(
+                "Failed to pull image %s; proceeding in case it exists locally",
+                config.image,
+            )
+
+        # Build host-config section.
+        host_config: dict[str, JSONObject | list[str] | int | str] = {
+            "Binds": list(config.extra_volumes),
+        }
+        if cpu_limit is not None:
+            host_config["NanoCpus"] = int(cpu_limit * 1e9)
+        if memory_limit_bytes is not None:
+            host_config["Memory"] = memory_limit_bytes
+        if config.network is not None:
+            host_config["NetworkMode"] = config.network
+
+        # Build container-config dict.
+        container_config: JSONObject = {
+            "Image": config.image,
+            "Cmd": ["sleep", "infinity"],
+            "Labels": labels or {},
+            "Tty": False,
+            "HostConfig": host_config,
+        }
+        if config.extra_env:
+            container_config["Env"] = [f"{k}={v}" for k, v in config.extra_env.items()]
+
+        container = await docker.containers.create_or_replace(name, container_config)
+        await container.start()
+
+        conn = cls(container_id=container.id, socket_url=config.socket_url)
+        # Re-use the client we already created instead of making a new one.
+        conn._docker = docker
+        logger.info("Started Docker container %s (image=%s)", name, config.image)
+        return conn
+
+    @classmethod
+    def from_existing(cls, container_id: str, socket_url: str | None = None) -> DockerConnection:
+        """Wrap an already-running container without creating a client yet.
+
+        Args:
+            container_id: ID (or name) of the running container.
+            socket_url: Docker daemon socket URL, ``None`` for the default.
+
+        Returns:
+            A ``DockerConnection`` with lazy client initialization.
+        """
+        return cls(container_id=container_id, socket_url=socket_url)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _exec_and_collect(
+        self,
+        command: str,
+        *,
+        tty: bool = False,
+        timeout_secs: int | None = None,
+    ) -> tuple[int, str, str]:
+        """Run a command inside the container and collect output.
+
+        Args:
+            command: Shell command string to execute via ``/bin/bash -c``.
+            tty: Whether to allocate a pseudo-TTY for the exec session.
+            timeout_secs: Wall-clock timeout in seconds, ``None`` for unlimited.
+
+        Returns:
+            Tuple of ``(exit_code, stdout, stderr)``.  When *tty* is ``True``
+            stdout and stderr are merged into *stdout* and *stderr* is empty.
+        """
+        docker = self._ensure_client()
+        container = docker.containers.container(self._container_id)
+
+        exec_instance = await container.exec(
+            cmd=["/bin/bash", "-c", command],
+            stdout=True,
+            stderr=True,
+            tty=tty,
+        )
+
+        async def _collect() -> bytes:
+            raw_stream = exec_instance.start(detach=False)
+            stream = cast("collections.abc.AsyncIterator[bytes | str]", raw_stream)
+            chunks: list[bytes] = []
+            async for chunk in stream:
+                if isinstance(chunk, bytes):
+                    chunks.append(chunk)
+                elif isinstance(chunk, str):
+                    chunks.append(chunk.encode())
+                else:
+                    # aiodocker may yield Message namedtuples with a .data attr
+                    data = getattr(chunk, "data", b"")
+                    chunks.append(data if isinstance(data, bytes) else str(data).encode())
+            return b"".join(chunks)
+
+        try:
+            if timeout_secs is not None:
+                raw = await asyncio.wait_for(_collect(), timeout=float(timeout_secs))
+            else:
+                raw = await _collect()
+        except TimeoutError:
+            return -1, "", "Command timed out"
+
+        inspect = await exec_instance.inspect()
+        exit_code: int = inspect["ExitCode"]
+
+        decoded = raw.decode(errors="replace")
+        # With tty=True the streams are merged; report everything as stdout.
+        # With tty=False aiodocker still merges the multiplexed frames into a
+        # single byte stream for the async-for interface, so we cannot reliably
+        # separate stdout from stderr here.  This matches the PTY behaviour of
+        # SSHConnection where stderr is empty when a PTY is requested.
+        return exit_code, decoded, ""
+
+    # ------------------------------------------------------------------
+    # RemoteConnection protocol methods
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        command: str,
+        *,
+        timeout_secs: int | None = None,
+        stdin_data: str | None = None,
+        request_pty: bool = False,
+    ) -> RemoteResult:
+        """Execute a command inside the container.
+
+        Args:
+            command: Shell command to execute.
+            timeout_secs: Wall-clock timeout in seconds.
+            stdin_data: Optional string to pipe into the command's stdin.
+            request_pty: Allocate a pseudo-TTY for the exec session.
+
+        Returns:
+            ``RemoteResult`` with exit code, stdout, stderr, and timeout flag.
+        """
+        if stdin_data is not None:
+            encoded = base64.b64encode(stdin_data.encode()).decode()
+            command = f"echo '{encoded}' | base64 -d | {command}"
+
+        exit_code, stdout, stderr = await self._exec_and_collect(
+            command,
+            tty=request_pty,
+            timeout_secs=timeout_secs,
+        )
+
+        return RemoteResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=(exit_code == -1 and stderr == "Command timed out"),
+        )
+
+    async def upload_content(self, content: str, remote_path: str) -> None:
+        """Upload string content to a file inside the container.
+
+        Creates parent directories as needed.
+
+        Args:
+            content: File content to write.
+            remote_path: Absolute path inside the container.
+
+        Raises:
+            OSError: If the write command fails.
+        """
+        encoded = base64.b64encode(content.encode()).decode()
+        dir_path = shlex.quote(remote_path.rsplit("/", 1)[0]) if "/" in remote_path else "."
+        quoted_path = shlex.quote(remote_path)
+        cmd = (
+            f"mkdir -p {dir_path} && printf '%s' {shlex.quote(encoded)} | base64 -d > {quoted_path}"
+        )
+        result = await self.run(cmd, timeout_secs=30)
+        if result.exit_code != 0:
+            msg = result.stderr or result.stdout
+            raise OSError(f"upload_content to {remote_path} failed: {msg}")
+
+    async def download_content(self, remote_path: str) -> str | None:
+        """Download content from a file inside the container.
+
+        Args:
+            remote_path: Absolute path inside the container.
+
+        Returns:
+            File content as a string, or ``None`` if the file does not exist.
+        """
+        result = await self.run(
+            f"cat {shlex.quote(remote_path)} 2>/dev/null",
+            timeout_secs=30,
+        )
+        if result.exit_code != 0:
+            return None
+        return result.stdout
+
+    async def check_connection(self) -> bool:
+        """Test connectivity by running a simple echo inside the container.
+
+        Returns:
+            ``True`` if the container is reachable and responsive.
+        """
+        try:
+            result = await self.run("echo tanren-ok", timeout_secs=10)
+        except Exception:
+            logger.debug(
+                "check_connection failed for container %s",
+                self._container_id[:12],
+                exc_info=True,
+            )
+            return False
+        return result.exit_code == 0 and "tanren-ok" in result.stdout
+
+    def get_host_identifier(self) -> str:
+        """Return a human-readable identifier for this container.
+
+        Returns:
+            String in ``docker://<short-id>`` format.
+        """
+        return f"docker://{self._container_id[:12]}"
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers (not part of RemoteConnection)
+    # ------------------------------------------------------------------
+
+    async def stop_container(self, *, stop_timeout: int = 10) -> None:
+        """Stop the container gracefully.
+
+        Args:
+            stop_timeout: Seconds to wait before force-killing.
+        """
+        docker = self._ensure_client()
+        container = docker.containers.container(self._container_id)
+        await container.stop(t=stop_timeout)
+
+    async def remove_container(self, *, force: bool = True) -> None:
+        """Remove the container.
+
+        Args:
+            force: Force-remove even if the container is running.
+        """
+        docker = self._ensure_client()
+        container = docker.containers.container(self._container_id)
+        await container.delete(force=force)
+
+    async def close(self) -> None:
+        """Close the underlying aiodocker client."""
+        if self._docker is not None:
+            with contextlib.suppress(Exception):
+                await self._docker.close()
+            self._docker = None

--- a/packages/tanren-core/src/tanren_core/adapters/docker_connection.py
+++ b/packages/tanren-core/src/tanren_core/adapters/docker_connection.py
@@ -7,15 +7,13 @@ import base64
 import contextlib
 import logging
 import shlex
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from tanren_core.adapters.remote_types import RemoteResult
 
 if TYPE_CHECKING:
-    import collections.abc
-
     import aiodocker
     from aiodocker.types import JSONObject
 
@@ -123,7 +121,13 @@ class DockerConnection:
         Raises:
             ConnectionError: If the Docker client cannot be created.
         """
-        import aiodocker as _aiodocker  # noqa: PLC0415 — optional dep
+        try:
+            import aiodocker as _aiodocker  # noqa: PLC0415 — optional dep
+        except ModuleNotFoundError:
+            raise ConnectionError(
+                "aiodocker is required for Docker execution. "
+                "Install it with: uv sync --extra docker"
+            ) from None
 
         try:
             docker = _aiodocker.Docker(url=config.socket_url)
@@ -163,8 +167,19 @@ class DockerConnection:
         if config.extra_env:
             container_config["Env"] = [f"{k}={v}" for k, v in config.extra_env.items()]
 
-        container = await docker.containers.create_or_replace(name, container_config)
-        await container.start()
+        container = None
+        try:
+            container = await docker.containers.create_or_replace(name, container_config)
+            await container.start()
+        except BaseException:
+            # Clean up partially-created container and docker client so
+            # callers don't need to know about partial state.
+            if container is not None:
+                with contextlib.suppress(Exception):
+                    await container.delete(force=True)
+            with contextlib.suppress(Exception):
+                await docker.close()
+            raise
 
         conn = cls(container_id=container.id, socket_url=config.socket_url)
         # Re-use the client we already created instead of making a new one.
@@ -198,14 +213,18 @@ class DockerConnection:
     ) -> tuple[int, str, str]:
         """Run a command inside the container and collect output.
 
+        Uses ``Stream.read_out()`` to read ``Message`` objects from the
+        exec stream.  When *tty* is ``False`` each message carries a
+        *stream* field (1 = stdout, 2 = stderr) so we can separate them.
+        When *tty* is ``True`` the Docker daemon merges both into stream 1.
+
         Args:
             command: Shell command string to execute via ``/bin/bash -c``.
             tty: Whether to allocate a pseudo-TTY for the exec session.
             timeout_secs: Wall-clock timeout in seconds, ``None`` for unlimited.
 
         Returns:
-            Tuple of ``(exit_code, stdout, stderr)``.  When *tty* is ``True``
-            stdout and stderr are merged into *stdout* and *stderr* is empty.
+            Tuple of ``(exit_code, stdout, stderr)``.
         """
         docker = self._ensure_client()
         container = docker.containers.container(self._container_id)
@@ -217,39 +236,42 @@ class DockerConnection:
             tty=tty,
         )
 
-        async def _collect() -> bytes:
-            raw_stream = exec_instance.start(detach=False)
-            stream = cast("collections.abc.AsyncIterator[bytes | str]", raw_stream)
-            chunks: list[bytes] = []
-            async for chunk in stream:
-                if isinstance(chunk, bytes):
-                    chunks.append(chunk)
-                elif isinstance(chunk, str):
-                    chunks.append(chunk.encode())
+        stream = exec_instance.start(detach=False)
+
+        async def _collect() -> tuple[bytes, bytes]:
+            stdout_chunks: list[bytes] = []
+            stderr_chunks: list[bytes] = []
+            while True:
+                msg = await stream.read_out()
+                if msg is None:
+                    break
+                if msg.stream == 2:
+                    stderr_chunks.append(msg.data)
                 else:
-                    # aiodocker may yield Message namedtuples with a .data attr
-                    data = getattr(chunk, "data", b"")
-                    chunks.append(data if isinstance(data, bytes) else str(data).encode())
-            return b"".join(chunks)
+                    # stream 1 (stdout) or any other value → stdout
+                    stdout_chunks.append(msg.data)
+            return b"".join(stdout_chunks), b"".join(stderr_chunks)
 
         try:
             if timeout_secs is not None:
-                raw = await asyncio.wait_for(_collect(), timeout=float(timeout_secs))
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    _collect(), timeout=float(timeout_secs)
+                )
             else:
-                raw = await _collect()
+                stdout_bytes, stderr_bytes = await _collect()
         except TimeoutError:
+            with contextlib.suppress(Exception):
+                await stream.close()
             return -1, "", "Command timed out"
 
         inspect = await exec_instance.inspect()
         exit_code: int = inspect["ExitCode"]
 
-        decoded = raw.decode(errors="replace")
-        # With tty=True the streams are merged; report everything as stdout.
-        # With tty=False aiodocker still merges the multiplexed frames into a
-        # single byte stream for the async-for interface, so we cannot reliably
-        # separate stdout from stderr here.  This matches the PTY behaviour of
-        # SSHConnection where stderr is empty when a PTY is requested.
-        return exit_code, decoded, ""
+        return (
+            exit_code,
+            stdout_bytes.decode(errors="replace"),
+            stderr_bytes.decode(errors="replace"),
+        )
 
     # ------------------------------------------------------------------
     # RemoteConnection protocol methods

--- a/packages/tanren-core/src/tanren_core/adapters/docker_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/docker_environment.py
@@ -111,9 +111,10 @@ class DockerExecutionEnvironment:
 
         for a in assignments:
             try:
-                conn = DockerConnection.from_existing(
-                    a.vm_id, socket_url=self._docker_config.socket_url
-                )
+                # Use the socket URL recorded at assignment time so recovery
+                # targets the same daemon that created the container.
+                socket_url = None if a.host == "local" else a.host
+                conn = DockerConnection.from_existing(a.vm_id, socket_url=socket_url)
                 try:
                     await conn.stop_container()
                 except Exception:
@@ -591,9 +592,11 @@ class DockerExecutionEnvironment:
 
     async def release_vm(self, vm_handle: VMHandle) -> None:
         """Release a container by stopping and removing it."""
-        conn = DockerConnection.from_existing(
-            vm_handle.vm_id, socket_url=self._docker_config.socket_url
-        )
+        # Prefer the socket URL encoded in the handle's host field so we
+        # target the same Docker daemon the container was created on.
+        host = vm_handle.host
+        socket_url = None if host in ("", "local") else host
+        conn = DockerConnection.from_existing(vm_handle.vm_id, socket_url=socket_url)
         try:
             await conn.stop_container()
         finally:

--- a/packages/tanren-core/src/tanren_core/adapters/docker_environment.py
+++ b/packages/tanren-core/src/tanren_core/adapters/docker_environment.py
@@ -1,4 +1,4 @@
-"""SSHExecutionEnvironment — remote VM execution via SSH."""
+"""DockerExecutionEnvironment — execution via Docker containers."""
 
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from tanren_core.adapters.credentials import (
     all_credential_cleanup_paths,
     inject_all_cli_credentials,
 )
+from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
 from tanren_core.adapters.remote_shared import (
     CLI_AUTH_GROUPS,
     PUSH_PHASES,
@@ -33,12 +34,11 @@ from tanren_core.adapters.remote_types import (
     VMRequirements,
     WorkspaceSpec,
 )
-from tanren_core.adapters.ssh import SSHConfig, SSHConnection
 from tanren_core.adapters.types import (
     AccessInfo,
+    DockerEnvironmentRuntime,
     EnvironmentHandle,
     PhaseResult,
-    RemoteEnvironmentRuntime,
 )
 from tanren_core.ccusage import RemoteCommandRunner, collect_token_usage
 from tanren_core.errors import TRANSIENT_BACKOFF, ErrorClass, classify_error
@@ -52,9 +52,6 @@ if TYPE_CHECKING:
         VMStateStore,
     )
     from tanren_core.adapters.protocols import (
-        VMProvisioner as VMProvisionerProtocol,
-    )
-    from tanren_core.adapters.protocols import (
         WorkspaceManager as WorkspaceManagerProtocol,
     )
     from tanren_core.adapters.remote_runner import RemoteAgentRunner
@@ -63,59 +60,45 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SSH_READY_TIMEOUT_SECS = 300
-_SSH_READY_POLL_SECS = 3
 
+class DockerExecutionEnvironment:
+    """ExecutionEnvironment backed by Docker container execution.
 
-class SSHExecutionEnvironment:
-    """ExecutionEnvironment backed by remote VM execution over SSH.
-
-    Composes VMProvisioner, SSHConnection, EnvironmentBootstrapper,
-    WorkspaceManager, RemoteAgentRunner, and VMStateStore into the
-    provision/execute/teardown lifecycle.
+    Composes DockerConnection, EnvironmentBootstrapper, WorkspaceManager,
+    RemoteAgentRunner, and VMStateStore into the provision/execute/teardown
+    lifecycle.
     """
 
     def __init__(
         self,
         *,
-        vm_provisioner: VMProvisionerProtocol,
         bootstrapper: EnvironmentBootstrapper,
         workspace_mgr: WorkspaceManagerProtocol,
         runner: RemoteAgentRunner,
         state_store: VMStateStore,
         secret_loader: SecretLoader,
-        ssh_config_defaults: SSHConfig,
+        docker_config: DockerConfig,
         repo_urls: dict[str, str],
-        provider: VMProvider = VMProvider.MANUAL,
-        ssh_ready_timeout_secs: int = _SSH_READY_TIMEOUT_SECS,
         credential_providers: tuple[CredentialProvider, ...] = DEFAULT_CREDENTIAL_PROVIDERS,
         agent_user: str | None = None,
     ) -> None:
-        """Initialize with remote execution adapters and configuration."""
-        self._vm_provisioner = vm_provisioner
+        """Initialize with Docker execution adapters and configuration."""
         self._bootstrapper = bootstrapper
         self._workspace_mgr = workspace_mgr
         self._runner = runner
         self._state_store = state_store
         self._secret_loader = secret_loader
-        self._ssh_defaults = ssh_config_defaults
+        self._docker_config = docker_config
         self._repo_urls = repo_urls
-        self._provider = provider
-        self._ssh_ready_timeout_secs = ssh_ready_timeout_secs
         self._credential_providers = credential_providers
         self._agent_user = agent_user
-
-    @property
-    def ssh_defaults(self) -> SSHConfig:
-        """Return default SSH settings used for remote connections."""
-        return self._ssh_defaults
 
     async def close(self) -> None:
         """Release resources held by the environment (DB connections)."""
         await self._state_store.close()
 
     async def recover_stale_assignments(self) -> int:
-        """Release any unreleased VM assignments left by a prior crash.
+        """Release any unreleased container assignments left by a prior crash.
 
         Returns:
             Number of recovered assignments.
@@ -124,33 +107,43 @@ class SSHExecutionEnvironment:
         if not assignments:
             return 0
 
-        logger.info("Recovering %d stale VM assignment(s)...", len(assignments))
+        logger.info("Recovering %d stale container assignment(s)...", len(assignments))
 
         for a in assignments:
-            stale_handle = VMHandle(
-                vm_id=a.vm_id,
-                host=a.host,
-                provider=self._provider,
-                created_at=a.assigned_at,
-            )
             try:
-                await self._vm_provisioner.release(stale_handle)
-            except Exception:
-                logger.warning(
-                    "Failed provider release for stale VM %s (%s)",
-                    a.vm_id,
-                    a.host,
-                    exc_info=True,
+                conn = DockerConnection.from_existing(
+                    a.vm_id, socket_url=self._docker_config.socket_url
                 )
+                try:
+                    await conn.stop_container()
+                except Exception:
+                    logger.warning(
+                        "Failed to stop stale container %s (%s)",
+                        a.vm_id,
+                        a.host,
+                        exc_info=True,
+                    )
+                finally:
+                    try:
+                        await conn.remove_container()
+                    except Exception:
+                        logger.warning(
+                            "Failed to remove stale container %s (%s)",
+                            a.vm_id,
+                            a.host,
+                            exc_info=True,
+                        )
+                    finally:
+                        await conn.close()
             finally:
                 await self._state_store.record_release(a.vm_id)
-                logger.info("Recovered stale VM %s (%s)", a.vm_id, a.host)
+                logger.info("Recovered stale container %s (%s)", a.vm_id, a.host)
 
         return len(assignments)
 
     async def dry_run(
         self,
-        requirements: VMRequirements,  # noqa: ARG002 — requirements used by provisioner internally via self._vm_provisioner
+        requirements: VMRequirements,  # noqa: ARG002 — required by protocol interface
     ) -> DryRunInfo:
         """Dry-run provision — return what would happen without creating resources.
 
@@ -158,7 +151,7 @@ class SSHExecutionEnvironment:
             DryRunInfo with provider info from this environment.
         """
         return DryRunInfo(
-            provider=self._provider,
+            provider=VMProvider.MANUAL,
             would_provision=True,
         )
 
@@ -167,52 +160,51 @@ class SSHExecutionEnvironment:
         dispatch: Dispatch,
         config: WorkerConfig,  # noqa: ARG002 — required by protocol; config no longer read here
     ) -> EnvironmentHandle:
-        """Acquire VM, bootstrap, setup workspace, inject secrets.
+        """Create container, bootstrap, setup workspace, inject secrets.
 
         Returns:
-            EnvironmentHandle for remote execution.
+            EnvironmentHandle for Docker execution.
 
         Raises:
-            RuntimeError: If no repo URL is configured for the project.
+            RuntimeError: If no repo URL is configured for the project or
+                container fails to start.
         """
         # 1. Use dispatch-carried profile (resolved by CLI/API before dispatch)
         profile = dispatch.resolved_profile
 
-        # 2. Build VM requirements from profile
-        requirements = VMRequirements(
-            profile=dispatch.environment_profile,
-            cpu=profile.resources.cpu,
-            memory_gb=profile.resources.memory_gb,
-            gpu=profile.resources.gpu,
-            server_type=profile.server_type,
+        # 2. Build resource limits from profile
+        cpu_limit = float(profile.resources.cpu)
+        memory_limit_bytes = profile.resources.memory_gb * 1024**3
+
+        # 3. Generate container name
+        name = f"tanren-{dispatch.workflow_id[:20]}-{uuid.uuid4().hex[:8]}"
+        labels = {
+            "tanren.workflow": dispatch.workflow_id,
+            "tanren.project": dispatch.project,
+        }
+
+        # 4. Create and start container
+        conn = await DockerConnection.create_and_start(
+            self._docker_config,
+            name=name,
+            labels=labels,
+            cpu_limit=cpu_limit,
+            memory_limit_bytes=memory_limit_bytes,
         )
 
-        # 3. Acquire VM
-        vm_handle = await self._vm_provisioner.acquire(requirements)
-        conn: SSHConnection | None = None
-
         try:
-            # 4. Create SSH connection
-            ssh_config = SSHConfig(
-                host=vm_handle.host,
-                user=self._ssh_defaults.user,
-                key_path=self._ssh_defaults.key_path,
-                port=self._ssh_defaults.port,
-                connect_timeout=self._ssh_defaults.connect_timeout,
-                host_key_policy=self._ssh_defaults.host_key_policy,
-            )
-            conn = SSHConnection(ssh_config)
+            # 4b. Verify container is reachable
+            ok = await conn.check_connection()
+            if not ok:
+                raise RuntimeError(f"Docker container {name} failed connectivity check")
 
-            # 4b. Wait for SSH to accept connections (sshd lags behind API status)
-            await self._await_ssh_ready(conn, timeout_secs=self._ssh_ready_timeout_secs)
-
-            # 5. Bootstrap VM (idempotent)
+            # 5. Bootstrap container (idempotent)
             await self._bootstrapper.bootstrap(conn)
 
             # 6. Setup workspace — repo URL from dispatch profile or instance mapping
             repo_url = ""
-            if profile.remote_config is not None:
-                repo_url = profile.remote_config.repo_url
+            if profile.docker_config is not None:
+                repo_url = profile.docker_config.repo_url
             if not repo_url:
                 repo_url = self._repo_urls.get(dispatch.project, "")
             if not repo_url:
@@ -233,12 +225,12 @@ class SSHExecutionEnvironment:
             if dispatch.required_secrets:
                 resolved: dict[str, str] = {}
                 missing: list[str] = []
-                for name in dispatch.required_secrets:
-                    value = os.environ.get(name, "")
+                for secret_name in dispatch.required_secrets:
+                    value = os.environ.get(secret_name, "")
                     if value:
-                        resolved[name] = value
+                        resolved[secret_name] = value
                     else:
-                        missing.append(name)
+                        missing.append(secret_name)
                 if missing:
                     # Determine which missing secrets are non-auth (truly required)
                     # vs auth alternatives (handled by validate_cli_auth's group logic)
@@ -320,11 +312,11 @@ class SSHExecutionEnvironment:
 
             # 9. Record assignment
             await self._state_store.record_assignment(
-                vm_id=vm_handle.vm_id,
+                vm_id=conn.container_id,
                 workflow_id=dispatch.workflow_id,
                 project=dispatch.project,
                 spec=dispatch.spec_folder,
-                host=vm_handle.host,
+                host=self._docker_config.socket_url or "local",
             )
 
             # 10. Return handle
@@ -333,34 +325,39 @@ class SSHExecutionEnvironment:
                 worktree_path=Path(workspace_path.path),
                 branch=dispatch.branch,
                 project=dispatch.project,
-                runtime=RemoteEnvironmentRuntime(
-                    vm_handle=vm_handle,
+                runtime=DockerEnvironmentRuntime(
+                    container_id=conn.container_id,
                     connection=conn,
                     workspace_path=workspace_path,
                     profile=profile,
                     teardown_commands=profile.teardown,
                     provision_start=time.monotonic(),
                     workflow_id=dispatch.workflow_id,
+                    docker_socket_url=self._docker_config.socket_url,
                 ),
             )
 
         except BaseException:
-            # Clean up on failure — no orphaned VMs (including CancelledError)
-            if conn is not None:
-                try:
-                    await conn.close()
-                except Exception:
-                    logger.warning("SSH close failed during provision cleanup", exc_info=True)
+            # Clean up on failure — no orphaned containers (including CancelledError)
             try:
-                await self._vm_provisioner.release(vm_handle)
+                await conn.stop_container()
             except Exception:
-                logger.warning(
-                    "Provider release failed for VM %s during provision cleanup",
-                    vm_handle.vm_id,
-                    exc_info=True,
-                )
+                logger.warning("Container stop failed during provision cleanup", exc_info=True)
             finally:
-                await self._state_store.record_release(vm_handle.vm_id)
+                try:
+                    await conn.remove_container()
+                except Exception:
+                    logger.warning(
+                        "Container remove failed during provision cleanup", exc_info=True
+                    )
+                finally:
+                    try:
+                        await conn.close()
+                    except Exception:
+                        logger.warning(
+                            "Connection close failed during provision cleanup", exc_info=True
+                        )
+                    await self._state_store.record_release(conn.container_id)
             raise
 
     async def execute(
@@ -371,19 +368,19 @@ class SSHExecutionEnvironment:
         *,
         dispatch_stem: str = "",  # noqa: ARG002 — required by protocol interface
     ) -> PhaseResult:
-        """Run agent on remote VM with retry logic.
+        """Run agent in Docker container with retry logic.
 
         Returns:
             PhaseResult with outcome, signal, and metrics.
 
         Raises:
-            RuntimeError: If the handle does not contain a remote runtime.
+            RuntimeError: If the handle does not contain a Docker runtime.
         """
-        if handle.runtime.kind != "remote":
-            raise RuntimeError("SSHExecutionEnvironment requires remote runtime handle")
-        remote_runtime = cast("RemoteEnvironmentRuntime", handle.runtime)
-        conn = cast("SSHConnection", remote_runtime.connection)
-        workspace = remote_runtime.workspace_path
+        if handle.runtime.kind != "docker":
+            raise RuntimeError("DockerExecutionEnvironment requires docker runtime handle")
+        docker_runtime = cast("DockerEnvironmentRuntime", handle.runtime)
+        conn = cast("DockerConnection", docker_runtime.connection)
+        workspace = docker_runtime.workspace_path
 
         start = time.monotonic()
         dispatch_start_utc = datetime.now(UTC)
@@ -580,45 +577,44 @@ class SSHExecutionEnvironment:
         )
 
     async def get_access_info(self, handle: EnvironmentHandle) -> AccessInfo:
-        """Return SSH and VS Code connection info.
+        """Return container connection info.
 
         Raises:
-            RuntimeError: If the handle does not contain a remote runtime.
+            RuntimeError: If the handle does not contain a Docker runtime.
         """
-        if handle.runtime.kind != "remote":
-            raise RuntimeError("SSHExecutionEnvironment requires remote runtime handle")
-        remote_runtime = cast("RemoteEnvironmentRuntime", handle.runtime)
-        vm_handle = remote_runtime.vm_handle
-        ssh_str = f"ssh {self._ssh_defaults.user}@{vm_handle.host}"
-        vscode_str = (
-            f"vscode://vscode-remote/ssh-remote+"
-            f"{self._ssh_defaults.user}@{vm_handle.host}"
-            f"{handle.worktree_path}"
-        )
+        if handle.runtime.kind != "docker":
+            raise RuntimeError("DockerExecutionEnvironment requires docker runtime handle")
         return AccessInfo(
-            ssh=ssh_str,
-            vscode=vscode_str,
             working_dir=str(handle.worktree_path),
             status="running",
         )
 
     async def release_vm(self, vm_handle: VMHandle) -> None:
-        """Release a VM through the provisioner without full teardown."""
-        await self._vm_provisioner.release(vm_handle)
+        """Release a container by stopping and removing it."""
+        conn = DockerConnection.from_existing(
+            vm_handle.vm_id, socket_url=self._docker_config.socket_url
+        )
+        try:
+            await conn.stop_container()
+        finally:
+            try:
+                await conn.remove_container()
+            finally:
+                await conn.close()
 
     async def teardown(self, handle: EnvironmentHandle) -> None:
-        """Guaranteed VM release with try/finally at every step.
+        """Guaranteed container cleanup with try/finally at every step.
 
         Raises:
-            RuntimeError: If the handle does not contain a remote runtime.
+            RuntimeError: If the handle does not contain a Docker runtime.
         """
-        if handle.runtime.kind != "remote":
-            raise RuntimeError("SSHExecutionEnvironment requires remote runtime handle")
-        remote_runtime = cast("RemoteEnvironmentRuntime", handle.runtime)
-        conn = cast("SSHConnection", remote_runtime.connection)
-        workspace = remote_runtime.workspace_path
-        teardown_cmds = remote_runtime.teardown_commands
-        vm_handle = remote_runtime.vm_handle
+        if handle.runtime.kind != "docker":
+            raise RuntimeError("DockerExecutionEnvironment requires docker runtime handle")
+        docker_runtime = cast("DockerEnvironmentRuntime", handle.runtime)
+        conn = cast("DockerConnection", docker_runtime.connection)
+        workspace = docker_runtime.workspace_path
+        teardown_cmds = docker_runtime.teardown_commands
+        container_id = docker_runtime.container_id
 
         try:
             for cmd in teardown_cmds:
@@ -646,49 +642,27 @@ class SSHExecutionEnvironment:
                 logger.warning("Workspace cleanup failed", exc_info=True)
             finally:
                 try:
-                    await conn.close()
+                    await conn.stop_container()
                 except Exception:
-                    logger.warning("SSH close failed", exc_info=True)
+                    logger.warning(
+                        "Container stop failed for %s during teardown",
+                        container_id,
+                        exc_info=True,
+                    )
                 finally:
-                    # MUST happen — no orphaned VMs
                     try:
-                        await self._vm_provisioner.release(vm_handle)
+                        await conn.remove_container()
                     except Exception:
                         logger.warning(
-                            "Provider release failed for VM %s during teardown",
-                            vm_handle.vm_id,
+                            "Container remove failed for %s during teardown",
+                            container_id,
                             exc_info=True,
                         )
-                    await self._state_store.record_release(vm_handle.vm_id)
-
-    async def _await_ssh_ready(
-        self,
-        conn: SSHConnection,
-        *,
-        timeout_secs: int = _SSH_READY_TIMEOUT_SECS,
-    ) -> None:
-        """Poll SSH until the host accepts connections or deadline expires.
-
-        Raises:
-            TimeoutError: If SSH is not reachable within the timeout.
-        """
-        deadline = time.monotonic() + timeout_secs
-        attempt = 0
-        while time.monotonic() < deadline:
-            attempt += 1
-            if await conn.check_connection():
-                logger.info("SSH ready after %d attempt(s)", attempt)
-                return
-            logger.debug(
-                "SSH not ready (attempt %d), retrying in %ds",
-                attempt,
-                _SSH_READY_POLL_SECS,
-            )
-            await asyncio.sleep(_SSH_READY_POLL_SECS)
-        raise TimeoutError(
-            f"SSH not reachable within {timeout_secs}s on {conn.get_host_identifier()}"
-        )
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
+                    finally:
+                        try:
+                            await conn.close()
+                        except Exception:
+                            logger.warning("Connection close failed", exc_info=True)
+                        finally:
+                            # MUST happen — no orphaned containers
+                            await self._state_store.record_release(container_id)

--- a/packages/tanren-core/src/tanren_core/adapters/remote_shared.py
+++ b/packages/tanren-core/src/tanren_core/adapters/remote_shared.py
@@ -1,0 +1,126 @@
+"""Shared logic for remote-style execution environments (SSH, Docker).
+
+Contains signal extraction, CLI auth validation, CLI command building, and
+the set of push-eligible phases. Both SSHExecutionEnvironment and
+DockerExecutionEnvironment import from here to avoid duplication.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import TYPE_CHECKING
+
+from tanren_core.schemas import Cli, Phase
+from tanren_core.signals import parse_signal_token
+
+if TYPE_CHECKING:
+    from tanren_core.schemas import Dispatch
+    from tanren_core.worker_config import WorkerConfig
+
+PUSH_PHASES = frozenset({Phase.DO_TASK, Phase.AUDIT_TASK, Phase.RUN_DEMO, Phase.AUDIT_SPEC})
+
+# Per-CLI auth secrets: at least one key in each group must be resolved.
+# Bash/gate dispatches have no auth requirements.
+CLI_AUTH_GROUPS: dict[Cli, tuple[tuple[str, ...], ...]] = {
+    Cli.CLAUDE: (("CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CREDENTIALS_JSON"),),
+    Cli.OPENCODE: (("OPENCODE_ZAI_API_KEY",),),
+    Cli.CODEX: (("CODEX_AUTH_JSON",),),
+}
+
+
+def validate_cli_auth(cli: Cli, resolved: dict[str, str], *, phase: str = "") -> None:
+    """Ensure at least one auth secret was resolved for the dispatch CLI.
+
+    Raises:
+        RuntimeError: If no auth secret is available for the CLI.
+    """
+    groups = CLI_AUTH_GROUPS.get(cli)
+    if groups is None:
+        return  # bash/gate — no auth needed
+    for group in groups:
+        if not any(name in resolved for name in group):
+            names = " or ".join(group)
+            context = f" (phase {phase} uses {cli.value})" if phase else ""
+            raise RuntimeError(
+                f"No auth secret resolved for {cli.value}{context}: "
+                f"need {names} in daemon environment"
+            )
+
+
+def extract_signal_token(
+    command_name: str,
+    signal_content: str,
+    stdout: str,
+) -> str | None:
+    """Extract signal token from file content, falling back to stdout.
+
+    Mirrors the two-step resolution in ``signals.extract_signal``:
+    1. Parse the ``.agent-status`` file content
+    2. Grep stdout for ``{command}-status: {token}`` (last match)
+
+    Returns:
+        Signal token string or ``None``.
+    """
+    if signal_content.strip():
+        token = parse_signal_token(command_name, signal_content)
+        if token:
+            return token
+    if stdout:
+        pattern = rf"{re.escape(command_name)}-status:\s*(\w[\w-]*)"
+        matches = re.findall(pattern, stdout)
+        if matches:
+            return matches[-1]
+    return None
+
+
+def build_cli_command(dispatch: Dispatch, config: WorkerConfig) -> str:
+    """Build the CLI command string for remote execution.
+
+    Returns:
+        Shell command string for the agent CLI.
+
+    Raises:
+        ValueError: If the CLI type is unsupported or gate_cmd is empty for bash.
+    """
+    if dispatch.cli.value == "claude":
+        cmd = config.claude_path
+        cmd += " -p --dangerously-skip-permissions"
+        if dispatch.model:
+            cmd += f" --model {shlex.quote(dispatch.model)}"
+        cmd += " < .tanren-prompt.md"
+        return cmd
+    if dispatch.cli.value == "bash":
+        gate_cmd = (dispatch.gate_cmd or "").strip()
+        if gate_cmd:
+            return gate_cmd
+        raise ValueError("Gate dispatch requires a non-empty gate_cmd when cli=bash")
+    if dispatch.cli.value == "opencode":
+        cmd = config.opencode_path
+        cmd += " run"
+        if dispatch.model:
+            cmd += f" --model {shlex.quote(dispatch.model)}"
+        cmd += " --dir ."
+        cmd += ' "Read the attached file and follow its instructions exactly."'
+        cmd += " -f .tanren-prompt.md"
+        return cmd
+    if dispatch.cli.value == "codex":
+        cmd = config.codex_path
+        cmd += " exec --dangerously-bypass-approvals-and-sandbox"
+        if dispatch.model:
+            cmd += f" --model {shlex.quote(dispatch.model)}"
+        cmd += " -C ."
+        cmd += " < .tanren-prompt.md"
+        return cmd
+    raise ValueError(f"Unsupported CLI for remote execution: {dispatch.cli.value}")
+
+
+def wrap_for_agent_user(command: str, agent_user: str | None) -> str:
+    """Wrap a shell command to run as the agent user via ``su -``.
+
+    Returns:
+        The command wrapped with ``su -``, or unchanged when no agent_user is configured.
+    """
+    if agent_user:
+        return f"su - {shlex.quote(agent_user)} -c {shlex.quote(command)}"
+    return command

--- a/packages/tanren-core/src/tanren_core/adapters/types.py
+++ b/packages/tanren-core/src/tanren_core/adapters/types.py
@@ -56,6 +56,32 @@ class RemoteEnvironmentRuntime(BaseModel):
     workflow_id: str = Field(..., description="Workflow that owns this environment")
 
 
+class DockerEnvironmentRuntime(BaseModel):
+    """Runtime state for Docker container execution environments."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    kind: Literal["docker"] = Field(default="docker", description="Runtime kind discriminator")
+    container_id: str = Field(..., description="Docker container ID")
+    connection: SkipValidation[RemoteConnection] = Field(
+        ..., description="Active DockerConnection to the container"
+    )
+    workspace_path: WorkspacePath = Field(..., description="Workspace path inside the container")
+    profile: EnvironmentProfile = Field(
+        ..., description="Environment profile used for provisioning"
+    )
+    teardown_commands: tuple[str, ...] = Field(
+        default_factory=tuple, description="Commands to run during teardown"
+    )
+    provision_start: float = Field(
+        ..., ge=0.0, description="Monotonic timestamp when provisioning started"
+    )
+    workflow_id: str = Field(..., description="Workflow that owns this environment")
+    docker_socket_url: str | None = Field(
+        default=None, description="Docker socket URL for handle reconstruction"
+    )
+
+
 class CustomEnvironmentRuntime(BaseModel):
     """Generic runtime state for custom execution environments."""
 
@@ -77,8 +103,15 @@ class EnvironmentHandle(BaseModel):
     worktree_path: Path = Field(..., description="Local or remote path to the git worktree")
     branch: str = Field(..., description="Git branch checked out in this environment")
     project: str = Field(..., description="Target project name")
-    runtime: LocalEnvironmentRuntime | RemoteEnvironmentRuntime | CustomEnvironmentRuntime = Field(
-        ..., discriminator="kind", description="Typed runtime context (local, remote, or custom)"
+    runtime: (
+        LocalEnvironmentRuntime
+        | RemoteEnvironmentRuntime
+        | DockerEnvironmentRuntime
+        | CustomEnvironmentRuntime
+    ) = Field(
+        ...,
+        discriminator="kind",
+        description="Typed runtime context (local, remote, docker, or custom)",
     )
 
 

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -119,10 +119,19 @@ class UbuntuBootstrapper:
         *,
         required_clis: frozenset[Cli],
         extra_script: str | None = None,
+        skip_infra_tools: frozenset[str] = frozenset(),
     ) -> None:
-        """Initialize with required CLIs and an optional extra bootstrap script."""
+        """Initialize with required CLIs and an optional extra bootstrap script.
+
+        Args:
+            required_clis: CLIs to install (claude, opencode, codex).
+            extra_script: Optional bash script to run after standard bootstrap.
+            skip_infra_tools: Infrastructure tool names to skip (e.g. {"docker"}
+                when bootstrapping inside a Docker container).
+        """
         self._required_clis = required_clis
         self._extra_script = extra_script
+        self._skip_infra_tools = skip_infra_tools
 
     def _build_steps(self) -> tuple[tuple[str, str, str], ...]:
         """Build the full step list from infra + required CLI steps + ccusage.
@@ -130,13 +139,14 @@ class UbuntuBootstrapper:
         Returns:
             Tuple of (name, check_command, install_command) for each step.
         """
+        infra = tuple(s for s in _INFRA_STEPS if s[0] not in self._skip_infra_tools)
         cli_steps = tuple(
             _CLI_STEPS[cli]
             for cli in sorted(self._required_clis, key=lambda c: c.value)
             if cli in _CLI_STEPS
         )
         ccusage_step = _build_ccusage_step(self._required_clis)
-        return (*_INFRA_STEPS, *cli_steps, ccusage_step)
+        return (*infra, *cli_steps, ccusage_step)
 
     def plan(self) -> BootstrapPlan:
         """Return the bootstrap plan used by this bootstrapper."""

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -27,6 +27,7 @@ from tanren_core.adapters.ssh import SSHConfig
 from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 from tanren_core.adapters.ubuntu_bootstrap import UbuntuBootstrapper
 from tanren_core.env.environment_schema import (
+    DockerExecutionConfig,
     EnvironmentProfile,
     EnvironmentProfileType,
     RemoteExecutionConfig,
@@ -232,6 +233,79 @@ def _build_local(
     return env, None
 
 
+def _build_docker(
+    config: WorkerConfig,
+    docker_cfg: DockerExecutionConfig,
+    pool: asyncpg.Pool | None = None,
+) -> tuple[ExecutionEnvironment, VMStateStore]:
+    """Construct a DockerExecutionEnvironment from dispatch-carried config.
+
+    Args:
+        config: Worker operational config (data_dir, etc.).
+        docker_cfg: Docker execution config carried in the dispatch/profile.
+        pool: Optional asyncpg pool for Postgres-backed VM state.
+
+    Returns:
+        Tuple of (DockerExecutionEnvironment, VMStateStore).
+    """
+    from tanren_core.adapters.docker_connection import DockerConfig  # noqa: PLC0415 — optional dep
+    from tanren_core.adapters.docker_environment import (  # noqa: PLC0415 — optional dep
+        DockerExecutionEnvironment,
+    )
+
+    required_clis = frozenset(Cli(c) for c in docker_cfg.required_clis)
+    agent_user = docker_cfg.agent_user
+
+    if pool is not None:
+        from tanren_core.adapters.postgres_vm_state import (  # noqa: PLC0415 — conditional
+            PostgresVMStateStore,
+        )
+
+        state_store: VMStateStore = PostgresVMStateStore(pool)
+    else:
+        from tanren_core.adapters.sqlite_vm_state import (  # noqa: PLC0415 — conditional
+            SqliteVMStateStore,
+        )
+
+        state_store = SqliteVMStateStore(f"{config.data_dir}/vm-state.db")
+
+    secret_config = SecretConfig()
+    secret_loader = SecretLoader(secret_config, required_clis=required_clis)
+    secret_loader.autoload_into_env(override=False)
+
+    token = os.environ.get(docker_cfg.git.token_env, "")
+    git_auth = GitAuthConfig(
+        auth_method=GitAuthMethod(docker_cfg.git.auth_method),
+        token=token or None,
+    )
+
+    docker_config = DockerConfig(
+        image=docker_cfg.image,
+        socket_url=docker_cfg.socket_url,
+        network=docker_cfg.network,
+        extra_volumes=docker_cfg.extra_volumes,
+        extra_env=docker_cfg.extra_env,
+    )
+
+    env = DockerExecutionEnvironment(
+        bootstrapper=UbuntuBootstrapper(
+            required_clis=required_clis,
+            extra_script=docker_cfg.bootstrap_extra_script,
+            skip_infra_tools=frozenset({"docker"}),
+        ),
+        workspace_mgr=GitWorkspaceManager(git_auth),
+        runner=RemoteAgentRunner(run_as_user=agent_user),
+        state_store=state_store,
+        secret_loader=secret_loader,
+        docker_config=docker_config,
+        repo_urls={"__dispatch__": docker_cfg.repo_url},
+        credential_providers=providers_for_clis(required_clis),
+        agent_user=agent_user,
+    )
+
+    return env, state_store
+
+
 def build_execution_environment(
     config: WorkerConfig,
     profile: EnvironmentProfile,
@@ -252,7 +326,6 @@ def build_execution_environment(
 
     Raises:
         ValueError: If required config for the profile type is missing.
-        NotImplementedError: If the profile type is not yet supported.
     """
     if profile.type == EnvironmentProfileType.LOCAL:
         return _build_local(config)
@@ -261,6 +334,8 @@ def build_execution_environment(
             raise ValueError(f"remote_config is required for remote profile '{profile.name}'")
         return build_ssh_execution_environment(config, profile.remote_config, pool=pool)
     elif profile.type == EnvironmentProfileType.DOCKER:
-        raise NotImplementedError("Docker execution not yet supported")
+        if profile.docker_config is None:
+            raise ValueError(f"docker_config is required for docker profile '{profile.name}'")
+        return _build_docker(config, profile.docker_config, pool=pool)
     else:
         raise ValueError(f"Unknown profile type: {profile.type}")

--- a/packages/tanren-core/src/tanren_core/env/environment_schema.py
+++ b/packages/tanren-core/src/tanren_core/env/environment_schema.py
@@ -85,6 +85,33 @@ class DispatchProvisionerConfig(BaseModel):
     )
 
 
+class DockerExecutionConfig(BaseModel):
+    """Docker execution config carried in the dispatch — everything the daemon needs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    image: str = Field(default="ubuntu:24.04", description="Docker image to use")
+    socket_url: str | None = Field(
+        default=None, description="Docker socket URL (None = default /var/run/docker.sock)"
+    )
+    network: str | None = Field(default=None, description="Docker network to attach container to")
+    extra_volumes: tuple[str, ...] = Field(
+        default_factory=tuple, description="Additional volume mounts (host:container format)"
+    )
+    extra_env: dict[str, str] = Field(
+        default_factory=dict, description="Additional environment variables for the container"
+    )
+    repo_url: str = Field(..., description="Git clone URL for this project")
+    required_clis: tuple[str, ...] = Field(
+        default_factory=tuple, description="CLIs needed for bootstrap"
+    )
+    bootstrap_extra_script: str | None = Field(
+        default=None, description="Inline bootstrap script content"
+    )
+    agent_user: str = Field(default="tanren", description="Unprivileged user in the container")
+    git: DispatchGitConfig = Field(default_factory=DispatchGitConfig, description="Git auth config")
+
+
 class RemoteExecutionConfig(BaseModel):
     """Remote execution config carried in the dispatch — everything the daemon needs."""
 
@@ -142,6 +169,9 @@ class EnvironmentProfile(BaseModel):
     )
     remote_config: RemoteExecutionConfig | None = Field(
         default=None, description="Remote execution config (required when type is remote)"
+    )
+    docker_config: DockerExecutionConfig | None = Field(
+        default=None, description="Docker execution config (required when type is docker)"
     )
 
     @field_validator("mcp")

--- a/packages/tanren-core/src/tanren_core/store/handle.py
+++ b/packages/tanren-core/src/tanren_core/store/handle.py
@@ -52,6 +52,19 @@ class PersistedVMInfo(BaseModel):
     )
 
 
+class PersistedDockerConfig(BaseModel):
+    """Serializable Docker connection configuration.
+
+    Contains everything needed to reconnect to a previously provisioned
+    container without holding a live connection object.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    container_id: str = Field(..., description="Docker container ID")
+    socket_url: str | None = Field(default=None, description="Docker socket URL (None = default)")
+
+
 class PersistedEnvironmentHandle(BaseModel):
     """Serializable environment handle persisted in ``StepCompleted`` events.
 
@@ -102,6 +115,12 @@ class PersistedEnvironmentHandle(BaseModel):
     agent_user: str | None = Field(
         default=None,
         description="Agent user for su - wrapping on remote VMs",
+    )
+
+    # Docker fields (all None for non-Docker environments)
+    docker_config: PersistedDockerConfig | None = Field(
+        default=None,
+        description="Docker connection config (None for non-Docker environments)",
     )
 
     # Local fields

--- a/packages/tanren-core/src/tanren_core/worker.py
+++ b/packages/tanren-core/src/tanren_core/worker.py
@@ -940,6 +940,7 @@ class Worker:
 
         vm = None
         ssh_config = None
+        docker_config = None
         workspace_remote_path = None
         agent_user = None
         teardown_commands: tuple[str, ...] = ()
@@ -978,6 +979,19 @@ class Worker:
                 workspace_remote_path = rt.workspace_path.path
                 teardown_commands = rt.teardown_commands
                 profile_name = rt.profile.name
+        elif handle.runtime.kind == "docker":
+            from tanren_core.adapters.types import DockerEnvironmentRuntime
+
+            if isinstance(handle.runtime, DockerEnvironmentRuntime):
+                from tanren_core.store.handle import PersistedDockerConfig
+
+                docker_config = PersistedDockerConfig(
+                    container_id=handle.runtime.container_id,
+                    socket_url=handle.runtime.docker_socket_url,
+                )
+                workspace_remote_path = handle.runtime.workspace_path.path
+                teardown_commands = handle.runtime.teardown_commands
+                profile_name = handle.runtime.profile.name
         elif handle.runtime.kind == "local":
             from tanren_core.adapters.types import LocalEnvironmentRuntime
 
@@ -1000,6 +1014,7 @@ class Worker:
             dispatch_id=dispatch_id,
             provision_timestamp=_utc_now(),
             agent_user=agent_user,
+            docker_config=docker_config,
             task_env=task_env,
             preflight_hashes=preflight_hashes,
             preflight_backups=preflight_backups,
@@ -1063,6 +1078,42 @@ class Worker:
                 teardown_commands=persisted.teardown_commands,
                 provision_start=provision_start,
                 workflow_id=persisted.dispatch_id or f"reconstructed-{persisted.env_id}",
+            )
+        elif persisted.docker_config is not None:
+            # Docker handle — create fresh DockerConnection
+            from tanren_core.adapters.docker_connection import DockerConnection
+            from tanren_core.adapters.remote_types import WorkspacePath as _WP
+            from tanren_core.adapters.types import DockerEnvironmentRuntime
+            from tanren_core.env.environment_schema import (
+                EnvironmentProfile as _EP,
+            )
+
+            docker_conn = DockerConnection.from_existing(
+                persisted.docker_config.container_id,
+                socket_url=persisted.docker_config.socket_url,
+            )
+            docker_workspace = _WP(
+                path=persisted.workspace_remote_path or persisted.worktree_path,
+                project=persisted.project,
+                branch=persisted.branch,
+            )
+            docker_prov_start = time.monotonic()
+            try:
+                prov_dt = datetime.fromisoformat(persisted.provision_timestamp)
+                elapsed = (datetime.now(UTC) - prov_dt).total_seconds()
+                docker_prov_start = max(0.0, time.monotonic() - elapsed)
+            except ValueError, TypeError:
+                pass
+
+            runtime = DockerEnvironmentRuntime(
+                container_id=persisted.docker_config.container_id,
+                connection=docker_conn,
+                workspace_path=docker_workspace,
+                profile=_EP(name=persisted.profile_name),
+                teardown_commands=persisted.teardown_commands,
+                provision_start=docker_prov_start,
+                workflow_id=persisted.dispatch_id or f"reconstructed-{persisted.env_id}",
+                docker_socket_url=persisted.docker_config.socket_url,
             )
         else:
             # Local handle — rebuild preflight_result from persisted hashes/backups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ hetzner = ["tanren-core[hetzner]"]
 gcp = ["tanren-core[gcp]"]
 github = ["tanren-core[github]"]
 linear = ["tanren-core[linear]"]
+docker = ["tanren-core[docker]"]
 all = ["tanren-core[all]"]
 
 [tool.uv]
@@ -104,12 +105,13 @@ markers = [
     "postgres: requires a real Postgres database",
     "github: requires GitHub token and accesses real GitHub API",
     "linear: requires Linear API token and accesses real Linear API",
+    "docker: requires Docker daemon and provisions real containers",
 ]
 
 # ===== COVERAGE =====
 [tool.coverage.run]
 source = ["packages", "services"]
-omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py", "*/adapters/github_issue.py", "*/adapters/linear_issue.py", "*/store/postgres.py"]
+omit = ["*/tests/*", "*/__pycache__/*", "*/adapters/hetzner_vm.py", "*/adapters/gcp_vm.py", "*/adapters/github_issue.py", "*/adapters/linear_issue.py", "*/adapters/docker_connection.py", "*/adapters/docker_environment.py", "*/store/postgres.py"]
 
 [tool.coverage.report]
 fail_under = 80

--- a/tests/integration/test_docker_integration.py
+++ b/tests/integration/test_docker_integration.py
@@ -1,0 +1,91 @@
+"""Integration tests for DockerConnection — requires a running Docker daemon.
+
+Run with: uv run pytest tests/integration/test_docker_integration.py -v -m docker --timeout=120
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
+
+pytestmark = pytest.mark.docker
+
+
+@pytest.fixture
+async def docker_conn():
+    """Create a real container and yield a DockerConnection, then cleanup."""
+    config = DockerConfig(image="ubuntu:24.04")
+    conn = await DockerConnection.create_and_start(
+        config,
+        name="tanren-test-integration",
+        labels={"tanren.test": "true"},
+    )
+    try:
+        yield conn
+    finally:
+        with contextlib.suppress(Exception):
+            await conn.stop_container()
+        with contextlib.suppress(Exception):
+            await conn.remove_container()
+        await conn.close()
+
+
+async def test_run_echo(docker_conn: DockerConnection):
+    """Run a simple echo command and verify output."""
+    result = await docker_conn.run("echo hello", timeout_secs=10)
+    assert result.exit_code == 0
+    assert "hello" in result.stdout
+
+
+async def test_run_exit_code(docker_conn: DockerConnection):
+    """Run a failing command and verify nonzero exit code."""
+    result = await docker_conn.run("false", timeout_secs=10)
+    assert result.exit_code == 1
+
+
+async def test_upload_download_roundtrip(docker_conn: DockerConnection):
+    """Upload content and download it back, verifying a perfect roundtrip."""
+    content = "test content"
+    remote_path = "/tmp/tanren-test-roundtrip.txt"
+
+    await docker_conn.upload_content(content, remote_path)
+    downloaded = await docker_conn.download_content(remote_path)
+
+    assert downloaded == content
+
+
+async def test_upload_special_characters(docker_conn: DockerConnection):
+    """Upload content with single quotes, newlines, and dollar signs."""
+    content = "it's a $HOME\nwith newlines\nand 'quotes' $VAR\n"
+    remote_path = "/tmp/tanren-test-special.txt"
+
+    await docker_conn.upload_content(content, remote_path)
+    downloaded = await docker_conn.download_content(remote_path)
+
+    assert downloaded == content
+
+
+async def test_download_missing_file(docker_conn: DockerConnection):
+    """download_content returns None for a nonexistent path."""
+    result = await docker_conn.download_content("/tmp/tanren-nonexistent-file.txt")
+    assert result is None
+
+
+async def test_check_connection(docker_conn: DockerConnection):
+    """Verify check_connection returns True for a running container."""
+    assert await docker_conn.check_connection() is True
+
+
+def test_get_host_identifier(docker_conn: DockerConnection):
+    """Verify host identifier starts with docker:// prefix."""
+    identifier = docker_conn.get_host_identifier()
+    assert identifier.startswith("docker://")
+
+
+async def test_run_timeout(docker_conn: DockerConnection):
+    """Run a long-sleeping command with a short timeout and verify it times out."""
+    result = await docker_conn.run("sleep 60", timeout_secs=2)
+    assert result.timed_out is True

--- a/tests/integration/test_signal_extraction.py
+++ b/tests/integration/test_signal_extraction.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from tanren_core.adapters.ssh_environment import _extract_signal_token, _validate_cli_auth
+from tanren_core.adapters.remote_shared import extract_signal_token, validate_cli_auth
 from tanren_core.dispatch_resolver import (
     resolve_agent_tool,
     resolve_cloud_secrets,
@@ -20,30 +20,30 @@ from tanren_core.worker_config import WorkerConfig
 
 
 class TestExtractSignalTokenIntegration:
-    """Verify _extract_signal_token covers all dispatch phase signal patterns."""
+    """Verify extract_signal_token covers all dispatch phase signal patterns."""
 
     def test_do_task_signals(self):
         for signal in ("complete", "blocked", "all-done", "error"):
-            token = _extract_signal_token("do-task", f"do-task-status: {signal}", "")
+            token = extract_signal_token("do-task", f"do-task-status: {signal}", "")
             assert token == signal
 
     def test_audit_task_signals(self):
         for signal in ("pass", "fail", "error"):
-            token = _extract_signal_token("audit-task", f"audit-task-status: {signal}", "")
+            token = extract_signal_token("audit-task", f"audit-task-status: {signal}", "")
             assert token == signal
 
     def test_run_demo_signals(self):
         for signal in ("pass", "fail", "error"):
-            token = _extract_signal_token("run-demo", f"run-demo-status: {signal}", "")
+            token = extract_signal_token("run-demo", f"run-demo-status: {signal}", "")
             assert token == signal
 
     def test_stdout_fallback_all_phases(self):
         for cmd in ("do-task", "audit-task", "run-demo"):
-            token = _extract_signal_token(cmd, "", f"output\n{cmd}-status: complete\n")
+            token = extract_signal_token(cmd, "", f"output\n{cmd}-status: complete\n")
             assert token == "complete"
 
     def test_file_precedence_over_stdout(self):
-        token = _extract_signal_token(
+        token = extract_signal_token(
             "do-task", "do-task-status: blocked", "do-task-status: complete"
         )
         assert token == "blocked"
@@ -53,23 +53,23 @@ class TestValidateCliAuthIntegration:
     """Verify CLI auth validation for all supported CLIs."""
 
     def test_claude_requires_at_least_one_auth(self):
-        _validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CODE_OAUTH_TOKEN": "tok"})
-        _validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CREDENTIALS_JSON": "{}"})
+        validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CODE_OAUTH_TOKEN": "tok"})
+        validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CREDENTIALS_JSON": "{}"})
         with pytest.raises(RuntimeError):
-            _validate_cli_auth(Cli.CLAUDE, {})
+            validate_cli_auth(Cli.CLAUDE, {})
 
     def test_opencode_requires_api_key(self):
-        _validate_cli_auth(Cli.OPENCODE, {"OPENCODE_ZAI_API_KEY": "key"})
+        validate_cli_auth(Cli.OPENCODE, {"OPENCODE_ZAI_API_KEY": "key"})
         with pytest.raises(RuntimeError):
-            _validate_cli_auth(Cli.OPENCODE, {})
+            validate_cli_auth(Cli.OPENCODE, {})
 
     def test_codex_requires_auth_json(self):
-        _validate_cli_auth(Cli.CODEX, {"CODEX_AUTH_JSON": "{}"})
+        validate_cli_auth(Cli.CODEX, {"CODEX_AUTH_JSON": "{}"})
         with pytest.raises(RuntimeError):
-            _validate_cli_auth(Cli.CODEX, {})
+            validate_cli_auth(Cli.CODEX, {})
 
     def test_bash_needs_no_auth(self):
-        _validate_cli_auth(Cli.BASH, {})
+        validate_cli_auth(Cli.BASH, {})
 
 
 def _make_config(tmp_path: Path) -> WorkerConfig:

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -18,6 +18,7 @@ from tanren_core.builder import (
 )
 from tanren_core.env.environment_schema import (
     DispatchProvisionerConfig,
+    DockerExecutionConfig,
     EnvironmentProfile,
     EnvironmentProfileType,
     RemoteExecutionConfig,
@@ -197,8 +198,25 @@ class TestBuildExecutionEnvironment:
         assert isinstance(env, SSHExecutionEnvironment)
         assert vm_store is not None
 
-    def test_docker_profile_raises_not_implemented(self, tmp_path):
+    def test_docker_profile_raises_without_docker_config(self, tmp_path):
         config = _make_config(tmp_path)
         profile = EnvironmentProfile(name="ci", type=EnvironmentProfileType.DOCKER)
-        with pytest.raises(NotImplementedError, match="Docker execution not yet supported"):
+        with pytest.raises(ValueError, match="docker_config is required"):
             build_execution_environment(config, profile)
+
+    def test_docker_profile_builds_docker_environment(self, tmp_path):
+        from tanren_core.adapters.docker_environment import DockerExecutionEnvironment
+
+        config = _make_config(tmp_path)
+        docker_cfg = DockerExecutionConfig(
+            repo_url="https://github.com/test/repo.git",
+            required_clis=("claude",),
+        )
+        profile = EnvironmentProfile(
+            name="ci-docker",
+            type=EnvironmentProfileType.DOCKER,
+            docker_config=docker_cfg,
+        )
+        env, vm_store = build_execution_environment(config, profile)
+        assert isinstance(env, DockerExecutionEnvironment)
+        assert vm_store is not None

--- a/tests/unit/test_docker_connection.py
+++ b/tests/unit/test_docker_connection.py
@@ -23,21 +23,39 @@ def _make_conn(
     return DockerConnection(container_id=container_id, socket_url=socket_url)
 
 
-def _mock_exec_instance(output: bytes = b"", exit_code: int = 0) -> MagicMock:
-    """Return a mock aiodocker exec instance with an async-iterable start().
+def _mock_exec_instance(
+    output: bytes = b"",
+    exit_code: int = 0,
+    *,
+    stderr_output: bytes = b"",
+) -> MagicMock:
+    """Return a mock aiodocker exec instance with a Stream-like start().
 
-    ``start(detach=False)`` is called *without* await in the implementation,
-    so it must be a regular callable that returns an async iterable.
-    ``inspect()`` *is* awaited, so it stays as an AsyncMock.
+    ``start(detach=False)`` is called *without* await in the implementation
+    and returns a Stream object whose ``read_out()`` yields ``Message``
+    namedtuples.  ``inspect()`` *is* awaited.
     """
+    from collections import namedtuple
+
+    Message = namedtuple("Message", ["stream", "data"])
     exec_inst = MagicMock()
 
-    async def _stream():  # noqa: RUF029 — async generator for exec stream
-        yield output
+    # Build the message sequence: stdout messages then stderr messages.
+    messages: list[Message | None] = []
+    if output:
+        messages.append(Message(stream=1, data=output))
+    if stderr_output:
+        messages.append(Message(stream=2, data=stderr_output))
+    messages.append(None)  # sentinel for end-of-stream
 
-    # start() is called synchronously, returns an async iterator
-    exec_inst.start = MagicMock(side_effect=lambda detach=False: _stream())
-    # inspect() is awaited
+    def _make_stream(detach: bool = False) -> MagicMock:
+        it = iter(messages)
+        stream = AsyncMock()
+        stream.read_out = AsyncMock(side_effect=lambda: next(it))
+        stream.close = AsyncMock()
+        return stream
+
+    exec_inst.start = MagicMock(side_effect=_make_stream)
     exec_inst.inspect = AsyncMock(return_value={"ExitCode": exit_code})
     return exec_inst
 

--- a/tests/unit/test_docker_connection.py
+++ b/tests/unit/test_docker_connection.py
@@ -1,0 +1,631 @@
+"""Tests for Docker container connection adapter."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tanren_core.adapters.docker_connection import DockerConfig, DockerConnection
+from tanren_core.adapters.remote_types import RemoteResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(
+    container_id: str = "abc123def456",
+    socket_url: str | None = None,
+) -> DockerConnection:
+    return DockerConnection(container_id=container_id, socket_url=socket_url)
+
+
+def _mock_exec_instance(output: bytes = b"", exit_code: int = 0) -> MagicMock:
+    """Return a mock aiodocker exec instance with an async-iterable start().
+
+    ``start(detach=False)`` is called *without* await in the implementation,
+    so it must be a regular callable that returns an async iterable.
+    ``inspect()`` *is* awaited, so it stays as an AsyncMock.
+    """
+    exec_inst = MagicMock()
+
+    async def _stream():  # noqa: RUF029 — async generator for exec stream
+        yield output
+
+    # start() is called synchronously, returns an async iterator
+    exec_inst.start = MagicMock(side_effect=lambda detach=False: _stream())
+    # inspect() is awaited
+    exec_inst.inspect = AsyncMock(return_value={"ExitCode": exit_code})
+    return exec_inst
+
+
+def _patch_ensure_client(conn: DockerConnection, exec_inst: MagicMock) -> MagicMock:
+    """Wire up a mock Docker client -> container -> exec chain on *conn*."""
+    mock_docker = MagicMock()
+    mock_container = AsyncMock()
+    mock_docker.containers.container.return_value = mock_container
+    mock_container.exec.return_value = exec_inst
+    conn._docker = mock_docker
+    return mock_docker
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionRun
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionRun:
+    async def test_run_simple_command(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"hello\n", exit_code=0)
+        _patch_ensure_client(conn, exec_inst)
+
+        result = await conn.run("echo hello")
+
+        assert isinstance(result, RemoteResult)
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+        assert result.timed_out is False
+
+    async def test_run_exit_code_propagation(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"error msg\n", exit_code=127)
+        _patch_ensure_client(conn, exec_inst)
+
+        result = await conn.run("nonexistent-cmd")
+
+        assert result.exit_code == 127
+        assert result.timed_out is False
+
+    async def test_run_timeout(self):
+        conn = _make_conn()
+
+        exec_inst = MagicMock()
+
+        async def _hanging_stream():
+            import asyncio
+
+            await asyncio.sleep(999)
+            yield b""  # pragma: no cover
+
+        exec_inst.start = MagicMock(side_effect=lambda detach=False: _hanging_stream())
+        exec_inst.inspect = AsyncMock(return_value={"ExitCode": 0})
+
+        _patch_ensure_client(conn, exec_inst)
+
+        result = await conn.run("sleep 999", timeout_secs=0)
+
+        assert result.timed_out is True
+        assert result.exit_code == -1
+        assert "timed out" in result.stderr.lower()
+
+    async def test_run_with_stdin_data(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"piped\n", exit_code=0)
+        mock_docker = _patch_ensure_client(conn, exec_inst)
+
+        await conn.run("cat", stdin_data="hello world")
+
+        # Verify the command was wrapped with base64 piping
+        mock_container = mock_docker.containers.container.return_value
+        call_args = mock_container.exec.call_args
+        cmd_list = call_args.kwargs.get("cmd") or call_args[1].get("cmd") or call_args[0][0]
+        actual_command = cmd_list[2]  # /bin/bash -c <command>
+        encoded = base64.b64encode(b"hello world").decode()
+        assert f"echo '{encoded}' | base64 -d | cat" == actual_command
+
+    async def test_run_with_request_pty(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"tty-out\n", exit_code=0)
+        mock_docker = _patch_ensure_client(conn, exec_inst)
+
+        await conn.run("cmd", request_pty=True)
+
+        mock_container = mock_docker.containers.container.return_value
+        call_kwargs = mock_container.exec.call_args.kwargs
+        assert call_kwargs["tty"] is True
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionUploadContent
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionUploadContent:
+    async def test_upload_creates_parent_dir(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"", exit_code=0)
+        mock_docker = _patch_ensure_client(conn, exec_inst)
+
+        await conn.upload_content("file body", "/tmp/sub/test.txt")
+
+        mock_container = mock_docker.containers.container.return_value
+        call_args = mock_container.exec.call_args
+        cmd_list = call_args.kwargs.get("cmd") or call_args[0][0]
+        actual_command = cmd_list[2]
+
+        assert "mkdir -p" in actual_command
+        assert "/tmp/sub" in actual_command
+        assert "base64 -d" in actual_command
+
+    async def test_upload_raises_on_failure(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"permission denied\n", exit_code=1)
+        _patch_ensure_client(conn, exec_inst)
+
+        with pytest.raises(OSError, match=r"upload_content to /root/secret\.txt failed"):
+            await conn.upload_content("data", "/root/secret.txt")
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionDownloadContent
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionDownloadContent:
+    async def test_download_existing_file(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"file content here", exit_code=0)
+        _patch_ensure_client(conn, exec_inst)
+
+        content = await conn.download_content("/tmp/test.txt")
+
+        assert content == "file content here"
+
+    async def test_download_missing_file(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"", exit_code=1)
+        _patch_ensure_client(conn, exec_inst)
+
+        content = await conn.download_content("/tmp/nonexistent.txt")
+
+        assert content is None
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionCheckConnection
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionCheckConnection:
+    async def test_check_returns_true_when_running(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"tanren-ok\n", exit_code=0)
+        _patch_ensure_client(conn, exec_inst)
+
+        assert await conn.check_connection() is True
+
+    async def test_check_returns_false_on_error(self):
+        conn = _make_conn()
+        # Make _ensure_client raise to simulate unreachable container
+        conn._docker = None
+        with patch.object(
+            DockerConnection,
+            "_ensure_client",
+            side_effect=ConnectionError("cannot connect"),
+        ):
+            assert await conn.check_connection() is False
+
+    async def test_check_returns_false_on_nonzero_exit(self):
+        conn = _make_conn()
+        exec_inst = _mock_exec_instance(output=b"", exit_code=1)
+        _patch_ensure_client(conn, exec_inst)
+
+        assert await conn.check_connection() is False
+
+    async def test_check_connection_logs_failure_at_debug(self, caplog):
+        conn = _make_conn()
+        conn._docker = None
+        with (
+            patch.object(
+                DockerConnection,
+                "_ensure_client",
+                side_effect=Exception("container gone"),
+            ),
+            caplog.at_level(logging.DEBUG, logger="tanren_core.adapters.docker_connection"),
+        ):
+            result = await conn.check_connection()
+
+        assert result is False
+        assert "check_connection failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionClose
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionClose:
+    async def test_close_closes_client(self):
+        conn = _make_conn()
+        mock_docker = AsyncMock()
+        conn._docker = mock_docker
+
+        await conn.close()
+
+        mock_docker.close.assert_awaited_once()
+        assert conn._docker is None
+
+    async def test_close_idempotent(self):
+        conn = _make_conn()
+        mock_docker = AsyncMock()
+        conn._docker = mock_docker
+
+        await conn.close()
+        await conn.close()
+
+        # close() on the client is only called once because _docker is set to None
+        mock_docker.close.assert_awaited_once()
+        assert conn._docker is None
+
+    async def test_close_suppresses_exceptions(self):
+        conn = _make_conn()
+        mock_docker = AsyncMock()
+        mock_docker.close.side_effect = Exception("socket error")
+        conn._docker = mock_docker
+
+        # Should not raise
+        await conn.close()
+        assert conn._docker is None
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionFromExisting
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionFromExisting:
+    async def test_creates_instance_without_client(self):
+        conn = DockerConnection.from_existing("deadbeef1234")
+
+        assert conn._container_id == "deadbeef1234"
+        assert conn._docker is None
+
+    async def test_lazy_client_created_on_first_run(self):
+        conn = DockerConnection.from_existing("deadbeef1234")
+        assert conn._docker is None
+
+        # Patch the aiodocker import inside _ensure_client
+        mock_aiodocker = MagicMock()
+        mock_docker_client = MagicMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        # Set up the exec chain on the lazily-created client
+        mock_container = AsyncMock()
+        exec_inst = _mock_exec_instance(output=b"ok\n", exit_code=0)
+        mock_docker_client.containers.container.return_value = mock_container
+        mock_container.exec.return_value = exec_inst
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            result = await conn.run("echo ok")
+
+        assert conn._docker is mock_docker_client
+        assert result.exit_code == 0
+
+    async def test_from_existing_with_socket_url(self):
+        conn = DockerConnection.from_existing("deadbeef1234", socket_url="unix:///custom.sock")
+
+        assert conn._container_id == "deadbeef1234"
+        assert conn._socket_url == "unix:///custom.sock"
+        assert conn._docker is None
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionCreateAndStart
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionCreateAndStart:
+    async def test_pulls_image_and_creates_container(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "new-container-123"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(image="python:3.14")
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            conn = await DockerConnection.create_and_start(config, name="test-vm")
+
+        mock_docker_client.images.pull.assert_awaited_once_with("python:3.14")
+        mock_docker_client.containers.create_or_replace.assert_awaited_once()
+        mock_container.start.assert_awaited_once()
+        assert conn._container_id == "new-container-123"
+        assert conn._docker is mock_docker_client
+
+    async def test_cpu_and_memory_limits_in_config(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "limited-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(image="ubuntu:24.04")
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            await DockerConnection.create_and_start(
+                config,
+                name="limited-vm",
+                cpu_limit=2.0,
+                memory_limit_bytes=4_000_000_000,
+            )
+
+        call_args = mock_docker_client.containers.create_or_replace.call_args
+        container_config = call_args[0][1]  # positional: name, config
+        host_config = container_config["HostConfig"]
+
+        assert host_config["NanoCpus"] == int(2.0 * 1e9)
+        assert host_config["Memory"] == 4_000_000_000
+
+    async def test_network_in_config(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "networked-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(image="ubuntu:24.04", network="my-network")
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            await DockerConnection.create_and_start(config, name="net-vm")
+
+        call_args = mock_docker_client.containers.create_or_replace.call_args
+        container_config = call_args[0][1]
+        host_config = container_config["HostConfig"]
+
+        assert host_config["NetworkMode"] == "my-network"
+
+    async def test_labels_applied(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "labeled-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(image="ubuntu:24.04")
+        labels = {"app": "tanren", "env": "test"}
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            await DockerConnection.create_and_start(config, name="label-vm", labels=labels)
+
+        call_args = mock_docker_client.containers.create_or_replace.call_args
+        container_config = call_args[0][1]
+
+        assert container_config["Labels"] == {"app": "tanren", "env": "test"}
+
+    async def test_pull_failure_logged_not_raised(self, caplog):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "fallback-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock(side_effect=Exception("network error"))
+
+        config = DockerConfig(image="my-local-image:latest")
+
+        with (
+            patch.dict("sys.modules", {"aiodocker": mock_aiodocker}),
+            caplog.at_level(logging.WARNING, logger="tanren_core.adapters.docker_connection"),
+        ):
+            conn = await DockerConnection.create_and_start(config, name="pull-fail-vm")
+
+        # Container should still be created and started despite pull failure
+        mock_docker_client.containers.create_or_replace.assert_awaited_once()
+        mock_container.start.assert_awaited_once()
+        assert conn._container_id == "fallback-container"
+        assert "Failed to pull image" in caplog.text
+
+    async def test_extra_env_in_config(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "env-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(image="ubuntu:24.04", extra_env={"FOO": "bar", "BAZ": "qux"})
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            await DockerConnection.create_and_start(config, name="env-vm")
+
+        call_args = mock_docker_client.containers.create_or_replace.call_args
+        container_config = call_args[0][1]
+
+        assert "Env" in container_config
+        assert "FOO=bar" in container_config["Env"]
+        assert "BAZ=qux" in container_config["Env"]
+
+    async def test_extra_volumes_in_config(self):
+        mock_aiodocker = MagicMock()
+        mock_docker_client = AsyncMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        mock_container = AsyncMock()
+        mock_container.id = "vol-container"
+        mock_docker_client.containers.create_or_replace.return_value = mock_container
+        mock_docker_client.images.pull = AsyncMock()
+
+        config = DockerConfig(
+            image="ubuntu:24.04",
+            extra_volumes=("/host/path:/container/path", "/data:/data:ro"),
+        )
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            await DockerConnection.create_and_start(config, name="vol-vm")
+
+        call_args = mock_docker_client.containers.create_or_replace.call_args
+        container_config = call_args[0][1]
+        host_config = container_config["HostConfig"]
+
+        assert host_config["Binds"] == ["/host/path:/container/path", "/data:/data:ro"]
+
+    async def test_docker_client_creation_failure_raises_connection_error(self):
+        mock_aiodocker = MagicMock()
+        mock_aiodocker.Docker.side_effect = Exception("socket not found")
+
+        config = DockerConfig(image="ubuntu:24.04")
+
+        with (
+            patch.dict("sys.modules", {"aiodocker": mock_aiodocker}),
+            pytest.raises(ConnectionError, match="Failed to create Docker client"),
+        ):
+            await DockerConnection.create_and_start(config, name="fail-vm")
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionGetHostIdentifier
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionGetHostIdentifier:
+    async def test_returns_docker_prefix(self):
+        conn = _make_conn(container_id="abc123def456789xyz")
+
+        assert conn.get_host_identifier() == "docker://abc123def456"
+
+    async def test_short_id_unchanged(self):
+        conn = _make_conn(container_id="short")
+
+        assert conn.get_host_identifier() == "docker://short"
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionStopContainer
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionStopContainer:
+    async def test_stop_calls_container_stop(self):
+        conn = _make_conn()
+        mock_docker = MagicMock()
+        mock_container = AsyncMock()
+        mock_docker.containers.container.return_value = mock_container
+        conn._docker = mock_docker
+
+        await conn.stop_container()
+
+        mock_container.stop.assert_awaited_once_with(t=10)
+
+    async def test_stop_with_custom_timeout(self):
+        conn = _make_conn()
+        mock_docker = MagicMock()
+        mock_container = AsyncMock()
+        mock_docker.containers.container.return_value = mock_container
+        conn._docker = mock_docker
+
+        await conn.stop_container(stop_timeout=30)
+
+        mock_container.stop.assert_awaited_once_with(t=30)
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionRemoveContainer
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionRemoveContainer:
+    async def test_remove_calls_container_delete(self):
+        conn = _make_conn()
+        mock_docker = MagicMock()
+        mock_container = AsyncMock()
+        mock_docker.containers.container.return_value = mock_container
+        conn._docker = mock_docker
+
+        await conn.remove_container()
+
+        mock_container.delete.assert_awaited_once_with(force=True)
+
+    async def test_remove_without_force(self):
+        conn = _make_conn()
+        mock_docker = MagicMock()
+        mock_container = AsyncMock()
+        mock_docker.containers.container.return_value = mock_container
+        conn._docker = mock_docker
+
+        await conn.remove_container(force=False)
+
+        mock_container.delete.assert_awaited_once_with(force=False)
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConnectionEnsureClient
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConnectionEnsureClient:
+    async def test_ensure_client_raises_connection_error(self):
+        conn = _make_conn()
+
+        mock_aiodocker = MagicMock()
+        mock_aiodocker.Docker.side_effect = Exception("no socket")
+
+        with (
+            patch.dict("sys.modules", {"aiodocker": mock_aiodocker}),
+            pytest.raises(ConnectionError, match="Failed to create Docker client"),
+        ):
+            conn._ensure_client()
+
+    async def test_ensure_client_reuses_existing(self):
+        conn = _make_conn()
+        mock_docker = MagicMock()
+        conn._docker = mock_docker
+
+        result = conn._ensure_client()
+
+        assert result is mock_docker
+
+    async def test_ensure_client_passes_socket_url(self):
+        conn = _make_conn(socket_url="tcp://remote:2375")
+
+        mock_aiodocker = MagicMock()
+        mock_docker_client = MagicMock()
+        mock_aiodocker.Docker.return_value = mock_docker_client
+
+        with patch.dict("sys.modules", {"aiodocker": mock_aiodocker}):
+            result = conn._ensure_client()
+
+        mock_aiodocker.Docker.assert_called_once_with(url="tcp://remote:2375")
+        assert result is mock_docker_client
+
+
+# ---------------------------------------------------------------------------
+# TestDockerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDockerConfig:
+    def test_defaults(self):
+        cfg = DockerConfig()
+        assert cfg.image == "ubuntu:24.04"
+        assert cfg.socket_url is None
+        assert cfg.network is None
+        assert cfg.extra_volumes == ()
+        assert cfg.extra_env == {}
+        assert cfg.api_version == "v1.45"
+
+    def test_frozen(self):
+        from pydantic import ValidationError
+
+        cfg = DockerConfig()
+        with pytest.raises(ValidationError, match="frozen"):
+            cfg.image = "other"

--- a/tests/unit/test_docker_environment.py
+++ b/tests/unit/test_docker_environment.py
@@ -1,0 +1,1326 @@
+"""Tests for DockerExecutionEnvironment composition layer."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tanren_core.adapters.docker_connection import DockerConfig
+from tanren_core.adapters.docker_environment import DockerExecutionEnvironment
+from tanren_core.adapters.remote_types import (
+    DryRunInfo,
+    RemoteAgentResult,
+    RemoteResult,
+    SecretBundle,
+    VMAssignment,
+    VMProvider,
+    VMRequirements,
+    WorkspacePath,
+)
+from tanren_core.adapters.types import (
+    AccessInfo,
+    DockerEnvironmentRuntime,
+    EnvironmentHandle,
+    PhaseResult,
+)
+from tanren_core.env.environment_schema import (
+    DockerExecutionConfig,
+    EnvironmentProfile,
+    EnvironmentProfileType,
+    McpServerConfig,
+    ResourceRequirements,
+)
+from tanren_core.errors import ErrorClass
+from tanren_core.schemas import Cli, Dispatch, Outcome, Phase
+from tanren_core.worker_config import WorkerConfig
+
+_DOCKER_ENV = "tanren_core.adapters.docker_environment"
+
+DEFAULT_PROFILE = EnvironmentProfile(name="default")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path: Path) -> WorkerConfig:
+    return WorkerConfig(
+        ipc_dir=str(tmp_path / "ipc"),
+        github_dir=str(tmp_path),
+        data_dir=str(tmp_path / "data"),
+        db_url=str(tmp_path / "events.db"),
+        worktree_registry_path=str(tmp_path / "data" / "worktrees.json"),
+        roles_config_path=str(tmp_path / "roles.yml"),
+    )
+
+
+def _make_dispatch(
+    phase: Phase = Phase.DO_TASK,
+    cli: Cli = Cli.CLAUDE,
+    project: str = "test-project",
+    branch: str = "main",
+    context: str = "Do the work",
+    resolved_profile: EnvironmentProfile | None = None,
+    project_env: dict[str, str] | None = None,
+    cloud_secrets: dict[str, str] | None = None,
+    required_secrets: tuple[str, ...] = (),
+) -> Dispatch:
+    return Dispatch(
+        workflow_id="wf-test-project-42-1000",
+        phase=phase,
+        project=project,
+        spec_folder="tanren/specs/feature",
+        branch=branch,
+        cli=cli,
+        model="sonnet",
+        gate_cmd="make check" if cli == Cli.BASH else None,
+        context=context,
+        timeout=300,
+        environment_profile="default",
+        resolved_profile=resolved_profile or _make_docker_profile(),
+        project_env=project_env or {},
+        cloud_secrets=cloud_secrets or {},
+        required_secrets=required_secrets,
+    )
+
+
+def _make_docker_profile(
+    *,
+    setup: tuple[str, ...] = ("make setup",),
+    teardown: tuple[str, ...] = ("make clean",),
+    mcp: dict[str, McpServerConfig] | None = None,
+    resources: ResourceRequirements | None = None,
+    docker_config: DockerExecutionConfig | None = None,
+) -> EnvironmentProfile:
+    return EnvironmentProfile(
+        name="default",
+        type=EnvironmentProfileType.DOCKER,
+        resources=resources or ResourceRequirements(cpu=2, memory_gb=4, gpu=False),
+        setup=setup,
+        teardown=teardown,
+        mcp=mcp or {},
+        docker_config=docker_config
+        or DockerExecutionConfig(
+            image="ubuntu:24.04",
+            repo_url="https://github.com/test/repo.git",
+        ),
+    )
+
+
+def _make_workspace() -> WorkspacePath:
+    return WorkspacePath(path="/workspace/test-project", project="test-project", branch="main")
+
+
+_OK_REMOTE_RESULT = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+
+
+def _make_agent_result(
+    exit_code: int = 0,
+    stdout: str = "done",
+    stderr: str = "",
+    timed_out: bool = False,
+    signal_content: str = "success",
+) -> RemoteAgentResult:
+    return RemoteAgentResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        timed_out=timed_out,
+        duration_secs=30,
+        stderr=stderr,
+        signal_content=signal_content,
+    )
+
+
+def _make_handle(
+    conn=None, workspace=None, *, teardown_commands=("make clean",)
+) -> EnvironmentHandle:
+    """Build a minimal EnvironmentHandle for execute/teardown tests."""
+    ws = workspace or _make_workspace()
+    return EnvironmentHandle(
+        env_id="env-test-1",
+        worktree_path=Path(ws.path),
+        branch="main",
+        project="test-project",
+        runtime=DockerEnvironmentRuntime(
+            container_id="abc123container",
+            connection=conn or AsyncMock(),
+            workspace_path=ws,
+            profile=_make_docker_profile(),
+            teardown_commands=teardown_commands,
+            provision_start=time.monotonic(),
+            workflow_id="wf-test-project-42-1000",
+            docker_socket_url=None,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def docker_env_kit(tmp_path: Path):
+    """Build a DockerExecutionEnvironment with all sub-adapters mocked."""
+    bootstrapper = AsyncMock()
+    workspace_mgr = AsyncMock()
+    runner = AsyncMock()
+    state_store = AsyncMock()
+    secret_loader = MagicMock()
+
+    # Configure workspace_mgr return values
+    workspace_mgr.setup.return_value = _make_workspace()
+    workspace_mgr.inject_secrets.return_value = None
+    workspace_mgr.inject_mcp_config = AsyncMock()
+    workspace_mgr.cleanup.return_value = None
+    workspace_mgr.push_command = MagicMock(return_value="git push origin main")
+
+    # Configure runner return value
+    runner.run.return_value = _make_agent_result()
+
+    # Configure secret_loader
+    secret_loader.build_bundle.return_value = SecretBundle()
+
+    # Configure state_store
+    state_store.record_assignment.return_value = None
+    state_store.record_release.return_value = None
+    state_store.get_active_assignments.return_value = []
+    state_store.close.return_value = None
+
+    docker_config = DockerConfig(image="ubuntu:24.04")
+
+    env = DockerExecutionEnvironment(
+        bootstrapper=bootstrapper,
+        workspace_mgr=workspace_mgr,
+        runner=runner,
+        state_store=state_store,
+        secret_loader=secret_loader,
+        docker_config=docker_config,
+        repo_urls={"test-project": "https://github.com/test/repo.git"},
+        agent_user="tanren",
+    )
+
+    return {
+        "env": env,
+        "bootstrapper": bootstrapper,
+        "workspace_mgr": workspace_mgr,
+        "runner": runner,
+        "state_store": state_store,
+        "secret_loader": secret_loader,
+        "docker_config": docker_config,
+        "config": _make_config(tmp_path),
+        "tmp_path": tmp_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProvision:
+    async def test_happy_path(self, docker_env_kit):
+        """provision() creates container, bootstraps, sets up workspace,
+        injects secrets and credentials, records assignment, returns handle."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch(project_env={"KEY": "val"})
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=["claude"],
+            ) as mock_inject_creds,
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            handle = await env.provision(dispatch, config)
+
+        # Container created
+        MockDockerConn.create_and_start.assert_awaited_once()
+        create_kwargs = MockDockerConn.create_and_start.call_args
+        assert create_kwargs.args[0] == docker_env_kit["docker_config"]
+
+        # Connection check called
+        mock_conn.check_connection.assert_awaited_once()
+
+        # Bootstrap called
+        docker_env_kit["bootstrapper"].bootstrap.assert_awaited_once_with(mock_conn)
+
+        # Workspace setup called with empty setup_commands (clone only)
+        docker_env_kit["workspace_mgr"].setup.assert_awaited_once()
+        ws_spec = docker_env_kit["workspace_mgr"].setup.call_args.args[1]
+        assert ws_spec.setup_commands == ()
+
+        # Secrets injected
+        docker_env_kit["workspace_mgr"].inject_secrets.assert_awaited_once()
+
+        # CLI credentials injected
+        mock_inject_creds.assert_awaited_once()
+
+        # State assignment recorded
+        docker_env_kit["state_store"].record_assignment.assert_awaited_once()
+
+        # Handle returned with correct shape
+        assert isinstance(handle, EnvironmentHandle)
+        assert handle.project == "test-project"
+        assert handle.branch == "main"
+        assert handle.runtime.kind == "docker"
+        assert handle.runtime.container_id == "abc123container"
+        assert handle.runtime.connection is mock_conn
+
+    async def test_cleanup_on_bootstrap_failure(self, docker_env_kit):
+        """provision() cleans up container when bootstrap fails."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        docker_env_kit["bootstrapper"].bootstrap.side_effect = RuntimeError("bootstrap boom")
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(RuntimeError, match="bootstrap boom"):
+                await env.provision(dispatch, config)
+
+        # Container must be stopped and removed
+        mock_conn.stop_container.assert_awaited_once()
+        mock_conn.remove_container.assert_awaited_once()
+        mock_conn.close.assert_awaited_once()
+
+        # State store records release
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_cleanup_on_cancelled_error(self, docker_env_kit):
+        """provision() cleans up container when cancelled (no orphaned containers)."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        docker_env_kit["bootstrapper"].bootstrap.side_effect = asyncio.CancelledError()
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(asyncio.CancelledError):
+                await env.provision(dispatch, config)
+
+        # Container must be cleaned up even on cancellation
+        mock_conn.stop_container.assert_awaited_once()
+        mock_conn.remove_container.assert_awaited_once()
+        mock_conn.close.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_resource_limits_passed_to_connection(self, docker_env_kit):
+        """provision() computes cpu_limit and memory_limit_bytes from profile.resources."""
+        env = docker_env_kit["env"]
+        profile = _make_docker_profile(
+            resources=ResourceRequirements(cpu=4, memory_gb=8, gpu=False),
+        )
+        dispatch = _make_dispatch(resolved_profile=profile)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        create_kwargs = MockDockerConn.create_and_start.call_args
+        assert create_kwargs.kwargs["cpu_limit"] == pytest.approx(4.0)
+        assert create_kwargs.kwargs["memory_limit_bytes"] == 8 * 1024**3
+
+    async def test_missing_repo_url_raises(self, docker_env_kit):
+        """provision() raises RuntimeError when no repo URL is configured."""
+        env = docker_env_kit["env"]
+        # Profile with no repo_url in docker_config and unknown project
+        profile = _make_docker_profile(
+            docker_config=DockerExecutionConfig(
+                image="ubuntu:24.04",
+                repo_url="",
+            ),
+        )
+        dispatch = _make_dispatch(project="unknown-project", resolved_profile=profile)
+        config = docker_env_kit["config"]
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(RuntimeError, match="No repo URL configured"):
+                await env.provision(dispatch, config)
+
+        # Container must still be cleaned up
+        mock_conn.stop_container.assert_awaited_once()
+        mock_conn.remove_container.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once()
+
+    async def test_repo_url_from_profile_docker_config(self, docker_env_kit):
+        """provision() prefers repo_url from profile.docker_config over instance mapping."""
+        env = docker_env_kit["env"]
+        profile = _make_docker_profile(
+            docker_config=DockerExecutionConfig(
+                image="ubuntu:24.04",
+                repo_url="https://github.com/from-profile/repo.git",
+            ),
+        )
+        dispatch = _make_dispatch(resolved_profile=profile)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        # Workspace setup called with repo_url from profile
+        ws_spec = docker_env_kit["workspace_mgr"].setup.call_args.args[1]
+        assert ws_spec.repo_url == "https://github.com/from-profile/repo.git"
+
+    async def test_connection_check_failure_raises(self, docker_env_kit):
+        """provision() raises RuntimeError when container fails connectivity check."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = False
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(RuntimeError, match="failed connectivity check"):
+                await env.provision(dispatch, config)
+
+        mock_conn.stop_container.assert_awaited_once()
+        mock_conn.remove_container.assert_awaited_once()
+
+    async def test_provision_injects_mcp_config(self, docker_env_kit):
+        """provision() calls inject_mcp_config when profile has MCP servers."""
+        env = docker_env_kit["env"]
+        config = docker_env_kit["config"]
+        workspace_mgr = docker_env_kit["workspace_mgr"]
+
+        mcp_profile = _make_docker_profile(
+            mcp={
+                "context7": McpServerConfig(
+                    url="https://mcp.context7.com/sse",
+                    headers={"Authorization": "MCP_CONTEXT7_KEY"},
+                )
+            },
+        )
+        dispatch = _make_dispatch(resolved_profile=mcp_profile)
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        workspace_mgr.inject_mcp_config.assert_awaited_once()
+        call_args = workspace_mgr.inject_mcp_config.call_args
+        assert "context7" in call_args.args[2]
+        assert call_args.args[2]["context7"].url == "https://mcp.context7.com/sse"
+
+    async def test_provision_skips_mcp_when_empty(self, docker_env_kit):
+        """provision() does not call inject_mcp_config when profile has no MCP servers."""
+        env = docker_env_kit["env"]
+        config = docker_env_kit["config"]
+        workspace_mgr = docker_env_kit["workspace_mgr"]
+
+        dispatch = _make_dispatch(resolved_profile=_make_docker_profile(mcp={}))
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        workspace_mgr.inject_mcp_config.assert_not_awaited()
+
+    async def test_provision_runs_setup_commands_as_agent_user(self, docker_env_kit):
+        """provision() runs setup commands wrapped with su for agent user."""
+        env = docker_env_kit["env"]
+        profile = _make_docker_profile(setup=("make setup",))
+        dispatch = _make_dispatch(resolved_profile=profile)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        setup_calls = [c for c in mock_conn.run.call_args_list if "make setup" in str(c)]
+        assert len(setup_calls) == 1
+        assert "su - tanren -c" in setup_calls[0].args[0]
+
+    async def test_provision_chowns_workspace_to_agent_user(self, docker_env_kit):
+        """provision() transfers workspace ownership to agent user."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        chown_calls = [c for c in mock_conn.run.call_args_list if "chown" in str(c)]
+        assert len(chown_calls) >= 1
+        # First chown should be workspace ownership transfer
+        assert "tanren:tanren" in chown_calls[0].args[0]
+
+    async def test_provision_passes_target_home_to_credential_injection(self, docker_env_kit):
+        """provision() passes agent_user home as target_home to credential injection."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=["claude"],
+            ) as mock_inject,
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        mock_inject.assert_awaited_once()
+        _, kwargs = mock_inject.call_args
+        assert kwargs["target_home"] == "/home/tanren"
+
+    async def test_provision_resolves_required_secrets(self, docker_env_kit, monkeypatch):
+        """provision() resolves required_secrets from os.environ as developer_overrides."""
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-test-123")
+
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch(
+            project_env={"PROJ_KEY": "val"},
+            required_secrets=("CLAUDE_CODE_OAUTH_TOKEN",),
+        )
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        call_kwargs = docker_env_kit["secret_loader"].build_bundle.call_args
+        assert call_kwargs.kwargs["developer_overrides"] == {
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-123",
+        }
+
+    async def test_provision_no_required_secrets_passes_none(self, docker_env_kit):
+        """Without required_secrets, developer_overrides is None."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            await env.provision(dispatch, config)
+
+        call_kwargs = docker_env_kit["secret_loader"].build_bundle.call_args
+        assert call_kwargs.kwargs.get("developer_overrides") is None
+
+    async def test_provision_stores_workflow_id_in_runtime(self, docker_env_kit):
+        """provision() stores workflow_id in the typed runtime context."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn,
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.run.return_value = _OK_REMOTE_RESULT
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            handle = await env.provision(dispatch, config)
+
+        assert handle.runtime.kind == "docker"
+        assert handle.runtime.workflow_id == "wf-test-project-42-1000"
+
+    async def test_cleanup_records_release_even_when_stop_fails(self, docker_env_kit):
+        """record_release is still called when container stop raises during provision cleanup."""
+        env = docker_env_kit["env"]
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        docker_env_kit["bootstrapper"].bootstrap.side_effect = RuntimeError("boom")
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            mock_conn.stop_container.side_effect = RuntimeError("stop failed")
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await env.provision(dispatch, config)
+
+        # stop was attempted
+        mock_conn.stop_container.assert_awaited_once()
+        # remove was still attempted
+        mock_conn.remove_container.assert_awaited_once()
+        # record_release still called despite stop failure
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_setup_command_failure_raises(self, docker_env_kit):
+        """provision() raises RuntimeError when a setup command fails."""
+        env = docker_env_kit["env"]
+        profile = _make_docker_profile(setup=("failing-cmd",))
+        dispatch = _make_dispatch(resolved_profile=profile)
+        config = docker_env_kit["config"]
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            mock_conn = AsyncMock()
+            mock_conn.container_id = "abc123container"
+            mock_conn.check_connection.return_value = True
+            # First call (chown) succeeds, second call (setup) fails
+            mock_conn.run.side_effect = [
+                _OK_REMOTE_RESULT,  # chown workspace
+                RemoteResult(exit_code=1, stdout="", stderr="setup error", timed_out=False),
+            ]
+            MockDockerConn.create_and_start = AsyncMock(return_value=mock_conn)
+
+            with pytest.raises(RuntimeError, match="Setup command failed"):
+                await env.provision(dispatch, config)
+
+        # Container cleaned up
+        mock_conn.stop_container.assert_awaited_once()
+        mock_conn.remove_container.assert_awaited_once()
+
+
+class TestExecute:
+    async def test_happy_path(self, docker_env_kit):
+        """execute() runs agent and returns PhaseResult with correct outcome."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(
+            exit_code=0, stdout="pushed", stderr="", timed_out=False
+        )
+        conn.download_content = AsyncMock(return_value="do the task")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome") as mock_map,
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            mock_map.return_value = (Outcome.SUCCESS, "success")
+
+            result = await env.execute(handle, dispatch, config)
+
+        assert isinstance(result, PhaseResult)
+        assert result.outcome == Outcome.SUCCESS
+        assert result.signal == "success"
+        docker_env_kit["runner"].run.assert_awaited_once()
+
+    async def test_transient_retry(self, docker_env_kit):
+        """execute() retries on transient errors."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="ok", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        # First two calls: transient error. Third call: success.
+        transient_result = _make_agent_result(
+            exit_code=1, stdout="rate limit 429", timed_out=False, signal_content=""
+        )
+        success_result = _make_agent_result(exit_code=0, signal_content="do-task-status: complete")
+        docker_env_kit["runner"].run.side_effect = [
+            transient_result,
+            transient_result,
+            success_result,
+        ]
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome") as mock_map,
+            patch(f"{_DOCKER_ENV}.classify_error") as mock_classify,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            mock_map.side_effect = [
+                (Outcome.ERROR, None),
+                (Outcome.ERROR, None),
+                (Outcome.SUCCESS, "complete"),
+            ]
+            mock_classify.return_value = ErrorClass.TRANSIENT
+
+            result = await env.execute(handle, dispatch, config)
+
+        assert result.outcome == Outcome.SUCCESS
+        assert result.retries == 2
+        assert docker_env_kit["runner"].run.await_count == 3
+
+    async def test_push_on_push_phases(self, docker_env_kit):
+        """execute() pushes to remote on DO_TASK phase."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = docker_env_kit["config"]
+
+        docker_env_kit[
+            "workspace_mgr"
+        ].push_command.return_value = (
+            "GIT_ASKPASS=/workspace/.git-askpass GIT_TERMINAL_PROMPT=0 git push origin main"
+        )
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome") as mock_map,
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            mock_map.return_value = (Outcome.SUCCESS, "success")
+
+            await env.execute(handle, dispatch, config)
+
+        # push_command called with correct args
+        docker_env_kit["workspace_mgr"].push_command.assert_called_once_with(
+            "/workspace/test-project", "main"
+        )
+        # conn.run should have been called with the push command wrapped for agent user
+        push_calls = [c for c in conn.run.call_args_list if "git push" in str(c)]
+        assert len(push_calls) == 1
+
+    async def test_skips_push_on_error_outcome(self, docker_env_kit):
+        """execute() skips push when outcome is ERROR."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = docker_env_kit["config"]
+
+        docker_env_kit["runner"].run.return_value = _make_agent_result(
+            exit_code=1,
+            stdout="fatal error",
+            signal_content="do-task-status: error",
+        )
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome") as mock_map,
+            patch(f"{_DOCKER_ENV}.classify_error") as mock_classify,
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            mock_map.return_value = (Outcome.ERROR, "error")
+            mock_classify.return_value = ErrorClass.FATAL
+
+            await env.execute(handle, dispatch, config)
+
+        # No push should have been called
+        push_calls = [c for c in conn.run.call_args_list if "git push" in str(c)]
+        assert len(push_calls) == 0
+
+    async def test_execute_wraps_push_with_su(self, docker_env_kit):
+        """execute() wraps git push with su when agent_user is set."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = docker_env_kit["config"]
+
+        docker_env_kit["workspace_mgr"].push_command.return_value = "git push origin main"
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            await env.execute(handle, dispatch, config)
+
+        push_calls = [c for c in conn.run.call_args_list if "git push" in str(c)]
+        assert len(push_calls) == 1
+        assert push_calls[0].args[0].startswith("su - tanren -c ")
+
+    async def test_execute_collects_token_usage(self, docker_env_kit):
+        """execute() collects token usage and populates result.token_usage."""
+        from tanren_core.ccusage import TokenUsage
+
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(
+            exit_code=0, stdout="pushed", stderr="", timed_out=False
+        )
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(cli=Cli.CLAUDE)
+        config = docker_env_kit["config"]
+
+        mock_usage = TokenUsage(
+            input_tokens=100,
+            output_tokens=200,
+            total_tokens=300,
+            total_cost=1.50,
+            provider="claude",
+        )
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(
+                f"{_DOCKER_ENV}.collect_token_usage",
+                new_callable=AsyncMock,
+                return_value=mock_usage,
+            ),
+        ):
+            result = await env.execute(handle, dispatch, config)
+
+        assert result.token_usage is not None
+        assert result.token_usage.total_cost == pytest.approx(1.50)
+        assert result.token_usage.total_tokens == 300
+
+    async def test_execute_skips_token_usage_for_bash(self, docker_env_kit):
+        """execute() does not collect token usage for Cli.BASH dispatches."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="ok", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(cli=Cli.BASH)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock) as mock_collect,
+        ):
+            result = await env.execute(handle, dispatch, config)
+
+        mock_collect.assert_not_awaited()
+        assert result.token_usage is None
+
+    async def test_execute_does_not_inject_cli_auth(self, docker_env_kit):
+        """execute() does NOT inject CLI auth -- all auth happens at provision."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(cli=Cli.CLAUDE)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+            patch(
+                f"{_DOCKER_ENV}.inject_all_cli_credentials", new_callable=AsyncMock
+            ) as mock_inject,
+        ):
+            await env.execute(handle, dispatch, config)
+
+        mock_inject.assert_not_awaited()
+
+    async def test_execute_wrong_runtime_kind_raises(self, docker_env_kit):
+        """execute() raises RuntimeError if handle has wrong runtime kind."""
+        from tanren_core.adapters.types import LocalEnvironmentRuntime
+
+        env = docker_env_kit["env"]
+        handle = EnvironmentHandle(
+            env_id="env-test-1",
+            worktree_path=Path("/workspace/test"),
+            branch="main",
+            project="test-project",
+            runtime=LocalEnvironmentRuntime(),
+        )
+        dispatch = _make_dispatch()
+        config = docker_env_kit["config"]
+
+        with pytest.raises(RuntimeError, match="requires docker runtime handle"):
+            await env.execute(handle, dispatch, config)
+
+    async def test_execute_passes_agent_user_to_ccusage_runner(self, docker_env_kit):
+        """execute() passes agent_user as run_as_user to RemoteCommandRunner."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(cli=Cli.CLAUDE)
+        config = docker_env_kit["config"]
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_DOCKER_ENV}.RemoteCommandRunner") as MockRunner,
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            await env.execute(handle, dispatch, config)
+
+        MockRunner.assert_called_once_with(conn, run_as_user="tanren")
+
+    async def test_push_failure_includes_diagnostic_in_stdout(self, docker_env_kit):
+        """execute() appends push failure diagnostic to stdout."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        # Push fails
+        conn.run.return_value = RemoteResult(
+            exit_code=1, stdout="", stderr="push rejected", timed_out=False
+        )
+        conn.download_content = AsyncMock(return_value="prompt")
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.DO_TASK)
+        config = docker_env_kit["config"]
+
+        docker_env_kit["runner"].run.return_value = _make_agent_result(
+            stdout="agent output", signal_content="do-task-status: complete"
+        )
+
+        with (
+            patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, "success")),
+            patch(f"{_DOCKER_ENV}.collect_token_usage", new_callable=AsyncMock, return_value=None),
+        ):
+            result = await env.execute(handle, dispatch, config)
+
+        assert "Remote git push failed" in result.stdout
+        assert result.postflight_result is not None
+        assert result.postflight_result.pushed is False
+
+    async def test_gate_phase_captures_output(self, docker_env_kit):
+        """execute() captures gate output for gate phases."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = RemoteResult(exit_code=0, stdout="", stderr="", timed_out=False)
+        handle = _make_handle(conn=conn)
+        dispatch = _make_dispatch(phase=Phase.GATE, cli=Cli.BASH)
+        config = docker_env_kit["config"]
+
+        docker_env_kit["runner"].run.return_value = _make_agent_result(
+            stdout="gate output here", stderr="gate stderr"
+        )
+
+        with patch(f"{_DOCKER_ENV}.map_outcome", return_value=(Outcome.SUCCESS, None)):
+            result = await env.execute(handle, dispatch, config)
+
+        assert result.gate_output is not None
+        assert "gate output here" in result.gate_output
+
+
+class TestTeardown:
+    async def test_happy_path(self, docker_env_kit):
+        """teardown() runs teardown commands, cleans workspace, stops/removes
+        container, records release."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        workspace = _make_workspace()
+        handle = _make_handle(conn=conn, workspace=workspace)
+
+        await env.teardown(handle)
+
+        # Teardown commands executed
+        teardown_calls = [c for c in conn.run.call_args_list if "make clean" in str(c)]
+        assert len(teardown_calls) == 1
+
+        # Workspace cleaned
+        docker_env_kit["workspace_mgr"].cleanup.assert_awaited_once_with(conn, workspace)
+
+        # Container stopped and removed
+        conn.stop_container.assert_awaited_once()
+        conn.remove_container.assert_awaited_once()
+
+        # Connection closed
+        conn.close.assert_awaited_once()
+
+        # State store records release
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_cleanup_continues_on_teardown_command_failure(self, docker_env_kit):
+        """teardown() continues cleanup when teardown commands fail."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.side_effect = RuntimeError("teardown cmd failed")
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        # Container still stopped/removed despite teardown command failure
+        conn.stop_container.assert_awaited_once()
+        conn.remove_container.assert_awaited_once()
+        conn.close.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_release_recorded_even_on_container_stop_error(self, docker_env_kit):
+        """record_release is still called when container stop fails."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        conn.stop_container.side_effect = RuntimeError("stop boom")
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        conn.stop_container.assert_awaited_once()
+        # remove still attempted
+        conn.remove_container.assert_awaited_once()
+        conn.close.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_release_recorded_even_on_container_remove_error(self, docker_env_kit):
+        """record_release is still called when container remove fails."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        conn.remove_container.side_effect = RuntimeError("remove boom")
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        conn.stop_container.assert_awaited_once()
+        conn.remove_container.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_release_recorded_even_on_close_error(self, docker_env_kit):
+        """record_release is still called when connection close fails."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        conn.close.side_effect = RuntimeError("close boom")
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        conn.close.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_workspace_cleanup_failure_still_stops_container(self, docker_env_kit):
+        """teardown() stops container even when workspace cleanup fails."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        docker_env_kit["workspace_mgr"].cleanup.side_effect = RuntimeError("cleanup boom")
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        conn.stop_container.assert_awaited_once()
+        conn.remove_container.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("abc123container")
+
+    async def test_teardown_wraps_commands_with_su(self, docker_env_kit):
+        """teardown() wraps user teardown commands with su when agent_user is set."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        teardown_calls = [c for c in conn.run.call_args_list if "make clean" in str(c)]
+        assert len(teardown_calls) == 1
+        assert teardown_calls[0].args[0].startswith("su - tanren -c ")
+
+    async def test_teardown_wrong_runtime_kind_raises(self, docker_env_kit):
+        """teardown() raises RuntimeError if handle has wrong runtime kind."""
+        from tanren_core.adapters.types import LocalEnvironmentRuntime
+
+        env = docker_env_kit["env"]
+        handle = EnvironmentHandle(
+            env_id="env-test-1",
+            worktree_path=Path("/workspace/test"),
+            branch="main",
+            project="test-project",
+            runtime=LocalEnvironmentRuntime(),
+        )
+
+        with pytest.raises(RuntimeError, match="requires docker runtime handle"):
+            await env.teardown(handle)
+
+    async def test_teardown_cleans_credential_files(self, docker_env_kit):
+        """teardown() removes credential files using absolute paths."""
+        env = docker_env_kit["env"]
+        conn = AsyncMock()
+        conn.run.return_value = _OK_REMOTE_RESULT
+        handle = _make_handle(conn=conn)
+
+        await env.teardown(handle)
+
+        # Check that credential cleanup uses absolute paths (not tilde)
+        rm_calls = [
+            call.args[0] for call in conn.run.call_args_list if call.args[0].startswith("rm -f ")
+        ]
+        for rm_cmd in rm_calls:
+            path = rm_cmd.replace("rm -f ", "")
+            assert path.startswith("/home/tanren"), f"Expected absolute path, got: {path}"
+            assert "~" not in path
+
+
+class TestGetAccessInfo:
+    async def test_returns_working_dir(self, docker_env_kit):
+        """get_access_info() returns AccessInfo with working_dir and status."""
+        env = docker_env_kit["env"]
+        handle = _make_handle()
+
+        info = await env.get_access_info(handle)
+
+        assert isinstance(info, AccessInfo)
+        assert info.working_dir == "/workspace/test-project"
+        assert info.status == "running"
+
+    async def test_wrong_runtime_kind_raises(self, docker_env_kit):
+        """get_access_info() raises RuntimeError if handle has wrong runtime kind."""
+        from tanren_core.adapters.types import LocalEnvironmentRuntime
+
+        env = docker_env_kit["env"]
+        handle = EnvironmentHandle(
+            env_id="env-test-1",
+            worktree_path=Path("/workspace/test"),
+            branch="main",
+            project="test-project",
+            runtime=LocalEnvironmentRuntime(),
+        )
+
+        with pytest.raises(RuntimeError, match="requires docker runtime handle"):
+            await env.get_access_info(handle)
+
+
+class TestRecoverStaleAssignments:
+    async def test_no_assignments_returns_zero(self, docker_env_kit):
+        """Returns 0 and does not call release when no stale assignments exist."""
+        env = docker_env_kit["env"]
+        docker_env_kit["state_store"].get_active_assignments.return_value = []
+
+        result = await env.recover_stale_assignments()
+
+        assert result == 0
+        docker_env_kit["state_store"].record_release.assert_not_awaited()
+
+    async def test_recovers_assignments(self, docker_env_kit):
+        """Recovers stale assignments: stops/removes containers and records release."""
+        env = docker_env_kit["env"]
+        assignments = [
+            VMAssignment(
+                vm_id="container-1",
+                workflow_id="wf-1",
+                project="proj",
+                spec="spec",
+                host="local",
+                assigned_at="2026-01-01T00:00:00Z",
+            ),
+            VMAssignment(
+                vm_id="container-2",
+                workflow_id="wf-2",
+                project="proj",
+                spec="spec",
+                host="local",
+                assigned_at="2026-01-01T00:00:00Z",
+            ),
+        ]
+        docker_env_kit["state_store"].get_active_assignments.return_value = assignments
+
+        mock_conn = AsyncMock()
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            MockDockerConn.from_existing.return_value = mock_conn
+
+            result = await env.recover_stale_assignments()
+
+        assert result == 2
+        assert MockDockerConn.from_existing.call_count == 2
+        assert mock_conn.stop_container.await_count == 2
+        assert mock_conn.remove_container.await_count == 2
+        assert mock_conn.close.await_count == 2
+        assert docker_env_kit["state_store"].record_release.await_count == 2
+        docker_env_kit["state_store"].record_release.assert_any_await("container-1")
+        docker_env_kit["state_store"].record_release.assert_any_await("container-2")
+
+    async def test_records_release_on_stop_failure(self, docker_env_kit):
+        """record_release is still called when container stop raises during recovery."""
+        env = docker_env_kit["env"]
+        assignments = [
+            VMAssignment(
+                vm_id="container-1",
+                workflow_id="wf-1",
+                project="proj",
+                spec="spec",
+                host="local",
+                assigned_at="2026-01-01T00:00:00Z",
+            ),
+        ]
+        docker_env_kit["state_store"].get_active_assignments.return_value = assignments
+
+        mock_conn = AsyncMock()
+        mock_conn.stop_container.side_effect = RuntimeError("stop failed")
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            MockDockerConn.from_existing.return_value = mock_conn
+
+            result = await env.recover_stale_assignments()
+
+        assert result == 1
+        # stop was attempted
+        mock_conn.stop_container.assert_awaited_once()
+        # remove still called
+        mock_conn.remove_container.assert_awaited_once()
+        # release recorded despite failure
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("container-1")
+
+    async def test_records_release_on_remove_failure(self, docker_env_kit):
+        """record_release is still called when container remove raises during recovery."""
+        env = docker_env_kit["env"]
+        assignments = [
+            VMAssignment(
+                vm_id="container-1",
+                workflow_id="wf-1",
+                project="proj",
+                spec="spec",
+                host="local",
+                assigned_at="2026-01-01T00:00:00Z",
+            ),
+        ]
+        docker_env_kit["state_store"].get_active_assignments.return_value = assignments
+
+        mock_conn = AsyncMock()
+        mock_conn.remove_container.side_effect = RuntimeError("remove failed")
+
+        with patch(f"{_DOCKER_ENV}.DockerConnection") as MockDockerConn:
+            MockDockerConn.from_existing.return_value = mock_conn
+
+            result = await env.recover_stale_assignments()
+
+        assert result == 1
+        mock_conn.close.assert_awaited_once()
+        docker_env_kit["state_store"].record_release.assert_awaited_once_with("container-1")
+
+
+class TestDryRun:
+    async def test_returns_manual_provider(self, docker_env_kit):
+        """dry_run() returns DryRunInfo with MANUAL provider."""
+        env = docker_env_kit["env"]
+        requirements = VMRequirements(profile="default", cpu=2, memory_gb=4, gpu=False)
+
+        result = await env.dry_run(requirements)
+
+        assert isinstance(result, DryRunInfo)
+        assert result.provider == VMProvider.MANUAL
+        assert result.would_provision is True
+
+
+class TestClose:
+    async def test_close_closes_state_store(self, docker_env_kit):
+        """close() delegates to _state_store.close()."""
+        env = docker_env_kit["env"]
+        await env.close()
+        docker_env_kit["state_store"].close.assert_awaited_once()

--- a/tests/unit/test_ssh_environment.py
+++ b/tests/unit/test_ssh_environment.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tanren_core.adapters.remote_shared import extract_signal_token, validate_cli_auth
 from tanren_core.adapters.remote_types import (
     BootstrapResult,
     RemoteAgentResult,
@@ -18,11 +19,7 @@ from tanren_core.adapters.remote_types import (
     WorkspacePath,
 )
 from tanren_core.adapters.ssh import SSHConfig
-from tanren_core.adapters.ssh_environment import (
-    SSHExecutionEnvironment,
-    _extract_signal_token,
-    _validate_cli_auth,
-)
+from tanren_core.adapters.ssh_environment import SSHExecutionEnvironment
 from tanren_core.adapters.types import (
     AccessInfo,
     EnvironmentHandle,
@@ -839,81 +836,81 @@ class TestExecute:
 
 class TestExtractSignalToken:
     def test_extracts_from_file_content(self):
-        token = _extract_signal_token("do-task", "do-task-status: complete", "")
+        token = extract_signal_token("do-task", "do-task-status: complete", "")
         assert token == "complete"
 
     def test_falls_back_to_stdout(self):
-        token = _extract_signal_token("do-task", "", "output\ndo-task-status: all-done\n")
+        token = extract_signal_token("do-task", "", "output\ndo-task-status: all-done\n")
         assert token == "all-done"
 
     def test_file_takes_precedence(self):
-        token = _extract_signal_token(
+        token = extract_signal_token(
             "do-task", "do-task-status: complete", "do-task-status: blocked"
         )
         assert token == "complete"
 
     def test_returns_none_when_no_signal(self):
-        token = _extract_signal_token("do-task", "", "no signal here")
+        token = extract_signal_token("do-task", "", "no signal here")
         assert token is None
 
     def test_last_stdout_match_wins(self):
-        token = _extract_signal_token(
+        token = extract_signal_token(
             "do-task", "", "do-task-status: error\ndo-task-status: complete"
         )
         assert token == "complete"
 
     def test_works_with_audit_task(self):
-        token = _extract_signal_token("audit-task", "audit-task-status: pass", "")
+        token = extract_signal_token("audit-task", "audit-task-status: pass", "")
         assert token == "pass"
 
     def test_whitespace_only_file_falls_through(self):
-        token = _extract_signal_token("do-task", "  \n  ", "do-task-status: blocked")
+        token = extract_signal_token("do-task", "  \n  ", "do-task-status: blocked")
         assert token == "blocked"
 
     def test_file_has_wrong_command_name(self):
-        token = _extract_signal_token(
+        token = extract_signal_token(
             "do-task", "audit-task-status: pass", "do-task-status: complete"
         )
         assert token == "complete"
 
     def test_empty_everything(self):
-        assert _extract_signal_token("do-task", "", "") is None
+        assert extract_signal_token("do-task", "", "") is None
 
 
 class TestValidateCliAuth:
     def test_claude_oauth_token_sufficient(self):
-        _validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CODE_OAUTH_TOKEN": "tok"})
+        validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CODE_OAUTH_TOKEN": "tok"})
 
     def test_claude_credentials_json_sufficient(self):
-        _validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CREDENTIALS_JSON": "{}"})
+        validate_cli_auth(Cli.CLAUDE, {"CLAUDE_CREDENTIALS_JSON": "{}"})
 
     def test_claude_both_present(self):
-        _validate_cli_auth(
+        validate_cli_auth(
             Cli.CLAUDE,
             {"CLAUDE_CODE_OAUTH_TOKEN": "tok", "CLAUDE_CREDENTIALS_JSON": "{}"},
         )
 
     def test_claude_neither_raises(self):
         with pytest.raises(RuntimeError, match="No auth secret resolved for claude"):
-            _validate_cli_auth(Cli.CLAUDE, {})
+            validate_cli_auth(Cli.CLAUDE, {})
 
     def test_opencode_present(self):
-        _validate_cli_auth(Cli.OPENCODE, {"OPENCODE_ZAI_API_KEY": "key"})
+        validate_cli_auth(Cli.OPENCODE, {"OPENCODE_ZAI_API_KEY": "key"})
 
     def test_opencode_missing_raises(self):
         with pytest.raises(RuntimeError, match="No auth secret resolved for opencode"):
-            _validate_cli_auth(Cli.OPENCODE, {})
+            validate_cli_auth(Cli.OPENCODE, {})
 
     def test_codex_missing_raises(self):
         with pytest.raises(RuntimeError, match="No auth secret resolved for codex"):
-            _validate_cli_auth(Cli.CODEX, {})
+            validate_cli_auth(Cli.CODEX, {})
 
     def test_bash_no_auth_needed(self):
-        _validate_cli_auth(Cli.BASH, {})
+        validate_cli_auth(Cli.BASH, {})
 
     def test_unrelated_secrets_dont_satisfy(self):
         with pytest.raises(RuntimeError, match="No auth secret resolved for claude"):
-            _validate_cli_auth(Cli.CLAUDE, {"SOME_OTHER_KEY": "val"})
+            validate_cli_auth(Cli.CLAUDE, {"SOME_OTHER_KEY": "val"})
 
 
 class TestSignalExtraction:
@@ -1174,10 +1171,11 @@ class TestTeardown:
 
 
 class TestBuildCliCommand:
-    """Test _build_cli_command for each CLI type."""
+    """Test build_cli_command for each CLI type."""
 
     def _build(self, env_kit, cli: Cli, model: str = "sonnet", gate_cmd: str | None = None):
-        env = env_kit["env"]
+        from tanren_core.adapters.remote_shared import build_cli_command
+
         dispatch = _make_dispatch(cli=cli)
         dispatch = Dispatch(
             workflow_id=dispatch.workflow_id,
@@ -1194,7 +1192,7 @@ class TestBuildCliCommand:
             resolved_profile=DEFAULT_PROFILE,
         )
         config = env_kit["config"]
-        return env._build_cli_command(dispatch, config)
+        return build_cli_command(dispatch, config)
 
     def test_claude_command(self, env_kit):
         cmd = self._build(env_kit, Cli.CLAUDE)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -376,3 +376,94 @@ class TestWorkerHandlePersistence:
         assert reconstructed.env_id == original.env_id
         assert reconstructed.project == original.project
         assert reconstructed.branch == original.branch
+
+    def test_persist_docker_handle(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock as _MM
+
+        from tanren_core.adapters.remote_types import WorkspacePath
+        from tanren_core.adapters.types import DockerEnvironmentRuntime
+
+        conn = _MM()
+        workspace = WorkspacePath(path="/workspace/proj", project="proj", branch="main")
+        handle = EnvironmentHandle(
+            env_id="env-docker",
+            worktree_path=tmp_path / "workspace",
+            branch="main",
+            project="proj",
+            runtime=DockerEnvironmentRuntime(
+                container_id="abc123def456",
+                connection=conn,
+                workspace_path=workspace,
+                profile=EnvironmentProfile(name="docker-ci"),
+                provision_start=100.0,
+                workflow_id="wf-1",
+                docker_socket_url="unix:///var/run/docker.sock",
+            ),
+        )
+        persisted = Worker._persist_handle(handle, profile_name="docker-ci")
+
+        assert persisted.docker_config is not None
+        assert persisted.docker_config.container_id == "abc123def456"
+        assert persisted.docker_config.socket_url == "unix:///var/run/docker.sock"
+        assert persisted.workspace_remote_path == "/workspace/proj"
+        assert persisted.profile_name == "docker-ci"
+        assert persisted.vm is None
+        assert persisted.ssh_config is None
+
+    def test_reconstruct_docker_handle(self) -> None:
+        from tanren_core.store.handle import PersistedDockerConfig
+
+        persisted = PersistedEnvironmentHandle(
+            env_id="env-docker",
+            worktree_path="/workspace/proj",
+            branch="main",
+            project="proj",
+            provision_timestamp="2026-01-01T00:00:00Z",
+            workspace_remote_path="/workspace/proj",
+            profile_name="docker-ci",
+            docker_config=PersistedDockerConfig(
+                container_id="abc123def456",
+                socket_url=None,
+            ),
+        )
+        handle = Worker._reconstruct_handle(persisted)
+
+        from tanren_core.adapters.types import DockerEnvironmentRuntime
+
+        assert handle.env_id == "env-docker"
+        assert handle.runtime.kind == "docker"
+        assert isinstance(handle.runtime, DockerEnvironmentRuntime)
+        assert handle.runtime.container_id == "abc123def456"
+        assert handle.runtime.workspace_path.path == "/workspace/proj"
+        assert handle.runtime.profile.name == "docker-ci"
+
+    def test_docker_persist_roundtrip(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock as _MM
+
+        from tanren_core.adapters.remote_types import WorkspacePath
+        from tanren_core.adapters.types import DockerEnvironmentRuntime
+
+        conn = _MM()
+        workspace = WorkspacePath(path="/workspace/proj", project="proj", branch="feat")
+        original = EnvironmentHandle(
+            env_id="env-rt",
+            worktree_path=tmp_path / "ws",
+            branch="feat",
+            project="proj",
+            runtime=DockerEnvironmentRuntime(
+                container_id="deadbeef1234",
+                connection=conn,
+                workspace_path=workspace,
+                profile=EnvironmentProfile(name="ci"),
+                provision_start=50.0,
+                workflow_id="wf-rt",
+            ),
+        )
+        persisted = Worker._persist_handle(original, profile_name="ci")
+        reconstructed = Worker._reconstruct_handle(persisted)
+
+        assert reconstructed.env_id == original.env_id
+        assert reconstructed.project == original.project
+        assert reconstructed.runtime.kind == "docker"
+        assert isinstance(reconstructed.runtime, DockerEnvironmentRuntime)
+        assert reconstructed.runtime.container_id == "deadbeef1234"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ members = [
 ]
 
 [[package]]
+name = "aiodocker"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/64/3b724f650cedc6d5c1cad7fdae3dd3b53c976d075547ff5268e2f1e56db5/aiodocker-0.26.0.tar.gz", hash = "sha256:7e4ee40c6f98e6d1cf95d712f15aef3853087c0475bc7ea5ec499c2d485ba7ec", size = 162018, upload-time = "2026-02-17T18:53:23.234Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/0d/e8f4164cbd950195900dd77aad23136f9ddc7feb0fb478d71839d1fda573/aiodocker-0.26.0-py3-none-any.whl", hash = "sha256:f450acf0b402a03c6a6f1517d06bdff739c404e62578b332182ca272fde6e986", size = 47825, upload-time = "2026-02-17T18:53:22.088Z" },
+]
+
+[[package]]
 name = "aiofile"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -21,6 +33,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/36/5b6514a9f5d66f4e2597e40dea2e3db271e023eb7a5d22defe96ba560996/aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808", size = 737238, upload-time = "2026-01-03T17:31:17.909Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/49/459327f0d5bcd8c6c9ca69e60fdeebc3622861e696490d8674a6d0cb90a6/aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415", size = 492292, upload-time = "2026-01-03T17:31:19.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f", size = 493021, upload-time = "2026-01-03T17:31:21.636Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6", size = 1717263, upload-time = "2026-01-03T17:31:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f2/7bddc7fd612367d1459c5bcf598a9e8f7092d6580d98de0e057eb42697ad/aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687", size = 1669107, upload-time = "2026-01-03T17:31:25.334Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5a/1aeaecca40e22560f97610a329e0e5efef5e0b5afdf9f857f0d93839ab2e/aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26", size = 1760196, upload-time = "2026-01-03T17:31:27.394Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f8/0ff6992bea7bd560fc510ea1c815f87eedd745fe035589c71ce05612a19a/aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a", size = 1843591, upload-time = "2026-01-03T17:31:29.238Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1", size = 1720277, upload-time = "2026-01-03T17:31:31.053Z" },
+    { url = "https://files.pythonhosted.org/packages/84/45/23f4c451d8192f553d38d838831ebbc156907ea6e05557f39563101b7717/aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25", size = 1548575, upload-time = "2026-01-03T17:31:32.87Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ed/0a42b127a43712eda7807e7892c083eadfaf8429ca8fb619662a530a3aab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603", size = 1679455, upload-time = "2026-01-03T17:31:34.76Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b5/c05f0c2b4b4fe2c9d55e73b6d3ed4fd6c9dc2684b1d81cbdf77e7fad9adb/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a", size = 1687417, upload-time = "2026-01-03T17:31:36.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/915bc5dad66aef602b9e459b5a973529304d4e89ca86999d9d75d80cbd0b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926", size = 1729968, upload-time = "2026-01-03T17:31:38.622Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3b/e84581290a9520024a08640b63d07673057aec5ca548177a82026187ba73/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba", size = 1545690, upload-time = "2026-01-03T17:31:40.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/04/0c3655a566c43fd647c81b895dfe361b9f9ad6d58c19309d45cff52d6c3b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c", size = 1746390, upload-time = "2026-01-03T17:31:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/71165b26978f719c3419381514c9690bd5980e764a09440a10bb816ea4ab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43", size = 1702188, upload-time = "2026-01-03T17:31:44.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a7/cbe6c9e8e136314fa1980da388a59d2f35f35395948a08b6747baebb6aa6/aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1", size = 433126, upload-time = "2026-01-03T17:31:47.463Z" },
+    { url = "https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984", size = 459128, upload-time = "2026-01-03T17:31:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2a/3c79b638a9c3d4658d345339d22070241ea341ed4e07b5ac60fb0f418003/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c", size = 769512, upload-time = "2026-01-03T17:31:51.134Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b9/3e5014d46c0ab0db8707e0ac2711ed28c4da0218c358a4e7c17bae0d8722/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592", size = 506444, upload-time = "2026-01-03T17:31:52.85Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/c1d4ef9a054e151cd7839cdc497f2638f00b93cbe8043983986630d7a80c/aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f", size = 510798, upload-time = "2026-01-03T17:31:54.91Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/76/8c1e5abbfe8e127c893fe7ead569148a4d5a799f7cf958d8c09f3eedf097/aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29", size = 1868835, upload-time = "2026-01-03T17:31:56.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/984c5a6f74c363b01ff97adc96a3976d9c98940b8969a1881575b279ac5d/aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc", size = 1720486, upload-time = "2026-01-03T17:31:58.65Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9a/b7039c5f099c4eb632138728828b33428585031a1e658d693d41d07d89d1/aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2", size = 1847951, upload-time = "2026-01-03T17:32:00.989Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/02/3bec2b9a1ba3c19ff89a43a19324202b8eb187ca1e928d8bdac9bbdddebd/aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587", size = 1941001, upload-time = "2026-01-03T17:32:03.122Z" },
+    { url = "https://files.pythonhosted.org/packages/37/df/d879401cedeef27ac4717f6426c8c36c3091c6e9f08a9178cc87549c537f/aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8", size = 1797246, upload-time = "2026-01-03T17:32:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/15/be122de1f67e6953add23335c8ece6d314ab67c8bebb3f181063010795a7/aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632", size = 1627131, upload-time = "2026-01-03T17:32:07.607Z" },
+    { url = "https://files.pythonhosted.org/packages/12/12/70eedcac9134cfa3219ab7af31ea56bc877395b1ac30d65b1bc4b27d0438/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64", size = 1795196, upload-time = "2026-01-03T17:32:09.59Z" },
+    { url = "https://files.pythonhosted.org/packages/32/11/b30e1b1cd1f3054af86ebe60df96989c6a414dd87e27ad16950eee420bea/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0", size = 1782841, upload-time = "2026-01-03T17:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/88/0d/d98a9367b38912384a17e287850f5695c528cff0f14f791ce8ee2e4f7796/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56", size = 1795193, upload-time = "2026-01-03T17:32:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/a2dfd1f5ff5581632c7f6a30e1744deda03808974f94f6534241ef60c751/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72", size = 1621979, upload-time = "2026-01-03T17:32:15.965Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/12973c382ae7c1cccbc4417e129c5bf54c374dfb85af70893646e1f0e749/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df", size = 1822193, upload-time = "2026-01-03T17:32:18.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5f/24155e30ba7f8c96918af1350eb0663e2430aad9e001c0489d89cd708ab1/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa", size = 1769801, upload-time = "2026-01-03T17:32:20.25Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/7314031ff5c10e6ece114da79b338ec17eeff3a079e53151f7e9f43c4723/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767", size = 466523, upload-time = "2026-01-03T17:32:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/278a98c715ae467624eafe375542d8ba9b4383a016df8fdefe0ae28382a7/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344", size = 499694, upload-time = "2026-01-03T17:32:24.546Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
 ]
 
 [[package]]
@@ -52,14 +136,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -88,11 +172,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -233,27 +317,43 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
-    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
-    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
-    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
 ]
 
 [[package]]
@@ -279,41 +379,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.13.4"
+version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
-    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
-    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
-    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
-    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
-    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
-    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
 ]
 
 [[package]]
@@ -371,7 +471,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -379,9 +479,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/c4/2ce2ca1451487dc7d59f09334c3fa1182c46cfcf0a2d5f19f9b26d53ac74/cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0", size = 166623, upload-time = "2026-03-23T14:43:01.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/06/d68a5d5d292c2ad2bc6a02e5ca2cb1bb9c15e941ab02f004a06a342d7f0f/cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7", size = 204097, upload-time = "2026-03-14T14:09:32.504Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/2261922126b2e50c601fe22d7ff5194e0a4d50e654836260c0665e24d862/cyclopts-4.10.1-py3-none-any.whl", hash = "sha256:35f37257139380a386d9fe4475e1e7c87ca7795765ef4f31abba579fcfcb6ecd", size = 204331, upload-time = "2026-03-23T14:43:02.625Z" },
 ]
 
 [[package]]
@@ -435,7 +535,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.1"
+version = "0.135.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -444,9 +544,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/73/5903c4b13beae98618d64eb9870c3fac4f605523dd0312ca5c80dadbd5b9/fastapi-0.135.2.tar.gz", hash = "sha256:88a832095359755527b7f63bb4c6bc9edb8329a026189eed83d6c1afcf419d56", size = 395833, upload-time = "2026-03-23T14:12:41.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ea/18f6d0457f9efb2fc6fa594857f92810cadb03024975726db6546b3d6fcf/fastapi-0.135.2-py3-none-any.whl", hash = "sha256:0af0447d541867e8db2a6a25c23a8c4bd80e2394ac5529bd87501bbb9e240ca5", size = 117407, upload-time = "2026-03-23T14:12:43.284Z" },
 ]
 
 [[package]]
@@ -479,6 +579,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
 [[package]]
@@ -626,15 +767,15 @@ wheels = [
 
 [[package]]
 name = "hcloud"
-version = "2.17.0"
+version = "2.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/46/0f97c3ca36e909488e028b6fef80f3fdff158fa0daa6e6ab7629f2c5327b/hcloud-2.17.0.tar.gz", hash = "sha256:3996adef6bc0f5755650bb8b8b024acebab2c29e217dac579c303722fc37ae85", size = 154427, upload-time = "2026-03-05T18:15:02.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/38/2902e1a9c05c58c4523d10b95e685c69e93c08abed6a7ab8822fac31561f/hcloud-2.17.1.tar.gz", hash = "sha256:04f1b7d1bb21e05a6b21dafc7fd3632698e2cf0c36d8447880145fd7f412fc13", size = 154481, upload-time = "2026-03-23T10:52:08.462Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/fe/5a4c4f0f484eafb081066fb2bb63650ae55409297d6ce44f566074663d13/hcloud-2.17.0-py3-none-any.whl", hash = "sha256:b72096f5a6cd91a962cc1a26d76e4575e25fc337a5b589336f62a7f3b1b7b0b6", size = 111524, upload-time = "2026-03-05T18:15:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/46/d37cf11666561101c8f4425fbc0fa5cbc066480eeb2b87539af2e5c7eae2/hcloud-2.17.1-py3-none-any.whl", hash = "sha256:6b4adb35aed57ef7bedbcdf307df94496a5d15c1b47e9594a936f664589c6016", size = 111543, upload-time = "2026-03-23T10:52:07.035Z" },
 ]
 
 [[package]]
@@ -718,11 +859,11 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.1.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]
@@ -869,6 +1010,51 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -941,6 +1127,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/5c/bca52d654a896f831b8256683457ceddd490ec18d9ec50e97dfd8fc726a8/propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12", size = 78152, upload-time = "2025-10-08T19:47:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c", size = 44869, upload-time = "2025-10-08T19:47:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded", size = 46596, upload-time = "2025-10-08T19:47:54.073Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641", size = 206981, upload-time = "2025-10-08T19:47:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f6/c5fa1357cc9748510ee55f37173eb31bfde6d94e98ccd9e6f033f2fc06e1/propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4", size = 211490, upload-time = "2025-10-08T19:47:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1e/e5889652a7c4a3846683401a48f0f2e5083ce0ec1a8a5221d8058fbd1adf/propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44", size = 215371, upload-time = "2025-10-08T19:47:59.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d", size = 201424, upload-time = "2025-10-08T19:48:00.67Z" },
+    { url = "https://files.pythonhosted.org/packages/27/73/033d63069b57b0812c8bd19f311faebeceb6ba31b8f32b73432d12a0b826/propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b", size = 197566, upload-time = "2025-10-08T19:48:02.604Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/89/ce24f3dc182630b4e07aa6d15f0ff4b14ed4b9955fae95a0b54c58d66c05/propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e", size = 193130, upload-time = "2025-10-08T19:48:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/ef0d5fd1a811fb5c609278d0209c9f10c35f20581fcc16f818da959fc5b4/propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f", size = 202625, upload-time = "2025-10-08T19:48:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/02/98ec20ff5546f68d673df2f7a69e8c0d076b5abd05ca882dc7ee3a83653d/propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49", size = 204209, upload-time = "2025-10-08T19:48:08.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/87/492694f76759b15f0467a2a93ab68d32859672b646aa8a04ce4864e7932d/propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144", size = 197797, upload-time = "2025-10-08T19:48:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/36/66367de3575db1d2d3f3d177432bd14ee577a39d3f5d1b3d5df8afe3b6e2/propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f", size = 38140, upload-time = "2025-10-08T19:48:11.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153", size = 41257, upload-time = "2025-10-08T19:48:12.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5e/63bd5896c3fec12edcbd6f12508d4890d23c265df28c74b175e1ef9f4f3b/propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992", size = 38097, upload-time = "2025-10-08T19:48:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/9ff785d787ccf9bbb3f3106f79884a130951436f58392000231b4c737c80/propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f", size = 81455, upload-time = "2025-10-08T19:48:15.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/85/2431c10c8e7ddb1445c1f7c4b54d886e8ad20e3c6307e7218f05922cad67/propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393", size = 46372, upload-time = "2025-10-08T19:48:16.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/b0972d902472da9bcb683fa595099911f4d2e86e5683bcc45de60dd05dc3/propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0", size = 48411, upload-time = "2025-10-08T19:48:17.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e3/7dc89f4f21e8f99bad3d5ddb3a3389afcf9da4ac69e3deb2dcdc96e74169/propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a", size = 275712, upload-time = "2025-10-08T19:48:18.901Z" },
+    { url = "https://files.pythonhosted.org/packages/20/67/89800c8352489b21a8047c773067644e3897f02ecbbd610f4d46b7f08612/propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be", size = 273557, upload-time = "2025-10-08T19:48:20.762Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/b52b055c766a54ce6d9c16d9aca0cad8059acd9637cdf8aa0222f4a026ef/propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc", size = 280015, upload-time = "2025-10-08T19:48:22.592Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c8/33cee30bd890672c63743049f3c9e4be087e6780906bfc3ec58528be59c1/propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a", size = 262880, upload-time = "2025-10-08T19:48:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b1/8f08a143b204b418285c88b83d00edbd61afbc2c6415ffafc8905da7038b/propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89", size = 260938, upload-time = "2025-10-08T19:48:25.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/12/96e4664c82ca2f31e1c8dff86afb867348979eb78d3cb8546a680287a1e9/propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726", size = 247641, upload-time = "2025-10-08T19:48:27.207Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ed/e7a9cfca28133386ba52278136d42209d3125db08d0a6395f0cba0c0285c/propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367", size = 262510, upload-time = "2025-10-08T19:48:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/16d8bf65e8845dd62b4e2b57444ab81f07f40caa5652b8969b87ddcf2ef6/propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36", size = 263161, upload-time = "2025-10-08T19:48:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/c99e9edb5d91d5ad8a49fa3c1e8285ba64f1476782fed10ab251ff413ba1/propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455", size = 257393, upload-time = "2025-10-08T19:48:31.567Z" },
+    { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
 ]
 
 [[package]]
@@ -1309,7 +1534,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1317,9 +1542,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]
@@ -1399,27 +1624,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]
@@ -1468,14 +1693,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -1544,10 +1769,14 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "aiodocker" },
     { name = "google-cloud-compute" },
     { name = "google-cloud-secret-manager" },
     { name = "hcloud" },
     { name = "httpx" },
+]
+docker = [
+    { name = "aiodocker" },
 ]
 gcp = [
     { name = "google-cloud-compute" },
@@ -1565,6 +1794,8 @@ linear = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiodocker", marker = "extra == 'all'", specifier = ">=0.23,<1" },
+    { name = "aiodocker", marker = "extra == 'docker'", specifier = ">=0.23,<1" },
     { name = "aiosqlite", specifier = ">=0.20,<1" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
     { name = "google-cloud-compute", marker = "extra == 'all'", specifier = ">=1.20.0,<2" },
@@ -1581,7 +1812,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
 ]
-provides-extras = ["gcp", "github", "hetzner", "linear", "all"]
+provides-extras = ["gcp", "github", "hetzner", "linear", "docker", "all"]
 
 [[package]]
 name = "tanren-daemon"
@@ -1620,6 +1851,9 @@ source = { virtual = "." }
 all = [
     { name = "tanren-core", extra = ["all"] },
 ]
+docker = [
+    { name = "tanren-core", extra = ["docker"] },
+]
 gcp = [
     { name = "tanren-core", extra = ["gcp"] },
 ]
@@ -1652,12 +1886,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "tanren-core", extras = ["all"], marker = "extra == 'all'", editable = "packages/tanren-core" },
+    { name = "tanren-core", extras = ["docker"], marker = "extra == 'docker'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["gcp"], marker = "extra == 'gcp'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["github"], marker = "extra == 'github'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["hetzner"], marker = "extra == 'hetzner'", editable = "packages/tanren-core" },
     { name = "tanren-core", extras = ["linear"], marker = "extra == 'linear'", editable = "packages/tanren-core" },
 ]
-provides-extras = ["hetzner", "gcp", "github", "linear", "all"]
+provides-extras = ["hetzner", "gcp", "github", "linear", "docker", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1680,26 +1915,26 @@ dev = [
 
 [[package]]
 name = "ty"
-version = "0.0.22"
+version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/ee/b73c99daf598ae66a2d5d3ba6de7729d2152ab732dee7ccb8ab9446cc6d7/ty-0.0.22.tar.gz", hash = "sha256:391fc4d3a543950341b750d7f4aa94866a73e7cdbf3e9e4e4e8cfc8b7bef4f10", size = 5333861, upload-time = "2026-03-12T17:40:30.052Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/bf/3c3147c7237277b0e8a911ff89de7183408be96b31fb42b38edb666d287f/ty-0.0.25.tar.gz", hash = "sha256:8ae3891be17dfb6acab51a2df3a8f8f6c551eb60ea674c10946dc92aae8d4401", size = 5375500, upload-time = "2026-03-24T22:32:34.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/f7/078f554f612723597f76cc6af70da4daed63ed721241a3f60788259c9adf/ty-0.0.22-py3-none-linux_armv6l.whl", hash = "sha256:03d37220d81016cb9d2a9c9ec11704d84f2df838f1dbf1296d91ea7fba57f8b5", size = 10328232, upload-time = "2026-03-12T17:40:19.402Z" },
-    { url = "https://files.pythonhosted.org/packages/90/0b/4cfe84485d1b20bb50cdbc990f6e66b8c50cff569c7544adf0805b57ddb9/ty-0.0.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3249c65b24829a312cd5cbf722ff5551ffe17b0a9781a8a372ca037d23aa1c71", size = 10148554, upload-time = "2026-03-12T17:40:25.586Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/7e/df31baf70d63880c9719d2cc8403b0b99c3c0d0f68f390a1109d9b231933/ty-0.0.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:470778f4335f1660f017fe2970afb7e4ce4f8b608795b19406976b8902b221a5", size = 9627910, upload-time = "2026-03-12T17:40:17.447Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a418bcca9c87083533d6c73b65e56c6ade26b8d76a7558b3d3cc0f0eb52a/ty-0.0.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75649b04b84ace92cb5c6e27013247f220f58a9a30b30eb2301992814deea0c4", size = 10155025, upload-time = "2026-03-12T17:40:21.344Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/3d/1974c567a58f369602065409d9109c0a81f5abbf1ae552433a89d07141a9/ty-0.0.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc270f2344210cbed7d965ddeade61ffa81d93dffcdc0fded3540dccb860a9e1", size = 10133614, upload-time = "2026-03-12T17:40:23.549Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/c1/2da9e27c79a1fe9209589a73c989e416a7380bd77dcdf22960b3d30252bf/ty-0.0.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:548215b226f9726ea4d9beb77055363a8a398eb42809f042895f7a285afcb538", size = 10647101, upload-time = "2026-03-12T17:40:15.569Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/93/4e12c2f0ec792fd4ab9c9f70e59465d09345a453ebedb67d3bf99fd75a71/ty-0.0.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0bd1d34eba800b82ebee65269a85a9bbb2a325237e4baaf1413223f69e1899", size = 11231886, upload-time = "2026-03-12T17:40:06.875Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/9f/c255a078e4f2ce135497fffa4a5d3a122e4c49a00416fb78d72d7b79e119/ty-0.0.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbd429a31507da9a1b0873a21215113c42cc683aa5fba96c978794485db5560a", size = 10901527, upload-time = "2026-03-12T17:40:34.429Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/0d/d1bdee7e16d978ea929837fb03463efc116ee8ad05d215a5efd5d80e56d3/ty-0.0.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7eb85a437b3be817796e7c0f84243611de53c7d4ea102a0dca179debfe7cec0", size = 10726505, upload-time = "2026-03-12T17:40:36.342Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d4/6548d2a353f794582ec94d886b310589c70316fe43476a558e53073ea911/ty-0.0.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b8e32e362e0666cc0769d2862a273def6b61117b8fbb9df493274d536afcd02e", size = 10128777, upload-time = "2026-03-12T17:40:38.517Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d2/eb9185d3fe1fa12decb1c0a045416063bc40122187769b3dfb324da9e51c/ty-0.0.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:667deb1aaf802f396a626cc5a52cd55d935e8d0b46d1be068cf874f7d6f4bdb5", size = 10164992, upload-time = "2026-03-12T17:40:27.833Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ec/067bb6d78cc6f5c4f55f0c3f760eb792b144697b454938fb9d10652caeb2/ty-0.0.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e160681dbf602160e091d94a68207d1393733aedd95e3dc0b2d010bb39a70d78", size = 10342871, upload-time = "2026-03-12T17:40:13.447Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/04/dd3a87f54f78ceef5e6ab2add2f3bb85d45829318740f459886654b71a5d/ty-0.0.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:255598763079b80513d98084c4897df688e42666d7e4371349f97d258166389d", size = 10823909, upload-time = "2026-03-12T17:40:11.444Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/29/4b12e8ff99dec65487ec5342bd5b51fae1482e93a669d098777d55ca5eda/ty-0.0.22-py3-none-win32.whl", hash = "sha256:de0d88d9f788defddfec5507bf356bfc8b90ee301b7d6204f7609e7ac270276f", size = 9746013, upload-time = "2026-03-12T17:40:32.272Z" },
-    { url = "https://files.pythonhosted.org/packages/84/16/e246795ed66ff8ee1a47497019f86ea1b4fb238bfca3068f2e08c52ef03b/ty-0.0.22-py3-none-win_amd64.whl", hash = "sha256:c216f750769ac9f3e9e61feabf3fd44c0697dce762bdcd105443d47e1a81c2b9", size = 10709350, upload-time = "2026-03-12T17:40:40.82Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/a4/5aafcebc4f597164381b0a82e7a8780d8f9f52df3884b16909a76282a0da/ty-0.0.22-py3-none-win_arm64.whl", hash = "sha256:49795260b9b9e3d6f04424f8ddb34907fac88c33a91b83478a74cead5dde567f", size = 10137248, upload-time = "2026-03-12T17:40:09.244Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a4/6c289cbd1474285223124a4ffb55c078dbe9ae1d925d0b6a948643c7f115/ty-0.0.25-py3-none-linux_armv6l.whl", hash = "sha256:26d6d5aede5d54fb055779460f896d9c1473c6fb996716bd11cb90f027d8fee7", size = 10452747, upload-time = "2026-03-24T22:32:32.662Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/74cb9de356b9ceb3f281ab048f8c4ac2207122161b0ac0066886ce129abe/ty-0.0.25-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aedcfbc7b6b96dbc55b0da78fa02bd049373ff3d8a827f613dadd8bd17d10758", size = 10271349, upload-time = "2026-03-24T22:32:13.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/93/ffc5a20cc9e14fa9b32b0c54884864bede30d144ce2ae013805bce0c86d0/ty-0.0.25-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0a8fb3c1e28f73618941811e2568dca195178a1a6314651d4ee97086a4497253", size = 9730308, upload-time = "2026-03-24T22:32:19.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/78/52e05ef32a5f172fce70633a4e19d8e04364271a4322ae12382c7344b0de/ty-0.0.25-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814870b7f347b5d0276304cddb98a0958f08de183bf159abc920ebe321247ad4", size = 10247664, upload-time = "2026-03-24T22:32:08.669Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/64/0d0a47ed0aa1d634c666c2cc15d3b0af4b95d0fd3dbb796032bd493f3433/ty-0.0.25-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:781150e23825dc110cd5e1f50ca3d61664f7a5db5b4a55d5dbf7d3b1e246b917", size = 10261961, upload-time = "2026-03-24T22:32:43.935Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ba/4666b96f0499465efb97c244554107c541d74a1add393e62276b3de9b54f/ty-0.0.25-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc81ff2a0143911321251dc81d1c259fa5cdc56d043019a733c845d55409e2a", size = 10746076, upload-time = "2026-03-24T22:32:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ed/aa958ccbcd85cc206600e48fbf0a1c27aef54b4b90112d9a73f69ed0c739/ty-0.0.25-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f03c5c5b5c10355ea030cbe3cd93b2e759b9492c66688288ea03a68086069f2e", size = 11287331, upload-time = "2026-03-24T22:32:21.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e4/f4a004e1952e6042f5bfeeb7d09cffb379270ef009d9f8568471863e86e6/ty-0.0.25-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fc1ef49cd6262eb9223ccf6e258ac899aaa53e7dc2151ba65a2c9fa248dfa75", size = 11028804, upload-time = "2026-03-24T22:32:39.088Z" },
+    { url = "https://files.pythonhosted.org/packages/56/32/5c15bb8ea20ed54d43c734f253a2a5da95d41474caecf4ef3682df9f68f5/ty-0.0.25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ad98da1393161096235a387cc36abecd31861060c68416761eccdb7c1bc326b", size = 10845246, upload-time = "2026-03-24T22:32:41.33Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fe/4ddd83e810c8682fcfada0d1c9d38936a34a024d32d7736075c1e53a038e/ty-0.0.25-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2d4336aa5381eb4eab107c3dec75fe22943a648ef6646f5a8431ef1c8cdabb66", size = 10233515, upload-time = "2026-03-24T22:32:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/db/9fe54f6fb952e5b218f2e661e64ed656512edf2046cfbb9c159558e255db/ty-0.0.25-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e10ed39564227de2b7bd89398250b65daaedbef15a25cef8eee70078f5d9e0b2", size = 10275289, upload-time = "2026-03-24T22:32:28.21Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/090d7b33791b42bc7ec29463ac6a634738e16b289e027608ebe542682773/ty-0.0.25-py3-none-musllinux_1_2_i686.whl", hash = "sha256:aca04e9ed9b61c706064a1c0b71a247c3f92f373d0222103f3bc54b649421796", size = 10461195, upload-time = "2026-03-24T22:32:24.252Z" },
+    { url = "https://files.pythonhosted.org/packages/42/31/5bf12bce01b80b72a7a4e627380779b41510e730f6000862a1d078e423f7/ty-0.0.25-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:18a5443e4ef339c1bd8c57fc13112c22080617ea582bfc22b497d82d65361325", size = 10931471, upload-time = "2026-03-24T22:32:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/ab60c11f8a6dd2a0ae96daac83458ef2e9be1ae70481d1ad9c59d3eaf20f/ty-0.0.25-py3-none-win32.whl", hash = "sha256:a685b9a611b69195b5a557e05dbb7ebcd12815f6c32fb27fdf15edeb1fa33d8f", size = 9835974, upload-time = "2026-03-24T22:32:36.86Z" },
+    { url = "https://files.pythonhosted.org/packages/41/55/625acc2ef34646268bc2baa8fdd6e22fb47cd5965e2acd3be92c687fb6b0/ty-0.0.25-py3-none-win_amd64.whl", hash = "sha256:0d4d37a1f1ab7f2669c941c38c65144ff223eb51ececd7ccfc0d623afbc0f729", size = 10815449, upload-time = "2026-03-24T22:32:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/0147bfb543df97740b45b222c54ff79ef20fa57f14b9d2c1dab3cd7d3faa/ty-0.0.25-py3-none-win_arm64.whl", hash = "sha256:d80b8cd965cbacbfd887ac2d985f5b6da09b7aa3569371e2894e0b30b26b89cd", size = 10225494, upload-time = "2026-03-24T22:32:30.611Z" },
 ]
 
 [[package]]
@@ -1758,15 +1993,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.41.0"
+version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]
 
 [[package]]
@@ -1828,6 +2063,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/98/b85a038d65d1b92c3903ab89444f48d3cee490a883477b716d7a24b1a78c/yarl-1.23.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:21d1b7305a71a15b4794b5ff22e8eef96ff4a6d7f9657155e5aa419444b28912", size = 124455, upload-time = "2026-03-01T22:06:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/39/54/bc2b45559f86543d163b6e294417a107bb87557609007c007ad889afec18/yarl-1.23.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:85610b4f27f69984932a7abbe52703688de3724d9f72bceb1cca667deff27474", size = 86752, upload-time = "2026-03-01T22:06:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23f371bd662cf44a7630d4d113101eafc0cfa7518a2760d20760b26021454719", size = 86291, upload-time = "2026-03-01T22:06:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/d8/d1cb2378c81dd729e98c716582b1ccb08357e8488e4c24714658cc6630e8/yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a80f77dc1acaaa61f0934176fccca7096d9b1ff08c8ba9cddf5ae034a24319", size = 99026, upload-time = "2026-03-01T22:06:48.459Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ff/7196790538f31debe3341283b5b0707e7feb947620fc5e8236ef28d44f72/yarl-1.23.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:bd654fad46d8d9e823afbb4f87c79160b5a374ed1ff5bde24e542e6ba8f41434", size = 92355, upload-time = "2026-03-01T22:06:50.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/56/25d58c3eddde825890a5fe6aa1866228377354a3c39262235234ab5f616b/yarl-1.23.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:682bae25f0a0dd23a056739f23a134db9f52a63e2afd6bfb37ddc76292bbd723", size = 106417, upload-time = "2026-03-01T22:06:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8a/882c0e7bc8277eb895b31bce0138f51a1ba551fc2e1ec6753ffc1e7c1377/yarl-1.23.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a82836cab5f197a0514235aaf7ffccdc886ccdaa2324bc0aafdd4ae898103039", size = 106422, upload-time = "2026-03-01T22:06:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c57676bdedc94cd3bc37724cf6f8cd2779f02f6aba48de45feca073e714fe52", size = 101915, upload-time = "2026-03-01T22:06:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6a/530e16aebce27c5937920f3431c628a29a4b6b430fab3fd1c117b26ff3f6/yarl-1.23.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7f8dc16c498ff06497c015642333219871effba93e4a2e8604a06264aca5c5c", size = 100690, upload-time = "2026-03-01T22:06:58.21Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/93749219179a45e27b036e03260fda05190b911de8e18225c294ac95bbc9/yarl-1.23.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5ee586fb17ff8f90c91cf73c6108a434b02d69925f44f5f8e0d7f2f260607eae", size = 98750, upload-time = "2026-03-01T22:06:59.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/ea424a004969f5d81a362110a6ac1496d79efdc6d50c2c4b2e3ea0fc2519/yarl-1.23.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:17235362f580149742739cc3828b80e24029d08cbb9c4bda0242c7b5bc610a8e", size = 94685, upload-time = "2026-03-01T22:07:01.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b7/14341481fe568e2b0408bcf1484c652accafe06a0ade9387b5d3fd9df446/yarl-1.23.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0793e2bd0cf14234983bbb371591e6bea9e876ddf6896cdcc93450996b0b5c85", size = 106009, upload-time = "2026-03-01T22:07:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/5c744a9b54f4e8007ad35bce96fbc9218338e84812d36f3390cea616881a/yarl-1.23.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3650dc2480f94f7116c364096bc84b1d602f44224ef7d5c7208425915c0475dd", size = 100033, upload-time = "2026-03-01T22:07:04.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/23/e3bfc188d0b400f025bc49d99793d02c9abe15752138dcc27e4eaf0c4a9e/yarl-1.23.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f40e782d49630ad384db66d4d8b73ff4f1b8955dc12e26b09a3e3af064b3b9d6", size = 106483, upload-time = "2026-03-01T22:07:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/f0505f949a90b3f8b7a363d6cbdf398f6e6c58946d85c6d3a3bc70595b26/yarl-1.23.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94f8575fbdf81749008d980c17796097e645574a3b8c28ee313931068dad14fe", size = 102175, upload-time = "2026-03-01T22:07:08.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/65/b39290f1d892a9dd671d1c722014ca062a9c35d60885d57e5375db0404b5/yarl-1.23.0-cp314-cp314-win32.whl", hash = "sha256:c8aa34a5c864db1087d911a0b902d60d203ea3607d91f615acd3f3108ac32169", size = 83871, upload-time = "2026-03-01T22:07:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5b/9b92f54c784c26e2a422e55a8d2607ab15b7ea3349e28359282f84f01d43/yarl-1.23.0-cp314-cp314-win_amd64.whl", hash = "sha256:63e92247f383c85ab00dd0091e8c3fa331a96e865459f5ee80353c70a4a42d70", size = 89093, upload-time = "2026-03-01T22:07:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7d/8a84dc9381fd4412d5e7ff04926f9865f6372b4c2fd91e10092e65d29eb8/yarl-1.23.0-cp314-cp314-win_arm64.whl", hash = "sha256:70efd20be968c76ece7baa8dafe04c5be06abc57f754d6f36f3741f7aa7a208e", size = 83384, upload-time = "2026-03-01T22:07:13.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8d/d2fad34b1c08aa161b74394183daa7d800141aaaee207317e82c790b418d/yarl-1.23.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a18d6f9359e45722c064c97464ec883eb0e0366d33eda61cb19a244bf222679", size = 131019, upload-time = "2026-03-01T22:07:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ff/33009a39d3ccf4b94d7d7880dfe17fb5816c5a4fe0096d9b56abceea9ac7/yarl-1.23.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2803ed8b21ca47a43da80a6fd1ed3019d30061f7061daa35ac54f63933409412", size = 89894, upload-time = "2026-03-01T22:07:17.372Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f1/dab7ac5e7306fb79c0190766a3c00b4cb8d09a1f390ded68c85a5934faf5/yarl-1.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:394906945aa8b19fc14a61cf69743a868bb8c465efe85eee687109cc540b98f4", size = 89979, upload-time = "2026-03-01T22:07:19.361Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b1/08e95f3caee1fad6e65017b9f26c1d79877b502622d60e517de01e72f95d/yarl-1.23.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71d006bee8397a4a89f469b8deb22469fe7508132d3c17fa6ed871e79832691c", size = 95943, upload-time = "2026-03-01T22:07:21.266Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/6409f9018864a6aa186c61175b977131f373f1988e198e031236916e87e4/yarl-1.23.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:62694e275c93d54f7ccedcfef57d42761b2aad5234b6be1f3e3026cae4001cd4", size = 88786, upload-time = "2026-03-01T22:07:23.129Z" },
+    { url = "https://files.pythonhosted.org/packages/76/40/cc22d1d7714b717fde2006fad2ced5efe5580606cb059ae42117542122f3/yarl-1.23.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a31de1613658308efdb21ada98cbc86a97c181aa050ba22a808120bb5be3ab94", size = 101307, upload-time = "2026-03-01T22:07:24.689Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0d/476c38e85ddb4c6ec6b20b815bdd779aa386a013f3d8b85516feee55c8dc/yarl-1.23.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb1e8b8d66c278b21d13b0a7ca22c41dd757a7c209c6b12c313e445c31dd3b28", size = 100904, upload-time = "2026-03-01T22:07:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/0abe4a76d59adf2081dcb0397168553ece4616ada1c54d1c49d8936c74f8/yarl-1.23.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50f9d8d531dfb767c565f348f33dd5139a6c43f5cbdf3f67da40d54241df93f6", size = 97728, upload-time = "2026-03-01T22:07:27.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/35/7b30f4810fba112f60f5a43237545867504e15b1c7647a785fbaf588fac2/yarl-1.23.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575aa4405a656e61a540f4a80eaa5260f2a38fff7bfdc4b5f611840d76e9e277", size = 95964, upload-time = "2026-03-01T22:07:30.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/86/ed7a73ab85ef00e8bb70b0cb5421d8a2a625b81a333941a469a6f4022828/yarl-1.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:041b1a4cefacf65840b4e295c6985f334ba83c30607441ae3cf206a0eed1a2e4", size = 95882, upload-time = "2026-03-01T22:07:32.132Z" },
+    { url = "https://files.pythonhosted.org/packages/19/90/d56967f61a29d8498efb7afb651e0b2b422a1e9b47b0ab5f4e40a19b699b/yarl-1.23.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:d38c1e8231722c4ce40d7593f28d92b5fc72f3e9774fe73d7e800ec32299f63a", size = 90797, upload-time = "2026-03-01T22:07:34.404Z" },
+    { url = "https://files.pythonhosted.org/packages/72/00/8b8f76909259f56647adb1011d7ed8b321bcf97e464515c65016a47ecdf0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d53834e23c015ee83a99377db6e5e37d8484f333edb03bd15b4bc312cc7254fb", size = 101023, upload-time = "2026-03-01T22:07:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e2/cab11b126fb7d440281b7df8e9ddbe4851e70a4dde47a202b6642586b8d9/yarl-1.23.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2e27c8841126e017dd2a054a95771569e6070b9ee1b133366d8b31beb5018a41", size = 96227, upload-time = "2026-03-01T22:07:37.594Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9b/2c893e16bfc50e6b2edf76c1a9eb6cb0c744346197e74c65e99ad8d634d0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:76855800ac56f878847a09ce6dba727c93ca2d89c9e9d63002d26b916810b0a2", size = 100302, upload-time = "2026-03-01T22:07:39.334Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ec/5498c4e3a6d5f1003beb23405671c2eb9cdbf3067d1c80f15eeafe301010/yarl-1.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e09fd068c2e169a7070d83d3bde728a4d48de0549f975290be3c108c02e499b4", size = 98202, upload-time = "2026-03-01T22:07:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/cd737e2d45e70717907f83e146f6949f20cc23cd4bf7b2688727763aa458/yarl-1.23.0-cp314-cp314t-win32.whl", hash = "sha256:73309162a6a571d4cbd3b6a1dcc703c7311843ae0d1578df6f09be4e98df38d4", size = 90558, upload-time = "2026-03-01T22:07:43.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
+    { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #41

- Implements `DockerExecutionEnvironment` so tanren can run dispatches in local Docker containers, both from bare metal (native socket) and from inside a container (DooD via mounted socket)
- `DockerConnection` implements the `RemoteConnection` protocol via `aiodocker` exec, enabling full reuse of `UbuntuBootstrapper`, `GitWorkspaceManager`, `RemoteAgentRunner`, and credential providers — zero new adapter code for workspace setup, secret injection, or agent execution
- First-class `DockerEnvironmentRuntime(kind="docker")` with type-safe discriminated union, handle persistence via `PersistedDockerConfig`, and builder/worker wiring
- Resource limits honored: `profile.resources.cpu` → Docker `--cpus`, `profile.resources.memory_gb` → Docker `--memory`
- Network isolation: spawned containers join a configurable Docker network (e.g. `aegis-agents`)
- Shared execute logic extracted to `remote_shared.py` to eliminate duplication between SSH and Docker environments

## What this PR does NOT do
- No automatic environment selection (Docker vs Hetzner routing stays manual per dispatch profile)
- No GPU passthrough (future scope)
- No container image building (assumes pre-built images; Ubuntu base + bootstrap is default)

## Test plan
- [x] 84 new Docker-specific unit tests (connection + environment)
- [x] 8 Docker integration tests gated behind `@pytest.mark.docker`
- [x] All 1183 unit tests pass (80.25% coverage, above 80% floor)
- [x] All 342 integration tests pass (75.01% coverage, above 75% floor)
- [x] Format, lint, and type checks all pass (`make check`)
- [x] Existing SSH environment tests updated for shared module extraction
- [ ] Manual: `tanren run full --profile docker` provisions a container, executes, tears down
- [ ] Manual: Same flow works when daemon is containerized with Docker socket mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)