### PR TITLE
fix: P1 bug batch — xhealth onboarding fixes (#83, #84, #90)

### DIFF
--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -223,12 +223,13 @@ class UbuntuBootstrapper:
         useradd_result = await conn.run(useradd_cmd, timeout_secs=30)
         if useradd_result.exit_code != 0:
             raise RuntimeError(f"Agent user setup failed: {useradd_result.stderr}")
-        docker_group_result = await conn.run(
-            f"usermod -aG docker {_AGENT_USER}",
-            timeout_secs=10,
-        )
-        if docker_group_result.exit_code != 0:
-            raise RuntimeError(f"Docker group setup failed: {docker_group_result.stderr}")
+        if "docker" not in self._skip_infra_tools:
+            docker_group_result = await conn.run(
+                f"usermod -aG docker {_AGENT_USER}",
+                timeout_secs=10,
+            )
+            if docker_group_result.exit_code != 0:
+                raise RuntimeError(f"Docker group setup failed: {docker_group_result.stderr}")
         workspace_result = await conn.run(
             f"mkdir -p /workspace && chown {_AGENT_USER}:{_AGENT_USER} /workspace",
             timeout_secs=10,

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -24,7 +24,11 @@ _NODE_INSTALL = (
 
 # Infrastructure steps — always installed regardless of required CLIs.
 _INFRA_STEPS: tuple[tuple[str, str, str], ...] = (
-    ("docker", "command -v docker", "curl -fsSL https://get.docker.com | sh"),
+    (
+        "docker",
+        "command -v docker",
+        "curl -fsSL https://get.docker.com | sh && systemctl enable --now docker && docker info",
+    ),
     ("node", "command -v node", _NODE_INSTALL),
     (
         "uv",
@@ -219,6 +223,12 @@ class UbuntuBootstrapper:
         useradd_result = await conn.run(useradd_cmd, timeout_secs=30)
         if useradd_result.exit_code != 0:
             raise RuntimeError(f"Agent user setup failed: {useradd_result.stderr}")
+        docker_group_result = await conn.run(
+            f"usermod -aG docker {_AGENT_USER}",
+            timeout_secs=10,
+        )
+        if docker_group_result.exit_code != 0:
+            raise RuntimeError(f"Docker group setup failed: {docker_group_result.stderr}")
         workspace_result = await conn.run(
             f"mkdir -p /workspace && chown {_AGENT_USER}:{_AGENT_USER} /workspace",
             timeout_secs=10,

--- a/packages/tanren-core/src/tanren_core/secrets.py
+++ b/packages/tanren-core/src/tanren_core/secrets.py
@@ -135,8 +135,8 @@ class SecretLoader:
         else:
             developer = self.load_developer()
             developer.update(self.load_credential_files())
-            if cloud_secrets:
-                developer.update(cloud_secrets)
+        if cloud_secrets:
+            developer.update(cloud_secrets)
         return SecretBundle(
             developer=developer,
             project=project_secrets or {},

--- a/services/tanren-api/src/tanren_api/services/vm.py
+++ b/services/tanren-api/src/tanren_api/services/vm.py
@@ -133,6 +133,9 @@ class VMService:
             timeout=1800,
             environment_profile=body.resolved_profile.name,
             resolved_profile=body.resolved_profile,
+            project_env=body.project_env,
+            cloud_secrets=body.cloud_secrets,
+            required_secrets=body.required_secrets,
         )
 
         lane = cli_to_lane(dispatch.cli)

--- a/tests/unit/api/test_vm_service.py
+++ b/tests/unit/api/test_vm_service.py
@@ -1,0 +1,68 @@
+"""Tests for VMService."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from tanren_api.models import ProvisionRequest
+from tanren_api.services.vm import VMService
+from tanren_core.env.environment_schema import EnvironmentProfile
+from tanren_core.store.sqlite import SqliteStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+DEFAULT_PROFILE = EnvironmentProfile(name="default")
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    s = SqliteStore(tmp_path / "test.db")
+    await s._ensure_conn()
+    yield s
+    await s.close()
+
+
+def _make_provision_request(**overrides: Any) -> ProvisionRequest:
+    defaults: dict[str, Any] = {
+        "project": "test",
+        "branch": "main",
+        "resolved_profile": DEFAULT_PROFILE,
+    }
+    return ProvisionRequest.model_validate(defaults | overrides)
+
+
+class TestVMServiceProvision:
+    async def test_provision_returns_env_id(self, store: SqliteStore) -> None:
+        svc = VMService(event_store=store, job_queue=store, state_store=store)
+        result = await svc.provision(_make_provision_request())
+        assert result.env_id.startswith("vm-provision-test-")
+
+    async def test_provision_passes_required_secrets(self, store: SqliteStore) -> None:
+        svc = VMService(event_store=store, job_queue=store, state_store=store)
+        body = _make_provision_request(required_secrets=("SECRET_A", "SECRET_B"))
+        result = await svc.provision(body)
+
+        view = await store.get_dispatch(result.env_id)
+        assert view is not None
+        assert view.dispatch.required_secrets == ("SECRET_A", "SECRET_B")
+
+    async def test_provision_passes_cloud_secrets(self, store: SqliteStore) -> None:
+        svc = VMService(event_store=store, job_queue=store, state_store=store)
+        body = _make_provision_request(cloud_secrets={"CLOUD_KEY": "cloud_val"})
+        result = await svc.provision(body)
+
+        view = await store.get_dispatch(result.env_id)
+        assert view is not None
+        assert view.dispatch.cloud_secrets == {"CLOUD_KEY": "cloud_val"}
+
+    async def test_provision_passes_project_env(self, store: SqliteStore) -> None:
+        svc = VMService(event_store=store, job_queue=store, state_store=store)
+        body = _make_provision_request(project_env={"DB_URL": "postgres://localhost"})
+        result = await svc.provision(body)
+
+        view = await store.get_dispatch(result.env_id)
+        assert view is not None
+        assert view.dispatch.project_env == {"DB_URL": "postgres://localhost"}

--- a/tests/unit/test_secrets_loader.py
+++ b/tests/unit/test_secrets_loader.py
@@ -176,6 +176,50 @@ class TestBuildBundle:
         assert bundle.project == {"PROJ_KEY": "proj_val"}
         assert bundle.infrastructure == {"GIT_TOKEN": "ghp_xyz"}
 
+    def test_cloud_secrets_merged_with_developer_overrides(self, tmp_path: Path, monkeypatch):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        monkeypatch.setenv("GIT_TOKEN", "ghp_xyz")
+        config = SecretConfig(
+            developer_secrets_path=str(secrets_file),
+            infrastructure_env_vars=("GIT_TOKEN",),
+        )
+        loader = SecretLoader(config, required_clis=frozenset({Cli.CLAUDE}))
+
+        overrides = {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}
+        bundle = loader.build_bundle(
+            developer_overrides=overrides,
+            cloud_secrets={"CLOUD_SECRET": "cloud_val"},
+        )
+
+        assert bundle.developer["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-test"
+        assert bundle.developer["CLOUD_SECRET"] == "cloud_val"
+
+    def test_cloud_secrets_override_developer_overrides_on_conflict(
+        self, tmp_path: Path, monkeypatch
+    ):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        config = SecretConfig(developer_secrets_path=str(secrets_file))
+        loader = SecretLoader(config, required_clis=frozenset({Cli.CLAUDE}))
+
+        bundle = loader.build_bundle(
+            developer_overrides={"SHARED_KEY": "from_overrides"},
+            cloud_secrets={"SHARED_KEY": "from_cloud"},
+        )
+
+        assert bundle.developer["SHARED_KEY"] == "from_cloud"
+
+    def test_cloud_secrets_alone_without_overrides(self, tmp_path: Path, monkeypatch):
+        secrets_file = tmp_path / "secrets.env"
+        secrets_file.write_text("")
+        config = SecretConfig(developer_secrets_path=str(secrets_file))
+        loader = SecretLoader(config, required_clis=frozenset({Cli.CLAUDE}))
+
+        bundle = loader.build_bundle(cloud_secrets={"CLOUD_ONLY": "val"})
+
+        assert bundle.developer["CLOUD_ONLY"] == "val"
+
     def test_developer_overrides_skip_filesystem(self, tmp_path: Path, monkeypatch):
         secrets_file = tmp_path / "secrets.env"
         secrets_file.write_text("SHOULD_NOT_APPEAR=filesystem_val\n")

--- a/tests/unit/test_ubuntu_bootstrap.py
+++ b/tests/unit/test_ubuntu_bootstrap.py
@@ -340,6 +340,19 @@ class TestDockerDaemonSetup:
         run_cmds = [call.args[0] for call in conn.run.call_args_list]
         assert any(f"usermod -aG docker {_AGENT_USER}" in c for c in run_cmds)
 
+    @pytest.mark.asyncio
+    async def test_docker_group_skipped_when_docker_infra_skipped(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(
+            required_clis=frozenset({Cli.CLAUDE}),
+            skip_infra_tools=frozenset({"docker"}),
+        )
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert not any("usermod -aG docker" in c for c in run_cmds)
+
 
 class TestPlan:
     def test_plan_returns_only_configured_clis(self):

--- a/tests/unit/test_ubuntu_bootstrap.py
+++ b/tests/unit/test_ubuntu_bootstrap.py
@@ -305,6 +305,42 @@ class TestClaudeOnboardingFlag:
         assert not any(".claude.json" in c for c in run_cmds)
 
 
+class TestDockerDaemonSetup:
+    @pytest.mark.asyncio
+    async def test_docker_install_enables_and_starts_daemon(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        docker_install = [c for c in run_cmds if "get.docker.com" in c]
+        assert len(docker_install) == 1
+        assert "systemctl enable --now docker" in docker_install[0]
+
+    @pytest.mark.asyncio
+    async def test_docker_install_verifies_responsiveness(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        docker_install = [c for c in run_cmds if "get.docker.com" in c]
+        assert len(docker_install) == 1
+        assert "docker info" in docker_install[0]
+
+    @pytest.mark.asyncio
+    async def test_agent_user_added_to_docker_group(self):
+        conn = _make_conn()
+        bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))
+
+        await bs.bootstrap(conn)
+
+        run_cmds = [call.args[0] for call in conn.run.call_args_list]
+        assert any(f"usermod -aG docker {_AGENT_USER}" in c for c in run_cmds)
+
+
 class TestPlan:
     def test_plan_returns_only_configured_clis(self):
         bs = UbuntuBootstrapper(required_clis=frozenset({Cli.CLAUDE}))


### PR DESCRIPTION
## Summary

- **#83** — `VMService.provision()` was building a `Dispatch` without `required_secrets`, `cloud_secrets`, or `project_env`, silently losing secrets on `/vm/provision` dispatches. Added the three missing fields to match `RunService.provision()`.
- **#84** — `SecretLoader.build_bundle()` only merged `cloud_secrets` in the `else` branch (when `developer_overrides` was `None`), making the two mutually exclusive. Moved the `cloud_secrets` merge after the if/else block so both are always combined.
- **#90** — Docker install via `get.docker.com` didn't ensure the daemon was running. Appended `systemctl enable --now docker && docker info` to the install command, and added `usermod -aG docker tanren` after agent user creation.

## Test plan

- [x] New `tests/unit/api/test_vm_service.py` — verifies `required_secrets`, `cloud_secrets`, and `project_env` propagate from request to dispatch on the VM endpoint
- [x] New tests in `tests/unit/test_secrets_loader.py` — verifies `cloud_secrets` merge with `developer_overrides`, conflict resolution, and standalone path
- [x] New tests in `tests/unit/test_ubuntu_bootstrap.py` — verifies `systemctl enable --now docker`, `docker info`, and `usermod -aG docker tanren` in executed commands
- [x] `make check` passes (format, lint, type, unit @ 80.43%, integration @ 75.04%)

Closes #83, Closes #84, Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)