### PR TITLE
fix: wire MCP lifespan into FastAPI app + Claude onboarding flag (#82)

### DIFF
--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -226,6 +226,22 @@ class UbuntuBootstrapper:
         if workspace_result.exit_code != 0:
             raise RuntimeError(f"Workspace directory setup failed: {workspace_result.stderr}")
 
+        # Create Claude onboarding flag — required for CLAUDE_CODE_OAUTH_TOKEN to work
+        # (workaround for anthropics/claude-code#8938)
+        if Cli.CLAUDE in self._required_clis:
+            await conn.run(
+                "echo '{\"hasCompletedOnboarding\": true}' > ~/.claude.json"
+                " && chmod 644 ~/.claude.json",
+                timeout_secs=10,
+            )
+            await conn.run(
+                f"echo '{{\"hasCompletedOnboarding\": true}}'"
+                f" > /home/{_AGENT_USER}/.claude.json"
+                f" && chown {_AGENT_USER}:{_AGENT_USER}"
+                f" /home/{_AGENT_USER}/.claude.json",
+                timeout_secs=10,
+            )
+
         # Extra script (if configured)
         if self._extra_script is not None:
             logger.info("Running extra bootstrap script...")

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -229,18 +229,23 @@ class UbuntuBootstrapper:
         # Create Claude onboarding flag — required for CLAUDE_CODE_OAUTH_TOKEN to work
         # (workaround for anthropics/claude-code#8938)
         if Cli.CLAUDE in self._required_clis:
-            await conn.run(
+            onboard_root = await conn.run(
                 "echo '{\"hasCompletedOnboarding\": true}' > ~/.claude.json"
                 " && chmod 644 ~/.claude.json",
                 timeout_secs=10,
             )
-            await conn.run(
+            if onboard_root.exit_code != 0:
+                raise RuntimeError(f"Claude onboarding flag (root) failed: {onboard_root.stderr}")
+            onboard_agent = await conn.run(
                 f"echo '{{\"hasCompletedOnboarding\": true}}'"
                 f" > /home/{_AGENT_USER}/.claude.json"
+                f" && chmod 644 /home/{_AGENT_USER}/.claude.json"
                 f" && chown {_AGENT_USER}:{_AGENT_USER}"
                 f" /home/{_AGENT_USER}/.claude.json",
                 timeout_secs=10,
             )
+            if onboard_agent.exit_code != 0:
+                raise RuntimeError(f"Claude onboarding flag (agent) failed: {onboard_agent.stderr}")
 
         # Extra script (if configured)
         if self._extra_script is not None:

--- a/services/tanren-api/src/tanren_api/main.py
+++ b/services/tanren-api/src/tanren_api/main.py
@@ -9,6 +9,8 @@ from contextlib import asynccontextmanager
 import uvicorn
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastmcp.utilities.lifespan import combine_lifespans
+from starlette.applications import Starlette
 
 from tanren_api.auth import verify_api_key
 from tanren_api.errors import TanrenAPIError, tanren_error_handler
@@ -55,7 +57,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     mcp_app = mcp.http_app(path="/")
 
     @asynccontextmanager
-    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async def app_lifespan(app: Starlette) -> AsyncIterator[None]:
         app.state.settings = settings
 
         # Register MCP auth middleware (clear any stale instances first)
@@ -112,11 +114,6 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
             metrics=metrics_svc,
         )
 
-        # NOTE: FastMCP's http_app() has its own lifespan, but we don't
-        # invoke it here because it uses anyio cancel scopes that conflict
-        # with httpx-based test clients. Our MCP setup works without it:
-        # set_services() injects service instances directly and
-        # MCPApiKeyAuth is registered as middleware above.
         try:
             yield
         finally:
@@ -126,7 +123,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         title="tanren",
         description="Tanren HTTP API",
         version="0.1.0",
-        lifespan=lifespan,
+        lifespan=combine_lifespans(app_lifespan, mcp_app.lifespan),
     )
 
     # Middleware: outermost first (add_middleware wraps each layer around the app)

--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -145,6 +145,13 @@ class TestBootstrapRunsExpectedSteps:
         # Verify workspace dir created with chown
         assert any(f"chown {_AGENT_USER}:{_AGENT_USER} /workspace" in c for c in run_cmds)
 
+        # Verify Claude onboarding flag created (claude is in _DEFAULT_CLIS)
+        assert any(".claude.json" in c and "hasCompletedOnboarding" in c for c in run_cmds)
+        assert any(
+            f"/home/{_AGENT_USER}/.claude.json" in c and "hasCompletedOnboarding" in c
+            for c in run_cmds
+        )
+
         # Verify marker written
         marker_calls = [c for c in conn.run.call_args_list if f"touch {_MARKER_PATH}" in c[0][0]]
         assert len(marker_calls) == 1

--- a/tests/integration/test_lifespan_wiring.py
+++ b/tests/integration/test_lifespan_wiring.py
@@ -1,5 +1,7 @@
 """Integration test: API lifespan store wiring."""
 
+import asyncio
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -9,20 +11,45 @@ from tanren_api.settings import APISettings
 
 @pytest.fixture
 async def wired_client(tmp_path):
-    """Create a fully lifespan-wired app and yield an async client."""
+    """Create a fully lifespan-wired app and yield an async client.
+
+    The lifespan runs in a dedicated asyncio Task so that anyio cancel
+    scopes (used by FastMCP's StreamableHTTPSessionManager) are entered
+    and exited in the same task — matching how real ASGI servers work.
+    """
     settings = APISettings(
         api_key="test-key",
         db_url=str(tmp_path / "wired.db"),
     )
     app = create_app(settings)
-    async with (
-        app.router.lifespan_context(app),
-        AsyncClient(
+
+    startup_complete = asyncio.Event()
+    shutdown_trigger = asyncio.Event()
+    exc_holder: list[BaseException] = []
+
+    async def _run_lifespan() -> None:
+        try:
+            async with app.router.lifespan_context(app):
+                startup_complete.set()
+                await shutdown_trigger.wait()
+        except BaseException as exc:
+            exc_holder.append(exc)
+            startup_complete.set()
+
+    task = asyncio.create_task(_run_lifespan())
+    await startup_complete.wait()
+    if exc_holder:
+        raise exc_holder[0]
+
+    try:
+        async with AsyncClient(
             transport=ASGITransport(app=app),
             base_url="http://test",
-        ) as client,
-    ):
-        yield client
+        ) as client:
+            yield client
+    finally:
+        shutdown_trigger.set()
+        await task
 
 
 AUTH = {"X-API-Key": "test-key"}

--- a/tests/unit/test_ubuntu_bootstrap.py
+++ b/tests/unit/test_ubuntu_bootstrap.py
@@ -279,6 +279,32 @@ class TestAgentUserCreation:
         assert any(f"chown {_AGENT_USER}:{_AGENT_USER} /workspace" in c for c in run_cmds)
 
 
+class TestClaudeOnboardingFlag:
+    @pytest.mark.asyncio
+    async def test_creates_claude_json_when_claude_required(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert any(".claude.json" in c and "hasCompletedOnboarding" in c for c in run_cmds)
+        assert any(
+            f"/home/{_AGENT_USER}/.claude.json" in c and "hasCompletedOnboarding" in c
+            for c in run_cmds
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_claude_json_when_claude_not_required(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CODEX}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert not any(".claude.json" in c for c in run_cmds)
+
+
 class TestPlan:
     def test_plan_returns_only_configured_clis(self):
         bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))


### PR DESCRIPTION
## Summary

- **MCP 500 fix**: Compose FastMCP's `StreamableHTTPSessionManager` lifespan into the FastAPI app via `combine_lifespans` so the MCP task group initializes properly. Every `/mcp/` request was returning 500 because the session manager's anyio task group was never started.
- **Test fix**: Restructure the `wired_client` integration test fixture to run the lifespan in a dedicated `asyncio.Task`, matching how real ASGI servers (uvicorn) work. This avoids the anyio cancel scope cross-task error that was the original reason the MCP lifespan was skipped.
- **Bootstrap drive-by**: Create `~/.claude.json` with `{"hasCompletedOnboarding": true}` during VM bootstrap when Claude CLI is required. Workaround for anthropics/claude-code#8938 — without this file, `CLAUDE_CODE_OAUTH_TOKEN` is ignored on fresh VMs.

Closes #82

## Test plan

- [x] `make check` passes (format, lint, type, 1185 unit tests, 342 integration tests, docs)
- [x] New unit tests verify `.claude.json` is created when `Cli.CLAUDE` is required and skipped when it isn't
- [x] Integration test verifies onboarding flag commands in full bootstrap flow
- [x] Integration lifespan tests pass with the new `combine_lifespans` composition
- [ ] Manual: `POST /mcp/` with MCP initialize payload returns valid response (not 500)
- [ ] Manual: Verify MCP tools accessible from agent container via HTTP transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)