### PR TITLE
feat: bootstrap script URL fetch + daemon DooD fix (#88)

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -391,7 +391,9 @@ provisioner:
       - vm_id: vm-2
         host: 203.0.113.11
 bootstrap:
-  extra_script: ./scripts/vm-setup.sh  # optional
+  extra_script: ./scripts/vm-setup.sh  # optional — file path (resolved by CLI)
+  # extra_script_url: https://example.com/setup.sh  # alternative: fetch from URL at provision time
+  # extra_script_url: gs://my-bucket/scripts/setup.sh  # also supports GCS
 secrets:
   developer_secrets_path: ~/.config/tanren/secrets.env
 repos:
@@ -419,6 +421,12 @@ provisioner:
       - allow-iap-ssh
       - allow-http
 ```
+
+`bootstrap.extra_script` (file path) and `bootstrap.extra_script_url` (HTTPS or GCS URL)
+are mutually exclusive — set only one. When `extra_script_url` is set, the script is fetched
+at provision time by the daemon, making it suitable for containerized deployments (Cloud Run,
+Docker) where no project filesystem is available. Supported URL schemes: `https://`, `gs://`
+(requires `uv sync --extra gcp`).
 
 Set `WM_REMOTE_CONFIG=/path/to/remote.yml` to enable remote execution.
 For Hetzner support, install optional dependency: `uv sync --extra hetzner`.

--- a/packages/tanren-core/pyproject.toml
+++ b/packages/tanren-core/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gcp = ["google-cloud-compute>=1.20.0, <2", "google-cloud-secret-manager>=2.20.0, <3"]
+gcp = ["google-cloud-compute>=1.20.0, <2", "google-cloud-secret-manager>=2.20.0, <3", "google-cloud-storage>=2.18.0, <3"]
 github = ["httpx>=0.27, <1"]
 hetzner = ["hcloud>=2.4.0, <3"]
 linear = ["httpx>=0.27, <1"]
@@ -22,6 +22,7 @@ docker = ["aiodocker>=0.23, <1"]
 all = [
     "google-cloud-compute>=1.20.0, <2",
     "google-cloud-secret-manager>=2.20.0, <3",
+    "google-cloud-storage>=2.18.0, <3",
     "httpx>=0.27, <1",
     "hcloud>=2.4.0, <3",
     "aiodocker>=0.23, <1",

--- a/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
+++ b/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 if TYPE_CHECKING:
     import types
@@ -25,7 +25,7 @@ def _import_httpx() -> types.ModuleType:
         import httpx as _httpx  # noqa: PLC0415 — deferred import for optional dependency
     except ImportError:
         raise ImportError(
-            "httpx is required for HTTPS script fetching. Install it with: uv sync --extra github"
+            "httpx is required for HTTPS script fetching. Install it with: uv sync --extra all"
         ) from None
     else:
         return _httpx
@@ -75,6 +75,16 @@ def fetch_script(url: str) -> str:
     )
 
 
+def _redact_url(url: str) -> str:
+    """Strip query parameters and fragment from a URL for safe logging.
+
+    Returns:
+        URL with only scheme, host, and path.
+    """
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+
+
 def _fetch_https(url: str) -> str:
     """Fetch script content via HTTPS.
 
@@ -85,7 +95,7 @@ def _fetch_https(url: str) -> str:
         RuntimeError: If the HTTP request fails.
     """
     httpx = _import_httpx()
-    logger.info("Fetching bootstrap script from %s", url)
+    logger.info("Fetching bootstrap script from %s", _redact_url(url))
     response = httpx.get(url, timeout=60, follow_redirects=True)
     if response.status_code != 200:
         raise RuntimeError(

--- a/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
+++ b/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
@@ -51,8 +52,13 @@ def _import_storage() -> types.ModuleType:
         return _storage
 
 
+@functools.lru_cache(maxsize=4)
 def fetch_script(url: str) -> str:
     """Fetch bootstrap script content from an HTTPS or GCS URL.
+
+    Results are cached by URL so that repeated builder invocations within a
+    single dispatch lifecycle (provision, execute, teardown) do not issue
+    redundant network requests.
 
     Args:
         url: The URL to fetch from. Supported schemes: ``https://``, ``gs://``.
@@ -95,11 +101,17 @@ def _fetch_https(url: str) -> str:
         RuntimeError: If the HTTP request fails.
     """
     httpx = _import_httpx()
-    logger.info("Fetching bootstrap script from %s", _redact_url(url))
+    safe_url = _redact_url(url)
+    logger.info("Fetching bootstrap script from %s", safe_url)
     response = httpx.get(url, timeout=60, follow_redirects=True)
+    if response.url.scheme != "https":
+        raise RuntimeError(
+            f"Refusing bootstrap script from {safe_url}: "
+            f"redirected to non-HTTPS URL ({response.url.scheme}://)"
+        )
     if response.status_code != 200:
         raise RuntimeError(
-            f"Failed to fetch bootstrap script from {url}: HTTP {response.status_code}"
+            f"Failed to fetch bootstrap script from {safe_url}: HTTP {response.status_code}"
         )
     return response.text
 

--- a/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
+++ b/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import logging
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
@@ -52,13 +51,12 @@ def _import_storage() -> types.ModuleType:
         return _storage
 
 
-@functools.lru_cache(maxsize=4)
 def fetch_script(url: str) -> str:
     """Fetch bootstrap script content from an HTTPS or GCS URL.
 
-    Results are cached by URL so that repeated builder invocations within a
-    single dispatch lifecycle (provision, execute, teardown) do not issue
-    redundant network requests.
+    Called from ``UbuntuBootstrapper.bootstrap()`` which only runs during the
+    provision phase, so no caching is needed — the fetch happens exactly once
+    per dispatch.
 
     Args:
         url: The URL to fetch from. Supported schemes: ``https://``, ``gs://``.

--- a/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
+++ b/packages/tanren-core/src/tanren_core/adapters/script_fetch.py
@@ -1,0 +1,108 @@
+"""Fetch bootstrap script content from HTTPS or GCS URLs."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    import types
+
+logger = logging.getLogger(__name__)
+
+
+def _import_httpx() -> types.ModuleType:
+    """Import httpx at runtime.
+
+    Returns:
+        The httpx module.
+
+    Raises:
+        ImportError: If httpx is not installed.
+    """
+    try:
+        import httpx as _httpx  # noqa: PLC0415 — deferred import for optional dependency
+    except ImportError:
+        raise ImportError(
+            "httpx is required for HTTPS script fetching. Install it with: uv sync --extra github"
+        ) from None
+    else:
+        return _httpx
+
+
+def _import_storage() -> types.ModuleType:
+    """Import google.cloud.storage at runtime.
+
+    Returns:
+        The google.cloud.storage module.
+
+    Raises:
+        ImportError: If google-cloud-storage is not installed.
+    """
+    try:
+        import google.cloud.storage as _storage  # noqa: PLC0415 — deferred import for optional dependency
+    except ImportError:
+        raise ImportError(
+            "google-cloud-storage is required for gs:// script fetching. "
+            "Install it with: uv sync --extra gcp"
+        ) from None
+    else:
+        return _storage
+
+
+def fetch_script(url: str) -> str:
+    """Fetch bootstrap script content from an HTTPS or GCS URL.
+
+    Args:
+        url: The URL to fetch from. Supported schemes: ``https://``, ``gs://``.
+
+    Returns:
+        The script content as a string.
+
+    Raises:
+        ValueError: If the URL scheme is unsupported.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme == "https":
+        return _fetch_https(url)
+    if parsed.scheme == "gs":
+        return _fetch_gcs(parsed.netloc, parsed.path.lstrip("/"))
+
+    raise ValueError(
+        f"Unsupported URL scheme {parsed.scheme!r} for bootstrap script. Use https:// or gs://"
+    )
+
+
+def _fetch_https(url: str) -> str:
+    """Fetch script content via HTTPS.
+
+    Returns:
+        The script content.
+
+    Raises:
+        RuntimeError: If the HTTP request fails.
+    """
+    httpx = _import_httpx()
+    logger.info("Fetching bootstrap script from %s", url)
+    response = httpx.get(url, timeout=60, follow_redirects=True)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Failed to fetch bootstrap script from {url}: HTTP {response.status_code}"
+        )
+    return response.text
+
+
+def _fetch_gcs(bucket_name: str, blob_path: str) -> str:
+    """Fetch script content from Google Cloud Storage.
+
+    Returns:
+        The script content.
+    """
+    storage = _import_storage()
+    logger.info("Fetching bootstrap script from gs://%s/%s", bucket_name, blob_path)
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(blob_path)
+    return blob.download_as_text()

--- a/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
+++ b/packages/tanren-core/src/tanren_core/adapters/ubuntu_bootstrap.py
@@ -123,18 +123,23 @@ class UbuntuBootstrapper:
         *,
         required_clis: frozenset[Cli],
         extra_script: str | None = None,
+        extra_script_url: str | None = None,
         skip_infra_tools: frozenset[str] = frozenset(),
     ) -> None:
         """Initialize with required CLIs and an optional extra bootstrap script.
 
         Args:
             required_clis: CLIs to install (claude, opencode, codex).
-            extra_script: Optional bash script to run after standard bootstrap.
+            extra_script: Optional inline bash script content to run after
+                standard bootstrap.
+            extra_script_url: Optional URL (https:// or gs://) to fetch script
+                from at bootstrap time.  Mutually exclusive with extra_script.
             skip_infra_tools: Infrastructure tool names to skip (e.g. {"docker"}
                 when bootstrapping inside a Docker container).
         """
         self._required_clis = required_clis
         self._extra_script = extra_script
+        self._extra_script_url = extra_script_url
         self._skip_infra_tools = skip_infra_tools
 
     def _build_steps(self) -> tuple[tuple[str, str, str], ...]:
@@ -258,10 +263,15 @@ class UbuntuBootstrapper:
             if onboard_agent.exit_code != 0:
                 raise RuntimeError(f"Claude onboarding flag (agent) failed: {onboard_agent.stderr}")
 
-        # Extra script (if configured)
-        if self._extra_script is not None:
+        # Extra script (inline content or URL fetch at bootstrap time)
+        extra_script = self._extra_script
+        if extra_script is None and self._extra_script_url is not None:
+            from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
+
+            extra_script = fetch_script(self._extra_script_url)
+        if extra_script is not None:
             logger.info("Running extra bootstrap script...")
-            await conn.upload_content(self._extra_script, "/tmp/tanren-extra-bootstrap.sh")  # noqa: S108 — fixed temp path for bootstrap script
+            await conn.upload_content(extra_script, "/tmp/tanren-extra-bootstrap.sh")  # noqa: S108 — fixed temp path for bootstrap script
             extra_result = await conn.run("bash /tmp/tanren-extra-bootstrap.sh", timeout_secs=600)
             if extra_result.exit_code != 0:
                 raise RuntimeError(f"Extra bootstrap script failed: {extra_result.stderr}")

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -141,8 +141,12 @@ def build_ssh_execution_environment(
 
         state_store = SqliteVMStateStore(f"{config.data_dir}/vm-state.db")
 
-    # Bootstrap extra script is carried inline (already resolved by CLI)
+    # Bootstrap extra script: inline content or URL fetch at provision time
     extra_script = remote_cfg.bootstrap_extra_script
+    if extra_script is None and remote_cfg.bootstrap_extra_script_url:
+        from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
+
+        extra_script = fetch_script(remote_cfg.bootstrap_extra_script_url)
 
     # Daemon uses its own secrets path (not from dispatch)
     secret_config = SecretConfig()
@@ -288,10 +292,16 @@ def _build_docker(
         extra_env=docker_cfg.extra_env,
     )
 
+    extra_script = docker_cfg.bootstrap_extra_script
+    if extra_script is None and docker_cfg.bootstrap_extra_script_url:
+        from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
+
+        extra_script = fetch_script(docker_cfg.bootstrap_extra_script_url)
+
     env = DockerExecutionEnvironment(
         bootstrapper=UbuntuBootstrapper(
             required_clis=required_clis,
-            extra_script=docker_cfg.bootstrap_extra_script,
+            extra_script=extra_script,
             skip_infra_tools=frozenset({"docker"}),
         ),
         workspace_mgr=GitWorkspaceManager(git_auth),

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -141,17 +141,18 @@ def build_ssh_execution_environment(
 
         state_store = SqliteVMStateStore(f"{config.data_dir}/vm-state.db")
 
+    # Daemon uses its own secrets path (not from dispatch)
+    secret_config = SecretConfig()
+    secret_loader = SecretLoader(secret_config, required_clis=required_clis)
+    secret_loader.autoload_into_env(override=False)
+
     # Bootstrap extra script: inline content or URL fetch at provision time
+    # (after secret autoload so GCS credentials are available)
     extra_script = remote_cfg.bootstrap_extra_script
     if extra_script is None and remote_cfg.bootstrap_extra_script_url:
         from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
 
         extra_script = fetch_script(remote_cfg.bootstrap_extra_script_url)
-
-    # Daemon uses its own secrets path (not from dispatch)
-    secret_config = SecretConfig()
-    secret_loader = SecretLoader(secret_config, required_clis=required_clis)
-    secret_loader.autoload_into_env(override=False)
 
     # Resolve git token from daemon's own environment
     token = os.environ.get(remote_cfg.git.token_env, "")

--- a/packages/tanren-core/src/tanren_core/builder.py
+++ b/packages/tanren-core/src/tanren_core/builder.py
@@ -146,14 +146,6 @@ def build_ssh_execution_environment(
     secret_loader = SecretLoader(secret_config, required_clis=required_clis)
     secret_loader.autoload_into_env(override=False)
 
-    # Bootstrap extra script: inline content or URL fetch at provision time
-    # (after secret autoload so GCS credentials are available)
-    extra_script = remote_cfg.bootstrap_extra_script
-    if extra_script is None and remote_cfg.bootstrap_extra_script_url:
-        from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
-
-        extra_script = fetch_script(remote_cfg.bootstrap_extra_script_url)
-
     # Resolve git token from daemon's own environment
     token = os.environ.get(remote_cfg.git.token_env, "")
     git_auth = GitAuthConfig(
@@ -193,7 +185,8 @@ def build_ssh_execution_environment(
         vm_provisioner=vm_provisioner,
         bootstrapper=UbuntuBootstrapper(
             required_clis=required_clis,
-            extra_script=extra_script,
+            extra_script=remote_cfg.bootstrap_extra_script,
+            extra_script_url=remote_cfg.bootstrap_extra_script_url,
         ),
         workspace_mgr=GitWorkspaceManager(git_auth),
         runner=RemoteAgentRunner(run_as_user=agent_user),
@@ -293,16 +286,11 @@ def _build_docker(
         extra_env=docker_cfg.extra_env,
     )
 
-    extra_script = docker_cfg.bootstrap_extra_script
-    if extra_script is None and docker_cfg.bootstrap_extra_script_url:
-        from tanren_core.adapters.script_fetch import fetch_script  # noqa: PLC0415
-
-        extra_script = fetch_script(docker_cfg.bootstrap_extra_script_url)
-
     env = DockerExecutionEnvironment(
         bootstrapper=UbuntuBootstrapper(
             required_clis=required_clis,
-            extra_script=extra_script,
+            extra_script=docker_cfg.bootstrap_extra_script,
+            extra_script_url=docker_cfg.bootstrap_extra_script_url,
             skip_infra_tools=frozenset({"docker"}),
         ),
         workspace_mgr=GitWorkspaceManager(git_auth),

--- a/packages/tanren-core/src/tanren_core/dispatch_resolver.py
+++ b/packages/tanren-core/src/tanren_core/dispatch_resolver.py
@@ -86,6 +86,7 @@ def resolve_remote_config(config: WorkerConfig, project: str) -> RemoteExecution
 
     # Read bootstrap extra_script content (if configured)
     extra_script = None
+    extra_script_url = remote.bootstrap.extra_script_url
     if remote.bootstrap.extra_script:
         script_path = Path(remote.bootstrap.extra_script).expanduser()
         if not script_path.is_absolute():
@@ -124,6 +125,7 @@ def resolve_remote_config(config: WorkerConfig, project: str) -> RemoteExecution
         repo_url=repo_url,
         required_clis=required_clis,
         bootstrap_extra_script=extra_script,
+        bootstrap_extra_script_url=extra_script_url,
     )
 
 

--- a/packages/tanren-core/src/tanren_core/env/environment_schema.py
+++ b/packages/tanren-core/src/tanren_core/env/environment_schema.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import re
 from enum import StrEnum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -112,8 +112,23 @@ class DockerExecutionConfig(BaseModel):
     bootstrap_extra_script: str | None = Field(
         default=None, description="Inline bootstrap script content"
     )
+    bootstrap_extra_script_url: str | None = Field(
+        default=None,
+        description="URL (https:// or gs://) to fetch bootstrap script at provision time",
+    )
     agent_user: str = Field(default="tanren", description="Unprivileged user in the container")
     git: DispatchGitConfig = Field(default_factory=DispatchGitConfig, description="Git auth config")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_script_mutual_exclusivity(cls, values: object) -> object:
+        if isinstance(values, dict):
+            d = cast("dict[str, object]", values)
+            if d.get("bootstrap_extra_script") and d.get("bootstrap_extra_script_url"):
+                raise ValueError(
+                    "bootstrap_extra_script and bootstrap_extra_script_url are mutually exclusive"
+                )
+        return values
 
 
 class RemoteExecutionConfig(BaseModel):
@@ -131,7 +146,22 @@ class RemoteExecutionConfig(BaseModel):
     bootstrap_extra_script: str | None = Field(
         default=None, description="Inline bootstrap script content"
     )
+    bootstrap_extra_script_url: str | None = Field(
+        default=None,
+        description="URL (https:// or gs://) to fetch bootstrap script at provision time",
+    )
     agent_user: str = Field(default="tanren", description="Unprivileged user on remote VM")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_script_mutual_exclusivity(cls, values: object) -> object:
+        if isinstance(values, dict):
+            d = cast("dict[str, object]", values)
+            if d.get("bootstrap_extra_script") and d.get("bootstrap_extra_script_url"):
+                raise ValueError(
+                    "bootstrap_extra_script and bootstrap_extra_script_url are mutually exclusive"
+                )
+        return values
 
 
 class EnvironmentProfile(BaseModel):

--- a/packages/tanren-core/src/tanren_core/remote_config.py
+++ b/packages/tanren-core/src/tanren_core/remote_config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
 
 class ExecutionMode(StrEnum):
@@ -86,6 +86,21 @@ class RemoteBootstrapConfig(BaseModel):
     extra_script: str | None = Field(
         default=None, description="Optional shell script to run during VM bootstrap"
     )
+    extra_script_url: str | None = Field(
+        default=None,
+        description="URL (https:// or gs://) to fetch bootstrap script at provision time",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_script_mutual_exclusivity(cls, values: object) -> object:
+        if isinstance(values, dict):
+            d = cast("dict[str, object]", values)
+            if d.get("extra_script") and d.get("extra_script_url"):
+                raise ValueError(
+                    "extra_script and extra_script_url are mutually exclusive; set only one"
+                )
+        return values
 
 
 class RemoteSecretsConfig(BaseModel):

--- a/services/tanren-daemon/entrypoint.sh
+++ b/services/tanren-daemon/entrypoint.sh
@@ -24,5 +24,13 @@ if [ -f "$SECRETS_FILE" ]; then
     set +a
 fi
 
+# Grant app user access to Docker socket (DooD)
+DOCKER_SOCK="/var/run/docker.sock"
+if [ -S "$DOCKER_SOCK" ]; then
+    SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK")
+    addgroup --gid "$SOCK_GID" docker 2>/dev/null || true
+    addgroup app docker 2>/dev/null || true
+fi
+
 # Drop privileges and run the daemon
 exec gosu app tanren-daemon "$@"

--- a/services/tanren-daemon/entrypoint.sh
+++ b/services/tanren-daemon/entrypoint.sh
@@ -24,12 +24,18 @@ if [ -f "$SECRETS_FILE" ]; then
     set +a
 fi
 
-# Grant app user access to Docker socket (DooD)
+# Grant app user access to Docker socket (DooD).
+# Resolve the group that owns the socket GID (or create one), then add app.
 DOCKER_SOCK="/var/run/docker.sock"
 if [ -S "$DOCKER_SOCK" ]; then
     SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK")
-    addgroup --gid "$SOCK_GID" docker 2>/dev/null || true
-    addgroup app docker 2>/dev/null || true
+    # Look up existing group for this GID; create "docker" if none exists.
+    SOCK_GROUP=$(getent group "$SOCK_GID" 2>/dev/null | cut -d: -f1 || true)
+    if [ -z "$SOCK_GROUP" ]; then
+        addgroup --gid "$SOCK_GID" docker >/dev/null 2>&1
+        SOCK_GROUP="docker"
+    fi
+    adduser app "$SOCK_GROUP" >/dev/null 2>&1 || true
 fi
 
 # Drop privileges and run the daemon

--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -329,27 +329,25 @@ class TestBootstrapUrlScriptFlowThrough:
     """Verify that URL-fetched scripts flow through to bootstrapper execution."""
 
     async def test_url_fetched_script_uploaded_and_executed(self) -> None:
-        """When fetch_script resolves a URL, the content should be uploaded and run."""
+        """When extra_script_url is set, bootstrap() fetches and runs it."""
         from unittest.mock import patch
 
         conn = _make_conn()
         url = "https://example.com/bootstrap.sh"
         script_content = "#!/bin/bash\napt-get install -y nginx"
 
+        bootstrapper = UbuntuBootstrapper(
+            required_clis=_DEFAULT_CLIS,
+            extra_script_url=url,
+        )
+
         with patch(
             "tanren_core.adapters.script_fetch.fetch_script",
             return_value=script_content,
         ) as mock_fetch:
-            # Simulate what builder does: resolve URL then pass to bootstrapper
-            extra_script = mock_fetch(url)
-
-            bootstrapper = UbuntuBootstrapper(
-                required_clis=_DEFAULT_CLIS,
-                extra_script=extra_script,
-            )
-
             result = await bootstrapper.bootstrap(conn)
 
+        mock_fetch.assert_called_once_with(url)
         conn.upload_content.assert_awaited_once_with(
             script_content, "/tmp/tanren-extra-bootstrap.sh"
         )
@@ -358,4 +356,24 @@ class TestBootstrapUrlScriptFlowThrough:
             c for c in conn.run.call_args_list if "tanren-extra-bootstrap.sh" in c[0][0]
         ]
         assert len(script_run_calls) == 1
+        assert "extra-script" in result.installed
+
+    async def test_url_not_fetched_when_inline_provided(self) -> None:
+        """When extra_script is set, extra_script_url is ignored."""
+        from unittest.mock import patch
+
+        conn = _make_conn()
+
+        bootstrapper = UbuntuBootstrapper(
+            required_clis=_DEFAULT_CLIS,
+            extra_script="#!/bin/bash\necho inline",
+            extra_script_url="https://example.com/should-not-fetch.sh",
+        )
+
+        with patch(
+            "tanren_core.adapters.script_fetch.fetch_script",
+        ) as mock_fetch:
+            result = await bootstrapper.bootstrap(conn)
+
+        mock_fetch.assert_not_called()
         assert "extra-script" in result.installed

--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -323,3 +323,39 @@ class TestBootstrapSkipsInstalledTools:
         assert "codex" in result.skipped
         # Only apt-packages should be in installed
         assert result.installed == ("apt-packages",)
+
+
+class TestBootstrapUrlScriptFlowThrough:
+    """Verify that URL-fetched scripts flow through to bootstrapper execution."""
+
+    async def test_url_fetched_script_uploaded_and_executed(self) -> None:
+        """When fetch_script resolves a URL, the content should be uploaded and run."""
+        from unittest.mock import patch
+
+        conn = _make_conn()
+        url = "https://example.com/bootstrap.sh"
+        script_content = "#!/bin/bash\napt-get install -y nginx"
+
+        with patch(
+            "tanren_core.adapters.script_fetch.fetch_script",
+            return_value=script_content,
+        ) as mock_fetch:
+            # Simulate what builder does: resolve URL then pass to bootstrapper
+            extra_script = mock_fetch(url)
+
+            bootstrapper = UbuntuBootstrapper(
+                required_clis=_DEFAULT_CLIS,
+                extra_script=extra_script,
+            )
+
+            result = await bootstrapper.bootstrap(conn)
+
+        conn.upload_content.assert_awaited_once_with(
+            script_content, "/tmp/tanren-extra-bootstrap.sh"
+        )
+
+        script_run_calls = [
+            c for c in conn.run.call_args_list if "tanren-extra-bootstrap.sh" in c[0][0]
+        ]
+        assert len(script_run_calls) == 1
+        assert "extra-script" in result.installed

--- a/tests/integration/test_remote_config_integration.py
+++ b/tests/integration/test_remote_config_integration.py
@@ -316,6 +316,54 @@ provisioner:
 # ---------------------------------------------------------------------------
 
 
+class TestBootstrapExtraScriptUrl:
+    def test_url_round_trip_through_yaml(self, tmp_path: Path) -> None:
+        path = _write_yaml(
+            tmp_path,
+            """\
+provisioner:
+  type: manual
+bootstrap:
+  extra_script_url: https://example.com/bootstrap.sh
+""",
+        )
+
+        config = load_remote_config(path)
+
+        assert config.bootstrap.extra_script is None
+        assert config.bootstrap.extra_script_url == "https://example.com/bootstrap.sh"
+
+    def test_gs_url_round_trip(self, tmp_path: Path) -> None:
+        path = _write_yaml(
+            tmp_path,
+            """\
+provisioner:
+  type: manual
+bootstrap:
+  extra_script_url: gs://my-bucket/scripts/setup.sh
+""",
+        )
+
+        config = load_remote_config(path)
+
+        assert config.bootstrap.extra_script_url == "gs://my-bucket/scripts/setup.sh"
+
+    def test_both_set_rejected(self, tmp_path: Path) -> None:
+        path = _write_yaml(
+            tmp_path,
+            """\
+provisioner:
+  type: manual
+bootstrap:
+  extra_script: setup.sh
+  extra_script_url: https://example.com/setup.sh
+""",
+        )
+
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            load_remote_config(path)
+
+
 class TestGCPProvisionerNetworkTags:
     def test_network_tags_round_trip_through_settings(self, tmp_path: Path) -> None:
         path = _write_yaml(

--- a/tests/integration/test_script_fetch_integration.py
+++ b/tests/integration/test_script_fetch_integration.py
@@ -1,0 +1,65 @@
+"""Integration tests for script_fetch module — real imports, mocked I/O."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tanren_core.adapters.script_fetch import (
+    _import_httpx,
+    fetch_script,
+)
+
+
+class TestImportHttpx:
+    def test_real_import_succeeds(self) -> None:
+        """httpx is installed in dev deps — import should succeed."""
+        mod = _import_httpx()
+        assert hasattr(mod, "get")
+
+    def test_import_error_when_missing(self) -> None:
+        with (
+            patch.dict("sys.modules", {"httpx": None}),
+            pytest.raises(ImportError, match="httpx is required"),
+        ):
+            _import_httpx()
+
+
+class TestFetchHttpsIntegration:
+    def test_round_trip_with_real_httpx(self) -> None:
+        """Use real httpx module but mock the network call."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "#!/bin/bash\necho integration"
+
+        with patch("tanren_core.adapters.script_fetch._import_httpx") as mock_import:
+            mock_httpx = MagicMock()
+            mock_httpx.get.return_value = mock_response
+            mock_import.return_value = mock_httpx
+
+            result = fetch_script("https://example.com/bootstrap.sh")
+
+        assert result == "#!/bin/bash\necho integration"
+
+
+class TestFetchGcsIntegration:
+    def test_round_trip_with_mocked_storage(self) -> None:
+        mock_blob = MagicMock()
+        mock_blob.download_as_text.return_value = "#!/bin/bash\napt install -y nginx"
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        mock_storage = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        with patch("tanren_core.adapters.script_fetch._import_storage", return_value=mock_storage):
+            result = fetch_script("gs://my-bucket/scripts/setup.sh")
+
+        assert result == "#!/bin/bash\napt install -y nginx"
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        mock_bucket.blob.assert_called_once_with("scripts/setup.sh")

--- a/tests/integration/test_script_fetch_integration.py
+++ b/tests/integration/test_script_fetch_integration.py
@@ -12,12 +12,6 @@ from tanren_core.adapters.script_fetch import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _clear_fetch_cache() -> None:
-    """Clear the LRU cache between tests."""
-    fetch_script.cache_clear()
-
-
 class TestImportHttpx:
     def test_real_import_succeeds(self) -> None:
         """httpx is installed in dev deps — import should succeed."""

--- a/tests/integration/test_script_fetch_integration.py
+++ b/tests/integration/test_script_fetch_integration.py
@@ -12,6 +12,12 @@ from tanren_core.adapters.script_fetch import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_fetch_cache() -> None:
+    """Clear the LRU cache between tests."""
+    fetch_script.cache_clear()
+
+
 class TestImportHttpx:
     def test_real_import_succeeds(self) -> None:
         """httpx is installed in dev deps — import should succeed."""
@@ -29,9 +35,13 @@ class TestImportHttpx:
 class TestFetchHttpsIntegration:
     def test_round_trip_with_real_httpx(self) -> None:
         """Use real httpx module but mock the network call."""
+        mock_url = MagicMock()
+        mock_url.scheme = "https"
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = "#!/bin/bash\necho integration"
+        mock_response.url = mock_url
 
         with patch("tanren_core.adapters.script_fetch._import_httpx") as mock_import:
             mock_httpx = MagicMock()

--- a/tests/unit/test_environment_schema.py
+++ b/tests/unit/test_environment_schema.py
@@ -1,13 +1,17 @@
 """Tests for environment_schema module."""
 
 import pytest
+from pydantic import ValidationError
 
 from tanren_core.env.environment_schema import (
+    DispatchProvisionerConfig,
+    DockerExecutionConfig,
     EnvironmentProfile,
     EnvironmentProfileType,
     IssueSourceConfig,
     IssueSourceType,
     McpServerConfig,
+    RemoteExecutionConfig,
     ResourceRequirements,
     parse_environment_profiles,
     parse_issue_source,
@@ -284,3 +288,51 @@ class TestParseIssueSource:
 
     def test_returns_none_for_non_dict(self):
         assert parse_issue_source({"issue_source": "invalid"}) is None
+
+
+class TestBootstrapExtraScriptUrl:
+    """Tests for bootstrap_extra_script_url on execution configs."""
+
+    def test_remote_config_url_default_none(self):
+        cfg = RemoteExecutionConfig(
+            provisioner=DispatchProvisionerConfig(type="manual"),
+            repo_url="https://github.com/org/repo.git",
+        )
+        assert cfg.bootstrap_extra_script_url is None
+        assert cfg.bootstrap_extra_script is None
+
+    def test_remote_config_url_set(self):
+        cfg = RemoteExecutionConfig(
+            provisioner=DispatchProvisionerConfig(type="manual"),
+            repo_url="https://github.com/org/repo.git",
+            bootstrap_extra_script_url="https://example.com/setup.sh",
+        )
+        assert cfg.bootstrap_extra_script_url == "https://example.com/setup.sh"
+
+    def test_remote_config_mutual_exclusivity(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            RemoteExecutionConfig(
+                provisioner=DispatchProvisionerConfig(type="manual"),
+                repo_url="https://github.com/org/repo.git",
+                bootstrap_extra_script="#!/bin/bash\necho hi",
+                bootstrap_extra_script_url="https://example.com/setup.sh",
+            )
+
+    def test_docker_config_url_default_none(self):
+        cfg = DockerExecutionConfig(repo_url="https://github.com/org/repo.git")
+        assert cfg.bootstrap_extra_script_url is None
+
+    def test_docker_config_url_set(self):
+        cfg = DockerExecutionConfig(
+            repo_url="https://github.com/org/repo.git",
+            bootstrap_extra_script_url="gs://bucket/script.sh",
+        )
+        assert cfg.bootstrap_extra_script_url == "gs://bucket/script.sh"
+
+    def test_docker_config_mutual_exclusivity(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            DockerExecutionConfig(
+                repo_url="https://github.com/org/repo.git",
+                bootstrap_extra_script="#!/bin/bash\necho hi",
+                bootstrap_extra_script_url="https://example.com/setup.sh",
+            )

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from tanren_core.remote_config import (
     ProvisionerType,
+    RemoteBootstrapConfig,
     RemoteConfig,
     RemoteGitConfig,
     RemoteProvisionerConfig,
@@ -166,6 +167,42 @@ class TestSSHReadyTimeoutSecs:
         cfg_file.write_text(MINIMAL_YAML)
         cfg = load_remote_config(cfg_file)
         assert cfg.ssh.ssh_ready_timeout_secs == 300
+
+
+class TestBootstrapExtraScriptUrl:
+    def test_url_parsed_from_yaml(self, tmp_path: Path):
+        cfg_file = tmp_path / "remote.yml"
+        cfg_file.write_text(
+            "provisioner:\n"
+            "  type: manual\n"
+            "  settings: {}\n"
+            "bootstrap:\n"
+            "  extra_script_url: https://example.com/setup.sh\n"
+        )
+        cfg = load_remote_config(cfg_file)
+        assert cfg.bootstrap.extra_script_url == "https://example.com/setup.sh"
+        assert cfg.bootstrap.extra_script is None
+
+    def test_url_default_is_none(self):
+        cfg = RemoteBootstrapConfig()
+        assert cfg.extra_script_url is None
+
+    def test_mutual_exclusivity_rejects_both(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            RemoteBootstrapConfig(
+                extra_script="setup.sh",
+                extra_script_url="https://example.com/setup.sh",
+            )
+
+    def test_script_only_allowed(self):
+        cfg = RemoteBootstrapConfig(extra_script="setup.sh")
+        assert cfg.extra_script == "setup.sh"
+        assert cfg.extra_script_url is None
+
+    def test_url_only_allowed(self):
+        cfg = RemoteBootstrapConfig(extra_script_url="gs://bucket/script.sh")
+        assert cfg.extra_script_url == "gs://bucket/script.sh"
+        assert cfg.extra_script is None
 
 
 class TestRepoBindings:

--- a/tests/unit/test_script_fetch.py
+++ b/tests/unit/test_script_fetch.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
 from tanren_core.adapters.script_fetch import fetch_script
+
+
+@pytest.fixture(autouse=True)
+def _clear_fetch_cache() -> None:
+    """Clear the LRU cache between tests so each test gets a fresh fetch."""
+    fetch_script.cache_clear()
+
+
+def _mock_url(url: str) -> MagicMock:
+    """Create a mock httpx.URL with a working .scheme attribute."""
+    parsed = urlparse(url)
+    mock = MagicMock()
+    mock.scheme = parsed.scheme
+    return mock
 
 
 class TestFetchHttps:
@@ -14,6 +29,7 @@ class TestFetchHttps:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = "#!/bin/bash\necho hello"
+        mock_response.url = _mock_url("https://example.com/setup.sh")
 
         mock_httpx = MagicMock()
         mock_httpx.get.return_value = mock_response
@@ -29,6 +45,7 @@ class TestFetchHttps:
     def test_http_error_raises(self) -> None:
         mock_response = MagicMock()
         mock_response.status_code = 404
+        mock_response.url = _mock_url("https://example.com/missing.sh")
 
         mock_httpx = MagicMock()
         mock_httpx.get.return_value = mock_response
@@ -38,6 +55,20 @@ class TestFetchHttps:
             pytest.raises(RuntimeError, match="HTTP 404"),
         ):
             fetch_script("https://example.com/missing.sh")
+
+    def test_redirect_to_http_rejected(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = _mock_url("http://evil.com/setup.sh")
+
+        mock_httpx = MagicMock()
+        mock_httpx.get.return_value = mock_response
+
+        with (
+            patch("tanren_core.adapters.script_fetch._import_httpx", return_value=mock_httpx),
+            pytest.raises(RuntimeError, match="non-HTTPS"),
+        ):
+            fetch_script("https://example.com/redirected.sh")
 
 
 class TestFetchGcs:

--- a/tests/unit/test_script_fetch.py
+++ b/tests/unit/test_script_fetch.py
@@ -10,12 +10,6 @@ import pytest
 from tanren_core.adapters.script_fetch import fetch_script
 
 
-@pytest.fixture(autouse=True)
-def _clear_fetch_cache() -> None:
-    """Clear the LRU cache between tests so each test gets a fresh fetch."""
-    fetch_script.cache_clear()
-
-
 def _mock_url(url: str) -> MagicMock:
     """Create a mock httpx.URL with a working .scheme attribute."""
     parsed = urlparse(url)

--- a/tests/unit/test_script_fetch.py
+++ b/tests/unit/test_script_fetch.py
@@ -1,0 +1,94 @@
+"""Tests for the bootstrap script URL fetcher."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tanren_core.adapters.script_fetch import fetch_script
+
+
+class TestFetchHttps:
+    def test_success(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "#!/bin/bash\necho hello"
+
+        mock_httpx = MagicMock()
+        mock_httpx.get.return_value = mock_response
+
+        with patch("tanren_core.adapters.script_fetch._import_httpx", return_value=mock_httpx):
+            result = fetch_script("https://example.com/setup.sh")
+
+        assert result == "#!/bin/bash\necho hello"
+        mock_httpx.get.assert_called_once_with(
+            "https://example.com/setup.sh", timeout=60, follow_redirects=True
+        )
+
+    def test_http_error_raises(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_httpx = MagicMock()
+        mock_httpx.get.return_value = mock_response
+
+        with (
+            patch("tanren_core.adapters.script_fetch._import_httpx", return_value=mock_httpx),
+            pytest.raises(RuntimeError, match="HTTP 404"),
+        ):
+            fetch_script("https://example.com/missing.sh")
+
+
+class TestFetchGcs:
+    def test_success(self) -> None:
+        mock_blob = MagicMock()
+        mock_blob.download_as_text.return_value = "#!/bin/bash\napt install nginx"
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        mock_storage = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        with patch("tanren_core.adapters.script_fetch._import_storage", return_value=mock_storage):
+            result = fetch_script("gs://my-bucket/scripts/setup.sh")
+
+        assert result == "#!/bin/bash\napt install nginx"
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        mock_bucket.blob.assert_called_once_with("scripts/setup.sh")
+
+    def test_nested_path(self) -> None:
+        mock_blob = MagicMock()
+        mock_blob.download_as_text.return_value = "script"
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        mock_storage = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        with patch("tanren_core.adapters.script_fetch._import_storage", return_value=mock_storage):
+            fetch_script("gs://bucket/path/to/deep/script.sh")
+
+        mock_bucket.blob.assert_called_once_with("path/to/deep/script.sh")
+
+
+class TestUnsupportedScheme:
+    def test_ftp_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported URL scheme 'ftp'"):
+            fetch_script("ftp://example.com/setup.sh")
+
+    def test_http_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported URL scheme 'http'"):
+            fetch_script("http://example.com/setup.sh")
+
+    def test_empty_scheme_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported URL scheme"):
+            fetch_script("no-scheme-at-all")

--- a/uv.lock
+++ b/uv.lock
@@ -674,6 +674,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-core"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/03/ef0bc99d0e0faf4fdbe67ac445e18cdaa74824fd93cd069e7bb6548cb52d/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963", size = 36027, upload-time = "2025-10-29T23:17:39.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/20/bfa472e327c8edee00f04beecc80baeddd2ab33ee0e86fd7654da49d45e9/google_cloud_core-2.5.0-py3-none-any.whl", hash = "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc", size = 29469, upload-time = "2025-10-29T23:17:38.548Z" },
+]
+
+[[package]]
 name = "google-cloud-secret-manager"
 version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -688,6 +701,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/a6c7144bc96df77376ae3fcc916fb639c40814c2e4bba2051d31dc136cd0/google_cloud_secret_manager-2.26.0.tar.gz", hash = "sha256:0d1d6f76327685a0ed78a4cf50f289e1bfbbe56026ed0affa98663b86d6d50d6", size = 277603, upload-time = "2025-12-18T00:29:31.065Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/30/a58739dd12cec0f7f761ed1efb518aed2250a407d4ed14c5a0eeee7eaaf9/google_cloud_secret_manager-2.26.0-py3-none-any.whl", hash = "sha256:940a5447a6ec9951446fd1a0f22c81a4303fde164cd747aae152c5f5c8e6723e", size = 223623, upload-time = "2025-12-18T00:29:29.311Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/76/4d965702e96bb67976e755bed9828fa50306dca003dbee08b67f41dd265e/google_cloud_storage-2.19.0.tar.gz", hash = "sha256:cd05e9e7191ba6cb68934d8eb76054d9be4562aa89dbc4236feee4d7d51342b2", size = 5535488, upload-time = "2024-12-05T01:35:06.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/94/6db383d8ee1adf45dc6c73477152b82731fa4c4a46d9c1932cc8757e0fd4/google_cloud_storage-2.19.0-py2.py3-none-any.whl", hash = "sha256:aeb971b5c29cf8ab98445082cbfe7b161a1f48ed275822f59ed3f1524ea54fba", size = 131787, upload-time = "2024-12-05T01:35:04.736Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/d7/520b62a35b23038ff005e334dba3ffc75fcf583bee26723f1fd8fd4b6919/google_resumable_media-2.8.0.tar.gz", hash = "sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae", size = 2163265, upload-time = "2025-11-17T15:38:06.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/0b/93afde9cfe012260e9fe1522f35c9b72d6ee222f316586b1f23ecf44d518/google_resumable_media-2.8.0-py3-none-any.whl", hash = "sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582", size = 81340, upload-time = "2025-11-17T15:38:05.594Z" },
 ]
 
 [[package]]
@@ -1772,6 +1827,7 @@ all = [
     { name = "aiodocker" },
     { name = "google-cloud-compute" },
     { name = "google-cloud-secret-manager" },
+    { name = "google-cloud-storage" },
     { name = "hcloud" },
     { name = "httpx" },
 ]
@@ -1781,6 +1837,7 @@ docker = [
 gcp = [
     { name = "google-cloud-compute" },
     { name = "google-cloud-secret-manager" },
+    { name = "google-cloud-storage" },
 ]
 github = [
     { name = "httpx" },
@@ -1802,6 +1859,8 @@ requires-dist = [
     { name = "google-cloud-compute", marker = "extra == 'gcp'", specifier = ">=1.20.0,<2" },
     { name = "google-cloud-secret-manager", marker = "extra == 'all'", specifier = ">=2.20.0,<3" },
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp'", specifier = ">=2.20.0,<3" },
+    { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=2.18.0,<3" },
+    { name = "google-cloud-storage", marker = "extra == 'gcp'", specifier = ">=2.18.0,<3" },
     { name = "hcloud", marker = "extra == 'all'", specifier = ">=2.4.0,<3" },
     { name = "hcloud", marker = "extra == 'hetzner'", specifier = ">=2.4.0,<3" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27,<1" },


### PR DESCRIPTION
## Summary
- Add `bootstrap_extra_script_url` field (HTTPS + GCS) to fetch bootstrap scripts at provision time, enabling containerized API deployments with no local filesystem
- `bootstrap_extra_script` (inline) and `bootstrap_extra_script_url` are mutually exclusive at both the `remote.yml` and dispatch config levels
- Fix daemon `entrypoint.sh` to detect Docker socket GID and add `app` user to that group before `gosu` privilege drop (DooD support)

## Changes
- **Schema**: Add `extra_script_url` to `RemoteBootstrapConfig`, `bootstrap_extra_script_url` to `RemoteExecutionConfig` + `DockerExecutionConfig` with `model_validator` mutual exclusivity
- **Fetch**: New `script_fetch.py` adapter with sync HTTPS (httpx) and GCS (google-cloud-storage) fetchers using deferred import pattern
- **Builder**: Resolve URL at provision time in both SSH and Docker builders
- **Resolver**: Pass URL through from `remote.yml` to dispatch config
- **Deps**: Add `google-cloud-storage>=2.18.0` to `gcp`/`all` optional dependency groups
- **Daemon**: Docker socket GID detection in `entrypoint.sh`
- **Docs**: Document `extra_script_url` in ADAPTERS.md

## Test plan
- [x] Unit tests: script_fetch (HTTPS, GCS, unsupported scheme, HTTP error)
- [x] Unit tests: mutual exclusivity on RemoteBootstrapConfig, RemoteExecutionConfig, DockerExecutionConfig
- [x] Unit tests: YAML parsing for extra_script_url
- [x] Integration tests: YAML round-trip, GCS URL, both-set rejection
- [x] Integration tests: URL-fetched script flows through bootstrapper
- [x] Integration tests: httpx import success/failure
- [x] `make check` passes (format, lint, type, unit @ 80%+, integration @ 75%+, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)