### PR TITLE
Lane 0.3: harden store invariants and prepare lane 0.4 handoff

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,20 @@ failure-output = "immediate-final"
 status-level = "all"
 retries = 2
 slow-timeout = { period = "120s", terminate-after = 3 }
+
+# Serialize the tanren-store Postgres integration suite: all tests
+# in that binary share the same schema when running against a CI
+# service container, and concurrent `DROP SCHEMA public CASCADE`
+# calls collide on pg_catalog internals. `max-threads = 1` forces
+# nextest to run them one at a time. The SQLite suite (different
+# binary) is untouched and stays parallel.
+[test-groups]
+postgres-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = "binary(postgres_integration)"
+test-group = "postgres-integration"
+
+[[profile.ci.overrides]]
+filter = "binary(postgres_integration)"
+test-group = "postgres-integration"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: taplo fmt --check Cargo.toml bin/*/Cargo.toml crates/*/Cargo.toml .cargo/*.toml .config/*.toml rust-toolchain.toml clippy.toml taplo.toml deny.toml .rustfmt.toml
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --features tanren-store/test-hooks -- -D warnings
 
   # ============================================================
   # Test
@@ -65,7 +65,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Run tests
-        run: cargo nextest run --workspace --profile ci --no-tests=pass
+        run: cargo nextest run --workspace --features tanren-store/test-hooks --profile ci --no-tests=pass
 
   # ============================================================
   # Integration — Postgres
@@ -102,7 +102,7 @@ jobs:
       - name: Run Postgres integration tests
         env:
           TANREN_TEST_POSTGRES_URL: postgres://postgres:tanren@localhost:5432/postgres
-        run: cargo nextest run -p tanren-store --features postgres-integration
+        run: cargo nextest run -p tanren-store --features tanren-store/test-hooks,tanren-store/postgres-integration
 
   # ============================================================
   # Coverage (Linux only)
@@ -124,7 +124,7 @@ jobs:
           tool: cargo-nextest,cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --no-tests=pass
+        run: cargo llvm-cov nextest --workspace --features tanren-store/test-hooks --lcov --output-path lcov.info --no-tests=pass
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -181,13 +181,17 @@ jobs:
         run: cargo machete
 
   # ============================================================
-  # Quality gates (file length + inline suppression)
+  # Quality gates (file length + inline suppression + crate layering)
   # ============================================================
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - uses: taiki-e/install-action@v2
         with:
@@ -198,3 +202,6 @@ jobs:
 
       - name: Check inline lint suppression
         run: just check-suppression
+
+      - name: Check crate dependency layering
+        run: just check-deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,38 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,16 +44,152 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -40,15 +208,153 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -67,6 +373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +393,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,7 +455,23 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -96,6 +479,221 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -116,7 +714,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -126,10 +746,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -142,6 +784,141 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -169,11 +946,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -184,10 +978,190 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -214,10 +1188,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -232,6 +1326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +1348,12 @@ dependencies = [
  "similar",
  "tempfile",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -261,6 +1372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,10 +1393,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -285,10 +1449,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -297,6 +1576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -304,6 +1584,183 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -321,7 +1778,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -334,6 +1822,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,15 +1842,35 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -380,13 +1901,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -396,7 +1944,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -414,7 +1971,77 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -424,16 +2051,169 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -452,6 +2232,245 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more",
+ "futures-util",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+dependencies = [
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+dependencies = [
+ "async-trait",
+ "clap",
+ "dotenvy",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "inherent",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "rust_decimal",
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -487,7 +2506,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -504,16 +2523,455 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.1",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.13.1",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags 2.11.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rand 0.8.5",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -524,6 +2982,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -610,6 +3079,19 @@ version = "0.1.0"
 [[package]]
 name = "tanren-store"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde_json",
+ "tanren-domain",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "tanren-tui"
@@ -618,6 +3100,12 @@ version = "0.1.0"
 [[package]]
 name = "tanrend"
 version = "0.1.0"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -629,7 +3117,45 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -649,8 +3175,244 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.13.1",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unarray"
@@ -659,16 +3421,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -683,6 +3497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +3516,21 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -710,6 +3551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +3565,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -741,7 +3589,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -771,7 +3619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -782,11 +3630,61 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -809,7 +3707,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -820,7 +3718,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -849,11 +3747,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -872,7 +3918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -883,10 +3929,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
- "indexmap",
+ "heck 0.5.0",
+ "indexmap 2.13.1",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -902,7 +3948,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -914,8 +3960,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -934,7 +3980,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -942,6 +3988,60 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -961,7 +4061,67 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,11 @@ serde_json = "1"
 thiserror = "2"
 anyhow = "1"
 
+# Async traits — needed for dyn-compatible trait objects that the store
+# and other workspace crates expose (Rust 2024's native async-fn-in-trait
+# is not yet dyn-compatible on stable).
+async-trait = "0.1"
+
 # Logging / tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/crates/tanren-store/Cargo.toml
+++ b/crates/tanren-store/Cargo.toml
@@ -36,3 +36,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+# Test-only: enable SeaORM's `mock` feature so unit tests can use
+# `MockDatabase` without a real database. The feature is additive,
+# so production builds are unaffected.
+sea-orm = { workspace = true, features = ["mock"] }

--- a/crates/tanren-store/Cargo.toml
+++ b/crates/tanren-store/Cargo.toml
@@ -7,9 +7,32 @@ license.workspace = true
 publish = false
 description = "Event-sourced persistence — event log, projections, migrations, and repository APIs"
 
+[features]
+default = []
+# Enables the Postgres-backed integration test suite. Gated so the default
+# `cargo nextest run -p tanren-store` path stays SQLite-only and does not
+# require a running Postgres instance.
+postgres-integration = []
+
 [lints]
 workspace = true
 
 [dependencies]
+tanren-domain = { version = "0.1", path = "../tanren-domain" }
+
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+
+serde_json = { workspace = true }
+
+thiserror = { workspace = true }
+
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+async-trait = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }

--- a/crates/tanren-store/Cargo.toml
+++ b/crates/tanren-store/Cargo.toml
@@ -13,6 +13,27 @@ default = []
 # `cargo nextest run -p tanren-store` path stays SQLite-only and does not
 # require a running Postgres instance.
 postgres-integration = []
+# Exposes `Store::append` / `Store::append_batch` for integration tests.
+# Production code must NOT enable this feature — these methods bypass
+# projection consistency. Test binaries that use these methods declare
+# `required-features = ["test-hooks"]` so bare `cargo test` silently
+# skips them rather than failing to compile.
+test-hooks = []
+
+[[test]]
+name = "sqlite_integration"
+path = "tests/sqlite_integration.rs"
+required-features = ["test-hooks"]
+
+[[test]]
+name = "sqlite_liveness"
+path = "tests/sqlite_liveness.rs"
+required-features = ["test-hooks"]
+
+[[test]]
+name = "postgres_integration"
+path = "tests/postgres_integration.rs"
+required-features = ["test-hooks", "postgres-integration"]
 
 [lints]
 workspace = true

--- a/crates/tanren-store/src/connection.rs
+++ b/crates/tanren-store/src/connection.rs
@@ -9,10 +9,13 @@
 //! Callers pass a URL. `sqlite://` and `postgres://` schemes are
 //! supported; anything else is rejected by `SeaORM` at connect time.
 //!
-//! For `SQLite`, include `?mode=rwc` to create the file if missing,
-//! and append `?busy_timeout=5000` (ms) to get automatic retries on
-//! `SQLITE_BUSY` so the atomic dequeue path does not propagate
-//! spurious contention errors.
+//! For `SQLite`, the connector enforces `busy_timeout = 5 seconds`
+//! via `SeaORM`'s `map_sqlx_sqlite_opts` hook. This makes the
+//! atomic dequeue path race-safe across processes by pushing
+//! contention retries into the driver instead of bubbling
+//! `SQLITE_BUSY` up to the caller. The value is set programmatically
+//! (not via URL query parameter, which `sqlx-sqlite` does not accept
+//! for `busy_timeout`).
 //!
 //! [`EventStore`]: crate::EventStore
 //! [`JobQueue`]: crate::JobQueue
@@ -21,6 +24,12 @@
 use std::time::Duration;
 
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
+
+/// How long the `SQLite` driver retries on a busy database before
+/// surfacing `SQLITE_BUSY`. Five seconds is long enough for normal
+/// contention between dequeue workers on a shared database but
+/// short enough to surface genuine deadlocks.
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Open a connection pool to the given database URL.
 ///
@@ -35,5 +44,10 @@ pub(crate) async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
         .connect_timeout(Duration::from_secs(10))
         .idle_timeout(Duration::from_secs(60))
         .sqlx_logging(false);
+    // `sqlx-sqlite` does not accept `busy_timeout` as a URL query
+    // parameter, so we set it programmatically via SeaORM's sqlx
+    // options hook. Called once per pool connection; non-SQLite
+    // backends ignore this hook entirely.
+    opt.map_sqlx_sqlite_opts(|options| options.busy_timeout(SQLITE_BUSY_TIMEOUT));
     Database::connect(opt).await
 }

--- a/crates/tanren-store/src/connection.rs
+++ b/crates/tanren-store/src/connection.rs
@@ -1,0 +1,39 @@
+//! Database connection factory.
+//!
+//! The store threads a single [`DatabaseConnection`] through every
+//! trait implementation. `SeaORM`'s connection type is internally a
+//! reference-counted pool for network backends and a single handle
+//! for `SQLite`, so sharing one instance across [`EventStore`],
+//! [`JobQueue`], and [`StateStore`] is cheap and correct.
+//!
+//! Callers pass a URL. `sqlite://` and `postgres://` schemes are
+//! supported; anything else is rejected by `SeaORM` at connect time.
+//!
+//! For `SQLite`, include `?mode=rwc` to create the file if missing,
+//! and append `?busy_timeout=5000` (ms) to get automatic retries on
+//! `SQLITE_BUSY` so the atomic dequeue path does not propagate
+//! spurious contention errors.
+//!
+//! [`EventStore`]: crate::EventStore
+//! [`JobQueue`]: crate::JobQueue
+//! [`StateStore`]: crate::StateStore
+
+use std::time::Duration;
+
+use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
+
+/// Open a connection pool to the given database URL.
+///
+/// # Errors
+///
+/// Returns any [`DbErr`] raised by `SeaORM` during connection — bad
+/// URL, unreachable host, failed handshake, etc.
+pub(crate) async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
+    let mut opt = ConnectOptions::new(url.to_owned());
+    opt.min_connections(1)
+        .max_connections(8)
+        .connect_timeout(Duration::from_secs(10))
+        .idle_timeout(Duration::from_secs(60))
+        .sqlx_logging(false);
+    Database::connect(opt).await
+}

--- a/crates/tanren-store/src/connection.rs
+++ b/crates/tanren-store/src/connection.rs
@@ -31,18 +31,63 @@ use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
 /// short enough to surface genuine deadlocks.
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Open a connection pool to the given database URL.
+/// Pool sizing and timeout knobs for the database connection.
+///
+/// Every field corresponds to a `SeaORM` [`ConnectOptions`] setter.
+/// The defaults match the hardcoded values the store used prior to
+/// this struct's introduction, so callers that do not need custom
+/// tuning can use [`ConnectConfig::default()`].
+#[derive(Debug, Clone)]
+pub struct ConnectConfig {
+    /// Minimum number of connections the pool keeps open.
+    pub min_connections: u32,
+    /// Maximum number of connections the pool may open.
+    pub max_connections: u32,
+    /// Timeout for establishing a new connection.
+    pub connect_timeout: Duration,
+    /// How long an idle connection sits in the pool before being
+    /// closed.
+    pub idle_timeout: Duration,
+}
+
+impl Default for ConnectConfig {
+    fn default() -> Self {
+        Self {
+            min_connections: 1,
+            max_connections: 8,
+            connect_timeout: Duration::from_secs(10),
+            idle_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+/// Open a connection pool to the given database URL using the
+/// default pool configuration.
 ///
 /// # Errors
 ///
 /// Returns any [`DbErr`] raised by `SeaORM` during connection — bad
 /// URL, unreachable host, failed handshake, etc.
 pub(crate) async fn connect(url: &str) -> Result<DatabaseConnection, DbErr> {
+    connect_with_config(url, &ConnectConfig::default()).await
+}
+
+/// Open a connection pool to the given database URL using the
+/// supplied pool configuration.
+///
+/// # Errors
+///
+/// Returns any [`DbErr`] raised by `SeaORM` during connection — bad
+/// URL, unreachable host, failed handshake, etc.
+pub(crate) async fn connect_with_config(
+    url: &str,
+    config: &ConnectConfig,
+) -> Result<DatabaseConnection, DbErr> {
     let mut opt = ConnectOptions::new(url.to_owned());
-    opt.min_connections(1)
-        .max_connections(8)
-        .connect_timeout(Duration::from_secs(10))
-        .idle_timeout(Duration::from_secs(60))
+    opt.min_connections(config.min_connections)
+        .max_connections(config.max_connections)
+        .connect_timeout(config.connect_timeout)
+        .idle_timeout(config.idle_timeout)
         .sqlx_logging(false);
     // `sqlx-sqlite` does not accept `busy_timeout` as a URL query
     // parameter, so we set it programmatically via SeaORM's sqlx

--- a/crates/tanren-store/src/connection.rs
+++ b/crates/tanren-store/src/connection.rs
@@ -93,6 +93,8 @@ pub(crate) async fn connect_with_config(
     // parameter, so we set it programmatically via SeaORM's sqlx
     // options hook. Called once per pool connection; non-SQLite
     // backends ignore this hook entirely.
-    opt.map_sqlx_sqlite_opts(|options| options.busy_timeout(SQLITE_BUSY_TIMEOUT));
+    opt.map_sqlx_sqlite_opts(|options| {
+        options.busy_timeout(SQLITE_BUSY_TIMEOUT).foreign_keys(true)
+    });
     Database::connect(opt).await
 }

--- a/crates/tanren-store/src/converters/dispatch.rs
+++ b/crates/tanren-store/src/converters/dispatch.rs
@@ -1,0 +1,203 @@
+//! `CreateDispatchParams` / `DispatchView` <-> `dispatch_projection::Model`
+//! converters.
+
+use sea_orm::ActiveValue::Set;
+use tanren_domain::{
+    ActorContext, DispatchId, DispatchMode, DispatchSnapshot, DispatchStatus, DispatchView,
+    GraphRevision, Lane, Outcome,
+};
+
+use crate::entity::dispatch_projection;
+use crate::errors::StoreError;
+use crate::params::CreateDispatchParams;
+
+/// Build the initial projection row for a newly-created dispatch.
+pub(crate) fn params_to_active_model(
+    params: &CreateDispatchParams,
+) -> Result<dispatch_projection::ActiveModel, StoreError> {
+    let dispatch_value = serde_json::to_value(&params.dispatch)?;
+    let actor_value = serde_json::to_value(&params.actor)?;
+
+    let graph_revision =
+        i32::try_from(params.graph_revision.get()).map_err(|_| StoreError::Conversion {
+            context: "dispatch::params_to_active_model",
+            reason: "graph_revision exceeds i32::MAX".to_owned(),
+        })?;
+
+    Ok(dispatch_projection::ActiveModel {
+        dispatch_id: Set(params.dispatch_id.into_uuid()),
+        mode: Set(mode_to_string(params.mode).to_owned()),
+        status: Set(status_to_string(DispatchStatus::Pending).to_owned()),
+        outcome: Set(None),
+        lane: Set(lane_to_string(params.lane).to_owned()),
+        dispatch: Set(dispatch_value),
+        actor: Set(actor_value),
+        graph_revision: Set(graph_revision),
+        user_id: Set(params.actor.user_id.into_uuid()),
+        project: Set(params.dispatch.project.as_str().to_owned()),
+        created_at: Set(params.created_at),
+        updated_at: Set(params.created_at),
+    })
+}
+
+/// Read a projection row back into the domain [`DispatchView`].
+pub(crate) fn model_to_view(model: dispatch_projection::Model) -> Result<DispatchView, StoreError> {
+    let mode = parse_mode(&model.mode)?;
+    let status = parse_status(&model.status)?;
+    let outcome = model.outcome.as_deref().map(parse_outcome).transpose()?;
+    let lane = parse_lane(&model.lane)?;
+
+    let dispatch: DispatchSnapshot =
+        serde_json::from_value(model.dispatch).map_err(|err| StoreError::Conversion {
+            context: "dispatch::model_to_view",
+            reason: format!("dispatch snapshot deserialize failed: {err}"),
+        })?;
+    let actor: ActorContext =
+        serde_json::from_value(model.actor).map_err(|err| StoreError::Conversion {
+            context: "dispatch::model_to_view",
+            reason: format!("actor deserialize failed: {err}"),
+        })?;
+
+    let graph_revision_u32 =
+        u32::try_from(model.graph_revision).map_err(|_| StoreError::Conversion {
+            context: "dispatch::model_to_view",
+            reason: "graph_revision is negative".to_owned(),
+        })?;
+
+    Ok(DispatchView {
+        dispatch_id: DispatchId::from_uuid(model.dispatch_id),
+        mode,
+        status,
+        outcome,
+        lane,
+        dispatch: Box::new(dispatch),
+        actor,
+        graph_revision: GraphRevision::new(graph_revision_u32),
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Small enum <-> string helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn mode_to_string(mode: DispatchMode) -> &'static str {
+    match mode {
+        DispatchMode::Auto => "auto",
+        DispatchMode::Manual => "manual",
+    }
+}
+
+pub(crate) fn status_to_string(status: DispatchStatus) -> &'static str {
+    match status {
+        DispatchStatus::Pending => "pending",
+        DispatchStatus::Running => "running",
+        DispatchStatus::Completed => "completed",
+        DispatchStatus::Failed => "failed",
+        DispatchStatus::Cancelled => "cancelled",
+    }
+}
+
+pub(crate) fn outcome_to_string(outcome: Outcome) -> &'static str {
+    match outcome {
+        Outcome::Success => "success",
+        Outcome::Fail => "fail",
+        Outcome::Blocked => "blocked",
+        Outcome::Error => "error",
+        Outcome::Timeout => "timeout",
+    }
+}
+
+pub(crate) fn lane_to_string(lane: Lane) -> &'static str {
+    match lane {
+        Lane::Impl => "impl",
+        Lane::Audit => "audit",
+        Lane::Gate => "gate",
+    }
+}
+
+pub(crate) fn parse_mode(value: &str) -> Result<DispatchMode, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
+            context: "dispatch::parse_mode",
+            reason: format!("unknown dispatch mode `{value}`: {err}"),
+        }
+    })
+}
+
+pub(crate) fn parse_status(value: &str) -> Result<DispatchStatus, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
+            context: "dispatch::parse_status",
+            reason: format!("unknown dispatch status `{value}`: {err}"),
+        }
+    })
+}
+
+pub(crate) fn parse_outcome(value: &str) -> Result<Outcome, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
+            context: "dispatch::parse_outcome",
+            reason: format!("unknown outcome `{value}`: {err}"),
+        }
+    })
+}
+
+pub(crate) fn parse_lane(value: &str) -> Result<Lane, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
+            context: "dispatch::parse_lane",
+            reason: format!("unknown lane `{value}`: {err}"),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_round_trip() {
+        for mode in [DispatchMode::Auto, DispatchMode::Manual] {
+            let s = mode_to_string(mode);
+            assert_eq!(parse_mode(s).expect("parse"), mode);
+        }
+    }
+
+    #[test]
+    fn status_round_trip() {
+        for status in [
+            DispatchStatus::Pending,
+            DispatchStatus::Running,
+            DispatchStatus::Completed,
+            DispatchStatus::Failed,
+            DispatchStatus::Cancelled,
+        ] {
+            let s = status_to_string(status);
+            assert_eq!(parse_status(s).expect("parse"), status);
+        }
+    }
+
+    #[test]
+    fn lane_round_trip() {
+        for lane in [Lane::Impl, Lane::Audit, Lane::Gate] {
+            let s = lane_to_string(lane);
+            assert_eq!(parse_lane(s).expect("parse"), lane);
+        }
+    }
+
+    #[test]
+    fn outcome_round_trip() {
+        for outcome in [
+            Outcome::Success,
+            Outcome::Fail,
+            Outcome::Blocked,
+            Outcome::Error,
+            Outcome::Timeout,
+        ] {
+            let s = outcome_to_string(outcome);
+            assert_eq!(parse_outcome(s).expect("parse"), outcome);
+        }
+    }
+}

--- a/crates/tanren-store/src/converters/dispatch.rs
+++ b/crates/tanren-store/src/converters/dispatch.rs
@@ -26,10 +26,10 @@ pub(crate) fn params_to_active_model(
 
     Ok(dispatch_projection::ActiveModel {
         dispatch_id: Set(params.dispatch_id.into_uuid()),
-        mode: Set(mode_to_string(params.mode).to_owned()),
-        status: Set(status_to_string(DispatchStatus::Pending).to_owned()),
+        mode: Set(params.mode.to_string()),
+        status: Set(DispatchStatus::Pending.to_string()),
         outcome: Set(None),
-        lane: Set(lane_to_string(params.lane).to_owned()),
+        lane: Set(params.lane.to_string()),
         dispatch: Set(dispatch_value),
         actor: Set(actor_value),
         graph_revision: Set(graph_revision),
@@ -79,43 +79,10 @@ pub(crate) fn model_to_view(model: dispatch_projection::Model) -> Result<Dispatc
 }
 
 // ---------------------------------------------------------------------------
-// Small enum <-> string helpers
+// Enum <-> string helpers — domain `Display` is the source of truth
+// for the write path, serde is the source of truth for the read path.
+// See S-02 in LANE-0.3-AUDIT.md.
 // ---------------------------------------------------------------------------
-
-pub(crate) fn mode_to_string(mode: DispatchMode) -> &'static str {
-    match mode {
-        DispatchMode::Auto => "auto",
-        DispatchMode::Manual => "manual",
-    }
-}
-
-pub(crate) fn status_to_string(status: DispatchStatus) -> &'static str {
-    match status {
-        DispatchStatus::Pending => "pending",
-        DispatchStatus::Running => "running",
-        DispatchStatus::Completed => "completed",
-        DispatchStatus::Failed => "failed",
-        DispatchStatus::Cancelled => "cancelled",
-    }
-}
-
-pub(crate) fn outcome_to_string(outcome: Outcome) -> &'static str {
-    match outcome {
-        Outcome::Success => "success",
-        Outcome::Fail => "fail",
-        Outcome::Blocked => "blocked",
-        Outcome::Error => "error",
-        Outcome::Timeout => "timeout",
-    }
-}
-
-pub(crate) fn lane_to_string(lane: Lane) -> &'static str {
-    match lane {
-        Lane::Impl => "impl",
-        Lane::Audit => "audit",
-        Lane::Gate => "gate",
-    }
-}
 
 pub(crate) fn parse_mode(value: &str) -> Result<DispatchMode, StoreError> {
     serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
@@ -160,8 +127,7 @@ mod tests {
     #[test]
     fn mode_round_trip() {
         for mode in [DispatchMode::Auto, DispatchMode::Manual] {
-            let s = mode_to_string(mode);
-            assert_eq!(parse_mode(s).expect("parse"), mode);
+            assert_eq!(parse_mode(&mode.to_string()).expect("parse"), mode);
         }
     }
 
@@ -174,16 +140,14 @@ mod tests {
             DispatchStatus::Failed,
             DispatchStatus::Cancelled,
         ] {
-            let s = status_to_string(status);
-            assert_eq!(parse_status(s).expect("parse"), status);
+            assert_eq!(parse_status(&status.to_string()).expect("parse"), status);
         }
     }
 
     #[test]
     fn lane_round_trip() {
         for lane in [Lane::Impl, Lane::Audit, Lane::Gate] {
-            let s = lane_to_string(lane);
-            assert_eq!(parse_lane(s).expect("parse"), lane);
+            assert_eq!(parse_lane(&lane.to_string()).expect("parse"), lane);
         }
     }
 
@@ -196,8 +160,31 @@ mod tests {
             Outcome::Error,
             Outcome::Timeout,
         ] {
-            let s = outcome_to_string(outcome);
-            assert_eq!(parse_outcome(s).expect("parse"), outcome);
+            assert_eq!(parse_outcome(&outcome.to_string()).expect("parse"), outcome);
         }
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown_variant() {
+        let err = parse_mode("does_not_exist").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn parse_status_rejects_unknown_variant() {
+        let err = parse_status("not_a_status").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn parse_lane_rejects_unknown_variant() {
+        let err = parse_lane("not_a_lane").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn parse_outcome_rejects_unknown_variant() {
+        let err = parse_outcome("not_an_outcome").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
     }
 }

--- a/crates/tanren-store/src/converters/events.rs
+++ b/crates/tanren-store/src/converters/events.rs
@@ -1,0 +1,235 @@
+//! `EventEnvelope` <-> `events::Model` converters.
+//!
+//! The `entity_kind`, `entity_id`, and `event_type` columns are
+//! derived from the envelope's `entity_ref` and `payload` fields by
+//! round-tripping through `serde_json::Value`. The serde
+//! representation is authoritative — it is the same tag the rest of
+//! the codebase uses when filtering events by type, so deriving it at
+//! the converter boundary guarantees consistency with every query
+//! filter the store accepts.
+
+use sea_orm::ActiveValue::Set;
+use serde_json::Value as JsonValue;
+use tanren_domain::{DomainEvent, EntityRef, EventEnvelope, EventId};
+
+use crate::entity::events;
+use crate::errors::StoreError;
+
+/// Build an [`events::ActiveModel`] from an envelope ready for
+/// `insert`.
+pub(crate) fn envelope_to_active_model(
+    envelope: &EventEnvelope,
+) -> Result<events::ActiveModel, StoreError> {
+    let payload_value = serde_json::to_value(&envelope.payload)?;
+    let event_type = extract_event_type(&payload_value)?;
+
+    let entity_ref_value = serde_json::to_value(envelope.entity_ref)?;
+    let entity_id = extract_entity_id(&entity_ref_value)?;
+    let entity_kind = envelope.entity_ref.kind().to_string();
+
+    let schema_version =
+        i32::try_from(envelope.schema_version).map_err(|_| StoreError::Conversion {
+            context: "events::envelope_to_active_model",
+            reason: "schema_version exceeds i32::MAX".to_owned(),
+        })?;
+
+    Ok(events::ActiveModel {
+        id: sea_orm::ActiveValue::NotSet,
+        event_id: Set(envelope.event_id.into_uuid()),
+        timestamp: Set(envelope.timestamp),
+        entity_kind: Set(entity_kind),
+        entity_id: Set(entity_id),
+        event_type: Set(event_type),
+        schema_version: Set(schema_version),
+        payload: Set(payload_value),
+    })
+}
+
+/// Reconstruct an [`EventEnvelope`] from a row.
+pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, StoreError> {
+    let payload: DomainEvent =
+        serde_json::from_value(model.payload).map_err(|err| StoreError::Conversion {
+            context: "events::model_to_envelope",
+            reason: format!("payload deserialize failed: {err}"),
+        })?;
+
+    // Round-trip `(entity_kind, entity_id)` through the same serde
+    // shape the domain `EntityRef` uses on the wire. Keeps the
+    // reconstruction authoritative against the serde representation.
+    let entity_ref_value = serde_json::json!({
+        "type": model.entity_kind,
+        "id": model.entity_id,
+    });
+    let entity_ref: EntityRef =
+        serde_json::from_value(entity_ref_value).map_err(|err| StoreError::Conversion {
+            context: "events::model_to_envelope",
+            reason: format!("entity_ref reconstruct failed: {err}"),
+        })?;
+
+    let schema_version =
+        u32::try_from(model.schema_version).map_err(|_| StoreError::Conversion {
+            context: "events::model_to_envelope",
+            reason: "schema_version is negative".to_owned(),
+        })?;
+
+    Ok(EventEnvelope {
+        schema_version,
+        event_id: EventId::from_uuid(model.event_id),
+        timestamp: model.timestamp,
+        entity_ref,
+        payload,
+    })
+}
+
+fn extract_event_type(payload: &JsonValue) -> Result<String, StoreError> {
+    payload
+        .get("event_type")
+        .and_then(JsonValue::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| StoreError::Conversion {
+            context: "events::envelope_to_active_model",
+            reason: "serialized payload missing `event_type` discriminant".to_owned(),
+        })
+}
+
+fn extract_entity_id(entity_ref: &JsonValue) -> Result<String, StoreError> {
+    entity_ref
+        .get("id")
+        .and_then(JsonValue::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| StoreError::Conversion {
+            context: "events::envelope_to_active_model",
+            reason: "serialized entity_ref missing `id` field".to_owned(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use sea_orm::ActiveValue;
+    use sea_orm::ActiveValue::{Set as ActiveSet, Unchanged as ActiveUnchanged};
+    use tanren_domain::{
+        ActorContext, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot, FiniteF64,
+        GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, TimeoutSecs, UserId,
+    };
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn snapshot() -> DispatchSnapshot {
+        DispatchSnapshot {
+            project: NonEmptyString::try_new("proj".to_owned()).expect("project"),
+            phase: Phase::DoTask,
+            cli: tanren_domain::Cli::Claude,
+            auth_mode: tanren_domain::AuthMode::ApiKey,
+            branch: NonEmptyString::try_new("main".to_owned()).expect("branch"),
+            spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("spec"),
+            workflow_id: NonEmptyString::try_new("wf".to_owned()).expect("wf"),
+            timeout: TimeoutSecs::try_new(60).expect("timeout"),
+            environment_profile: NonEmptyString::try_new("prof".to_owned()).expect("profile"),
+            gate_cmd: None,
+            context: None,
+            model: None,
+            project_env: ConfigKeys::default(),
+            required_secrets: vec![],
+            preserve_on_failure: false,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn envelope_dispatch_completed() -> EventEnvelope {
+        let dispatch_id = DispatchId::new();
+        EventEnvelope {
+            schema_version: tanren_domain::SCHEMA_VERSION,
+            event_id: EventId::from_uuid(Uuid::now_v7()),
+            timestamp: Utc::now(),
+            entity_ref: EntityRef::Dispatch(dispatch_id),
+            payload: DomainEvent::DispatchCompleted {
+                dispatch_id,
+                outcome: Outcome::Success,
+                total_duration_secs: FiniteF64::try_new(12.5).expect("finite"),
+            },
+        }
+    }
+
+    fn envelope_dispatch_created() -> EventEnvelope {
+        let dispatch_id = DispatchId::new();
+        EventEnvelope {
+            schema_version: tanren_domain::SCHEMA_VERSION,
+            event_id: EventId::from_uuid(Uuid::now_v7()),
+            timestamp: Utc::now(),
+            entity_ref: EntityRef::Dispatch(dispatch_id),
+            payload: DomainEvent::DispatchCreated {
+                dispatch_id,
+                dispatch: Box::new(snapshot()),
+                mode: DispatchMode::Manual,
+                lane: Lane::Impl,
+                actor: ActorContext {
+                    org_id: OrgId::new(),
+                    user_id: UserId::new(),
+                    team_id: None,
+                    api_key_id: None,
+                    project_id: None,
+                },
+                graph_revision: GraphRevision::INITIAL,
+            },
+        }
+    }
+
+    fn unwrap_active<T>(value: ActiveValue<T>) -> T
+    where
+        T: Clone + Into<sea_orm::Value> + sea_orm::sea_query::Nullable,
+    {
+        match value {
+            ActiveSet(v) | ActiveUnchanged(v) => v,
+            ActiveValue::NotSet => unreachable!("active value not set in test"),
+        }
+    }
+
+    fn active_to_model(active: events::ActiveModel) -> events::Model {
+        events::Model {
+            id: 1,
+            event_id: unwrap_active(active.event_id),
+            timestamp: unwrap_active(active.timestamp),
+            entity_kind: unwrap_active(active.entity_kind),
+            entity_id: unwrap_active(active.entity_id),
+            event_type: unwrap_active(active.event_type),
+            schema_version: unwrap_active(active.schema_version),
+            payload: unwrap_active(active.payload),
+        }
+    }
+
+    #[test]
+    fn round_trip_dispatch_completed() {
+        let original = envelope_dispatch_completed();
+        let active = envelope_to_active_model(&original).expect("to active");
+        let model = active_to_model(active);
+        let back = model_to_envelope(model).expect("to envelope");
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn round_trip_dispatch_created() {
+        let original = envelope_dispatch_created();
+        let active = envelope_to_active_model(&original).expect("to active");
+        let model = active_to_model(active);
+        let back = model_to_envelope(model).expect("to envelope");
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn event_type_column_matches_serde_tag() {
+        let original = envelope_dispatch_completed();
+        let active = envelope_to_active_model(&original).expect("to active");
+        let event_type = unwrap_active(active.event_type);
+        assert_eq!(event_type, "dispatch_completed");
+    }
+
+    #[test]
+    fn entity_kind_column_matches_entity_ref_kind() {
+        let original = envelope_dispatch_completed();
+        let active = envelope_to_active_model(&original).expect("to active");
+        let entity_kind = unwrap_active(active.entity_kind);
+        assert_eq!(entity_kind, "dispatch");
+    }
+}

--- a/crates/tanren-store/src/converters/events.rs
+++ b/crates/tanren-store/src/converters/events.rs
@@ -81,6 +81,28 @@ pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, S
     })
 }
 
+/// Validate that an envelope's `entity_ref` matches the expected value.
+///
+/// Called by every store method that accepts a caller-supplied
+/// [`EventEnvelope`] before committing the transaction. This catches
+/// misrouted envelopes early rather than persisting inconsistent
+/// routing metadata.
+pub(crate) fn validate_envelope_entity_ref(
+    envelope: &EventEnvelope,
+    expected: EntityRef,
+) -> Result<(), StoreError> {
+    if envelope.entity_ref != expected {
+        return Err(StoreError::Conversion {
+            context: "envelope validation",
+            reason: format!(
+                "entity_ref mismatch: envelope={}, expected={}",
+                envelope.entity_ref, expected,
+            ),
+        });
+    }
+    Ok(())
+}
+
 fn extract_event_type(payload: &JsonValue) -> Result<String, StoreError> {
     payload
         .get("event_type")

--- a/crates/tanren-store/src/converters/events.rs
+++ b/crates/tanren-store/src/converters/events.rs
@@ -95,50 +95,28 @@ pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, S
     })
 }
 
-/// Validate that a caller-supplied step-event envelope matches the
-/// mutation being committed: correct routing, correct variant, and
-/// correct `step_id`.
-pub(crate) fn validate_step_event(
-    envelope: &EventEnvelope,
-    expected_step_id: tanren_domain::StepId,
-    expected_tag: &str,
-) -> Result<(), StoreError> {
-    validate_routing(envelope)?;
-    let json = serde_json::to_value(&envelope.payload)?;
-    check_event_type(&json, expected_tag)?;
-    check_step_id(&json, expected_step_id)?;
-    Ok(())
-}
-
-/// Validate that a caller-supplied dispatch-event envelope matches
-/// the mutation being committed: correct routing, correct variant,
-/// and correct `dispatch_id`.
-pub(crate) fn validate_dispatch_event(
-    envelope: &EventEnvelope,
-    expected_dispatch_id: tanren_domain::DispatchId,
-    expected_tag: &str,
-) -> Result<(), StoreError> {
-    validate_routing(envelope)?;
-    let json = serde_json::to_value(&envelope.payload)?;
-    check_event_type(&json, expected_tag)?;
-    check_dispatch_id(&json, expected_dispatch_id)?;
-    Ok(())
-}
-
 /// Map a [`DispatchStatus`] to the expected `event_type` tag of its
-/// companion lifecycle event.
-pub(crate) fn dispatch_status_event_tag(status: tanren_domain::DispatchStatus) -> &'static str {
+/// companion lifecycle event. Returns an error for `Pending` because
+/// that status is only set at creation time via
+/// [`create_dispatch_projection`] — there is no valid lifecycle event
+/// that transitions a dispatch *to* `Pending`.
+pub(crate) fn dispatch_status_event_tag(
+    status: tanren_domain::DispatchStatus,
+) -> Result<&'static str, StoreError> {
     match status {
-        tanren_domain::DispatchStatus::Pending | tanren_domain::DispatchStatus::Running => {
-            "dispatch_started"
-        }
-        tanren_domain::DispatchStatus::Completed => "dispatch_completed",
-        tanren_domain::DispatchStatus::Failed => "dispatch_failed",
-        tanren_domain::DispatchStatus::Cancelled => "dispatch_cancelled",
+        tanren_domain::DispatchStatus::Running => Ok("dispatch_started"),
+        tanren_domain::DispatchStatus::Completed => Ok("dispatch_completed"),
+        tanren_domain::DispatchStatus::Failed => Ok("dispatch_failed"),
+        tanren_domain::DispatchStatus::Cancelled => Ok("dispatch_cancelled"),
+        tanren_domain::DispatchStatus::Pending => Err(StoreError::InvalidTransition {
+            entity: "dispatch".to_owned(),
+            from: "any".to_owned(),
+            to: "pending".to_owned(),
+        }),
     }
 }
 
-fn validate_routing(envelope: &EventEnvelope) -> Result<(), StoreError> {
+pub(crate) fn validate_routing(envelope: &EventEnvelope) -> Result<(), StoreError> {
     let canonical = envelope.payload.entity_root();
     if envelope.entity_ref != canonical {
         return Err(StoreError::Conversion {
@@ -146,57 +124,6 @@ fn validate_routing(envelope: &EventEnvelope) -> Result<(), StoreError> {
             reason: format!(
                 "entity_ref mismatch: envelope={}, canonical={}",
                 envelope.entity_ref, canonical,
-            ),
-        });
-    }
-    Ok(())
-}
-
-fn check_event_type(json: &JsonValue, expected: &str) -> Result<(), StoreError> {
-    let actual = json
-        .get("event_type")
-        .and_then(JsonValue::as_str)
-        .unwrap_or("<missing>");
-    if actual != expected {
-        return Err(StoreError::Conversion {
-            context: "envelope validation",
-            reason: format!("expected event_type `{expected}`, got `{actual}`"),
-        });
-    }
-    Ok(())
-}
-
-fn check_step_id(json: &JsonValue, expected: tanren_domain::StepId) -> Result<(), StoreError> {
-    let actual_str = json
-        .get("step_id")
-        .and_then(JsonValue::as_str)
-        .unwrap_or("");
-    let expected_str = expected.into_uuid().to_string();
-    if actual_str != expected_str {
-        return Err(StoreError::Conversion {
-            context: "envelope validation",
-            reason: format!(
-                "step_id mismatch: envelope has `{actual_str}`, expected `{expected_str}`",
-            ),
-        });
-    }
-    Ok(())
-}
-
-fn check_dispatch_id(
-    json: &JsonValue,
-    expected: tanren_domain::DispatchId,
-) -> Result<(), StoreError> {
-    let actual_str = json
-        .get("dispatch_id")
-        .and_then(JsonValue::as_str)
-        .unwrap_or("");
-    let expected_str = expected.into_uuid().to_string();
-    if actual_str != expected_str {
-        return Err(StoreError::Conversion {
-            context: "envelope validation",
-            reason: format!(
-                "dispatch_id mismatch: envelope has `{actual_str}`, expected `{expected_str}`",
             ),
         });
     }
@@ -353,5 +280,11 @@ mod tests {
         let active = envelope_to_active_model(&original).expect("to active");
         let entity_kind = unwrap_active(active.entity_kind);
         assert_eq!(entity_kind, "dispatch");
+    }
+
+    #[test]
+    fn dispatch_status_event_tag_rejects_pending() {
+        let result = dispatch_status_event_tag(tanren_domain::DispatchStatus::Pending);
+        assert!(result.is_err(), "Pending has no lifecycle event tag");
     }
 }

--- a/crates/tanren-store/src/converters/events.rs
+++ b/crates/tanren-store/src/converters/events.rs
@@ -72,6 +72,20 @@ pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, S
             reason: "schema_version is negative".to_owned(),
         })?;
 
+    // Verify the reconstructed entity_ref matches the payload's own
+    // root. If these disagree, the row was written with a misrouted
+    // envelope — surface the inconsistency now rather than returning
+    // a silently corrupt envelope.
+    let expected = EventEnvelope::expected_entity_ref(&payload);
+    if entity_ref != expected {
+        return Err(StoreError::Conversion {
+            context: "events::model_to_envelope",
+            reason: format!(
+                "stored entity_ref ({entity_ref}) disagrees with payload root ({expected})",
+            ),
+        });
+    }
+
     Ok(EventEnvelope {
         schema_version,
         event_id: EventId::from_uuid(model.event_id),
@@ -81,22 +95,21 @@ pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, S
     })
 }
 
-/// Validate that an envelope's `entity_ref` matches the expected value.
+/// Validate that an envelope's `entity_ref` matches the canonical
+/// routing derived from its payload via [`DomainEvent::entity_root`].
 ///
 /// Called by every store method that accepts a caller-supplied
 /// [`EventEnvelope`] before committing the transaction. This catches
 /// misrouted envelopes early rather than persisting inconsistent
 /// routing metadata.
-pub(crate) fn validate_envelope_entity_ref(
-    envelope: &EventEnvelope,
-    expected: EntityRef,
-) -> Result<(), StoreError> {
-    if envelope.entity_ref != expected {
+pub(crate) fn validate_envelope_entity_ref(envelope: &EventEnvelope) -> Result<(), StoreError> {
+    let canonical = envelope.payload.entity_root();
+    if envelope.entity_ref != canonical {
         return Err(StoreError::Conversion {
             context: "envelope validation",
             reason: format!(
-                "entity_ref mismatch: envelope={}, expected={}",
-                envelope.entity_ref, expected,
+                "entity_ref mismatch: envelope={}, canonical={}",
+                envelope.entity_ref, canonical,
             ),
         });
     }

--- a/crates/tanren-store/src/converters/events.rs
+++ b/crates/tanren-store/src/converters/events.rs
@@ -95,14 +95,50 @@ pub(crate) fn model_to_envelope(model: events::Model) -> Result<EventEnvelope, S
     })
 }
 
-/// Validate that an envelope's `entity_ref` matches the canonical
-/// routing derived from its payload via [`DomainEvent::entity_root`].
-///
-/// Called by every store method that accepts a caller-supplied
-/// [`EventEnvelope`] before committing the transaction. This catches
-/// misrouted envelopes early rather than persisting inconsistent
-/// routing metadata.
-pub(crate) fn validate_envelope_entity_ref(envelope: &EventEnvelope) -> Result<(), StoreError> {
+/// Validate that a caller-supplied step-event envelope matches the
+/// mutation being committed: correct routing, correct variant, and
+/// correct `step_id`.
+pub(crate) fn validate_step_event(
+    envelope: &EventEnvelope,
+    expected_step_id: tanren_domain::StepId,
+    expected_tag: &str,
+) -> Result<(), StoreError> {
+    validate_routing(envelope)?;
+    let json = serde_json::to_value(&envelope.payload)?;
+    check_event_type(&json, expected_tag)?;
+    check_step_id(&json, expected_step_id)?;
+    Ok(())
+}
+
+/// Validate that a caller-supplied dispatch-event envelope matches
+/// the mutation being committed: correct routing, correct variant,
+/// and correct `dispatch_id`.
+pub(crate) fn validate_dispatch_event(
+    envelope: &EventEnvelope,
+    expected_dispatch_id: tanren_domain::DispatchId,
+    expected_tag: &str,
+) -> Result<(), StoreError> {
+    validate_routing(envelope)?;
+    let json = serde_json::to_value(&envelope.payload)?;
+    check_event_type(&json, expected_tag)?;
+    check_dispatch_id(&json, expected_dispatch_id)?;
+    Ok(())
+}
+
+/// Map a [`DispatchStatus`] to the expected `event_type` tag of its
+/// companion lifecycle event.
+pub(crate) fn dispatch_status_event_tag(status: tanren_domain::DispatchStatus) -> &'static str {
+    match status {
+        tanren_domain::DispatchStatus::Pending | tanren_domain::DispatchStatus::Running => {
+            "dispatch_started"
+        }
+        tanren_domain::DispatchStatus::Completed => "dispatch_completed",
+        tanren_domain::DispatchStatus::Failed => "dispatch_failed",
+        tanren_domain::DispatchStatus::Cancelled => "dispatch_cancelled",
+    }
+}
+
+fn validate_routing(envelope: &EventEnvelope) -> Result<(), StoreError> {
     let canonical = envelope.payload.entity_root();
     if envelope.entity_ref != canonical {
         return Err(StoreError::Conversion {
@@ -110,6 +146,57 @@ pub(crate) fn validate_envelope_entity_ref(envelope: &EventEnvelope) -> Result<(
             reason: format!(
                 "entity_ref mismatch: envelope={}, canonical={}",
                 envelope.entity_ref, canonical,
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn check_event_type(json: &JsonValue, expected: &str) -> Result<(), StoreError> {
+    let actual = json
+        .get("event_type")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("<missing>");
+    if actual != expected {
+        return Err(StoreError::Conversion {
+            context: "envelope validation",
+            reason: format!("expected event_type `{expected}`, got `{actual}`"),
+        });
+    }
+    Ok(())
+}
+
+fn check_step_id(json: &JsonValue, expected: tanren_domain::StepId) -> Result<(), StoreError> {
+    let actual_str = json
+        .get("step_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    let expected_str = expected.into_uuid().to_string();
+    if actual_str != expected_str {
+        return Err(StoreError::Conversion {
+            context: "envelope validation",
+            reason: format!(
+                "step_id mismatch: envelope has `{actual_str}`, expected `{expected_str}`",
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn check_dispatch_id(
+    json: &JsonValue,
+    expected: tanren_domain::DispatchId,
+) -> Result<(), StoreError> {
+    let actual_str = json
+        .get("dispatch_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    let expected_str = expected.into_uuid().to_string();
+    if actual_str != expected_str {
+        return Err(StoreError::Conversion {
+            context: "envelope validation",
+            reason: format!(
+                "dispatch_id mismatch: envelope has `{actual_str}`, expected `{expected_str}`",
             ),
         });
     }

--- a/crates/tanren-store/src/converters/mod.rs
+++ b/crates/tanren-store/src/converters/mod.rs
@@ -1,0 +1,18 @@
+//! Map between `SeaORM` entity `Model` rows and `tanren-domain` types.
+//!
+//! Infallible directions (domain → `ActiveModel`) use [`From`]. Fallible
+//! directions (`Model` → domain types, where malformed JSON is possible
+//! in principle) use [`TryFrom`] returning [`crate::StoreError`]. This
+//! keeps the trait implementations free of conversion boilerplate and
+//! funnels every failure through [`StoreError::Conversion`].
+//!
+//! Every converter uses the `serde_json::Value` path (never string
+//! intermediate) — Lane 0.2's `event_value_roundtrip` test certifies
+//! that every domain variant survives this path losslessly, and it's
+//! the exact API `SeaORM` uses for `JsonBinary` columns.
+//!
+//! [`StoreError::Conversion`]: crate::StoreError::Conversion
+
+pub(crate) mod dispatch;
+pub(crate) mod events;
+pub(crate) mod step;

--- a/crates/tanren-store/src/converters/mod.rs
+++ b/crates/tanren-store/src/converters/mod.rs
@@ -16,3 +16,4 @@
 pub(crate) mod dispatch;
 pub(crate) mod events;
 pub(crate) mod step;
+pub(crate) mod validate;

--- a/crates/tanren-store/src/converters/step.rs
+++ b/crates/tanren-store/src/converters/step.rs
@@ -1,0 +1,276 @@
+//! Step-projection converters.
+//!
+//! Covers both the projection-row direction (domain → `ActiveModel` for
+//! inserts / Model → `StepView` for reads) and the queue direction
+//! (Model → [`QueuedStep`](crate::params::QueuedStep) for dequeue).
+//! Every enum column round-trips through exhaustive helpers defined
+//! here rather than through the serde string path, so the
+//! `snake_case` spelling is authoritative and checked at compile time.
+
+use sea_orm::ActiveValue::Set;
+use tanren_domain::{
+    DispatchId, GraphRevision, StepId, StepPayload, StepReadyState, StepResult, StepStatus,
+    StepType, StepView,
+};
+
+use crate::entity::step_projection;
+use crate::errors::StoreError;
+use crate::params::{EnqueueStepParams, QueuedStep};
+
+/// Build an [`step_projection::ActiveModel`] from
+/// [`EnqueueStepParams`] ready for insert.
+pub(crate) fn enqueue_to_active_model(
+    params: &EnqueueStepParams,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<step_projection::ActiveModel, StoreError> {
+    let payload_value = serde_json::to_value(&params.payload)?;
+    let depends_on_value = serde_json::to_value(&params.depends_on)?;
+    let graph_revision =
+        i32::try_from(params.graph_revision.get()).map_err(|_| StoreError::Conversion {
+            context: "step::enqueue_to_active_model",
+            reason: "graph_revision exceeds i32::MAX".to_owned(),
+        })?;
+    let step_sequence =
+        i32::try_from(params.step_sequence).map_err(|_| StoreError::Conversion {
+            context: "step::enqueue_to_active_model",
+            reason: "step_sequence exceeds i32::MAX".to_owned(),
+        })?;
+
+    Ok(step_projection::ActiveModel {
+        step_id: Set(params.step_id.into_uuid()),
+        dispatch_id: Set(params.dispatch_id.into_uuid()),
+        step_type: Set(step_type_to_string(params.step_type).to_owned()),
+        step_sequence: Set(step_sequence),
+        lane: Set(params
+            .lane
+            .map(|l| super::dispatch::lane_to_string(l).to_owned())),
+        status: Set(step_status_to_string(StepStatus::Pending).to_owned()),
+        ready_state: Set(ready_state_to_string(params.ready_state).to_owned()),
+        depends_on: Set(depends_on_value),
+        graph_revision: Set(graph_revision),
+        worker_id: Set(None),
+        payload: Set(Some(payload_value)),
+        result: Set(None),
+        error: Set(None),
+        retry_count: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+    })
+}
+
+/// Read a projection row back into the domain [`StepView`].
+pub(crate) fn model_to_view(model: step_projection::Model) -> Result<StepView, StoreError> {
+    let step_type = parse_step_type(&model.step_type)?;
+    let status = parse_step_status(&model.status)?;
+    let ready_state = parse_ready_state(&model.ready_state)?;
+    let lane = model
+        .lane
+        .as_deref()
+        .map(super::dispatch::parse_lane)
+        .transpose()?;
+
+    let depends_on: Vec<StepId> =
+        serde_json::from_value(model.depends_on).map_err(|err| StoreError::Conversion {
+            context: "step::model_to_view",
+            reason: format!("depends_on deserialize failed: {err}"),
+        })?;
+
+    let payload = model
+        .payload
+        .map(serde_json::from_value::<StepPayload>)
+        .transpose()
+        .map_err(|err| StoreError::Conversion {
+            context: "step::model_to_view",
+            reason: format!("payload deserialize failed: {err}"),
+        })?;
+
+    let result = model
+        .result
+        .map(serde_json::from_value::<StepResult>)
+        .transpose()
+        .map_err(|err| StoreError::Conversion {
+            context: "step::model_to_view",
+            reason: format!("result deserialize failed: {err}"),
+        })?;
+
+    let graph_revision_u32 =
+        u32::try_from(model.graph_revision).map_err(|_| StoreError::Conversion {
+            context: "step::model_to_view",
+            reason: "graph_revision is negative".to_owned(),
+        })?;
+    let step_sequence = u32::try_from(model.step_sequence).map_err(|_| StoreError::Conversion {
+        context: "step::model_to_view",
+        reason: "step_sequence is negative".to_owned(),
+    })?;
+    let retry_count = u32::try_from(model.retry_count).map_err(|_| StoreError::Conversion {
+        context: "step::model_to_view",
+        reason: "retry_count is negative".to_owned(),
+    })?;
+
+    Ok(StepView {
+        step_id: StepId::from_uuid(model.step_id),
+        dispatch_id: DispatchId::from_uuid(model.dispatch_id),
+        step_type,
+        step_sequence,
+        lane,
+        status,
+        ready_state,
+        depends_on,
+        graph_revision: GraphRevision::new(graph_revision_u32),
+        worker_id: model.worker_id,
+        payload,
+        result,
+        error: model.error,
+        retry_count,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}
+
+/// Read a projection row into a [`QueuedStep`] shape for the dequeue
+/// path. Populated from the same columns as `StepView`, but drops the
+/// fields a worker handing off a task does not need (status, result,
+/// retry count, timestamps).
+pub(crate) fn model_to_queued_step(
+    model: step_projection::Model,
+) -> Result<QueuedStep, StoreError> {
+    let step_type = parse_step_type(&model.step_type)?;
+    let lane = model
+        .lane
+        .as_deref()
+        .map(super::dispatch::parse_lane)
+        .transpose()?;
+    let step_sequence = u32::try_from(model.step_sequence).map_err(|_| StoreError::Conversion {
+        context: "step::model_to_queued_step",
+        reason: "step_sequence is negative".to_owned(),
+    })?;
+    let payload = model
+        .payload
+        .ok_or_else(|| StoreError::Conversion {
+            context: "step::model_to_queued_step",
+            reason: "queued step missing payload".to_owned(),
+        })
+        .and_then(|value| {
+            serde_json::from_value::<StepPayload>(value).map_err(|err| StoreError::Conversion {
+                context: "step::model_to_queued_step",
+                reason: format!("payload deserialize failed: {err}"),
+            })
+        })?;
+
+    Ok(QueuedStep {
+        step_id: StepId::from_uuid(model.step_id),
+        dispatch_id: DispatchId::from_uuid(model.dispatch_id),
+        step_type,
+        step_sequence,
+        lane,
+        payload,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Enum <-> string helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn step_type_to_string(kind: StepType) -> &'static str {
+    match kind {
+        StepType::Provision => "provision",
+        StepType::Execute => "execute",
+        StepType::Teardown => "teardown",
+        StepType::DryRun => "dry_run",
+    }
+}
+
+pub(crate) fn step_status_to_string(status: StepStatus) -> &'static str {
+    match status {
+        StepStatus::Pending => "pending",
+        StepStatus::Running => "running",
+        StepStatus::Completed => "completed",
+        StepStatus::Failed => "failed",
+        StepStatus::Cancelled => "cancelled",
+    }
+}
+
+pub(crate) fn ready_state_to_string(state: StepReadyState) -> &'static str {
+    match state {
+        StepReadyState::Blocked => "blocked",
+        StepReadyState::Ready => "ready",
+    }
+}
+
+pub(crate) fn parse_step_type(value: &str) -> Result<StepType, StoreError> {
+    match value {
+        "provision" => Ok(StepType::Provision),
+        "execute" => Ok(StepType::Execute),
+        "teardown" => Ok(StepType::Teardown),
+        "dry_run" => Ok(StepType::DryRun),
+        other => Err(StoreError::Conversion {
+            context: "step::parse_step_type",
+            reason: format!("unknown step type `{other}`"),
+        }),
+    }
+}
+
+pub(crate) fn parse_step_status(value: &str) -> Result<StepStatus, StoreError> {
+    match value {
+        "pending" => Ok(StepStatus::Pending),
+        "running" => Ok(StepStatus::Running),
+        "completed" => Ok(StepStatus::Completed),
+        "failed" => Ok(StepStatus::Failed),
+        "cancelled" => Ok(StepStatus::Cancelled),
+        other => Err(StoreError::Conversion {
+            context: "step::parse_step_status",
+            reason: format!("unknown step status `{other}`"),
+        }),
+    }
+}
+
+pub(crate) fn parse_ready_state(value: &str) -> Result<StepReadyState, StoreError> {
+    match value {
+        "blocked" => Ok(StepReadyState::Blocked),
+        "ready" => Ok(StepReadyState::Ready),
+        other => Err(StoreError::Conversion {
+            context: "step::parse_ready_state",
+            reason: format!("unknown ready state `{other}`"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_type_round_trip() {
+        for kind in [
+            StepType::Provision,
+            StepType::Execute,
+            StepType::Teardown,
+            StepType::DryRun,
+        ] {
+            let s = step_type_to_string(kind);
+            assert_eq!(parse_step_type(s).expect("parse"), kind);
+        }
+    }
+
+    #[test]
+    fn step_status_round_trip() {
+        for status in [
+            StepStatus::Pending,
+            StepStatus::Running,
+            StepStatus::Completed,
+            StepStatus::Failed,
+            StepStatus::Cancelled,
+        ] {
+            let s = step_status_to_string(status);
+            assert_eq!(parse_step_status(s).expect("parse"), status);
+        }
+    }
+
+    #[test]
+    fn ready_state_round_trip() {
+        for state in [StepReadyState::Blocked, StepReadyState::Ready] {
+            let s = ready_state_to_string(state);
+            assert_eq!(parse_ready_state(s).expect("parse"), state);
+        }
+    }
+}

--- a/crates/tanren-store/src/converters/step.rs
+++ b/crates/tanren-store/src/converters/step.rs
@@ -39,13 +39,11 @@ pub(crate) fn enqueue_to_active_model(
     Ok(step_projection::ActiveModel {
         step_id: Set(params.step_id.into_uuid()),
         dispatch_id: Set(params.dispatch_id.into_uuid()),
-        step_type: Set(step_type_to_string(params.step_type).to_owned()),
+        step_type: Set(params.step_type.to_string()),
         step_sequence: Set(step_sequence),
-        lane: Set(params
-            .lane
-            .map(|l| super::dispatch::lane_to_string(l).to_owned())),
-        status: Set(step_status_to_string(StepStatus::Pending).to_owned()),
-        ready_state: Set(ready_state_to_string(params.ready_state).to_owned()),
+        lane: Set(params.lane.map(|l| l.to_string())),
+        status: Set(StepStatus::Pending.to_string()),
+        ready_state: Set(params.ready_state.to_string()),
         depends_on: Set(depends_on_value),
         graph_revision: Set(graph_revision),
         worker_id: Set(None),
@@ -53,6 +51,7 @@ pub(crate) fn enqueue_to_active_model(
         result: Set(None),
         error: Set(None),
         retry_count: Set(0),
+        last_heartbeat_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     })
@@ -169,70 +168,43 @@ pub(crate) fn model_to_queued_step(
 
 // ---------------------------------------------------------------------------
 // Enum <-> string helpers
+//
+// Write path: use the domain `Display` impl directly
+// (`enum.to_string()`). Every persisted enum already renders as the
+// canonical snake_case tag, so there is no store-local mapping to
+// maintain and adding a new domain variant does not require editing
+// this file. See S-02 in LANE-0.3-AUDIT.md.
+//
+// Read path: parse via `serde_json::from_value(Value::String(...))`
+// so the same `#[serde(rename_all = "snake_case")]` impl the domain
+// uses on the wire is the source of truth.
 // ---------------------------------------------------------------------------
 
-pub(crate) fn step_type_to_string(kind: StepType) -> &'static str {
-    match kind {
-        StepType::Provision => "provision",
-        StepType::Execute => "execute",
-        StepType::Teardown => "teardown",
-        StepType::DryRun => "dry_run",
-    }
-}
-
-pub(crate) fn step_status_to_string(status: StepStatus) -> &'static str {
-    match status {
-        StepStatus::Pending => "pending",
-        StepStatus::Running => "running",
-        StepStatus::Completed => "completed",
-        StepStatus::Failed => "failed",
-        StepStatus::Cancelled => "cancelled",
-    }
-}
-
-pub(crate) fn ready_state_to_string(state: StepReadyState) -> &'static str {
-    match state {
-        StepReadyState::Blocked => "blocked",
-        StepReadyState::Ready => "ready",
-    }
-}
-
 pub(crate) fn parse_step_type(value: &str) -> Result<StepType, StoreError> {
-    match value {
-        "provision" => Ok(StepType::Provision),
-        "execute" => Ok(StepType::Execute),
-        "teardown" => Ok(StepType::Teardown),
-        "dry_run" => Ok(StepType::DryRun),
-        other => Err(StoreError::Conversion {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
             context: "step::parse_step_type",
-            reason: format!("unknown step type `{other}`"),
-        }),
-    }
+            reason: format!("unknown step type `{value}`: {err}"),
+        }
+    })
 }
 
 pub(crate) fn parse_step_status(value: &str) -> Result<StepStatus, StoreError> {
-    match value {
-        "pending" => Ok(StepStatus::Pending),
-        "running" => Ok(StepStatus::Running),
-        "completed" => Ok(StepStatus::Completed),
-        "failed" => Ok(StepStatus::Failed),
-        "cancelled" => Ok(StepStatus::Cancelled),
-        other => Err(StoreError::Conversion {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
             context: "step::parse_step_status",
-            reason: format!("unknown step status `{other}`"),
-        }),
-    }
+            reason: format!("unknown step status `{value}`: {err}"),
+        }
+    })
 }
 
 pub(crate) fn parse_ready_state(value: &str) -> Result<StepReadyState, StoreError> {
-    match value {
-        "blocked" => Ok(StepReadyState::Blocked),
-        "ready" => Ok(StepReadyState::Ready),
-        other => Err(StoreError::Conversion {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|err| {
+        StoreError::Conversion {
             context: "step::parse_ready_state",
-            reason: format!("unknown ready state `{other}`"),
-        }),
-    }
+            reason: format!("unknown ready state `{value}`: {err}"),
+        }
+    })
 }
 
 #[cfg(test)]
@@ -247,8 +219,7 @@ mod tests {
             StepType::Teardown,
             StepType::DryRun,
         ] {
-            let s = step_type_to_string(kind);
-            assert_eq!(parse_step_type(s).expect("parse"), kind);
+            assert_eq!(parse_step_type(&kind.to_string()).expect("parse"), kind);
         }
     }
 
@@ -261,16 +232,35 @@ mod tests {
             StepStatus::Failed,
             StepStatus::Cancelled,
         ] {
-            let s = step_status_to_string(status);
-            assert_eq!(parse_step_status(s).expect("parse"), status);
+            assert_eq!(
+                parse_step_status(&status.to_string()).expect("parse"),
+                status
+            );
         }
     }
 
     #[test]
     fn ready_state_round_trip() {
         for state in [StepReadyState::Blocked, StepReadyState::Ready] {
-            let s = ready_state_to_string(state);
-            assert_eq!(parse_ready_state(s).expect("parse"), state);
+            assert_eq!(parse_ready_state(&state.to_string()).expect("parse"), state);
         }
+    }
+
+    #[test]
+    fn parse_step_type_rejects_unknown_variant() {
+        let err = parse_step_type("not_a_type").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn parse_step_status_rejects_unknown_variant() {
+        let err = parse_step_status("not_a_status").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn parse_ready_state_rejects_unknown_variant() {
+        let err = parse_ready_state("not_a_state").expect_err("should fail");
+        assert!(matches!(err, StoreError::Conversion { .. }));
     }
 }

--- a/crates/tanren-store/src/converters/validate.rs
+++ b/crates/tanren-store/src/converters/validate.rs
@@ -1,0 +1,490 @@
+//! Method-specific envelope validators.
+//!
+//! Each validator matches on the [`DomainEvent`] variant carried by the
+//! params' envelope and compares **every overlapping field** against the
+//! params struct that drives the projection write. This guarantees that
+//! the event appended co-transactionally with a projection mutation is
+//! semantically identical to it — not just routed to the same entity,
+//! but carrying the same data.
+//!
+//! Fields that exist only in the event (e.g. `duration_secs` in
+//! `StepCompleted`) and have no counterpart in the params struct are
+//! left unchecked — the store has no ground truth to compare them
+//! against.
+
+use tanren_domain::DomainEvent;
+
+use super::events::{dispatch_status_event_tag, validate_routing};
+use crate::errors::StoreError;
+use crate::params::{
+    AckAndEnqueueParams, AckParams, CreateDispatchParams, EnqueueStepParams, NackParams,
+    UpdateDispatchStatusParams,
+};
+
+/// Validate that an [`EnqueueStepParams`]'s envelope carries a
+/// `StepEnqueued` payload whose fields match the params that build the
+/// projection row.
+pub(crate) fn validate_enqueue_step(params: &EnqueueStepParams) -> Result<(), StoreError> {
+    validate_routing(&params.enqueue_event)?;
+    match &params.enqueue_event.payload {
+        DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type,
+            step_sequence,
+            lane,
+            depends_on,
+            graph_revision,
+        } => {
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.step_id == *step_id, "step_id")?;
+            check(params.step_type == *step_type, "step_type")?;
+            check(params.step_sequence == *step_sequence, "step_sequence")?;
+            check(params.lane == *lane, "lane")?;
+            check(params.depends_on == *depends_on, "depends_on")?;
+            check(params.graph_revision == *graph_revision, "graph_revision")?;
+            Ok(())
+        }
+        other => Err(wrong_variant("step_enqueued", other)),
+    }
+}
+
+/// Validate that an [`AckParams`]'s envelope carries a `StepCompleted`
+/// payload whose overlapping fields match the params.
+pub(crate) fn validate_ack(params: &AckParams) -> Result<(), StoreError> {
+    validate_routing(&params.completion_event)?;
+    match &params.completion_event.payload {
+        DomainEvent::StepCompleted {
+            dispatch_id,
+            step_id,
+            step_type,
+            result_payload,
+            ..
+        } => {
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.step_id == *step_id, "step_id")?;
+            check(params.step_type == *step_type, "step_type")?;
+            check(params.result == **result_payload, "result_payload")?;
+            Ok(())
+        }
+        other => Err(wrong_variant("step_completed", other)),
+    }
+}
+
+/// Validate that an [`AckAndEnqueueParams`]'s completion envelope
+/// matches the completion fields, and that the optional next-step
+/// envelope matches its enqueue params.
+pub(crate) fn validate_ack_and_enqueue(params: &AckAndEnqueueParams) -> Result<(), StoreError> {
+    validate_routing(&params.completion_event)?;
+    match &params.completion_event.payload {
+        DomainEvent::StepCompleted {
+            dispatch_id,
+            step_id,
+            step_type,
+            result_payload,
+            ..
+        } => {
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.step_id == *step_id, "step_id")?;
+            check(params.step_type == *step_type, "step_type")?;
+            check(params.result == **result_payload, "result_payload")?;
+        }
+        other => return Err(wrong_variant("step_completed", other)),
+    }
+    if let Some(ref next) = params.next_step {
+        validate_enqueue_step(next)?;
+        check(
+            params.dispatch_id == next.dispatch_id,
+            "next_step.dispatch_id must match params.dispatch_id",
+        )?;
+    }
+    Ok(())
+}
+
+/// Validate that a [`NackParams`]'s envelope carries a `StepFailed`
+/// payload whose overlapping fields match the params.
+pub(crate) fn validate_nack(params: &NackParams) -> Result<(), StoreError> {
+    validate_routing(&params.failure_event)?;
+    match &params.failure_event.payload {
+        DomainEvent::StepFailed {
+            dispatch_id,
+            step_id,
+            step_type,
+            error,
+            error_class,
+            ..
+        } => {
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.step_id == *step_id, "step_id")?;
+            check(params.step_type == *step_type, "step_type")?;
+            check(params.error == *error, "error")?;
+            check(params.error_class == *error_class, "error_class")?;
+            Ok(())
+        }
+        other => Err(wrong_variant("step_failed", other)),
+    }
+}
+
+/// Validate that a [`CreateDispatchParams`]'s envelope carries a
+/// `DispatchCreated` payload whose fields match the params.
+pub(crate) fn validate_create_dispatch(params: &CreateDispatchParams) -> Result<(), StoreError> {
+    validate_routing(&params.creation_event)?;
+    match &params.creation_event.payload {
+        DomainEvent::DispatchCreated {
+            dispatch_id,
+            dispatch,
+            mode,
+            lane,
+            actor,
+            graph_revision,
+        } => {
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.dispatch == **dispatch, "dispatch")?;
+            check(params.mode == *mode, "mode")?;
+            check(params.lane == *lane, "lane")?;
+            check(params.actor == *actor, "actor")?;
+            check(params.graph_revision == *graph_revision, "graph_revision")?;
+            Ok(())
+        }
+        other => Err(wrong_variant("dispatch_created", other)),
+    }
+}
+
+/// Validate that an [`UpdateDispatchStatusParams`]'s envelope carries
+/// the lifecycle event matching the target status, with a consistent
+/// outcome where applicable.
+pub(crate) fn validate_update_dispatch_status(
+    params: &UpdateDispatchStatusParams,
+) -> Result<(), StoreError> {
+    let expected_tag = dispatch_status_event_tag(params.status)?;
+    validate_routing(&params.status_event)?;
+    match &params.status_event.payload {
+        DomainEvent::DispatchStarted { dispatch_id } => {
+            check(expected_tag == "dispatch_started", "event_type")?;
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.outcome.is_none(), "outcome")?;
+            Ok(())
+        }
+        DomainEvent::DispatchCompleted {
+            dispatch_id,
+            outcome,
+            ..
+        } => {
+            check(expected_tag == "dispatch_completed", "event_type")?;
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.outcome == Some(*outcome), "outcome")?;
+            Ok(())
+        }
+        DomainEvent::DispatchFailed {
+            dispatch_id,
+            outcome,
+            ..
+        } => {
+            check(expected_tag == "dispatch_failed", "event_type")?;
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.outcome == Some(*outcome), "outcome")?;
+            Ok(())
+        }
+        DomainEvent::DispatchCancelled { dispatch_id, .. } => {
+            check(expected_tag == "dispatch_cancelled", "event_type")?;
+            check(params.dispatch_id == *dispatch_id, "dispatch_id")?;
+            check(params.outcome.is_none(), "outcome")?;
+            Ok(())
+        }
+        other => Err(wrong_variant(expected_tag, other)),
+    }
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+fn check(ok: bool, field: &str) -> Result<(), StoreError> {
+    if ok {
+        Ok(())
+    } else {
+        Err(StoreError::Conversion {
+            context: "envelope validation",
+            reason: format!("{field} mismatch between params and event payload"),
+        })
+    }
+}
+
+fn wrong_variant(expected: &str, actual: &DomainEvent) -> StoreError {
+    let actual_tag = serde_json::to_value(actual)
+        .ok()
+        .and_then(|v| {
+            v.get("event_type")
+                .and_then(|t| t.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_else(|| "<unknown>".to_owned());
+    StoreError::Conversion {
+        context: "envelope validation",
+        reason: format!("expected event_type `{expected}`, got `{actual_tag}`"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use tanren_domain::{
+        ActorContext, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot, DispatchStatus,
+        ErrorClass, EventEnvelope, EventId, FiniteF64, GraphRevision, Lane, NonEmptyString,
+        Outcome, Phase, StepId, StepType, TimeoutSecs,
+    };
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::params::{AckParams, EnqueueStepParams, NackParams};
+
+    fn snap() -> DispatchSnapshot {
+        DispatchSnapshot {
+            project: NonEmptyString::try_new("p".to_owned()).expect("p"),
+            phase: Phase::DoTask,
+            cli: tanren_domain::Cli::Claude,
+            auth_mode: tanren_domain::AuthMode::ApiKey,
+            branch: NonEmptyString::try_new("main".to_owned()).expect("b"),
+            spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("s"),
+            workflow_id: NonEmptyString::try_new("wf".to_owned()).expect("w"),
+            timeout: TimeoutSecs::try_new(60).expect("t"),
+            environment_profile: NonEmptyString::try_new("d".to_owned()).expect("e"),
+            gate_cmd: None,
+            context: None,
+            model: None,
+            project_env: ConfigKeys::default(),
+            required_secrets: vec![],
+            preserve_on_failure: false,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn actor() -> ActorContext {
+        ActorContext {
+            org_id: tanren_domain::OrgId::new(),
+            user_id: tanren_domain::UserId::new(),
+            team_id: None,
+            api_key_id: None,
+            project_id: None,
+        }
+    }
+
+    fn evt(payload: DomainEvent) -> EventEnvelope {
+        EventEnvelope::new(EventId::from_uuid(Uuid::now_v7()), Utc::now(), payload)
+    }
+
+    fn test_result() -> tanren_domain::StepResult {
+        tanren_domain::StepResult::Provision(Box::new(tanren_domain::ProvisionResult {
+            handle: tanren_domain::EnvironmentHandle {
+                id: NonEmptyString::try_new("h".to_owned()).expect("h"),
+                runtime_type: NonEmptyString::try_new("local".to_owned()).expect("rt"),
+            },
+        }))
+    }
+
+    // ---- enqueue_step ---------------------------------------------------
+
+    #[test]
+    fn enqueue_step_accepts_matching_fields() {
+        let did = DispatchId::new();
+        let sid = StepId::new();
+        let params = EnqueueStepParams {
+            dispatch_id: did,
+            step_id: sid,
+            step_type: StepType::Execute,
+            step_sequence: 0,
+            lane: Some(Lane::Impl),
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+            payload: tanren_domain::StepPayload::Provision(Box::new(
+                tanren_domain::ProvisionPayload { dispatch: snap() },
+            )),
+            ready_state: tanren_domain::StepReadyState::Ready,
+            enqueue_event: evt(DomainEvent::StepEnqueued {
+                dispatch_id: did,
+                step_id: sid,
+                step_type: StepType::Execute,
+                step_sequence: 0,
+                lane: Some(Lane::Impl),
+                depends_on: vec![],
+                graph_revision: GraphRevision::INITIAL,
+            }),
+        };
+        assert!(validate_enqueue_step(&params).is_ok());
+    }
+
+    #[test]
+    fn enqueue_step_rejects_step_type_mismatch() {
+        let did = DispatchId::new();
+        let sid = StepId::new();
+        let params = EnqueueStepParams {
+            dispatch_id: did,
+            step_id: sid,
+            step_type: StepType::Execute,
+            step_sequence: 0,
+            lane: None,
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+            payload: tanren_domain::StepPayload::Provision(Box::new(
+                tanren_domain::ProvisionPayload { dispatch: snap() },
+            )),
+            ready_state: tanren_domain::StepReadyState::Ready,
+            enqueue_event: evt(DomainEvent::StepEnqueued {
+                dispatch_id: did,
+                step_id: sid,
+                step_type: StepType::Provision, // mismatch
+                step_sequence: 0,
+                lane: None,
+                depends_on: vec![],
+                graph_revision: GraphRevision::INITIAL,
+            }),
+        };
+        let err = validate_enqueue_step(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    #[test]
+    fn enqueue_step_rejects_wrong_variant() {
+        let did = DispatchId::new();
+        let sid = StepId::new();
+        let params = EnqueueStepParams {
+            dispatch_id: did,
+            step_id: sid,
+            step_type: StepType::Execute,
+            step_sequence: 0,
+            lane: None,
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+            payload: tanren_domain::StepPayload::Provision(Box::new(
+                tanren_domain::ProvisionPayload { dispatch: snap() },
+            )),
+            ready_state: tanren_domain::StepReadyState::Ready,
+            enqueue_event: evt(DomainEvent::StepCompleted {
+                dispatch_id: did,
+                step_id: sid,
+                step_type: StepType::Execute,
+                duration_secs: FiniteF64::try_new(1.0).expect("f"),
+                result_payload: Box::new(test_result()),
+            }),
+        };
+        let err = validate_enqueue_step(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    // ---- ack ------------------------------------------------------------
+
+    #[test]
+    fn ack_rejects_result_mismatch() {
+        let did = DispatchId::new();
+        let sid = StepId::new();
+        let result_a = test_result();
+        // Different handle id => different result
+        let result_b =
+            tanren_domain::StepResult::Provision(Box::new(tanren_domain::ProvisionResult {
+                handle: tanren_domain::EnvironmentHandle {
+                    id: NonEmptyString::try_new("other".to_owned()).expect("o"),
+                    runtime_type: NonEmptyString::try_new("local".to_owned()).expect("rt"),
+                },
+            }));
+        let params = AckParams {
+            dispatch_id: did,
+            step_id: sid,
+            step_type: StepType::Provision,
+            result: result_a,
+            completion_event: evt(DomainEvent::StepCompleted {
+                dispatch_id: did,
+                step_id: sid,
+                step_type: StepType::Provision,
+                duration_secs: FiniteF64::try_new(1.0).expect("f"),
+                result_payload: Box::new(result_b),
+            }),
+        };
+        let err = validate_ack(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    // ---- nack -----------------------------------------------------------
+
+    #[test]
+    fn nack_rejects_error_class_mismatch() {
+        let did = DispatchId::new();
+        let sid = StepId::new();
+        let params = NackParams {
+            dispatch_id: did,
+            step_id: sid,
+            step_type: StepType::Execute,
+            error: "boom".to_owned(),
+            error_class: ErrorClass::Transient,
+            retry: false,
+            failure_event: evt(DomainEvent::StepFailed {
+                dispatch_id: did,
+                step_id: sid,
+                step_type: StepType::Execute,
+                error: "boom".to_owned(),
+                error_class: ErrorClass::Fatal, // mismatch
+                retry_count: 0,
+                duration_secs: FiniteF64::try_new(1.0).expect("f"),
+            }),
+        };
+        let err = validate_nack(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    // ---- create_dispatch ------------------------------------------------
+
+    #[test]
+    fn create_dispatch_rejects_mode_mismatch() {
+        let did = DispatchId::new();
+        let s = snap();
+        let a = actor();
+        let params = CreateDispatchParams {
+            dispatch_id: did,
+            mode: DispatchMode::Manual,
+            lane: Lane::Impl,
+            dispatch: s.clone(),
+            actor: a.clone(),
+            graph_revision: GraphRevision::INITIAL,
+            created_at: Utc::now(),
+            creation_event: evt(DomainEvent::DispatchCreated {
+                dispatch_id: did,
+                dispatch: Box::new(s),
+                mode: DispatchMode::Auto, // mismatch
+                lane: Lane::Impl,
+                actor: a,
+                graph_revision: GraphRevision::INITIAL,
+            }),
+        };
+        let err = validate_create_dispatch(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+
+    // ---- update_dispatch_status -----------------------------------------
+
+    #[test]
+    fn update_dispatch_status_rejects_pending() {
+        let did = DispatchId::new();
+        let params = UpdateDispatchStatusParams {
+            dispatch_id: did,
+            status: DispatchStatus::Pending,
+            outcome: None,
+            status_event: evt(DomainEvent::DispatchStarted { dispatch_id: did }),
+        };
+        let err = validate_update_dispatch_status(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn update_dispatch_status_rejects_outcome_mismatch() {
+        let did = DispatchId::new();
+        let params = UpdateDispatchStatusParams {
+            dispatch_id: did,
+            status: DispatchStatus::Completed,
+            outcome: Some(Outcome::Fail),
+            status_event: evt(DomainEvent::DispatchCompleted {
+                dispatch_id: did,
+                outcome: Outcome::Success, // mismatch
+                total_duration_secs: FiniteF64::try_new(1.0).expect("f"),
+            }),
+        };
+        let err = validate_update_dispatch_status(&params).expect_err("should reject");
+        assert!(matches!(err, StoreError::Conversion { .. }));
+    }
+}

--- a/crates/tanren-store/src/entity/dispatch_projection.rs
+++ b/crates/tanren-store/src/entity/dispatch_projection.rs
@@ -1,0 +1,74 @@
+//! `dispatch_projection` table — materialized view of dispatch state.
+//!
+//! One row per dispatch. Carries everything `StateStore::get_dispatch`
+//! needs to return a [`DispatchView`](tanren_domain::DispatchView)
+//! without re-reading the event log. Event appends that affect a
+//! dispatch update this row co-transactionally.
+//!
+//! `user_id` and `project` are denormalized out of the `actor` and
+//! `dispatch` JSON columns so the query filters in
+//! `DispatchFilter` can use plain column indexes — no JSON path
+//! operators, no scans.
+
+use sea_orm::entity::prelude::*;
+
+/// Row shape of the `dispatch_projection` table.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "dispatch_projection")]
+pub struct Model {
+    /// Dispatch identifier — same UUID as the domain [`DispatchId`].
+    ///
+    /// [`DispatchId`]: tanren_domain::DispatchId
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub dispatch_id: Uuid,
+
+    /// Snake-case tag of the [`DispatchMode`](tanren_domain::DispatchMode).
+    pub mode: String,
+
+    /// Snake-case tag of the [`DispatchStatus`](tanren_domain::DispatchStatus).
+    pub status: String,
+
+    /// Snake-case tag of the [`Outcome`](tanren_domain::Outcome), if
+    /// the dispatch has reached a terminal state.
+    pub outcome: Option<String>,
+
+    /// Snake-case tag of the [`Lane`](tanren_domain::Lane).
+    pub lane: String,
+
+    /// Serialized [`DispatchSnapshot`](tanren_domain::DispatchSnapshot).
+    /// Holds the original configuration so history queries reflect
+    /// exactly what the caller asked for, even after related config
+    /// has rotated.
+    #[sea_orm(column_type = "JsonBinary")]
+    pub dispatch: Json,
+
+    /// Serialized [`ActorContext`](tanren_domain::ActorContext).
+    #[sea_orm(column_type = "JsonBinary")]
+    pub actor: Json,
+
+    /// Graph revision this dispatch was planned against. Stored as
+    /// `i32` because `SeaORM`'s default `u32` column type is not
+    /// supported on all backends.
+    pub graph_revision: i32,
+
+    /// Denormalized `actor.user_id` for indexable queries.
+    pub user_id: Uuid,
+
+    /// Denormalized `dispatch.project` for indexable queries and
+    /// prefix/equality filtering.
+    pub project: String,
+
+    /// Wall-clock creation timestamp.
+    pub created_at: DateTimeUtc,
+
+    /// Wall-clock last-modified timestamp. Updated on every status
+    /// change and outcome materialization.
+    pub updated_at: DateTimeUtc,
+}
+
+/// Each dispatch has many steps; we don't declare it as a relation
+/// because all step queries are keyed on `dispatch_id` directly.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/events.rs
+++ b/crates/tanren-store/src/entity/events.rs
@@ -1,0 +1,64 @@
+//! `events` table — the canonical append-only event log.
+//!
+//! Every event ever emitted by the orchestrator lands here. The table
+//! is append-only; rows are never updated or deleted. All projection
+//! tables are derived from these rows and could in principle be
+//! rebuilt by replaying them.
+//!
+//! The `payload` column uses `SeaORM`'s `JsonBinary` column type, which
+//! emits `TEXT` on `SQLite` and `JSONB` on `Postgres` — letting a single
+//! column definition serve both backends. Lane 0.2's
+//! `event_value_roundtrip` test certified that every `DomainEvent`
+//! variant survives the `serde_json::Value` path that `SeaORM` uses for
+//! JSON columns, so this column is safe to read and write without
+//! string-based intermediate conversions.
+
+use sea_orm::entity::prelude::*;
+
+/// Row shape of the `events` table.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "events")]
+pub struct Model {
+    /// Auto-incrementing surrogate key — used only by the store for
+    /// stable ordering inside a single server; never exposed on the
+    /// wire. Domain code keys by [`event_id`](Self::event_id).
+    #[sea_orm(primary_key)]
+    pub id: i64,
+
+    /// Domain-level event identifier (UUID v7). Globally unique.
+    #[sea_orm(unique, indexed)]
+    pub event_id: Uuid,
+
+    /// Wall-clock timestamp at which the event was emitted.
+    pub timestamp: DateTimeUtc,
+
+    /// Snake-case discriminant of [`EntityKind`](tanren_domain::EntityKind).
+    pub entity_kind: String,
+
+    /// String form of the routing root's id. For entity kinds backed
+    /// by a UUID newtype this is the UUID's hyphenated string. We use
+    /// `String` rather than `Uuid` so future entity kinds with
+    /// non-UUID identifiers do not require a schema change.
+    pub entity_id: String,
+
+    /// Snake-case tag of the [`DomainEvent`](tanren_domain::DomainEvent)
+    /// variant carried in [`payload`](Self::payload).
+    pub event_type: String,
+
+    /// Envelope schema version. Matches
+    /// [`tanren_domain::SCHEMA_VERSION`] at insertion time.
+    pub schema_version: i32,
+
+    /// Serialized [`DomainEvent`](tanren_domain::DomainEvent) payload.
+    /// Other envelope fields (`event_id`, `timestamp`, `entity_ref`,
+    /// `schema_version`) are stored as dedicated columns so filter
+    /// queries don't need JSON path operators.
+    #[sea_orm(column_type = "JsonBinary")]
+    pub payload: Json,
+}
+
+/// No relations — projections are derived out-of-band, not via JOINs.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/mod.rs
+++ b/crates/tanren-store/src/entity/mod.rs
@@ -1,0 +1,11 @@
+//! SeaORM entity models for every table owned by the store.
+//!
+//! Each submodule defines one table. Entity models are intentionally
+//! "dumb" rows — all mapping between these and domain types lives in
+//! the `converters` module. Keeping the two separate means domain
+//! evolution never requires touching SeaORM generated glue, and
+//! SeaORM upgrades never require touching domain types.
+
+pub mod dispatch_projection;
+pub mod events;
+pub mod step_projection;

--- a/crates/tanren-store/src/entity/step_projection.rs
+++ b/crates/tanren-store/src/entity/step_projection.rs
@@ -69,11 +69,20 @@ pub struct Model {
     /// Number of times this step has been retried.
     pub retry_count: i32,
 
+    /// Worker-reported liveness timestamp. `NULL` while the step is
+    /// pending; set to the wall-clock time on dequeue claim; refreshed
+    /// by `JobQueue::heartbeat_step` while the worker holds the
+    /// claim. `recover_stale_steps` uses this field — **not**
+    /// `updated_at` — to decide whether a running step is stale.
+    /// This separation keeps liveness signalling independent of
+    /// ordinary row writes (ack, nack, etc.).
+    pub last_heartbeat_at: Option<DateTimeUtc>,
+
     /// Wall-clock creation timestamp.
     pub created_at: DateTimeUtc,
 
-    /// Wall-clock last-modified timestamp. Used by
-    /// `recover_stale_steps` as the heartbeat proxy.
+    /// Wall-clock last-modified timestamp. Bumped on any write. No
+    /// longer used as a liveness proxy — see `last_heartbeat_at`.
     pub updated_at: DateTimeUtc,
 }
 

--- a/crates/tanren-store/src/entity/step_projection.rs
+++ b/crates/tanren-store/src/entity/step_projection.rs
@@ -1,0 +1,85 @@
+//! `step_projection` table — materialized step state and job queue
+//! backing store.
+//!
+//! Every lifecycle step of every dispatch is one row here. The queue
+//! trait (`JobQueue::dequeue`, `ack_and_enqueue`, …) operates on this
+//! table directly, so it doubles as both a read projection and a
+//! write-heavy work queue. The index on `(status, created_at)` is
+//! what makes dequeue an O(1) scan over the pending head.
+
+use sea_orm::entity::prelude::*;
+
+/// Row shape of the `step_projection` table.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "step_projection")]
+pub struct Model {
+    /// Step identifier — same UUID as the domain [`StepId`].
+    ///
+    /// [`StepId`]: tanren_domain::StepId
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub step_id: Uuid,
+
+    /// Owning dispatch.
+    pub dispatch_id: Uuid,
+
+    /// Snake-case tag of the [`StepType`](tanren_domain::StepType).
+    pub step_type: String,
+
+    /// Monotonic sequence number within the dispatch. Stored as `i32`
+    /// for cross-backend compatibility.
+    pub step_sequence: i32,
+
+    /// Snake-case tag of the [`Lane`](tanren_domain::Lane), or `NULL`
+    /// for free-floating steps.
+    pub lane: Option<String>,
+
+    /// Snake-case tag of the [`StepStatus`](tanren_domain::StepStatus).
+    pub status: String,
+
+    /// Snake-case tag of the
+    /// [`StepReadyState`](tanren_domain::StepReadyState) — distinct
+    /// from `status` so the scheduler can look at dependency
+    /// readiness without querying the dependency graph.
+    pub ready_state: String,
+
+    /// Dependency list — a JSON array of [`StepId`](tanren_domain::StepId)
+    /// UUIDs. Persisted as JSON to avoid a second join table for a
+    /// rarely-scanned field.
+    #[sea_orm(column_type = "JsonBinary")]
+    pub depends_on: Json,
+
+    /// Graph revision this step was planned under.
+    pub graph_revision: i32,
+
+    /// The worker currently holding the claim, if `status = 'running'`.
+    pub worker_id: Option<String>,
+
+    /// Serialized [`StepPayload`](tanren_domain::StepPayload).
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub payload: Option<Json>,
+
+    /// Serialized [`StepResult`](tanren_domain::StepResult), populated
+    /// only after the step reaches a terminal state.
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub result: Option<Json>,
+
+    /// Free-form error text from the worker, if `status = 'failed'`.
+    pub error: Option<String>,
+
+    /// Number of times this step has been retried.
+    pub retry_count: i32,
+
+    /// Wall-clock creation timestamp.
+    pub created_at: DateTimeUtc,
+
+    /// Wall-clock last-modified timestamp. Used by
+    /// `recover_stale_steps` as the heartbeat proxy.
+    pub updated_at: DateTimeUtc,
+}
+
+/// No declared relations — all joins we care about live inside the
+/// store's query methods.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/errors.rs
+++ b/crates/tanren-store/src/errors.rs
@@ -1,0 +1,89 @@
+//! Store error type.
+//!
+//! [`StoreError`] is the single error returned by every `tanren-store`
+//! public API. It wraps `SeaORM`'s [`sea_orm::DbErr`] transparently,
+//! surfaces conversion failures with a stable context tag, and carries
+//! lightweight variants for the domain-adjacent failures callers need
+//! to react to (not found, state conflicts, invalid transitions).
+//!
+//! # Security
+//!
+//! No variant embeds raw SQL text, query parameters, or connection
+//! strings in its [`Display`] impl. [`DbErr`]'s own formatter is the
+//! only third-party string we forward, and it is the upstream contract
+//! of the driver we've already chosen to trust.
+//!
+//! [`Display`]: std::fmt::Display
+//! [`DbErr`]: sea_orm::DbErr
+
+use sea_orm::DbErr;
+
+/// All errors raised by the store layer.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// A `SeaORM` database error — connection, query, or driver-level.
+    #[error("database error: {0}")]
+    Database(#[from] DbErr),
+
+    /// A migration failed to apply. We keep the `SeaORM` migration error
+    /// as a string so callers do not pick up a transitive public
+    /// dependency on `sea-orm-migration`.
+    #[error("migration error: {0}")]
+    Migration(String),
+
+    /// A JSON round-trip between an entity model and a domain type
+    /// failed. `context` is a stable `&'static str` identifying the
+    /// conversion site (e.g., `events::to_model`); `reason` is the
+    /// free-form reason the conversion was rejected. We deliberately
+    /// do not embed the payload.
+    #[error("conversion error in {context}: {reason}")]
+    Conversion {
+        /// Stable identifier for the conversion site.
+        context: &'static str,
+        /// Human-readable reason the conversion failed.
+        reason: String,
+    },
+
+    /// A `serde_json` (de)serialization error.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The caller asked for an entity that does not exist. The
+    /// `entity` field is an already-rendered identifier (never raw
+    /// user input).
+    #[error("entity not found: {entity}")]
+    NotFound {
+        /// Already-rendered identifier describing what was missing.
+        entity: String,
+    },
+
+    /// A projection row was found in an unexpected state for the
+    /// requested transition. Used by `ack`, `ack_and_enqueue`, and
+    /// `nack` when the row affected by the update is not exactly 1.
+    #[error("invalid state transition on {entity}: {from} -> {to}")]
+    InvalidTransition {
+        /// The entity whose status we tried to change.
+        entity: String,
+        /// The status we expected the row to be in.
+        from: String,
+        /// The status we were attempting to move the row to.
+        to: String,
+    },
+
+    /// A concurrency conflict — e.g., `ack_and_enqueue` found the
+    /// current step already completed by another worker.
+    #[error("concurrency conflict: {0}")]
+    Conflict(String),
+}
+
+/// Convenient alias used throughout the store crate.
+pub type StoreResult<T> = Result<T, StoreError>;
+
+impl From<sea_orm::TransactionError<StoreError>> for StoreError {
+    fn from(err: sea_orm::TransactionError<StoreError>) -> Self {
+        match err {
+            sea_orm::TransactionError::Connection(db) => Self::Database(db),
+            sea_orm::TransactionError::Transaction(inner) => inner,
+        }
+    }
+}

--- a/crates/tanren-store/src/event_store.rs
+++ b/crates/tanren-store/src/event_store.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
-use tanren_domain::{EventEnvelope, EventQueryResult};
+use tanren_domain::EventQueryResult;
 
 use crate::converters::events as event_converters;
 use crate::entity::events;
@@ -17,27 +17,42 @@ use crate::params::EventFilter;
 use crate::store::Store;
 
 /// Append-only event log interface.
+///
+/// Event appends are not exposed on this trait — they are only
+/// available through co-transactional store methods (e.g.
+/// [`JobQueue::enqueue_step`](crate::JobQueue::enqueue_step),
+/// [`StateStore::create_dispatch_projection`](crate::StateStore::create_dispatch_projection))
+/// that guarantee event/projection consistency. Direct append is
+/// available via `Store::append` and `Store::append_batch` (behind
+/// the `test-hooks` feature) for testing and migration scenarios.
 #[async_trait]
 pub trait EventStore: Send + Sync {
-    /// Append a single event.
-    async fn append(&self, event: &EventEnvelope) -> StoreResult<()>;
-
-    /// Append a batch of events in one transaction.
-    async fn append_batch(&self, events: &[EventEnvelope]) -> StoreResult<()>;
-
     /// Query events by filter dimensions. Indexed; no table scans.
     async fn query_events(&self, filter: &EventFilter) -> StoreResult<EventQueryResult>;
 }
 
-#[async_trait]
-impl EventStore for Store {
-    async fn append(&self, event: &EventEnvelope) -> StoreResult<()> {
+/// Direct event-append methods — available for testing and migration
+/// scenarios but deliberately excluded from the [`EventStore`] trait
+/// to prevent event/projection divergence in normal operation.
+///
+/// Gated behind the `test-hooks` feature to prevent downstream
+/// crates from accidentally bypassing projection consistency.
+#[cfg(feature = "test-hooks")]
+impl Store {
+    /// Append a single event. Bypasses projection consistency — use
+    /// co-transactional trait methods for operational writes.
+    pub async fn append(&self, event: &tanren_domain::EventEnvelope) -> StoreResult<()> {
         let model = event_converters::envelope_to_active_model(event)?;
         events::Entity::insert(model).exec(self.conn()).await?;
         Ok(())
     }
 
-    async fn append_batch(&self, envelopes: &[EventEnvelope]) -> StoreResult<()> {
+    /// Append a batch of events. Bypasses projection consistency —
+    /// use co-transactional trait methods for operational writes.
+    pub async fn append_batch(
+        &self,
+        envelopes: &[tanren_domain::EventEnvelope],
+    ) -> StoreResult<()> {
         if envelopes.is_empty() {
             return Ok(());
         }
@@ -48,7 +63,10 @@ impl EventStore for Store {
         events::Entity::insert_many(rows).exec(self.conn()).await?;
         Ok(())
     }
+}
 
+#[async_trait]
+impl EventStore for Store {
     async fn query_events(&self, filter: &EventFilter) -> StoreResult<EventQueryResult> {
         let conn = self.conn();
         let total_count = build_count_query(filter).count(conn).await?;

--- a/crates/tanren-store/src/event_store.rs
+++ b/crates/tanren-store/src/event_store.rs
@@ -91,13 +91,17 @@ fn apply_filters(
     mut query: sea_orm::Select<events::Entity>,
     filter: &EventFilter,
 ) -> sea_orm::Select<events::Entity> {
+    // Typed entity references must constrain both `entity_kind` and
+    // `entity_id`. A bare `entity_id` filter would return events
+    // from a different entity kind that happens to share the same
+    // UUID — pathological, but not impossible.
     if let Some(ref entity_ref) = filter.entity_ref {
-        let entity_id = entity_ref_to_id_string(entity_ref);
-        query = query.filter(events::Column::EntityId.eq(entity_id));
+        query = query
+            .filter(events::Column::EntityId.eq(entity_ref_to_id_string(entity_ref)))
+            .filter(events::Column::EntityKind.eq(entity_ref.kind().to_string()));
     }
     if let Some(ref entity_refs) = filter.entity_refs {
-        let ids: Vec<String> = entity_refs.iter().map(entity_ref_to_id_string).collect();
-        query = query.filter(events::Column::EntityId.is_in(ids));
+        query = apply_entity_refs_filter(query, entity_refs);
     }
     if let Some(entity_kind) = filter.entity_kind {
         query = query.filter(events::Column::EntityKind.eq(entity_kind.to_string()));
@@ -114,6 +118,44 @@ fn apply_filters(
     query
 }
 
+/// Build the correct filter for a list of typed entity refs.
+///
+/// When all refs share the same kind (common case), we can emit a
+/// single `entity_kind = ? AND entity_id IN (...)` which is index-
+/// friendly. When they span multiple kinds, we emit an OR of
+/// `(entity_kind = ? AND entity_id = ?)` pairs.
+fn apply_entity_refs_filter(
+    query: sea_orm::Select<events::Entity>,
+    refs: &[tanren_domain::EntityRef],
+) -> sea_orm::Select<events::Entity> {
+    use sea_orm::sea_query::Condition;
+
+    if refs.is_empty() {
+        return query;
+    }
+
+    // Fast path: all refs share the same kind.
+    let first_kind = refs[0].kind();
+    let all_same_kind = refs.iter().all(|r| r.kind() == first_kind);
+    if all_same_kind {
+        let ids: Vec<String> = refs.iter().map(entity_ref_to_id_string).collect();
+        return query
+            .filter(events::Column::EntityKind.eq(first_kind.to_string()))
+            .filter(events::Column::EntityId.is_in(ids));
+    }
+
+    // Slow path: mixed kinds — OR of (kind, id) pairs.
+    let mut cond = Condition::any();
+    for r in refs {
+        cond = cond.add(
+            Condition::all()
+                .add(events::Column::EntityKind.eq(r.kind().to_string()))
+                .add(events::Column::EntityId.eq(entity_ref_to_id_string(r))),
+        );
+    }
+    query.filter(cond)
+}
+
 fn entity_ref_to_id_string(entity_ref: &tanren_domain::EntityRef) -> String {
     match *entity_ref {
         tanren_domain::EntityRef::Dispatch(id) => id.into_uuid().to_string(),
@@ -124,5 +166,149 @@ fn entity_ref_to_id_string(entity_ref: &tanren_domain::EntityRef) -> String {
         tanren_domain::EntityRef::Team(id) => id.into_uuid().to_string(),
         tanren_domain::EntityRef::Project(id) => id.into_uuid().to_string(),
         tanren_domain::EntityRef::ApiKey(id) => id.into_uuid().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use sea_orm::{DbBackend, QueryTrait};
+    use tanren_domain::{
+        ApiKeyId, DispatchId, EntityKind, EntityRef, EventId, LeaseId, OrgId, ProjectId, StepId,
+        TeamId, UserId,
+    };
+
+    use super::*;
+
+    fn filter_sql(filter: &EventFilter) -> String {
+        build_select_query(filter).build(DbBackend::Postgres).sql
+    }
+
+    #[test]
+    fn empty_filter_has_no_where_clause() {
+        let sql = filter_sql(&EventFilter::new());
+        assert!(!sql.contains("WHERE"), "unexpected WHERE: {sql}");
+    }
+
+    #[test]
+    fn entity_ref_filter_constrains_both_kind_and_id() {
+        let id = DispatchId::new();
+        let filter = EventFilter {
+            entity_ref: Some(EntityRef::Dispatch(id)),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(
+            sql.contains("\"entity_id\" ="),
+            "missing entity_id eq: {sql}"
+        );
+        assert!(
+            sql.contains("\"entity_kind\" ="),
+            "entity_ref must also constrain entity_kind: {sql}"
+        );
+    }
+
+    #[test]
+    fn entity_refs_same_kind_emits_kind_plus_in() {
+        let filter = EventFilter {
+            entity_refs: Some(vec![
+                EntityRef::Dispatch(DispatchId::new()),
+                EntityRef::Dispatch(DispatchId::new()),
+            ]),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(
+            sql.contains("\"entity_kind\" ="),
+            "same-kind refs must constrain kind: {sql}"
+        );
+        assert!(sql.contains("\"entity_id\" IN"), "missing IN: {sql}");
+    }
+
+    #[test]
+    fn entity_refs_mixed_kinds_emits_or_of_kind_id_pairs() {
+        let filter = EventFilter {
+            entity_refs: Some(vec![
+                EntityRef::Dispatch(DispatchId::new()),
+                EntityRef::Step(StepId::new()),
+            ]),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        // Mixed kinds: should have OR conditions with entity_kind
+        assert!(
+            sql.contains("\"entity_kind\" ="),
+            "mixed-kind refs must include kind constraints: {sql}"
+        );
+        assert!(sql.contains("OR"), "mixed-kind refs must use OR: {sql}");
+    }
+
+    #[test]
+    fn entity_kind_filter_emits_entity_kind_equality() {
+        let filter = EventFilter {
+            entity_kind: Some(EntityKind::Dispatch),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(
+            sql.contains("\"entity_kind\" ="),
+            "missing entity_kind: {sql}"
+        );
+    }
+
+    #[test]
+    fn event_type_filter_emits_event_type_equality() {
+        let filter = EventFilter {
+            event_type: Some("dispatch_created".to_owned()),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(
+            sql.contains("\"event_type\" ="),
+            "missing event_type: {sql}"
+        );
+    }
+
+    #[test]
+    fn since_filter_emits_timestamp_gte() {
+        let filter = EventFilter {
+            since: Some(Utc.timestamp_opt(1_700_000_000, 0).single().expect("ts")),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(sql.contains("\"timestamp\" >="), "missing since: {sql}");
+    }
+
+    #[test]
+    fn until_filter_emits_timestamp_lt() {
+        let filter = EventFilter {
+            until: Some(Utc.timestamp_opt(1_700_000_000, 0).single().expect("ts")),
+            ..EventFilter::new()
+        };
+        let sql = filter_sql(&filter);
+        assert!(sql.contains("\"timestamp\" <"), "missing until: {sql}");
+    }
+
+    #[test]
+    fn entity_ref_to_id_string_covers_every_variant() {
+        let event_id = EventId::from_uuid(uuid::Uuid::now_v7());
+        // Touch the unused EventId import so it is reachable.
+        let _ = event_id;
+        let refs = [
+            EntityRef::Dispatch(DispatchId::new()),
+            EntityRef::Step(StepId::new()),
+            EntityRef::Lease(LeaseId::new()),
+            EntityRef::User(UserId::new()),
+            EntityRef::Org(OrgId::new()),
+            EntityRef::Team(TeamId::new()),
+            EntityRef::Project(ProjectId::new()),
+            EntityRef::ApiKey(ApiKeyId::new()),
+        ];
+        for r in refs {
+            // Every variant must produce a 36-char hyphenated UUID.
+            let id = entity_ref_to_id_string(&r);
+            assert_eq!(id.len(), 36);
+            assert_eq!(id.chars().filter(|c| *c == '-').count(), 4);
+        }
     }
 }

--- a/crates/tanren-store/src/event_store.rs
+++ b/crates/tanren-store/src/event_store.rs
@@ -1,0 +1,128 @@
+//! [`EventStore`] trait and its implementation on [`Store`].
+//!
+//! `append` / `append_batch` insert rows directly via the entity API;
+//! `query_events` builds a filtered `Select` and runs it plus a
+//! companion `count()` query for the paginated view the domain
+//! exposes. Every filter dimension is backed by an index in
+//! `migration::m_0001_init`, so no scan-heavy paths exist here.
+
+use async_trait::async_trait;
+use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
+use tanren_domain::{EventEnvelope, EventQueryResult};
+
+use crate::converters::events as event_converters;
+use crate::entity::events;
+use crate::errors::StoreResult;
+use crate::params::EventFilter;
+use crate::store::Store;
+
+/// Append-only event log interface.
+#[async_trait]
+pub trait EventStore: Send + Sync {
+    /// Append a single event.
+    async fn append(&self, event: &EventEnvelope) -> StoreResult<()>;
+
+    /// Append a batch of events in one transaction.
+    async fn append_batch(&self, events: &[EventEnvelope]) -> StoreResult<()>;
+
+    /// Query events by filter dimensions. Indexed; no table scans.
+    async fn query_events(&self, filter: &EventFilter) -> StoreResult<EventQueryResult>;
+}
+
+#[async_trait]
+impl EventStore for Store {
+    async fn append(&self, event: &EventEnvelope) -> StoreResult<()> {
+        let model = event_converters::envelope_to_active_model(event)?;
+        events::Entity::insert(model).exec(self.conn()).await?;
+        Ok(())
+    }
+
+    async fn append_batch(&self, envelopes: &[EventEnvelope]) -> StoreResult<()> {
+        if envelopes.is_empty() {
+            return Ok(());
+        }
+        let mut rows = Vec::with_capacity(envelopes.len());
+        for envelope in envelopes {
+            rows.push(event_converters::envelope_to_active_model(envelope)?);
+        }
+        events::Entity::insert_many(rows).exec(self.conn()).await?;
+        Ok(())
+    }
+
+    async fn query_events(&self, filter: &EventFilter) -> StoreResult<EventQueryResult> {
+        let conn = self.conn();
+        let total_count = build_count_query(filter).count(conn).await?;
+
+        let rows = build_select_query(filter)
+            .limit(filter.limit)
+            .offset(filter.offset)
+            .order_by_asc(events::Column::Timestamp)
+            .order_by_asc(events::Column::Id)
+            .all(conn)
+            .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(event_converters::model_to_envelope(row)?);
+        }
+
+        let has_more = filter
+            .offset
+            .saturating_add(u64::try_from(out.len()).unwrap_or(u64::MAX))
+            < total_count;
+
+        Ok(EventQueryResult {
+            events: out,
+            total_count,
+            has_more,
+        })
+    }
+}
+
+fn build_select_query(filter: &EventFilter) -> sea_orm::Select<events::Entity> {
+    apply_filters(events::Entity::find(), filter)
+}
+
+fn build_count_query(filter: &EventFilter) -> sea_orm::Select<events::Entity> {
+    apply_filters(events::Entity::find(), filter)
+}
+
+fn apply_filters(
+    mut query: sea_orm::Select<events::Entity>,
+    filter: &EventFilter,
+) -> sea_orm::Select<events::Entity> {
+    if let Some(ref entity_ref) = filter.entity_ref {
+        let entity_id = entity_ref_to_id_string(entity_ref);
+        query = query.filter(events::Column::EntityId.eq(entity_id));
+    }
+    if let Some(ref entity_refs) = filter.entity_refs {
+        let ids: Vec<String> = entity_refs.iter().map(entity_ref_to_id_string).collect();
+        query = query.filter(events::Column::EntityId.is_in(ids));
+    }
+    if let Some(entity_kind) = filter.entity_kind {
+        query = query.filter(events::Column::EntityKind.eq(entity_kind.to_string()));
+    }
+    if let Some(ref event_type) = filter.event_type {
+        query = query.filter(events::Column::EventType.eq(event_type.as_str()));
+    }
+    if let Some(since) = filter.since {
+        query = query.filter(events::Column::Timestamp.gte(since));
+    }
+    if let Some(until) = filter.until {
+        query = query.filter(events::Column::Timestamp.lt(until));
+    }
+    query
+}
+
+fn entity_ref_to_id_string(entity_ref: &tanren_domain::EntityRef) -> String {
+    match *entity_ref {
+        tanren_domain::EntityRef::Dispatch(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::Step(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::Lease(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::User(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::Org(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::Team(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::Project(id) => id.into_uuid().to_string(),
+        tanren_domain::EntityRef::ApiKey(id) => id.into_uuid().to_string(),
+    }
+}

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -10,14 +10,19 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::sea_query::Expr;
-use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
-use tanren_domain::{DispatchId, StepId, StepStatus, StepType};
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, TransactionTrait,
+};
+use tanren_domain::{
+    DomainEvent, EntityRef, EventEnvelope, EventId, SCHEMA_VERSION, StepId, StepStatus, StepType,
+};
 
 use crate::converters::{events as event_converters, step as step_converters};
 use crate::entity::{events, step_projection};
 use crate::errors::{StoreError, StoreResult};
 use crate::params::{
-    AckAndEnqueueParams, DequeueParams, EnqueueStepParams, NackParams, QueuedStep,
+    AckAndEnqueueParams, AckParams, CancelPendingStepsParams, DequeueParams, EnqueueStepParams,
+    NackParams, QueuedStep,
 };
 use crate::store::Store;
 
@@ -33,10 +38,11 @@ pub trait JobQueue: Send + Sync {
     /// Returns `None` if no candidate qualifies.
     async fn dequeue(&self, params: DequeueParams) -> StoreResult<Option<QueuedStep>>;
 
-    /// Mark a step as completed, storing its result. Fails with
-    /// [`StoreError::InvalidTransition`] if the step is not currently
-    /// `running`.
-    async fn ack(&self, step_id: &StepId, result: &tanren_domain::StepResult) -> StoreResult<()>;
+    /// Mark a step as completed, storing its result. Appends the
+    /// companion `StepCompleted` envelope co-transactionally. Fails
+    /// with [`StoreError::InvalidTransition`] if the step is not
+    /// currently `running`.
+    async fn ack(&self, params: AckParams) -> StoreResult<()>;
 
     /// Single-transaction ack of the current step **and** enqueue of
     /// its successor. Both events (completion + optional next enqueue)
@@ -44,9 +50,11 @@ pub trait JobQueue: Send + Sync {
     /// path the orchestrator uses to drive dispatches forward.
     async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()>;
 
-    /// Cancel every pending non-teardown step belonging to a dispatch.
-    /// Returns the number of rows updated.
-    async fn cancel_pending_steps(&self, dispatch_id: &DispatchId) -> StoreResult<u64>;
+    /// Cancel every pending non-teardown step belonging to a dispatch,
+    /// generating one `StepCancelled` envelope per cancelled row and
+    /// appending them all co-transactionally. Returns the number of
+    /// rows updated.
+    async fn cancel_pending_steps(&self, params: CancelPendingStepsParams) -> StoreResult<u64>;
 
     /// Mark a step as failed. If `params.retry` is true, the row is
     /// reset to `pending` with an incremented `retry_count` instead.
@@ -94,31 +102,51 @@ impl JobQueue for Store {
         crate::job_queue_dequeue::dequeue_impl(self.conn(), params).await
     }
 
-    async fn ack(&self, step_id: &StepId, result: &tanren_domain::StepResult) -> StoreResult<()> {
-        let result_value = serde_json::to_value(result)?;
+    async fn ack(&self, params: AckParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(
+            &params.completion_event,
+            EntityRef::Step(params.step_id),
+        )?;
+
+        let result_value = serde_json::to_value(&params.result)?;
+        let event_model = event_converters::envelope_to_active_model(&params.completion_event)?;
         let now = Utc::now();
-        let update = step_projection::ActiveModel {
-            step_id: Set(step_id.into_uuid()),
-            status: Set(StepStatus::Completed.to_string()),
-            result: Set(Some(result_value)),
-            updated_at: Set(now),
-            worker_id: Set(None),
-            ..Default::default()
-        };
-        let outcome = step_projection::Entity::update(update)
-            .filter(step_projection::Column::StepId.eq(step_id.into_uuid()))
-            .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
-            .exec(self.conn())
-            .await;
-        match outcome {
-            Ok(_) => Ok(()),
-            Err(sea_orm::DbErr::RecordNotUpdated) => Err(StoreError::InvalidTransition {
-                entity: format!("step {step_id}"),
-                from: "running".to_owned(),
-                to: "completed".to_owned(),
-            }),
-            Err(err) => Err(err.into()),
-        }
+        let step_id = params.step_id;
+        let step_id_uuid = step_id.into_uuid();
+
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    let update = step_projection::ActiveModel {
+                        step_id: Set(step_id_uuid),
+                        status: Set(StepStatus::Completed.to_string()),
+                        result: Set(Some(result_value)),
+                        updated_at: Set(now),
+                        worker_id: Set(None),
+                        ..Default::default()
+                    };
+                    let outcome = step_projection::Entity::update(update)
+                        .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+                        .exec(txn)
+                        .await;
+                    match outcome {
+                        Ok(_) => {}
+                        Err(sea_orm::DbErr::RecordNotUpdated) => {
+                            return Err(StoreError::InvalidTransition {
+                                entity: format!("step {step_id}"),
+                                from: "running".to_owned(),
+                                to: "completed".to_owned(),
+                            });
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
+                    events::Entity::insert(event_model).exec(txn).await?;
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
     }
 
     async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()> {
@@ -180,19 +208,77 @@ impl JobQueue for Store {
         Ok(())
     }
 
-    async fn cancel_pending_steps(&self, dispatch_id: &DispatchId) -> StoreResult<u64> {
-        let result = step_projection::Entity::update_many()
-            .col_expr(
-                step_projection::Column::Status,
-                Expr::value(StepStatus::Cancelled.to_string()),
-            )
-            .col_expr(step_projection::Column::UpdatedAt, Expr::value(Utc::now()))
-            .filter(step_projection::Column::DispatchId.eq(dispatch_id.into_uuid()))
-            .filter(step_projection::Column::Status.eq(StepStatus::Pending.to_string()))
-            .filter(step_projection::Column::StepType.ne(StepType::Teardown.to_string()))
-            .exec(self.conn())
-            .await?;
-        Ok(result.rows_affected)
+    async fn cancel_pending_steps(&self, params: CancelPendingStepsParams) -> StoreResult<u64> {
+        let dispatch_id = params.dispatch_id;
+        let actor = params.actor;
+        let reason = params.reason;
+        let timestamp = params.timestamp;
+        let dispatch_uuid = dispatch_id.into_uuid();
+
+        self.conn()
+            .transaction::<_, u64, StoreError>(move |txn| {
+                Box::pin(async move {
+                    // SELECT the pending non-teardown rows so we can
+                    // generate one `StepCancelled` envelope per row.
+                    let rows = step_projection::Entity::find()
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_uuid))
+                        .filter(step_projection::Column::Status.eq(StepStatus::Pending.to_string()))
+                        .filter(
+                            step_projection::Column::StepType.ne(StepType::Teardown.to_string()),
+                        )
+                        .order_by_asc(step_projection::Column::StepSequence)
+                        .all(txn)
+                        .await?;
+
+                    if rows.is_empty() {
+                        return Ok(0);
+                    }
+
+                    let count = u64::try_from(rows.len()).unwrap_or(u64::MAX);
+
+                    // UPDATE all matching rows to cancelled.
+                    step_projection::Entity::update_many()
+                        .col_expr(
+                            step_projection::Column::Status,
+                            Expr::value(StepStatus::Cancelled.to_string()),
+                        )
+                        .col_expr(step_projection::Column::UpdatedAt, Expr::value(timestamp))
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_uuid))
+                        .filter(step_projection::Column::Status.eq(StepStatus::Pending.to_string()))
+                        .filter(
+                            step_projection::Column::StepType.ne(StepType::Teardown.to_string()),
+                        )
+                        .exec(txn)
+                        .await?;
+
+                    // Generate and insert one StepCancelled envelope
+                    // per cancelled row.
+                    let mut event_models = Vec::with_capacity(rows.len());
+                    for row in &rows {
+                        let step_id = StepId::from_uuid(row.step_id);
+                        let step_type = step_converters::parse_step_type(&row.step_type)?;
+                        let envelope = EventEnvelope {
+                            schema_version: SCHEMA_VERSION,
+                            event_id: EventId::from_uuid(uuid::Uuid::now_v7()),
+                            timestamp,
+                            entity_ref: EntityRef::Step(step_id),
+                            payload: DomainEvent::StepCancelled {
+                                dispatch_id,
+                                step_id,
+                                step_type,
+                                caused_by: actor.clone(),
+                                reason: reason.clone(),
+                            },
+                        };
+                        event_models.push(event_converters::envelope_to_active_model(&envelope)?);
+                    }
+                    events::Entity::insert_many(event_models).exec(txn).await?;
+
+                    Ok(count)
+                })
+            })
+            .await
+            .map_err(StoreError::from)
     }
 
     async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()> {

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -9,11 +9,9 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use sea_orm::{
-    ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Statement,
-    TransactionTrait,
-};
-use tanren_domain::{DispatchId, StepId, StepStatus};
+use sea_orm::sea_query::Expr;
+use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
+use tanren_domain::{DispatchId, StepId, StepStatus, StepType};
 
 use crate::converters::{events as event_converters, step as step_converters};
 use crate::entity::{events, step_projection};
@@ -52,13 +50,25 @@ pub trait JobQueue: Send + Sync {
 
     /// Mark a step as failed. If `params.retry` is true, the row is
     /// reset to `pending` with an incremented `retry_count` instead.
-    /// Appends the companion `StepFailed` envelope co-transactionally.
+    /// Fails with [`StoreError::InvalidTransition`] if the step is
+    /// not currently `running`. Appends the companion `StepFailed`
+    /// envelope co-transactionally.
     async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()>;
 
-    /// Reset steps that have been `running` longer than `timeout_secs`
-    /// back to `pending`. Crash recovery for workers that died
-    /// without releasing their claim. Returns the number of rows
-    /// reset.
+    /// Refresh the worker liveness signal (`last_heartbeat_at`) on a
+    /// running step. Workers call this periodically while executing
+    /// long-running work so [`JobQueue::recover_stale_steps`] does
+    /// not reclaim the step. Fails with
+    /// [`StoreError::InvalidTransition`] if the step is not
+    /// currently `running`.
+    async fn heartbeat_step(&self, step_id: &StepId) -> StoreResult<()>;
+
+    /// Reset `running` steps whose `last_heartbeat_at` is older than
+    /// `timeout_secs` (or has never been refreshed) back to
+    /// `pending`. Crash recovery for workers that died without
+    /// releasing their claim. Live workers that call
+    /// [`JobQueue::heartbeat_step`] within the threshold are never
+    /// touched. Returns the number of rows reset.
     async fn recover_stale_steps(&self, timeout_secs: u64) -> StoreResult<u64>;
 }
 
@@ -89,7 +99,7 @@ impl JobQueue for Store {
         let now = Utc::now();
         let update = step_projection::ActiveModel {
             step_id: Set(step_id.into_uuid()),
-            status: Set(step_converters::step_status_to_string(StepStatus::Completed).to_owned()),
+            status: Set(StepStatus::Completed.to_string()),
             result: Set(Some(result_value)),
             updated_at: Set(now),
             worker_id: Set(None),
@@ -97,10 +107,7 @@ impl JobQueue for Store {
         };
         let outcome = step_projection::Entity::update(update)
             .filter(step_projection::Column::StepId.eq(step_id.into_uuid()))
-            .filter(
-                step_projection::Column::Status
-                    .eq(step_converters::step_status_to_string(StepStatus::Running)),
-            )
+            .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
             .exec(self.conn())
             .await;
         match outcome {
@@ -134,15 +141,9 @@ impl JobQueue for Store {
         self.conn()
             .transaction::<_, (), StoreError>(move |txn| {
                 Box::pin(async move {
-                    // 1. Complete the current step. Require status='running'
-                    //    via a filter so the update reports RecordNotUpdated
-                    //    on any other state — a non-retryable bug.
                     let update = step_projection::ActiveModel {
                         step_id: Set(step_id_uuid),
-                        status: Set(
-                            step_converters::step_status_to_string(StepStatus::Completed)
-                                .to_owned(),
-                        ),
+                        status: Set(StepStatus::Completed.to_string()),
                         result: Set(Some(result_value)),
                         updated_at: Set(now),
                         worker_id: Set(None),
@@ -150,10 +151,7 @@ impl JobQueue for Store {
                     };
                     let result = step_projection::Entity::update(update)
                         .filter(step_projection::Column::StepId.eq(step_id_uuid))
-                        .filter(
-                            step_projection::Column::Status
-                                .eq(step_converters::step_status_to_string(StepStatus::Running)),
-                        )
+                        .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
                         .exec(txn)
                         .await;
                     match result {
@@ -168,11 +166,8 @@ impl JobQueue for Store {
                         Err(err) => return Err(err.into()),
                     }
 
-                    // 2. Append the completion envelope.
                     events::Entity::insert(completion_event).exec(txn).await?;
 
-                    // 3. (Optional) Insert the successor step and
-                    //    append its enqueue envelope.
                     if let Some((row, event_model)) = next {
                         step_projection::Entity::insert(row).exec(txn).await?;
                         events::Entity::insert(event_model).exec(txn).await?;
@@ -189,24 +184,12 @@ impl JobQueue for Store {
         let result = step_projection::Entity::update_many()
             .col_expr(
                 step_projection::Column::Status,
-                sea_orm::sea_query::Expr::value(step_converters::step_status_to_string(
-                    StepStatus::Cancelled,
-                )),
+                Expr::value(StepStatus::Cancelled.to_string()),
             )
-            .col_expr(
-                step_projection::Column::UpdatedAt,
-                sea_orm::sea_query::Expr::value(Utc::now()),
-            )
+            .col_expr(step_projection::Column::UpdatedAt, Expr::value(Utc::now()))
             .filter(step_projection::Column::DispatchId.eq(dispatch_id.into_uuid()))
-            .filter(
-                step_projection::Column::Status
-                    .eq(step_converters::step_status_to_string(StepStatus::Pending)),
-            )
-            .filter(
-                step_projection::Column::StepType.ne(step_converters::step_type_to_string(
-                    tanren_domain::StepType::Teardown,
-                )),
-            )
+            .filter(step_projection::Column::Status.eq(StepStatus::Pending.to_string()))
+            .filter(step_projection::Column::StepType.ne(StepType::Teardown.to_string()))
             .exec(self.conn())
             .await?;
         Ok(result.rows_affected)
@@ -216,6 +199,7 @@ impl JobQueue for Store {
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.failure_event)?;
         let step_id_uuid = step_id.into_uuid();
+        let step_id_display = step_id.to_string();
         let error = params.error.clone();
         let retry = params.retry;
 
@@ -230,30 +214,74 @@ impl JobQueue for Store {
                         ..Default::default()
                     };
                     if retry {
-                        active.status =
-                            Set(step_converters::step_status_to_string(StepStatus::Pending)
-                                .to_owned());
-                        // retry_count is bumped via raw SQL on the
-                        // executing connection so we don't have to
-                        // re-read the row to compute the new value.
-                        txn.execute(Statement::from_sql_and_values(
-                            txn.get_database_backend(),
-                            "UPDATE step_projection SET retry_count = retry_count + 1 WHERE step_id = $1",
-                            vec![step_id_uuid.into()],
-                        ))
-                        .await?;
+                        active.status = Set(StepStatus::Pending.to_string());
                     } else {
-                        active.status =
-                            Set(step_converters::step_status_to_string(StepStatus::Failed)
-                                .to_owned());
+                        active.status = Set(StepStatus::Failed.to_string());
                     }
-                    step_projection::Entity::update(active).exec(txn).await?;
+                    // Require `status = 'running'` so nack can only
+                    // move a step out of the running state — domain
+                    // rules (status/step.rs::can_transition_to) never
+                    // allow Pending -> Failed directly.
+                    let result = step_projection::Entity::update(active)
+                        .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+                        .exec(txn)
+                        .await;
+                    match result {
+                        Ok(_) => {}
+                        Err(sea_orm::DbErr::RecordNotUpdated) => {
+                            return Err(StoreError::InvalidTransition {
+                                entity: format!("step {step_id_display}"),
+                                from: "running".to_owned(),
+                                to: if retry { "pending" } else { "failed" }.to_owned(),
+                            });
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
+                    if retry {
+                        // Bump retry_count via the entity API. No raw
+                        // SQL needed — Expr::col().add(1) compiles to
+                        // `retry_count = retry_count + 1` on every
+                        // backend, keeping the raw-SQL surface limited
+                        // to the dequeue claim path (S-03).
+                        step_projection::Entity::update_many()
+                            .col_expr(
+                                step_projection::Column::RetryCount,
+                                Expr::col(step_projection::Column::RetryCount).add(1),
+                            )
+                            .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                            .exec(txn)
+                            .await?;
+                    }
                     events::Entity::insert(event_model).exec(txn).await?;
                     Ok(())
                 })
             })
             .await?;
         Ok(())
+    }
+
+    async fn heartbeat_step(&self, step_id: &StepId) -> StoreResult<()> {
+        let now = Utc::now();
+        let update = step_projection::ActiveModel {
+            step_id: Set(step_id.into_uuid()),
+            last_heartbeat_at: Set(Some(now)),
+            ..Default::default()
+        };
+        let outcome = step_projection::Entity::update(update)
+            .filter(step_projection::Column::StepId.eq(step_id.into_uuid()))
+            .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+            .exec(self.conn())
+            .await;
+        match outcome {
+            Ok(_) => Ok(()),
+            Err(sea_orm::DbErr::RecordNotUpdated) => Err(StoreError::InvalidTransition {
+                entity: format!("step {step_id}"),
+                from: "running".to_owned(),
+                to: "heartbeat".to_owned(),
+            }),
+            Err(err) => Err(err.into()),
+        }
     }
 
     async fn recover_stale_steps(&self, timeout_secs: u64) -> StoreResult<u64> {
@@ -264,23 +292,24 @@ impl JobQueue for Store {
         let result = step_projection::Entity::update_many()
             .col_expr(
                 step_projection::Column::Status,
-                sea_orm::sea_query::Expr::value(step_converters::step_status_to_string(
-                    StepStatus::Pending,
-                )),
+                Expr::value(StepStatus::Pending.to_string()),
             )
             .col_expr(
                 step_projection::Column::WorkerId,
-                sea_orm::sea_query::Expr::value(Option::<String>::None),
+                Expr::value(Option::<String>::None),
             )
             .col_expr(
-                step_projection::Column::UpdatedAt,
-                sea_orm::sea_query::Expr::value(Utc::now()),
+                step_projection::Column::LastHeartbeatAt,
+                Expr::value(Option::<chrono::DateTime<Utc>>::None),
             )
-            .filter(
-                step_projection::Column::Status
-                    .eq(step_converters::step_status_to_string(StepStatus::Running)),
-            )
-            .filter(step_projection::Column::UpdatedAt.lt(threshold))
+            .col_expr(step_projection::Column::UpdatedAt, Expr::value(Utc::now()))
+            .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+            // Only reclaim rows whose heartbeat is older than the
+            // threshold. Rows whose heartbeat was refreshed within
+            // the window stay running — liveness signal is
+            // independent of `updated_at`, which is bumped by every
+            // write and is not a reliable indicator of worker health.
+            .filter(step_projection::Column::LastHeartbeatAt.lt(threshold))
             .exec(self.conn())
             .await?;
         Ok(result.rows_affected)

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -1,0 +1,288 @@
+//! [`JobQueue`] trait and the non-dequeue half of its implementation.
+//!
+//! Dequeue is special — it must be race-safe under concurrent workers,
+//! and the SQL differs between backends — so it lives in a sibling
+//! module, [`crate::job_queue_dequeue`]. Every other queue method is
+//! a straightforward entity-API write, usually wrapped in a
+//! transaction closure so its companion event append lands
+//! co-transactionally.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Statement,
+    TransactionTrait,
+};
+use tanren_domain::{DispatchId, StepId, StepStatus};
+
+use crate::converters::{events as event_converters, step as step_converters};
+use crate::entity::{events, step_projection};
+use crate::errors::{StoreError, StoreResult};
+use crate::params::{
+    AckAndEnqueueParams, DequeueParams, EnqueueStepParams, NackParams, QueuedStep,
+};
+use crate::store::Store;
+
+/// Job queue / step lifecycle interface.
+#[async_trait]
+pub trait JobQueue: Send + Sync {
+    /// Insert a new pending step. Appends the companion
+    /// `StepEnqueued` envelope co-transactionally.
+    async fn enqueue_step(&self, params: EnqueueStepParams) -> StoreResult<()>;
+
+    /// Atomically claim the oldest pending step that matches the
+    /// given lane filter, provided `running_count < max_concurrent`.
+    /// Returns `None` if no candidate qualifies.
+    async fn dequeue(&self, params: DequeueParams) -> StoreResult<Option<QueuedStep>>;
+
+    /// Mark a step as completed, storing its result. Fails with
+    /// [`StoreError::InvalidTransition`] if the step is not currently
+    /// `running`.
+    async fn ack(&self, step_id: &StepId, result: &tanren_domain::StepResult) -> StoreResult<()>;
+
+    /// Single-transaction ack of the current step **and** enqueue of
+    /// its successor. Both events (completion + optional next enqueue)
+    /// are appended in the same transaction. This is the critical
+    /// path the orchestrator uses to drive dispatches forward.
+    async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()>;
+
+    /// Cancel every pending non-teardown step belonging to a dispatch.
+    /// Returns the number of rows updated.
+    async fn cancel_pending_steps(&self, dispatch_id: &DispatchId) -> StoreResult<u64>;
+
+    /// Mark a step as failed. If `params.retry` is true, the row is
+    /// reset to `pending` with an incremented `retry_count` instead.
+    /// Appends the companion `StepFailed` envelope co-transactionally.
+    async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()>;
+
+    /// Reset steps that have been `running` longer than `timeout_secs`
+    /// back to `pending`. Crash recovery for workers that died
+    /// without releasing their claim. Returns the number of rows
+    /// reset.
+    async fn recover_stale_steps(&self, timeout_secs: u64) -> StoreResult<u64>;
+}
+
+#[async_trait]
+impl JobQueue for Store {
+    async fn enqueue_step(&self, params: EnqueueStepParams) -> StoreResult<()> {
+        let now = Utc::now();
+        let row = step_converters::enqueue_to_active_model(&params, now)?;
+        let event_model = event_converters::envelope_to_active_model(&params.enqueue_event)?;
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    step_projection::Entity::insert(row).exec(txn).await?;
+                    events::Entity::insert(event_model).exec(txn).await?;
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn dequeue(&self, params: DequeueParams) -> StoreResult<Option<QueuedStep>> {
+        crate::job_queue_dequeue::dequeue_impl(self.conn(), params).await
+    }
+
+    async fn ack(&self, step_id: &StepId, result: &tanren_domain::StepResult) -> StoreResult<()> {
+        let result_value = serde_json::to_value(result)?;
+        let now = Utc::now();
+        let update = step_projection::ActiveModel {
+            step_id: Set(step_id.into_uuid()),
+            status: Set(step_converters::step_status_to_string(StepStatus::Completed).to_owned()),
+            result: Set(Some(result_value)),
+            updated_at: Set(now),
+            worker_id: Set(None),
+            ..Default::default()
+        };
+        let outcome = step_projection::Entity::update(update)
+            .filter(step_projection::Column::StepId.eq(step_id.into_uuid()))
+            .filter(
+                step_projection::Column::Status
+                    .eq(step_converters::step_status_to_string(StepStatus::Running)),
+            )
+            .exec(self.conn())
+            .await;
+        match outcome {
+            Ok(_) => Ok(()),
+            Err(sea_orm::DbErr::RecordNotUpdated) => Err(StoreError::InvalidTransition {
+                entity: format!("step {step_id}"),
+                from: "running".to_owned(),
+                to: "completed".to_owned(),
+            }),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()> {
+        let now = Utc::now();
+        let result_value = serde_json::to_value(&params.result)?;
+        let completion_event =
+            event_converters::envelope_to_active_model(&params.completion_event)?;
+        let step_id_uuid = params.step_id.into_uuid();
+        let step_id_display = params.step_id.to_string();
+
+        let next = match params.next_step {
+            Some(step) => {
+                let row = step_converters::enqueue_to_active_model(&step, now)?;
+                let event_model = event_converters::envelope_to_active_model(&step.enqueue_event)?;
+                Some((row, event_model))
+            }
+            None => None,
+        };
+
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    // 1. Complete the current step. Require status='running'
+                    //    via a filter so the update reports RecordNotUpdated
+                    //    on any other state — a non-retryable bug.
+                    let update = step_projection::ActiveModel {
+                        step_id: Set(step_id_uuid),
+                        status: Set(
+                            step_converters::step_status_to_string(StepStatus::Completed)
+                                .to_owned(),
+                        ),
+                        result: Set(Some(result_value)),
+                        updated_at: Set(now),
+                        worker_id: Set(None),
+                        ..Default::default()
+                    };
+                    let result = step_projection::Entity::update(update)
+                        .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(
+                            step_projection::Column::Status
+                                .eq(step_converters::step_status_to_string(StepStatus::Running)),
+                        )
+                        .exec(txn)
+                        .await;
+                    match result {
+                        Ok(_) => {}
+                        Err(sea_orm::DbErr::RecordNotUpdated) => {
+                            return Err(StoreError::InvalidTransition {
+                                entity: format!("step {step_id_display}"),
+                                from: "running".to_owned(),
+                                to: "completed".to_owned(),
+                            });
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
+
+                    // 2. Append the completion envelope.
+                    events::Entity::insert(completion_event).exec(txn).await?;
+
+                    // 3. (Optional) Insert the successor step and
+                    //    append its enqueue envelope.
+                    if let Some((row, event_model)) = next {
+                        step_projection::Entity::insert(row).exec(txn).await?;
+                        events::Entity::insert(event_model).exec(txn).await?;
+                    }
+
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn cancel_pending_steps(&self, dispatch_id: &DispatchId) -> StoreResult<u64> {
+        let result = step_projection::Entity::update_many()
+            .col_expr(
+                step_projection::Column::Status,
+                sea_orm::sea_query::Expr::value(step_converters::step_status_to_string(
+                    StepStatus::Cancelled,
+                )),
+            )
+            .col_expr(
+                step_projection::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(Utc::now()),
+            )
+            .filter(step_projection::Column::DispatchId.eq(dispatch_id.into_uuid()))
+            .filter(
+                step_projection::Column::Status
+                    .eq(step_converters::step_status_to_string(StepStatus::Pending)),
+            )
+            .filter(
+                step_projection::Column::StepType.ne(step_converters::step_type_to_string(
+                    tanren_domain::StepType::Teardown,
+                )),
+            )
+            .exec(self.conn())
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()> {
+        let now = Utc::now();
+        let event_model = event_converters::envelope_to_active_model(&params.failure_event)?;
+        let step_id_uuid = step_id.into_uuid();
+        let error = params.error.clone();
+        let retry = params.retry;
+
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    let mut active = step_projection::ActiveModel {
+                        step_id: Set(step_id_uuid),
+                        updated_at: Set(now),
+                        error: Set(Some(error)),
+                        worker_id: Set(None),
+                        ..Default::default()
+                    };
+                    if retry {
+                        active.status =
+                            Set(step_converters::step_status_to_string(StepStatus::Pending)
+                                .to_owned());
+                        // retry_count is bumped via raw SQL on the
+                        // executing connection so we don't have to
+                        // re-read the row to compute the new value.
+                        txn.execute(Statement::from_sql_and_values(
+                            txn.get_database_backend(),
+                            "UPDATE step_projection SET retry_count = retry_count + 1 WHERE step_id = $1",
+                            vec![step_id_uuid.into()],
+                        ))
+                        .await?;
+                    } else {
+                        active.status =
+                            Set(step_converters::step_status_to_string(StepStatus::Failed)
+                                .to_owned());
+                    }
+                    step_projection::Entity::update(active).exec(txn).await?;
+                    events::Entity::insert(event_model).exec(txn).await?;
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn recover_stale_steps(&self, timeout_secs: u64) -> StoreResult<u64> {
+        let threshold = Utc::now()
+            - chrono::Duration::try_seconds(i64::try_from(timeout_secs).unwrap_or(i64::MAX))
+                .unwrap_or_else(chrono::Duration::zero);
+
+        let result = step_projection::Entity::update_many()
+            .col_expr(
+                step_projection::Column::Status,
+                sea_orm::sea_query::Expr::value(step_converters::step_status_to_string(
+                    StepStatus::Pending,
+                )),
+            )
+            .col_expr(
+                step_projection::Column::WorkerId,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                step_projection::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(Utc::now()),
+            )
+            .filter(
+                step_projection::Column::Status
+                    .eq(step_converters::step_status_to_string(StepStatus::Running)),
+            )
+            .filter(step_projection::Column::UpdatedAt.lt(threshold))
+            .exec(self.conn())
+            .await?;
+        Ok(result.rows_affected)
+    }
+}

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -10,11 +10,13 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::sea_query::Expr;
-use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, Condition, EntityTrait, QueryFilter, TransactionTrait,
+};
 use tanren_domain::{DomainEvent, EventEnvelope, EventId, StepId, StepStatus, StepType};
 
-use crate::converters::{events as event_converters, step as step_converters};
-use crate::entity::{events, step_projection};
+use crate::converters::{events as event_converters, step as step_converters, validate};
+use crate::entity::{dispatch_projection, events, step_projection};
 use crate::errors::{StoreError, StoreResult};
 use crate::params::{
     AckAndEnqueueParams, AckParams, CancelPendingStepsParams, DequeueParams, EnqueueStepParams,
@@ -57,7 +59,7 @@ pub trait JobQueue: Send + Sync {
     /// Fails with [`StoreError::InvalidTransition`] if the step is
     /// not currently `running`. Appends the companion `StepFailed`
     /// envelope co-transactionally.
-    async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()>;
+    async fn nack(&self, params: NackParams) -> StoreResult<()>;
 
     /// Refresh the worker liveness signal (`last_heartbeat_at`) on a
     /// running step. Workers call this periodically while executing
@@ -79,17 +81,26 @@ pub trait JobQueue: Send + Sync {
 #[async_trait]
 impl JobQueue for Store {
     async fn enqueue_step(&self, params: EnqueueStepParams) -> StoreResult<()> {
-        event_converters::validate_step_event(
-            &params.enqueue_event,
-            params.step_id,
-            "step_enqueued",
-        )?;
+        validate::validate_enqueue_step(&params)?;
         let now = Utc::now();
         let row = step_converters::enqueue_to_active_model(&params, now)?;
         let event_model = event_converters::envelope_to_active_model(&params.enqueue_event)?;
+        let dispatch_uuid = params.dispatch_id.into_uuid();
+        let dispatch_id_display = params.dispatch_id;
         self.conn()
             .transaction::<_, (), StoreError>(move |txn| {
                 Box::pin(async move {
+                    // Verify the dispatch exists — application-level FK
+                    // that protects both backends (SQLite FK is backed
+                    // by PRAGMA foreign_keys, but belt-and-suspenders).
+                    let exists = dispatch_projection::Entity::find_by_id(dispatch_uuid)
+                        .one(txn)
+                        .await?;
+                    if exists.is_none() {
+                        return Err(StoreError::NotFound {
+                            entity: format!("dispatch {dispatch_id_display}"),
+                        });
+                    }
                     step_projection::Entity::insert(row).exec(txn).await?;
                     events::Entity::insert(event_model).exec(txn).await?;
                     Ok(())
@@ -104,17 +115,15 @@ impl JobQueue for Store {
     }
 
     async fn ack(&self, params: AckParams) -> StoreResult<()> {
-        event_converters::validate_step_event(
-            &params.completion_event,
-            params.step_id,
-            "step_completed",
-        )?;
+        validate::validate_ack(&params)?;
 
         let result_value = serde_json::to_value(&params.result)?;
         let event_model = event_converters::envelope_to_active_model(&params.completion_event)?;
         let now = Utc::now();
         let step_id = params.step_id;
         let step_id_uuid = step_id.into_uuid();
+        let dispatch_id_uuid = params.dispatch_id.into_uuid();
+        let step_type_string = params.step_type.to_string();
 
         self.conn()
             .transaction::<_, (), StoreError>(move |txn| {
@@ -123,13 +132,16 @@ impl JobQueue for Store {
                         step_id: Set(step_id_uuid),
                         status: Set(StepStatus::Completed.to_string()),
                         result: Set(Some(result_value)),
+                        error: Set(None),
                         updated_at: Set(now),
                         worker_id: Set(None),
                         ..Default::default()
                     };
                     let outcome = step_projection::Entity::update(update)
                         .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_id_uuid))
                         .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+                        .filter(step_projection::Column::StepType.eq(step_type_string.as_str()))
                         .exec(txn)
                         .await;
                     match outcome {
@@ -152,24 +164,15 @@ impl JobQueue for Store {
     }
 
     async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()> {
-        event_converters::validate_step_event(
-            &params.completion_event,
-            params.step_id,
-            "step_completed",
-        )?;
-        if let Some(ref next) = params.next_step {
-            event_converters::validate_step_event(
-                &next.enqueue_event,
-                next.step_id,
-                "step_enqueued",
-            )?;
-        }
+        validate::validate_ack_and_enqueue(&params)?;
         let now = Utc::now();
         let result_value = serde_json::to_value(&params.result)?;
         let completion_event =
             event_converters::envelope_to_active_model(&params.completion_event)?;
         let step_id_uuid = params.step_id.into_uuid();
+        let dispatch_id_uuid = params.dispatch_id.into_uuid();
         let step_id_display = params.step_id.to_string();
+        let step_type_string = params.step_type.to_string();
 
         let next = match params.next_step {
             Some(step) => {
@@ -187,13 +190,16 @@ impl JobQueue for Store {
                         step_id: Set(step_id_uuid),
                         status: Set(StepStatus::Completed.to_string()),
                         result: Set(Some(result_value)),
+                        error: Set(None),
                         updated_at: Set(now),
                         worker_id: Set(None),
                         ..Default::default()
                     };
                     let result = step_projection::Entity::update(update)
                         .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_id_uuid))
                         .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+                        .filter(step_projection::Column::StepType.eq(step_type_string.as_str()))
                         .exec(txn)
                         .await;
                     match result {
@@ -297,37 +303,42 @@ impl JobQueue for Store {
             .map_err(StoreError::from)
     }
 
-    async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()> {
-        event_converters::validate_step_event(&params.failure_event, *step_id, "step_failed")?;
+    async fn nack(&self, params: NackParams) -> StoreResult<()> {
+        validate::validate_nack(&params)?;
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.failure_event)?;
-        let step_id_uuid = step_id.into_uuid();
-        let step_id_display = step_id.to_string();
+        let step_id_uuid = params.step_id.into_uuid();
+        let dispatch_id_uuid = params.dispatch_id.into_uuid();
+        let step_id_display = params.step_id.to_string();
+        let step_type_string = params.step_type.to_string();
         let error = params.error.clone();
         let retry = params.retry;
 
         self.conn()
             .transaction::<_, (), StoreError>(move |txn| {
                 Box::pin(async move {
-                    let mut active = step_projection::ActiveModel {
+                    let (status, error_value) = if retry {
+                        (StepStatus::Pending, None)
+                    } else {
+                        (StepStatus::Failed, Some(error))
+                    };
+                    let active = step_projection::ActiveModel {
                         step_id: Set(step_id_uuid),
+                        status: Set(status.to_string()),
                         updated_at: Set(now),
-                        error: Set(Some(error)),
+                        error: Set(error_value),
                         worker_id: Set(None),
                         ..Default::default()
                     };
-                    if retry {
-                        active.status = Set(StepStatus::Pending.to_string());
-                    } else {
-                        active.status = Set(StepStatus::Failed.to_string());
-                    }
                     // Require `status = 'running'` so nack can only
                     // move a step out of the running state — domain
                     // rules (status/step.rs::can_transition_to) never
                     // allow Pending -> Failed directly.
                     let result = step_projection::Entity::update(active)
                         .filter(step_projection::Column::StepId.eq(step_id_uuid))
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_id_uuid))
                         .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
+                        .filter(step_projection::Column::StepType.eq(step_type_string.as_str()))
                         .exec(txn)
                         .await;
                     match result {
@@ -407,12 +418,17 @@ impl JobQueue for Store {
             )
             .col_expr(step_projection::Column::UpdatedAt, Expr::value(Utc::now()))
             .filter(step_projection::Column::Status.eq(StepStatus::Running.to_string()))
-            // Only reclaim rows whose heartbeat is older than the
-            // threshold. Rows whose heartbeat was refreshed within
-            // the window stay running — liveness signal is
-            // independent of `updated_at`, which is bumped by every
-            // write and is not a reliable indicator of worker health.
-            .filter(step_projection::Column::LastHeartbeatAt.lt(threshold))
+            // Reclaim rows whose heartbeat is older than the
+            // threshold OR has never been set (NULL). Rows whose
+            // heartbeat was refreshed within the window stay
+            // running — liveness signal is independent of
+            // `updated_at`, which is bumped by every write and is
+            // not a reliable indicator of worker health.
+            .filter(
+                Condition::any()
+                    .add(step_projection::Column::LastHeartbeatAt.lt(threshold))
+                    .add(step_projection::Column::LastHeartbeatAt.is_null()),
+            )
             .exec(self.conn())
             .await?;
         Ok(result.rows_affected)

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -10,12 +10,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::sea_query::Expr;
-use sea_orm::{
-    ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, TransactionTrait,
-};
-use tanren_domain::{
-    DomainEvent, EntityRef, EventEnvelope, EventId, SCHEMA_VERSION, StepId, StepStatus, StepType,
-};
+use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
+use tanren_domain::{DomainEvent, EventEnvelope, EventId, StepId, StepStatus, StepType};
 
 use crate::converters::{events as event_converters, step as step_converters};
 use crate::entity::{events, step_projection};
@@ -83,6 +79,7 @@ pub trait JobQueue: Send + Sync {
 #[async_trait]
 impl JobQueue for Store {
     async fn enqueue_step(&self, params: EnqueueStepParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(&params.enqueue_event)?;
         let now = Utc::now();
         let row = step_converters::enqueue_to_active_model(&params, now)?;
         let event_model = event_converters::envelope_to_active_model(&params.enqueue_event)?;
@@ -103,10 +100,7 @@ impl JobQueue for Store {
     }
 
     async fn ack(&self, params: AckParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(
-            &params.completion_event,
-            EntityRef::Step(params.step_id),
-        )?;
+        event_converters::validate_envelope_entity_ref(&params.completion_event)?;
 
         let result_value = serde_json::to_value(&params.result)?;
         let event_model = event_converters::envelope_to_active_model(&params.completion_event)?;
@@ -150,6 +144,10 @@ impl JobQueue for Store {
     }
 
     async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(&params.completion_event)?;
+        if let Some(ref next) = params.next_step {
+            event_converters::validate_envelope_entity_ref(&next.enqueue_event)?;
+        }
         let now = Utc::now();
         let result_value = serde_json::to_value(&params.result)?;
         let completion_event =
@@ -218,26 +216,13 @@ impl JobQueue for Store {
         self.conn()
             .transaction::<_, u64, StoreError>(move |txn| {
                 Box::pin(async move {
-                    // SELECT the pending non-teardown rows so we can
-                    // generate one `StepCancelled` envelope per row.
-                    let rows = step_projection::Entity::find()
-                        .filter(step_projection::Column::DispatchId.eq(dispatch_uuid))
-                        .filter(step_projection::Column::Status.eq(StepStatus::Pending.to_string()))
-                        .filter(
-                            step_projection::Column::StepType.ne(StepType::Teardown.to_string()),
-                        )
-                        .order_by_asc(step_projection::Column::StepSequence)
-                        .all(txn)
-                        .await?;
-
-                    if rows.is_empty() {
-                        return Ok(0);
-                    }
-
-                    let count = u64::try_from(rows.len()).unwrap_or(u64::MAX);
-
-                    // UPDATE all matching rows to cancelled.
-                    step_projection::Entity::update_many()
+                    // UPDATE first to atomically claim the rows.
+                    // A concurrent dequeue that races this UPDATE
+                    // will either see the row as still pending (and
+                    // claim it before we run) or see it as cancelled
+                    // (and skip it). Either way, the UPDATE's
+                    // rows_affected count is authoritative.
+                    let result = step_projection::Entity::update_many()
                         .col_expr(
                             step_projection::Column::Status,
                             Expr::value(StepStatus::Cancelled.to_string()),
@@ -251,28 +236,41 @@ impl JobQueue for Store {
                         .exec(txn)
                         .await?;
 
-                    // Generate and insert one StepCancelled envelope
-                    // per cancelled row.
+                    let count = result.rows_affected;
+                    if count == 0 {
+                        return Ok(0);
+                    }
+
+                    // Now SELECT the rows we actually cancelled to
+                    // generate events. These rows are already
+                    // status='cancelled' with our exact timestamp,
+                    // so no TOCTOU window exists.
+                    let rows = step_projection::Entity::find()
+                        .filter(step_projection::Column::DispatchId.eq(dispatch_uuid))
+                        .filter(
+                            step_projection::Column::Status.eq(StepStatus::Cancelled.to_string()),
+                        )
+                        .filter(step_projection::Column::UpdatedAt.eq(timestamp))
+                        .filter(
+                            step_projection::Column::StepType.ne(StepType::Teardown.to_string()),
+                        )
+                        .all(txn)
+                        .await?;
+
                     let mut event_models = Vec::with_capacity(rows.len());
                     for row in &rows {
-                        let step_id = StepId::from_uuid(row.step_id);
-                        let step_type = step_converters::parse_step_type(&row.step_type)?;
-                        let envelope = EventEnvelope {
-                            schema_version: SCHEMA_VERSION,
-                            event_id: EventId::from_uuid(uuid::Uuid::now_v7()),
+                        let envelope = mint_step_cancelled(
+                            dispatch_id,
+                            row,
+                            actor.as_ref(),
+                            reason.as_ref(),
                             timestamp,
-                            entity_ref: EntityRef::Step(step_id),
-                            payload: DomainEvent::StepCancelled {
-                                dispatch_id,
-                                step_id,
-                                step_type,
-                                caused_by: actor.clone(),
-                                reason: reason.clone(),
-                            },
-                        };
-                        event_models.push(event_converters::envelope_to_active_model(&envelope)?);
+                        )?;
+                        event_models.push(envelope);
                     }
-                    events::Entity::insert_many(event_models).exec(txn).await?;
+                    if !event_models.is_empty() {
+                        events::Entity::insert_many(event_models).exec(txn).await?;
+                    }
 
                     Ok(count)
                 })
@@ -282,6 +280,7 @@ impl JobQueue for Store {
     }
 
     async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(&params.failure_event)?;
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.failure_event)?;
         let step_id_uuid = step_id.into_uuid();
@@ -400,4 +399,29 @@ impl JobQueue for Store {
             .await?;
         Ok(result.rows_affected)
     }
+}
+
+/// Build a `StepCancelled` event active model from a cancelled
+/// projection row + caller metadata.
+fn mint_step_cancelled(
+    dispatch_id: tanren_domain::DispatchId,
+    row: &step_projection::Model,
+    actor: Option<&tanren_domain::ActorContext>,
+    reason: Option<&String>,
+    timestamp: chrono::DateTime<Utc>,
+) -> Result<events::ActiveModel, StoreError> {
+    let step_id = StepId::from_uuid(row.step_id);
+    let step_type = step_converters::parse_step_type(&row.step_type)?;
+    let envelope = EventEnvelope::new(
+        EventId::from_uuid(uuid::Uuid::now_v7()),
+        timestamp,
+        DomainEvent::StepCancelled {
+            dispatch_id,
+            step_id,
+            step_type,
+            caused_by: actor.cloned(),
+            reason: reason.cloned(),
+        },
+    );
+    event_converters::envelope_to_active_model(&envelope)
 }

--- a/crates/tanren-store/src/job_queue.rs
+++ b/crates/tanren-store/src/job_queue.rs
@@ -79,7 +79,11 @@ pub trait JobQueue: Send + Sync {
 #[async_trait]
 impl JobQueue for Store {
     async fn enqueue_step(&self, params: EnqueueStepParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.enqueue_event)?;
+        event_converters::validate_step_event(
+            &params.enqueue_event,
+            params.step_id,
+            "step_enqueued",
+        )?;
         let now = Utc::now();
         let row = step_converters::enqueue_to_active_model(&params, now)?;
         let event_model = event_converters::envelope_to_active_model(&params.enqueue_event)?;
@@ -100,7 +104,11 @@ impl JobQueue for Store {
     }
 
     async fn ack(&self, params: AckParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.completion_event)?;
+        event_converters::validate_step_event(
+            &params.completion_event,
+            params.step_id,
+            "step_completed",
+        )?;
 
         let result_value = serde_json::to_value(&params.result)?;
         let event_model = event_converters::envelope_to_active_model(&params.completion_event)?;
@@ -144,9 +152,17 @@ impl JobQueue for Store {
     }
 
     async fn ack_and_enqueue(&self, params: AckAndEnqueueParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.completion_event)?;
+        event_converters::validate_step_event(
+            &params.completion_event,
+            params.step_id,
+            "step_completed",
+        )?;
         if let Some(ref next) = params.next_step {
-            event_converters::validate_envelope_entity_ref(&next.enqueue_event)?;
+            event_converters::validate_step_event(
+                &next.enqueue_event,
+                next.step_id,
+                "step_enqueued",
+            )?;
         }
         let now = Utc::now();
         let result_value = serde_json::to_value(&params.result)?;
@@ -210,7 +226,9 @@ impl JobQueue for Store {
         let dispatch_id = params.dispatch_id;
         let actor = params.actor;
         let reason = params.reason;
-        let timestamp = params.timestamp;
+        // Store-minted timestamp — not caller-controlled — so the
+        // post-UPDATE SELECT key is unique to this operation.
+        let timestamp = Utc::now();
         let dispatch_uuid = dispatch_id.into_uuid();
 
         self.conn()
@@ -280,7 +298,7 @@ impl JobQueue for Store {
     }
 
     async fn nack(&self, step_id: &StepId, params: NackParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.failure_event)?;
+        event_converters::validate_step_event(&params.failure_event, *step_id, "step_failed")?;
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.failure_event)?;
         let step_id_uuid = step_id.into_uuid();

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -42,12 +42,14 @@
 //! cross-process contention by retrying inside the driver instead
 //! of bubbling `SQLITE_BUSY` up.
 
+use chrono::Utc;
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, TransactionTrait, Value,
 };
+use tanren_domain::{DomainEvent, EntityRef, EventEnvelope, EventId, SCHEMA_VERSION};
 
-use crate::converters::step as step_converters;
-use crate::entity::step_projection;
+use crate::converters::{events as event_converters, step as step_converters};
+use crate::entity::{events, step_projection};
 use crate::errors::{StoreError, StoreResult};
 use crate::params::{DequeueParams, QueuedStep};
 
@@ -62,12 +64,15 @@ pub(crate) async fn dequeue_impl(
             context: "job_queue_dequeue::dequeue_impl",
             reason: "max_concurrent exceeds i64::MAX".to_owned(),
         })?;
-    let lane_string = params.lane.map(|l| l.to_string());
+    let lane_typed = params.lane;
+    let lane_string = lane_typed.map(|l| l.to_string());
     let worker_id = params.worker_id;
 
     let backend = conn.get_database_backend();
     match backend {
-        DbBackend::Postgres => dequeue_postgres(conn, worker_id, lane_string, max_concurrent).await,
+        DbBackend::Postgres => {
+            dequeue_postgres(conn, worker_id, lane_string, lane_typed, max_concurrent).await
+        }
         DbBackend::Sqlite => dequeue_sqlite(conn, worker_id, lane_string, max_concurrent).await,
         DbBackend::MySql => Err(StoreError::Conversion {
             context: "job_queue_dequeue::dequeue_impl",
@@ -81,25 +86,59 @@ pub(crate) async fn dequeue_impl(
 /// by unrelated subsystems.
 const ADVISORY_LOCK_NAMESPACE: i32 = 42;
 
-/// All dequeue operations share key 0. See the module doc for
-/// why a per-lane key is unsound.
-const ADVISORY_LOCK_KEY: i32 = 0;
+/// Global dequeue key. `lane=None` takes an exclusive lock on this
+/// key; `lane=Some(L)` takes a shared lock on it (plus an exclusive
+/// lock on the lane-specific key). This ensures `lane=None` blocks
+/// all lane-specific dequeues, but different lanes can proceed in
+/// parallel.
+const ADVISORY_LOCK_GLOBAL: i32 = 0;
+
+/// Map a lane to a unique advisory-lock key.
+fn lane_advisory_key(lane: tanren_domain::Lane) -> i32 {
+    match lane {
+        tanren_domain::Lane::Impl => 1,
+        tanren_domain::Lane::Audit => 2,
+        tanren_domain::Lane::Gate => 3,
+    }
+}
 
 async fn dequeue_postgres(
     conn: &DatabaseConnection,
     worker_id: String,
     lane: Option<String>,
+    lane_typed: Option<tanren_domain::Lane>,
     max_concurrent: i64,
 ) -> StoreResult<Option<QueuedStep>> {
     conn.transaction::<_, Option<QueuedStep>, StoreError>(move |txn| {
         Box::pin(async move {
-            // Global serialization lock — see module doc.
-            txn.execute(Statement::from_sql_and_values(
-                DbBackend::Postgres,
-                "SELECT pg_advisory_xact_lock($1, $2)",
-                vec![ADVISORY_LOCK_NAMESPACE.into(), ADVISORY_LOCK_KEY.into()],
-            ))
-            .await?;
+            // Hierarchical advisory locks:
+            // - lane=None  -> exclusive on global key
+            // - lane=Some  -> exclusive on lane key, shared on global
+            match lane_typed {
+                None => {
+                    txn.execute(Statement::from_sql_and_values(
+                        DbBackend::Postgres,
+                        "SELECT pg_advisory_xact_lock($1, $2)",
+                        vec![ADVISORY_LOCK_NAMESPACE.into(), ADVISORY_LOCK_GLOBAL.into()],
+                    ))
+                    .await?;
+                }
+                Some(l) => {
+                    let lane_key = lane_advisory_key(l);
+                    txn.execute(Statement::from_sql_and_values(
+                        DbBackend::Postgres,
+                        "SELECT pg_advisory_xact_lock($1, $2)",
+                        vec![ADVISORY_LOCK_NAMESPACE.into(), lane_key.into()],
+                    ))
+                    .await?;
+                    txn.execute(Statement::from_sql_and_values(
+                        DbBackend::Postgres,
+                        "SELECT pg_advisory_xact_lock_shared($1, $2)",
+                        vec![ADVISORY_LOCK_NAMESPACE.into(), ADVISORY_LOCK_GLOBAL.into()],
+                    ))
+                    .await?;
+                }
+            }
 
             let stmt = postgres_claim_statement(&worker_id, lane, max_concurrent);
             let row = step_projection::Entity::find()
@@ -107,7 +146,13 @@ async fn dequeue_postgres(
                 .one(txn)
                 .await?;
             match row {
-                Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
+                Some(model) => {
+                    let queued = step_converters::model_to_queued_step(model)?;
+                    let dequeued_event =
+                        mint_step_dequeued(queued.dispatch_id, queued.step_id, &worker_id)?;
+                    events::Entity::insert(dequeued_event).exec(txn).await?;
+                    Ok(Some(queued))
+                }
                 None => Ok(None),
             }
         })
@@ -152,18 +197,44 @@ async fn dequeue_sqlite(
         .await;
 
     match result {
-        Ok(row) => {
+        Ok(Some(model)) => {
+            let queued = step_converters::model_to_queued_step(model)?;
+            let dequeued_event =
+                mint_step_dequeued(queued.dispatch_id, queued.step_id, &worker_id)?;
+            events::Entity::insert(dequeued_event).exec(&txn).await?;
             txn.commit().await?;
-            match row {
-                Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
-                None => Ok(None),
-            }
+            Ok(Some(queued))
+        }
+        Ok(None) => {
+            txn.commit().await?;
+            Ok(None)
         }
         Err(err) => {
             txn.rollback().await?;
             Err(err.into())
         }
     }
+}
+
+/// Build a `StepDequeued` event [`events::ActiveModel`] for the
+/// claimed row.
+fn mint_step_dequeued(
+    dispatch_id: tanren_domain::DispatchId,
+    step_id: tanren_domain::StepId,
+    worker_id: &str,
+) -> Result<events::ActiveModel, StoreError> {
+    let envelope = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(uuid::Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepDequeued {
+            dispatch_id,
+            step_id,
+            worker_id: worker_id.to_owned(),
+        },
+    };
+    event_converters::envelope_to_active_model(&envelope)
 }
 
 /// Build the `Postgres` `UPDATE...RETURNING` claim statement.
@@ -214,7 +285,7 @@ pub(crate) fn sqlite_claim_statement(
     lane: Option<String>,
     max_concurrent: i64,
 ) -> Statement {
-    let now = chrono::Utc::now();
+    let now = Utc::now();
     let sql = r"
         UPDATE step_projection
         SET status = 'running',

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -5,29 +5,54 @@
 //! will see the same pending row before either of them flips it to
 //! `running`. `SeaORM`'s entity API cannot express this: there's no
 //! dialect-neutral way to encode `SELECT ... FOR UPDATE SKIP LOCKED`
-//! (`Postgres`) or a guaranteed single-writer `SQLite` `UPDATE` with
-//! subquery count-check. This module therefore branches on
-//! `DbBackend` and hands each backend the canonical idiom for its
-//! locking model:
+//! (`Postgres`) or the serialization required on `SQLite`. This
+//! module therefore branches on `DbBackend` and hands each backend
+//! the canonical idiom for its locking model.
 //!
-//! - **`Postgres`** — `UPDATE ... WHERE step_id = (SELECT ... FOR
-//!   UPDATE SKIP LOCKED LIMIT 1) RETURNING ...`. Row-level locking
-//!   ensures two workers cannot pick the same candidate, and `SKIP
-//!   LOCKED` lets workers slide past rows already being considered.
+//! Both branches run inside an explicit transaction and claim at
+//! most one candidate row per call.
 //!
-//! - **`SQLite`** — the same single-statement shape, minus the
-//!   `FOR UPDATE` clause. `SQLite` holds its implicit write lock
-//!   across the whole statement, so the subquery and the update
-//!   execute together. The `busy_timeout` URL parameter handles
-//!   contention between processes without propagating `SQLITE_BUSY`
-//!   up.
+//! ## `Postgres` path
 //!
-//! Both variants embed the `running`-count check inside the WHERE
-//! clause so the lane concurrency cap cannot be violated under race.
+//! A single global `pg_advisory_xact_lock(42, 0)` is taken at the
+//! start of every dequeue transaction, regardless of the requested
+//! lane. This serializes all concurrent dequeue operations against
+//! the same cluster.
+//!
+//! A per-lane lock key would be tempting, but `lane=None` counts
+//! running rows across *all* lanes while `lane=Impl` counts only
+//! impl rows — those are overlapping predicate spaces, so keying
+//! by lane lets two callers with different specs both observe a
+//! passing count and over-claim. The global lock closes this race
+//! at the cost of serializing cross-lane dequeues. The throughput
+//! impact is negligible: the critical section is a single UPDATE
+//! that completes in microseconds.
+//!
+//! ## `SQLite` path
+//!
+//! `SQLite` is serialized at the database level by its single-writer
+//! lock. The dequeue is a single `UPDATE ... WHERE step_id =
+//! (SELECT ... LIMIT 1) RETURNING ...` statement — there are no
+//! pre-write reads in the transaction. `SQLite` acquires the
+//! **reserved lock** (equivalent to the write lock) when the first
+//! write statement executes, so the entire count+claim decision
+//! runs under that lock even under `BEGIN DEFERRED`. This makes the
+//! `DEFERRED` vs `IMMEDIATE` distinction a no-op for this specific
+//! statement shape: both modes acquire the write lock before the
+//! UPDATE's subquery reads the candidate set. The `busy_timeout`
+//! set in `connection.rs` handles cross-process contention by
+//! retrying inside the driver instead of bubbling `SQLITE_BUSY` up.
+//!
+//! We use `conn.transaction()` (which issues `BEGIN DEFERRED`) and
+//! document this reasoning explicitly so the audit trail is clear.
+//! Reference: <https://www.sqlite.org/lang_transaction.html>
+//! ("DEFERRED ... the first read operation ... creates a SHARED
+//! lock and the first write operation creates a RESERVED lock").
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, Value};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, TransactionTrait, Value,
+};
 
-use crate::converters::dispatch as dispatch_converters;
 use crate::converters::step as step_converters;
 use crate::entity::step_projection;
 use crate::errors::{StoreError, StoreResult};
@@ -44,43 +69,100 @@ pub(crate) async fn dequeue_impl(
             context: "job_queue_dequeue::dequeue_impl",
             reason: "max_concurrent exceeds i64::MAX".to_owned(),
         })?;
-    let lane_string = params
-        .lane
-        .map(|l| dispatch_converters::lane_to_string(l).to_owned());
+    let lane_string = params.lane.map(|l| l.to_string());
+    let worker_id = params.worker_id;
 
     let backend = conn.get_database_backend();
-    let statement = match backend {
-        DbBackend::Postgres => postgres_statement(&params.worker_id, lane_string, max_concurrent),
-        DbBackend::Sqlite => sqlite_statement(&params.worker_id, lane_string, max_concurrent),
-        DbBackend::MySql => {
-            return Err(StoreError::Conversion {
-                context: "job_queue_dequeue::dequeue_impl",
-                reason: "MySQL is not a supported backend".to_owned(),
-            });
-        }
-    };
-
-    // `find().from_raw_sql(...)` lets SeaORM reconstruct a full
-    // `step_projection::Model` from the RETURNING row without
-    // manual column extraction. This keeps the converter path the
-    // same as every other read: go through `model_to_queued_step`.
-    let row = step_projection::Entity::find()
-        .from_raw_sql(statement)
-        .one(conn)
-        .await?;
-
-    match row {
-        Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
-        None => Ok(None),
+    match backend {
+        DbBackend::Postgres => dequeue_postgres(conn, worker_id, lane_string, max_concurrent).await,
+        DbBackend::Sqlite => dequeue_sqlite(conn, worker_id, lane_string, max_concurrent).await,
+        DbBackend::MySql => Err(StoreError::Conversion {
+            context: "job_queue_dequeue::dequeue_impl",
+            reason: "MySQL is not a supported backend".to_owned(),
+        }),
     }
 }
 
-fn postgres_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) -> Statement {
+/// Fixed namespace for `pg_advisory_xact_lock` calls made by the
+/// store. Prevents accidental collisions with advisory locks taken
+/// by unrelated subsystems.
+const ADVISORY_LOCK_NAMESPACE: i32 = 42;
+
+/// All dequeue operations share key 0. See the module doc for
+/// why a per-lane key is unsound.
+const ADVISORY_LOCK_KEY: i32 = 0;
+
+async fn dequeue_postgres(
+    conn: &DatabaseConnection,
+    worker_id: String,
+    lane: Option<String>,
+    max_concurrent: i64,
+) -> StoreResult<Option<QueuedStep>> {
+    conn.transaction::<_, Option<QueuedStep>, StoreError>(move |txn| {
+        Box::pin(async move {
+            // Global serialization lock — see module doc.
+            txn.execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                "SELECT pg_advisory_xact_lock($1, $2)",
+                vec![ADVISORY_LOCK_NAMESPACE.into(), ADVISORY_LOCK_KEY.into()],
+            ))
+            .await?;
+
+            let stmt = postgres_claim_statement(&worker_id, lane, max_concurrent);
+            let row = step_projection::Entity::find()
+                .from_raw_sql(stmt)
+                .one(txn)
+                .await?;
+            match row {
+                Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
+                None => Ok(None),
+            }
+        })
+    })
+    .await
+    .map_err(StoreError::from)
+}
+
+/// `SQLite` dequeue inside a `conn.transaction()` closure.
+///
+/// See the module doc for why `BEGIN DEFERRED` is sufficient for
+/// this single-statement shape — the write lock is acquired at
+/// the UPDATE, before the subquery reads.
+async fn dequeue_sqlite(
+    conn: &DatabaseConnection,
+    worker_id: String,
+    lane: Option<String>,
+    max_concurrent: i64,
+) -> StoreResult<Option<QueuedStep>> {
+    conn.transaction::<_, Option<QueuedStep>, StoreError>(move |txn| {
+        Box::pin(async move {
+            let stmt = sqlite_claim_statement(&worker_id, lane, max_concurrent);
+            let row = step_projection::Entity::find()
+                .from_raw_sql(stmt)
+                .one(txn)
+                .await?;
+            match row {
+                Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
+                None => Ok(None),
+            }
+        })
+    })
+    .await
+    .map_err(StoreError::from)
+}
+
+/// Build the `Postgres` `UPDATE...RETURNING` claim statement.
+pub(crate) fn postgres_claim_statement(
+    worker_id: &str,
+    lane: Option<String>,
+    max_concurrent: i64,
+) -> Statement {
     let sql = r"
         UPDATE step_projection
         SET status = 'running',
             worker_id = $1,
-            updated_at = NOW()
+            updated_at = NOW(),
+            last_heartbeat_at = NOW()
         WHERE step_id = (
             SELECT step_id FROM step_projection
             WHERE status = 'pending'
@@ -97,7 +179,8 @@ fn postgres_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64
         )
         RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
                   ready_state, depends_on, graph_revision, worker_id, payload,
-                  result, error, retry_count, created_at, updated_at
+                  result, error, retry_count, last_heartbeat_at, created_at,
+                  updated_at
     ";
     Statement::from_sql_and_values(
         DbBackend::Postgres,
@@ -110,16 +193,19 @@ fn postgres_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64
     )
 }
 
-fn sqlite_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) -> Statement {
-    // SQLite's `DATETIME('now')` returns a TIMESTAMP without
-    // sub-second precision. We parameter-bind the current time
-    // instead, so the column writes are comparable across backends.
+/// Build the `SQLite` `UPDATE ... RETURNING` claim statement.
+pub(crate) fn sqlite_claim_statement(
+    worker_id: &str,
+    lane: Option<String>,
+    max_concurrent: i64,
+) -> Statement {
     let now = chrono::Utc::now();
     let sql = r"
         UPDATE step_projection
         SET status = 'running',
             worker_id = ?1,
-            updated_at = ?2
+            updated_at = ?2,
+            last_heartbeat_at = ?2
         WHERE step_id = (
             SELECT step_id FROM step_projection
             WHERE status = 'pending'
@@ -135,7 +221,8 @@ fn sqlite_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) 
         )
         RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
                   ready_state, depends_on, graph_revision, worker_id, payload,
-                  result, error, retry_count, created_at, updated_at
+                  result, error, retry_count, last_heartbeat_at, created_at,
+                  updated_at
     ";
     Statement::from_sql_and_values(
         DbBackend::Sqlite,
@@ -147,4 +234,82 @@ fn sqlite_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) 
             Value::from(max_concurrent),
         ],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::MockDatabase;
+    use tanren_domain::Lane;
+
+    use super::*;
+
+    #[test]
+    fn postgres_claim_statement_contains_required_clauses() {
+        let stmt = postgres_claim_statement("worker-1", Some("impl".to_owned()), 5);
+        let sql = stmt.sql;
+        assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(sql.contains("pending"));
+        assert!(sql.contains("ready_state = 'ready'"));
+        assert!(sql.contains("last_heartbeat_at"));
+        assert!(sql.contains("RETURNING"));
+    }
+
+    #[test]
+    fn sqlite_claim_statement_has_no_for_update() {
+        let stmt = sqlite_claim_statement("worker-1", Some("impl".to_owned()), 5);
+        let sql = stmt.sql;
+        assert!(!sql.contains("FOR UPDATE"));
+        assert!(sql.contains("pending"));
+        assert!(sql.contains("last_heartbeat_at"));
+        assert!(sql.contains("RETURNING"));
+    }
+
+    #[test]
+    fn postgres_claim_statement_carries_three_parameters() {
+        let stmt = postgres_claim_statement("worker-1", None, 3);
+        assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 3);
+    }
+
+    #[test]
+    fn sqlite_claim_statement_carries_four_parameters() {
+        let stmt = sqlite_claim_statement("worker-1", None, 3);
+        assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 4);
+    }
+
+    /// Reject `MySQL` at the dispatcher because we don't ship a
+    /// `MySQL` dequeue path.
+    #[tokio::test]
+    async fn dequeue_impl_rejects_mysql_backend() {
+        let conn = MockDatabase::new(DbBackend::MySql).into_connection();
+        let params = DequeueParams {
+            worker_id: "w".to_owned(),
+            lane: Some(Lane::Impl),
+            max_concurrent: 1,
+        };
+        let err = dequeue_impl(&conn, params)
+            .await
+            .expect_err("mysql must be rejected");
+        let StoreError::Conversion { context, reason } = err else {
+            unreachable!("expected Conversion variant");
+        };
+        assert_eq!(context, "job_queue_dequeue::dequeue_impl");
+        assert!(reason.contains("MySQL"));
+    }
+
+    #[tokio::test]
+    async fn dequeue_impl_rejects_max_concurrent_overflow() {
+        let conn = MockDatabase::new(DbBackend::Sqlite).into_connection();
+        let params = DequeueParams {
+            worker_id: "w".to_owned(),
+            lane: None,
+            max_concurrent: u64::MAX,
+        };
+        let err = dequeue_impl(&conn, params)
+            .await
+            .expect_err("overflow must surface");
+        assert!(
+            matches!(err, StoreError::Conversion { .. }),
+            "expected Conversion, got {err:?}"
+        );
+    }
 }

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -1,46 +1,21 @@
 //! Atomic dequeue — the one place raw SQL remains.
 //!
 //! `dequeue` must perform the "check running-count, claim pending
-//! candidate" decision in a single atomic step, otherwise two workers
-//! will see the same pending row before either of them flips it to
-//! `running`. `SeaORM`'s entity API cannot express this: there's no
-//! dialect-neutral way to encode `SELECT ... FOR UPDATE SKIP LOCKED`
-//! (`Postgres`) or the serialization required on `SQLite`. This
-//! module therefore branches on `DbBackend` and hands each backend
-//! the canonical idiom for its locking model.
+//! candidate" decision in a single atomic step. `SeaORM`'s entity
+//! API cannot express this, so we branch on `DbBackend`.
 //!
-//! Both branches run inside an explicit transaction and claim at
-//! most one candidate row per call.
+//! **Postgres**: hierarchical advisory locks serialize dequeue by
+//! lane scope. `lane=None` takes an exclusive lock on global key
+//! `(42, 0)`; `lane=Some(L)` takes exclusive on the lane key plus
+//! shared on global, so different lanes dequeue in parallel.
 //!
-//! ## `Postgres` path
+//! **`SQLite`**: `BEGIN IMMEDIATE` + `busy_timeout` (set in
+//! `connection.rs`). We upgrade from `SeaORM`'s `BEGIN DEFERRED` via
+//! `END; BEGIN IMMEDIATE` on the same sticky connection.
 //!
-//! A single global `pg_advisory_xact_lock(42, 0)` is taken at the
-//! start of every dequeue transaction, regardless of the requested
-//! lane. This serializes all concurrent dequeue operations against
-//! the same cluster.
-//!
-//! A per-lane lock key would be tempting, but `lane=None` counts
-//! running rows across *all* lanes while `lane=Impl` counts only
-//! impl rows — those are overlapping predicate spaces, so keying
-//! by lane lets two callers with different specs both observe a
-//! passing count and over-claim. The global lock closes this race
-//! at the cost of serializing cross-lane dequeues. The throughput
-//! impact is negligible: the critical section is a single UPDATE
-//! that completes in microseconds.
-//!
-//! ## `SQLite` path
-//!
-//! The audit brief requires `BEGIN IMMEDIATE` + `busy_timeout` for
-//! the `SQLite` dequeue path, and flags `BEGIN DEFERRED` as
-//! non-conformant. `SeaORM`'s `conn.transaction()` always issues
-//! `BEGIN DEFERRED` and ignores `IsolationLevel` on `SQLite`, so we
-//! bypass it: call `conn.begin()` to acquire a sticky pooled
-//! connection (which issues `BEGIN DEFERRED`), then immediately
-//! upgrade via `END; BEGIN IMMEDIATE` on the same connection. The
-//! claim statement and the final `COMMIT` all run on that same
-//! sticky handle. The `busy_timeout` set in `connection.rs` handles
-//! cross-process contention by retrying inside the driver instead
-//! of bubbling `SQLITE_BUSY` up.
+//! Both backends split claim SQL into lane-scoped and global
+//! variants so the query planner can use the `(lane, status)`
+//! composite index instead of the `IS NULL OR` disjunction.
 
 use chrono::Utc;
 use sea_orm::{
@@ -92,6 +67,16 @@ const ADVISORY_LOCK_NAMESPACE: i32 = 42;
 /// all lane-specific dequeues, but different lanes can proceed in
 /// parallel.
 const ADVISORY_LOCK_GLOBAL: i32 = 0;
+
+// Domain-enum string literals for raw SQL; drift caught by test below.
+const STATUS_PENDING: &str = "pending";
+const STATUS_RUNNING: &str = "running";
+const READY_STATE_READY: &str = "ready";
+
+const RETURNING_COLS: &str = "\
+RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status, \
+ready_state, depends_on, graph_revision, worker_id, payload, \
+result, error, retry_count, last_heartbeat_at, created_at, updated_at";
 
 /// Map a lane to a unique advisory-lock key.
 fn lane_advisory_key(lane: tanren_domain::Lane) -> i32 {
@@ -241,31 +226,35 @@ pub(crate) fn postgres_claim_statement(
     lane: Option<String>,
     max_concurrent: i64,
 ) -> Statement {
-    let sql = r"
-        UPDATE step_projection
-        SET status = 'running',
+    match lane {
+        Some(l) => postgres_claim_lane(worker_id, l, max_concurrent),
+        None => postgres_claim_global(worker_id, max_concurrent),
+    }
+}
+
+fn postgres_claim_lane(worker_id: &str, lane: String, max_concurrent: i64) -> Statement {
+    let sql = format!(
+        "UPDATE step_projection
+        SET status = '{STATUS_RUNNING}',
             worker_id = $1,
             updated_at = NOW(),
             last_heartbeat_at = NOW()
         WHERE step_id = (
             SELECT step_id FROM step_projection
-            WHERE status = 'pending'
-              AND ready_state = 'ready'
-              AND ($2::text IS NULL OR lane = $2)
+            WHERE status = '{STATUS_PENDING}'
+              AND ready_state = '{READY_STATE_READY}'
+              AND lane = $2
               AND (
                   SELECT COUNT(*) FROM step_projection
-                  WHERE status = 'running'
-                    AND ($2::text IS NULL OR lane = $2)
+                  WHERE status = '{STATUS_RUNNING}'
+                    AND lane = $2
               ) < $3
             ORDER BY created_at ASC, step_sequence ASC
             FOR UPDATE SKIP LOCKED
             LIMIT 1
         )
-        RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
-                  ready_state, depends_on, graph_revision, worker_id, payload,
-                  result, error, retry_count, last_heartbeat_at, created_at,
-                  updated_at
-    ";
+        {RETURNING_COLS}"
+    );
     Statement::from_sql_and_values(
         DbBackend::Postgres,
         sql,
@@ -277,37 +266,72 @@ pub(crate) fn postgres_claim_statement(
     )
 }
 
+fn postgres_claim_global(worker_id: &str, max_concurrent: i64) -> Statement {
+    let sql = format!(
+        "UPDATE step_projection
+        SET status = '{STATUS_RUNNING}',
+            worker_id = $1,
+            updated_at = NOW(),
+            last_heartbeat_at = NOW()
+        WHERE step_id = (
+            SELECT step_id FROM step_projection
+            WHERE status = '{STATUS_PENDING}'
+              AND ready_state = '{READY_STATE_READY}'
+              AND (
+                  SELECT COUNT(*) FROM step_projection
+                  WHERE status = '{STATUS_RUNNING}'
+              ) < $2
+            ORDER BY created_at ASC, step_sequence ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+        )
+        {RETURNING_COLS}"
+    );
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        sql,
+        vec![
+            Value::from(worker_id.to_owned()),
+            Value::from(max_concurrent),
+        ],
+    )
+}
+
 /// Build the `SQLite` `UPDATE ... RETURNING` claim statement.
 pub(crate) fn sqlite_claim_statement(
     worker_id: &str,
     lane: Option<String>,
     max_concurrent: i64,
 ) -> Statement {
+    match lane {
+        Some(l) => sqlite_claim_lane(worker_id, l, max_concurrent),
+        None => sqlite_claim_global(worker_id, max_concurrent),
+    }
+}
+
+fn sqlite_claim_lane(worker_id: &str, lane: String, max_concurrent: i64) -> Statement {
     let now = Utc::now();
-    let sql = r"
-        UPDATE step_projection
-        SET status = 'running',
+    let sql = format!(
+        "UPDATE step_projection
+        SET status = '{STATUS_RUNNING}',
             worker_id = ?1,
             updated_at = ?2,
             last_heartbeat_at = ?2
         WHERE step_id = (
             SELECT step_id FROM step_projection
-            WHERE status = 'pending'
-              AND ready_state = 'ready'
-              AND (?3 IS NULL OR lane = ?3)
+            WHERE status = '{STATUS_PENDING}'
+              AND ready_state = '{READY_STATE_READY}'
+              AND lane = ?3
               AND (
                   SELECT COUNT(*) FROM step_projection
-                  WHERE status = 'running'
-                    AND (?3 IS NULL OR lane = ?3)
+                  WHERE status = '{STATUS_RUNNING}'
+                    AND lane = ?3
               ) < ?4
             ORDER BY created_at ASC, step_sequence ASC
             LIMIT 1
         )
-        RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
-                  ready_state, depends_on, graph_revision, worker_id, payload,
-                  result, error, retry_count, last_heartbeat_at, created_at,
-                  updated_at
-    ";
+        {RETURNING_COLS}"
+    );
     Statement::from_sql_and_values(
         DbBackend::Sqlite,
         sql,
@@ -315,6 +339,38 @@ pub(crate) fn sqlite_claim_statement(
             Value::from(worker_id.to_owned()),
             Value::from(now),
             Value::from(lane),
+            Value::from(max_concurrent),
+        ],
+    )
+}
+
+fn sqlite_claim_global(worker_id: &str, max_concurrent: i64) -> Statement {
+    let now = Utc::now();
+    let sql = format!(
+        "UPDATE step_projection
+        SET status = '{STATUS_RUNNING}',
+            worker_id = ?1,
+            updated_at = ?2,
+            last_heartbeat_at = ?2
+        WHERE step_id = (
+            SELECT step_id FROM step_projection
+            WHERE status = '{STATUS_PENDING}'
+              AND ready_state = '{READY_STATE_READY}'
+              AND (
+                  SELECT COUNT(*) FROM step_projection
+                  WHERE status = '{STATUS_RUNNING}'
+              ) < ?3
+            ORDER BY created_at ASC, step_sequence ASC
+            LIMIT 1
+        )
+        {RETURNING_COLS}"
+    );
+    Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        sql,
+        vec![
+            Value::from(worker_id.to_owned()),
+            Value::from(now),
             Value::from(max_concurrent),
         ],
     )
@@ -328,7 +384,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn postgres_claim_statement_contains_required_clauses() {
+    fn postgres_claim_lane_contains_required_clauses() {
         let stmt = postgres_claim_statement("worker-1", Some("impl".to_owned()), 5);
         let sql = stmt.sql;
         assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
@@ -336,28 +392,65 @@ mod tests {
         assert!(sql.contains("ready_state = 'ready'"));
         assert!(sql.contains("last_heartbeat_at"));
         assert!(sql.contains("RETURNING"));
+        assert!(sql.contains("lane = $2"), "lane-scoped must use direct eq");
+        assert!(
+            !sql.contains("IS NULL"),
+            "lane-scoped must not use IS NULL pattern"
+        );
     }
 
     #[test]
-    fn sqlite_claim_statement_has_no_for_update() {
+    fn postgres_claim_global_omits_lane_filter() {
+        let stmt = postgres_claim_statement("worker-1", None, 5);
+        let sql = stmt.sql;
+        assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(!sql.contains("lane ="), "global must not filter by lane");
+    }
+
+    #[test]
+    fn sqlite_claim_lane_has_no_for_update() {
         let stmt = sqlite_claim_statement("worker-1", Some("impl".to_owned()), 5);
         let sql = stmt.sql;
         assert!(!sql.contains("FOR UPDATE"));
         assert!(sql.contains("pending"));
         assert!(sql.contains("last_heartbeat_at"));
         assert!(sql.contains("RETURNING"));
+        assert!(sql.contains("lane = ?3"), "lane-scoped must use direct eq");
+        assert!(
+            !sql.contains("IS NULL"),
+            "lane-scoped must not use IS NULL pattern"
+        );
     }
 
     #[test]
-    fn postgres_claim_statement_carries_three_parameters() {
-        let stmt = postgres_claim_statement("worker-1", None, 3);
+    fn sqlite_claim_global_omits_lane_filter() {
+        let stmt = sqlite_claim_statement("worker-1", None, 5);
+        let sql = stmt.sql;
+        assert!(!sql.contains("lane ="), "global must not filter by lane");
+    }
+
+    #[test]
+    fn postgres_claim_lane_carries_three_parameters() {
+        let stmt = postgres_claim_statement("worker-1", Some("impl".to_owned()), 3);
         assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 3);
     }
 
     #[test]
-    fn sqlite_claim_statement_carries_four_parameters() {
-        let stmt = sqlite_claim_statement("worker-1", None, 3);
+    fn postgres_claim_global_carries_two_parameters() {
+        let stmt = postgres_claim_statement("worker-1", None, 3);
+        assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 2);
+    }
+
+    #[test]
+    fn sqlite_claim_lane_carries_four_parameters() {
+        let stmt = sqlite_claim_statement("worker-1", Some("impl".to_owned()), 3);
         assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 4);
+    }
+
+    #[test]
+    fn sqlite_claim_global_carries_three_parameters() {
+        let stmt = sqlite_claim_statement("worker-1", None, 3);
+        assert_eq!(stmt.values.as_ref().map_or(0, |v| v.0.len()), 3);
     }
 
     /// Reject `MySQL` at the dispatcher because we don't ship a
@@ -395,5 +488,13 @@ mod tests {
             matches!(err, StoreError::Conversion { .. }),
             "expected Conversion, got {err:?}"
         );
+    }
+
+    #[test]
+    fn sql_literals_match_domain_enums() {
+        use tanren_domain::{StepReadyState, StepStatus};
+        assert_eq!(STATUS_PENDING, StepStatus::Pending.to_string());
+        assert_eq!(STATUS_RUNNING, StepStatus::Running.to_string());
+        assert_eq!(READY_STATE_READY, StepReadyState::Ready.to_string());
     }
 }

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -46,7 +46,7 @@ use chrono::Utc;
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, TransactionTrait, Value,
 };
-use tanren_domain::{DomainEvent, EntityRef, EventEnvelope, EventId, SCHEMA_VERSION};
+use tanren_domain::{DomainEvent, EventEnvelope, EventId};
 
 use crate::converters::{events as event_converters, step as step_converters};
 use crate::entity::{events, step_projection};
@@ -223,17 +223,15 @@ fn mint_step_dequeued(
     step_id: tanren_domain::StepId,
     worker_id: &str,
 ) -> Result<events::ActiveModel, StoreError> {
-    let envelope = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(uuid::Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepDequeued {
+    let envelope = EventEnvelope::new(
+        EventId::from_uuid(uuid::Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepDequeued {
             dispatch_id,
             step_id,
             worker_id: worker_id.to_owned(),
         },
-    };
+    );
     event_converters::envelope_to_active_model(&envelope)
 }
 

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -30,24 +30,17 @@
 //!
 //! ## `SQLite` path
 //!
-//! `SQLite` is serialized at the database level by its single-writer
-//! lock. The dequeue is a single `UPDATE ... WHERE step_id =
-//! (SELECT ... LIMIT 1) RETURNING ...` statement — there are no
-//! pre-write reads in the transaction. `SQLite` acquires the
-//! **reserved lock** (equivalent to the write lock) when the first
-//! write statement executes, so the entire count+claim decision
-//! runs under that lock even under `BEGIN DEFERRED`. This makes the
-//! `DEFERRED` vs `IMMEDIATE` distinction a no-op for this specific
-//! statement shape: both modes acquire the write lock before the
-//! UPDATE's subquery reads the candidate set. The `busy_timeout`
-//! set in `connection.rs` handles cross-process contention by
-//! retrying inside the driver instead of bubbling `SQLITE_BUSY` up.
-//!
-//! We use `conn.transaction()` (which issues `BEGIN DEFERRED`) and
-//! document this reasoning explicitly so the audit trail is clear.
-//! Reference: <https://www.sqlite.org/lang_transaction.html>
-//! ("DEFERRED ... the first read operation ... creates a SHARED
-//! lock and the first write operation creates a RESERVED lock").
+//! The audit brief requires `BEGIN IMMEDIATE` + `busy_timeout` for
+//! the `SQLite` dequeue path, and flags `BEGIN DEFERRED` as
+//! non-conformant. `SeaORM`'s `conn.transaction()` always issues
+//! `BEGIN DEFERRED` and ignores `IsolationLevel` on `SQLite`, so we
+//! bypass it: call `conn.begin()` to acquire a sticky pooled
+//! connection (which issues `BEGIN DEFERRED`), then immediately
+//! upgrade via `END; BEGIN IMMEDIATE` on the same connection. The
+//! claim statement and the final `COMMIT` all run on that same
+//! sticky handle. The `busy_timeout` set in `connection.rs` handles
+//! cross-process contention by retrying inside the driver instead
+//! of bubbling `SQLITE_BUSY` up.
 
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, TransactionTrait, Value,
@@ -123,32 +116,54 @@ async fn dequeue_postgres(
     .map_err(StoreError::from)
 }
 
-/// `SQLite` dequeue inside a `conn.transaction()` closure.
+/// `SQLite` dequeue under `BEGIN IMMEDIATE`.
 ///
-/// See the module doc for why `BEGIN DEFERRED` is sufficient for
-/// this single-statement shape — the write lock is acquired at
-/// the UPDATE, before the subquery reads.
+/// `SeaORM`'s `conn.transaction()` always issues `BEGIN DEFERRED`,
+/// so we acquire a sticky connection via `conn.begin()` and
+/// immediately upgrade to `IMMEDIATE` by ending the deferred
+/// transaction and starting a new immediate one on the same handle.
+/// This satisfies the audit brief's requirement and ensures the
+/// write lock is held from the very start of the transaction.
 async fn dequeue_sqlite(
     conn: &DatabaseConnection,
     worker_id: String,
     lane: Option<String>,
     max_concurrent: i64,
 ) -> StoreResult<Option<QueuedStep>> {
-    conn.transaction::<_, Option<QueuedStep>, StoreError>(move |txn| {
-        Box::pin(async move {
-            let stmt = sqlite_claim_statement(&worker_id, lane, max_concurrent);
-            let row = step_projection::Entity::find()
-                .from_raw_sql(stmt)
-                .one(txn)
-                .await?;
+    // `conn.begin()` acquires a sticky pooled connection and issues
+    // `BEGIN` (deferred). We hold this handle for the lifetime of
+    // the dequeue so every subsequent statement runs on the same
+    // connection.
+    let txn = conn.begin().await?;
+
+    // Upgrade: end the deferred transaction and immediately start
+    // an IMMEDIATE one. Both statements execute on the sticky
+    // connection held by `txn`. If `BEGIN IMMEDIATE` fails (e.g.,
+    // `SQLITE_BUSY` after busy_timeout exhaustion), the error
+    // propagates and `txn`'s drop handler is a no-op (no active
+    // transaction to rollback — we already ended it).
+    txn.execute_unprepared("END").await?;
+    txn.execute_unprepared("BEGIN IMMEDIATE").await?;
+
+    let stmt = sqlite_claim_statement(&worker_id, lane, max_concurrent);
+    let result = step_projection::Entity::find()
+        .from_raw_sql(stmt)
+        .one(&txn)
+        .await;
+
+    match result {
+        Ok(row) => {
+            txn.commit().await?;
             match row {
                 Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
                 None => Ok(None),
             }
-        })
-    })
-    .await
-    .map_err(StoreError::from)
+        }
+        Err(err) => {
+            txn.rollback().await?;
+            Err(err.into())
+        }
+    }
 }
 
 /// Build the `Postgres` `UPDATE...RETURNING` claim statement.

--- a/crates/tanren-store/src/job_queue_dequeue.rs
+++ b/crates/tanren-store/src/job_queue_dequeue.rs
@@ -1,0 +1,150 @@
+//! Atomic dequeue — the one place raw SQL remains.
+//!
+//! `dequeue` must perform the "check running-count, claim pending
+//! candidate" decision in a single atomic step, otherwise two workers
+//! will see the same pending row before either of them flips it to
+//! `running`. `SeaORM`'s entity API cannot express this: there's no
+//! dialect-neutral way to encode `SELECT ... FOR UPDATE SKIP LOCKED`
+//! (`Postgres`) or a guaranteed single-writer `SQLite` `UPDATE` with
+//! subquery count-check. This module therefore branches on
+//! `DbBackend` and hands each backend the canonical idiom for its
+//! locking model:
+//!
+//! - **`Postgres`** — `UPDATE ... WHERE step_id = (SELECT ... FOR
+//!   UPDATE SKIP LOCKED LIMIT 1) RETURNING ...`. Row-level locking
+//!   ensures two workers cannot pick the same candidate, and `SKIP
+//!   LOCKED` lets workers slide past rows already being considered.
+//!
+//! - **`SQLite`** — the same single-statement shape, minus the
+//!   `FOR UPDATE` clause. `SQLite` holds its implicit write lock
+//!   across the whole statement, so the subquery and the update
+//!   execute together. The `busy_timeout` URL parameter handles
+//!   contention between processes without propagating `SQLITE_BUSY`
+//!   up.
+//!
+//! Both variants embed the `running`-count check inside the WHERE
+//! clause so the lane concurrency cap cannot be violated under race.
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement, Value};
+
+use crate::converters::dispatch as dispatch_converters;
+use crate::converters::step as step_converters;
+use crate::entity::step_projection;
+use crate::errors::{StoreError, StoreResult};
+use crate::params::{DequeueParams, QueuedStep};
+
+/// Implementation entry point called from
+/// [`JobQueue::dequeue`](crate::JobQueue::dequeue).
+pub(crate) async fn dequeue_impl(
+    conn: &DatabaseConnection,
+    params: DequeueParams,
+) -> StoreResult<Option<QueuedStep>> {
+    let max_concurrent =
+        i64::try_from(params.max_concurrent).map_err(|_| StoreError::Conversion {
+            context: "job_queue_dequeue::dequeue_impl",
+            reason: "max_concurrent exceeds i64::MAX".to_owned(),
+        })?;
+    let lane_string = params
+        .lane
+        .map(|l| dispatch_converters::lane_to_string(l).to_owned());
+
+    let backend = conn.get_database_backend();
+    let statement = match backend {
+        DbBackend::Postgres => postgres_statement(&params.worker_id, lane_string, max_concurrent),
+        DbBackend::Sqlite => sqlite_statement(&params.worker_id, lane_string, max_concurrent),
+        DbBackend::MySql => {
+            return Err(StoreError::Conversion {
+                context: "job_queue_dequeue::dequeue_impl",
+                reason: "MySQL is not a supported backend".to_owned(),
+            });
+        }
+    };
+
+    // `find().from_raw_sql(...)` lets SeaORM reconstruct a full
+    // `step_projection::Model` from the RETURNING row without
+    // manual column extraction. This keeps the converter path the
+    // same as every other read: go through `model_to_queued_step`.
+    let row = step_projection::Entity::find()
+        .from_raw_sql(statement)
+        .one(conn)
+        .await?;
+
+    match row {
+        Some(model) => Ok(Some(step_converters::model_to_queued_step(model)?)),
+        None => Ok(None),
+    }
+}
+
+fn postgres_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) -> Statement {
+    let sql = r"
+        UPDATE step_projection
+        SET status = 'running',
+            worker_id = $1,
+            updated_at = NOW()
+        WHERE step_id = (
+            SELECT step_id FROM step_projection
+            WHERE status = 'pending'
+              AND ready_state = 'ready'
+              AND ($2::text IS NULL OR lane = $2)
+              AND (
+                  SELECT COUNT(*) FROM step_projection
+                  WHERE status = 'running'
+                    AND ($2::text IS NULL OR lane = $2)
+              ) < $3
+            ORDER BY created_at ASC, step_sequence ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+        )
+        RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
+                  ready_state, depends_on, graph_revision, worker_id, payload,
+                  result, error, retry_count, created_at, updated_at
+    ";
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        sql,
+        vec![
+            Value::from(worker_id.to_owned()),
+            Value::from(lane),
+            Value::from(max_concurrent),
+        ],
+    )
+}
+
+fn sqlite_statement(worker_id: &str, lane: Option<String>, max_concurrent: i64) -> Statement {
+    // SQLite's `DATETIME('now')` returns a TIMESTAMP without
+    // sub-second precision. We parameter-bind the current time
+    // instead, so the column writes are comparable across backends.
+    let now = chrono::Utc::now();
+    let sql = r"
+        UPDATE step_projection
+        SET status = 'running',
+            worker_id = ?1,
+            updated_at = ?2
+        WHERE step_id = (
+            SELECT step_id FROM step_projection
+            WHERE status = 'pending'
+              AND ready_state = 'ready'
+              AND (?3 IS NULL OR lane = ?3)
+              AND (
+                  SELECT COUNT(*) FROM step_projection
+                  WHERE status = 'running'
+                    AND (?3 IS NULL OR lane = ?3)
+              ) < ?4
+            ORDER BY created_at ASC, step_sequence ASC
+            LIMIT 1
+        )
+        RETURNING step_id, dispatch_id, step_type, step_sequence, lane, status,
+                  ready_state, depends_on, graph_revision, worker_id, payload,
+                  result, error, retry_count, created_at, updated_at
+    ";
+    Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        sql,
+        vec![
+            Value::from(worker_id.to_owned()),
+            Value::from(now),
+            Value::from(lane),
+            Value::from(max_concurrent),
+        ],
+    )
+}

--- a/crates/tanren-store/src/lib.rs
+++ b/crates/tanren-store/src/lib.rs
@@ -24,6 +24,10 @@
 // module (but not re-exporting anything from it at the crate root)
 // keeps the lint satisfied without leaking the entity types into the
 // documented API.
+// `connection` houses `ConnectConfig` (public) alongside internal
+// helpers (`connect`, `connect_with_config`).  Making the module
+// `pub(crate)` keeps the helpers private while letting `lib.rs`
+// re-export `ConnectConfig` by path.
 mod connection;
 mod converters;
 #[doc(hidden)]
@@ -37,12 +41,14 @@ mod params;
 mod state_store;
 mod store;
 
+pub use connection::ConnectConfig;
 pub use errors::{StoreError, StoreResult};
 pub use event_store::EventStore;
 pub use job_queue::JobQueue;
 pub use params::{
-    AckAndEnqueueParams, CreateDispatchParams, DEFAULT_QUERY_LIMIT, DequeueParams, DispatchFilter,
-    EnqueueStepParams, EventFilter, NackParams, QueuedStep,
+    AckAndEnqueueParams, AckParams, CancelPendingStepsParams, CreateDispatchParams,
+    DEFAULT_QUERY_LIMIT, DequeueParams, DispatchFilter, EnqueueStepParams, EventFilter, NackParams,
+    QueuedStep, UpdateDispatchStatusParams,
 };
 pub use state_store::StateStore;
 pub use store::Store;

--- a/crates/tanren-store/src/lib.rs
+++ b/crates/tanren-store/src/lib.rs
@@ -15,3 +15,34 @@
 //! - Supports `SQLite` (local/dev) and Postgres (team/enterprise)
 //! - Write-side uses transactional guarantees
 //! - Read-side uses purpose-built indexed projections (no scan-heavy paths)
+
+// `entity` is public as an escape hatch: external crates in this
+// workspace must not reach into it (linking rule: the store owns all
+// SQL and all row shapes), but SeaORM's `DeriveEntityModel` macro
+// always emits `pub` items, and the `unreachable_pub` lint requires
+// every `pub` item to be reachable from a public path. Exposing the
+// module (but not re-exporting anything from it at the crate root)
+// keeps the lint satisfied without leaking the entity types into the
+// documented API.
+mod connection;
+mod converters;
+#[doc(hidden)]
+pub mod entity;
+mod errors;
+mod event_store;
+mod job_queue;
+mod job_queue_dequeue;
+mod migration;
+mod params;
+mod state_store;
+mod store;
+
+pub use errors::{StoreError, StoreResult};
+pub use event_store::EventStore;
+pub use job_queue::JobQueue;
+pub use params::{
+    AckAndEnqueueParams, CreateDispatchParams, DEFAULT_QUERY_LIMIT, DequeueParams, DispatchFilter,
+    EnqueueStepParams, EventFilter, NackParams, QueuedStep,
+};
+pub use state_store::StateStore;
+pub use store::Store;

--- a/crates/tanren-store/src/migration/m_0001_init.rs
+++ b/crates/tanren-store/src/migration/m_0001_init.rs
@@ -1,0 +1,438 @@
+//! Initial schema — the three core tables and their indexes.
+//!
+//! Creates `events`, `dispatch_projection`, and `step_projection` plus
+//! every index listed in the Lane 0.3 spec. All JSON columns use
+//! [`ColumnDef::json_binary`], which emits `TEXT` on `SQLite` and
+//! `JSONB` on `Postgres` — backend-agnostic JSON support from a
+//! single definition.
+
+use sea_orm_migration::prelude::*;
+
+/// Migration implementation — `up` creates every table and index,
+/// `down` drops them in the reverse order.
+#[derive(Debug)]
+pub(crate) struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &'static str {
+        "m_0001_init"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(create_events_table(manager)).await?;
+        Box::pin(create_dispatch_projection_table(manager)).await?;
+        Box::pin(create_step_projection_table(manager)).await?;
+        Box::pin(create_events_indexes(manager)).await?;
+        Box::pin(create_dispatch_projection_indexes(manager)).await?;
+        Box::pin(create_step_projection_indexes(manager)).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(drop_step_projection_indexes(manager)).await?;
+        Box::pin(drop_dispatch_projection_indexes(manager)).await?;
+        Box::pin(drop_events_indexes(manager)).await?;
+        manager
+            .drop_table(Table::drop().table(StepProjection::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(DispatchProjection::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Events::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Table creation
+// ---------------------------------------------------------------------------
+
+async fn create_events_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(Events::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(Events::Id)
+                        .big_integer()
+                        .not_null()
+                        .auto_increment()
+                        .primary_key(),
+                )
+                .col(
+                    ColumnDef::new(Events::EventId)
+                        .uuid()
+                        .not_null()
+                        .unique_key(),
+                )
+                .col(
+                    ColumnDef::new(Events::Timestamp)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(Events::EntityKind).string().not_null())
+                .col(ColumnDef::new(Events::EntityId).string().not_null())
+                .col(ColumnDef::new(Events::EventType).string().not_null())
+                .col(ColumnDef::new(Events::SchemaVersion).integer().not_null())
+                .col(ColumnDef::new(Events::Payload).json_binary().not_null())
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_dispatch_projection_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(DispatchProjection::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(DispatchProjection::DispatchId)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(DispatchProjection::Mode).string().not_null())
+                .col(
+                    ColumnDef::new(DispatchProjection::Status)
+                        .string()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(DispatchProjection::Outcome).string().null())
+                .col(ColumnDef::new(DispatchProjection::Lane).string().not_null())
+                .col(
+                    ColumnDef::new(DispatchProjection::Dispatch)
+                        .json_binary()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(DispatchProjection::Actor)
+                        .json_binary()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(DispatchProjection::GraphRevision)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(DispatchProjection::UserId).uuid().not_null())
+                .col(
+                    ColumnDef::new(DispatchProjection::Project)
+                        .string()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(DispatchProjection::CreatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(DispatchProjection::UpdatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_step_projection_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(StepProjection::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(StepProjection::StepId)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(StepProjection::DispatchId).uuid().not_null())
+                .col(ColumnDef::new(StepProjection::StepType).string().not_null())
+                .col(
+                    ColumnDef::new(StepProjection::StepSequence)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(StepProjection::Lane).string().null())
+                .col(ColumnDef::new(StepProjection::Status).string().not_null())
+                .col(
+                    ColumnDef::new(StepProjection::ReadyState)
+                        .string()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StepProjection::DependsOn)
+                        .json_binary()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StepProjection::GraphRevision)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(StepProjection::WorkerId).string().null())
+                .col(ColumnDef::new(StepProjection::Payload).json_binary().null())
+                .col(ColumnDef::new(StepProjection::Result).json_binary().null())
+                .col(ColumnDef::new(StepProjection::Error).string().null())
+                .col(
+                    ColumnDef::new(StepProjection::RetryCount)
+                        .integer()
+                        .not_null()
+                        .default(0),
+                )
+                .col(
+                    ColumnDef::new(StepProjection::CreatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StepProjection::UpdatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Index creation
+// ---------------------------------------------------------------------------
+
+async fn create_events_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_events_entity_id")
+                .table(Events::Table)
+                .col(Events::EntityId)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_events_entity_kind")
+                .table(Events::Table)
+                .col(Events::EntityKind)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_events_event_type")
+                .table(Events::Table)
+                .col(Events::EventType)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_events_timestamp")
+                .table(Events::Table)
+                .col(Events::Timestamp)
+                .to_owned(),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn create_dispatch_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for (name, col) in [
+        ("ix_dispatch_status", DispatchProjection::Status),
+        ("ix_dispatch_lane", DispatchProjection::Lane),
+        ("ix_dispatch_created", DispatchProjection::CreatedAt),
+        ("ix_dispatch_user", DispatchProjection::UserId),
+        ("ix_dispatch_project", DispatchProjection::Project),
+    ] {
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(name)
+                    .table(DispatchProjection::Table)
+                    .col(col)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn create_step_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for (name, col) in [
+        ("ix_step_dispatch", StepProjection::DispatchId),
+        ("ix_step_status", StepProjection::Status),
+    ] {
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(name)
+                    .table(StepProjection::Table)
+                    .col(col)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    // Composite (lane, status) for lane-scoped counts and dequeue
+    // candidate selection.
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_lane_status")
+                .table(StepProjection::Table)
+                .col(StepProjection::Lane)
+                .col(StepProjection::Status)
+                .to_owned(),
+        )
+        .await?;
+    // Composite (status, created_at) to support the dequeue ORDER BY.
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_status_created")
+                .table(StepProjection::Table)
+                .col(StepProjection::Status)
+                .col(StepProjection::CreatedAt)
+                .to_owned(),
+        )
+        .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Index drops (down migration)
+// ---------------------------------------------------------------------------
+
+async fn drop_events_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for name in [
+        "ix_events_timestamp",
+        "ix_events_event_type",
+        "ix_events_entity_kind",
+        "ix_events_entity_id",
+    ] {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name(name)
+                    .table(Events::Table)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn drop_dispatch_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for name in [
+        "ix_dispatch_project",
+        "ix_dispatch_user",
+        "ix_dispatch_created",
+        "ix_dispatch_lane",
+        "ix_dispatch_status",
+    ] {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name(name)
+                    .table(DispatchProjection::Table)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn drop_step_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for name in [
+        "ix_step_status_created",
+        "ix_step_lane_status",
+        "ix_step_status",
+        "ix_step_dispatch",
+    ] {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name(name)
+                    .table(StepProjection::Table)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Column identifiers
+// ---------------------------------------------------------------------------
+
+#[derive(DeriveIden)]
+enum Events {
+    Table,
+    Id,
+    EventId,
+    Timestamp,
+    EntityKind,
+    EntityId,
+    EventType,
+    SchemaVersion,
+    Payload,
+}
+
+#[derive(DeriveIden)]
+enum DispatchProjection {
+    Table,
+    DispatchId,
+    Mode,
+    Status,
+    Outcome,
+    Lane,
+    Dispatch,
+    Actor,
+    GraphRevision,
+    UserId,
+    Project,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum StepProjection {
+    Table,
+    StepId,
+    DispatchId,
+    StepType,
+    StepSequence,
+    Lane,
+    Status,
+    ReadyState,
+    DependsOn,
+    GraphRevision,
+    WorkerId,
+    Payload,
+    Result,
+    Error,
+    RetryCount,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/tanren-store/src/migration/m_0001_init.rs
+++ b/crates/tanren-store/src/migration/m_0001_init.rs
@@ -189,6 +189,11 @@ async fn create_step_projection_table(manager: &SchemaManager<'_>) -> Result<(),
                         .default(0),
                 )
                 .col(
+                    ColumnDef::new(StepProjection::LastHeartbeatAt)
+                        .timestamp_with_time_zone()
+                        .null(),
+                )
+                .col(
                     ColumnDef::new(StepProjection::CreatedAt)
                         .timestamp_with_time_zone()
                         .not_null(),
@@ -270,6 +275,20 @@ async fn create_dispatch_projection_indexes(manager: &SchemaManager<'_>) -> Resu
             )
             .await?;
     }
+    // S-01: composite index for `query_dispatches(status=?, ...) ORDER BY
+    // created_at DESC` — without it, the planner spills to a temp B-tree
+    // for the sort.
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_dispatch_status_created")
+                .table(DispatchProjection::Table)
+                .col(DispatchProjection::Status)
+                .col(DispatchProjection::CreatedAt)
+                .to_owned(),
+        )
+        .await?;
     Ok(())
 }
 
@@ -314,6 +333,33 @@ async fn create_step_projection_indexes(manager: &SchemaManager<'_>) -> Result<(
                 .to_owned(),
         )
         .await?;
+    // S-01: composite index for `get_steps_for_dispatch` — without it,
+    // the planner does a (dispatch_id) index scan followed by a temp
+    // B-tree sort on step_sequence.
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_dispatch_sequence")
+                .table(StepProjection::Table)
+                .col(StepProjection::DispatchId)
+                .col(StepProjection::StepSequence)
+                .to_owned(),
+        )
+        .await?;
+    // Liveness scan for `recover_stale_steps`: find running rows
+    // whose heartbeat is older than the threshold.
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_status_heartbeat")
+                .table(StepProjection::Table)
+                .col(StepProjection::Status)
+                .col(StepProjection::LastHeartbeatAt)
+                .to_owned(),
+        )
+        .await?;
     Ok(())
 }
 
@@ -343,6 +389,7 @@ async fn drop_events_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
 
 async fn drop_dispatch_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     for name in [
+        "ix_dispatch_status_created",
         "ix_dispatch_project",
         "ix_dispatch_user",
         "ix_dispatch_created",
@@ -364,6 +411,8 @@ async fn drop_dispatch_projection_indexes(manager: &SchemaManager<'_>) -> Result
 
 async fn drop_step_projection_indexes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     for name in [
+        "ix_step_status_heartbeat",
+        "ix_step_dispatch_sequence",
         "ix_step_status_created",
         "ix_step_lane_status",
         "ix_step_status",
@@ -433,6 +482,7 @@ enum StepProjection {
     Result,
     Error,
     RetryCount,
+    LastHeartbeatAt,
     CreatedAt,
     UpdatedAt,
 }

--- a/crates/tanren-store/src/migration/m_0002_integrity.rs
+++ b/crates/tanren-store/src/migration/m_0002_integrity.rs
@@ -1,0 +1,207 @@
+//! Integrity hardening — FK constraints, unique indexes, and
+//! composite indexes that were missing from the initial schema.
+//!
+//! Addresses audit findings:
+//! - **P1**: orphan step rows (FK on `step_projection.dispatch_id`)
+//! - **P2**: advisory step ordering (unique on `(dispatch_id, step_sequence)`)
+//! - **P2**: temp-sort spills on `query_events` and `query_dispatches(lane)`
+
+use sea_orm_migration::prelude::*;
+
+#[derive(Debug)]
+pub(crate) struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &'static str {
+        "m_0002_integrity"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(create_step_dispatch_fk(manager)).await?;
+        Box::pin(create_unique_step_sequence(manager)).await?;
+        Box::pin(create_events_composite_index(manager)).await?;
+        Box::pin(create_dispatch_lane_created_index(manager)).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(drop_dispatch_lane_created_index(manager)).await?;
+        Box::pin(drop_events_composite_index(manager)).await?;
+        Box::pin(drop_unique_step_sequence(manager)).await?;
+        Box::pin(drop_step_dispatch_fk(manager)).await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Foreign key: step_projection.dispatch_id -> dispatch_projection.dispatch_id
+// ---------------------------------------------------------------------------
+
+/// Add FK `step_projection.dispatch_id → dispatch_projection.dispatch_id`.
+///
+/// `SQLite` does not support `ALTER TABLE ... ADD FOREIGN KEY`, so this
+/// constraint is only added on Postgres. On `SQLite`, the application-
+/// level existence check in `enqueue_step` (`job_queue.rs`) is the
+/// primary defense, backed by `PRAGMA foreign_keys = ON` for any
+/// future table recreations.
+async fn create_step_dispatch_fk(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !is_postgres(manager) {
+        return Ok(());
+    }
+    manager
+        .create_foreign_key(
+            ForeignKey::create()
+                .name("fk_step_dispatch")
+                .from(StepProjection::Table, StepProjection::DispatchId)
+                .to(DispatchProjection::Table, DispatchProjection::DispatchId)
+                .on_delete(ForeignKeyAction::Restrict)
+                .on_update(ForeignKeyAction::Cascade)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_step_dispatch_fk(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !is_postgres(manager) {
+        return Ok(());
+    }
+    manager
+        .drop_foreign_key(
+            ForeignKey::drop()
+                .name("fk_step_dispatch")
+                .table(StepProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+fn is_postgres(manager: &SchemaManager<'_>) -> bool {
+    matches!(manager.get_database_backend(), sea_orm::DbBackend::Postgres,)
+}
+
+// ---------------------------------------------------------------------------
+// Unique index: (dispatch_id, step_sequence)
+// ---------------------------------------------------------------------------
+
+async fn create_unique_step_sequence(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("uq_step_dispatch_sequence")
+                .table(StepProjection::Table)
+                .col(StepProjection::DispatchId)
+                .col(StepProjection::StepSequence)
+                .unique()
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_unique_step_sequence(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("uq_step_dispatch_sequence")
+                .table(StepProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Composite index: events (entity_kind, entity_id, timestamp, id)
+// Eliminates temp sort for query_events(entity_kind + entity_id
+// ORDER BY timestamp, id).
+// ---------------------------------------------------------------------------
+
+async fn create_events_composite_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_events_entity_kind_id_ts")
+                .table(Events::Table)
+                .col(Events::EntityKind)
+                .col(Events::EntityId)
+                .col(Events::Timestamp)
+                .col(Events::Id)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_events_composite_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("ix_events_entity_kind_id_ts")
+                .table(Events::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Composite index: dispatch_projection (lane, created_at)
+// Eliminates temp sort for query_dispatches(lane) ORDER BY created_at.
+// ---------------------------------------------------------------------------
+
+async fn create_dispatch_lane_created_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_dispatch_lane_created")
+                .table(DispatchProjection::Table)
+                .col(DispatchProjection::Lane)
+                .col(DispatchProjection::CreatedAt)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_dispatch_lane_created_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("ix_dispatch_lane_created")
+                .table(DispatchProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Column identifiers (each migration defines its own per SeaORM convention)
+// ---------------------------------------------------------------------------
+
+#[derive(DeriveIden)]
+enum Events {
+    Table,
+    Id,
+    EntityKind,
+    EntityId,
+    Timestamp,
+}
+
+#[derive(DeriveIden)]
+enum DispatchProjection {
+    Table,
+    DispatchId,
+    Lane,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum StepProjection {
+    Table,
+    DispatchId,
+    StepSequence,
+}

--- a/crates/tanren-store/src/migration/m_0003_dequeue_indexes.rs
+++ b/crates/tanren-store/src/migration/m_0003_dequeue_indexes.rs
@@ -1,0 +1,172 @@
+//! Covering indexes for the dequeue hot path.
+//!
+//! The original `(status, created_at)` index does not cover
+//! `ready_state` or `step_sequence`, causing `SQLite` to spill to a
+//! temp B-tree for the ORDER BY. This migration adds indexes that
+//! match the real dequeue predicate and ordering, and drops the
+//! subsumed `ix_step_status_created`.
+//!
+//! Addresses audit finding I-02.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(Debug)]
+pub(crate) struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &'static str {
+        "m_0003_dequeue_indexes"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(create_dequeue_global_index(manager)).await?;
+        Box::pin(create_dequeue_lane_index(manager)).await?;
+        Box::pin(drop_subsumed_index(manager)).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        Box::pin(restore_subsumed_index(manager)).await?;
+        Box::pin(drop_dequeue_lane_index(manager)).await?;
+        Box::pin(drop_dequeue_global_index(manager)).await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global dequeue index
+// ---------------------------------------------------------------------------
+
+async fn create_dequeue_global_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if is_postgres(manager) {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX IF NOT EXISTS ix_step_dequeue_global \
+                 ON step_projection (created_at, step_sequence) \
+                 WHERE status = 'pending' AND ready_state = 'ready'",
+            )
+            .await?;
+        return Ok(());
+    }
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_dequeue_global")
+                .table(StepProjection::Table)
+                .col(StepProjection::Status)
+                .col(StepProjection::ReadyState)
+                .col(StepProjection::CreatedAt)
+                .col(StepProjection::StepSequence)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_dequeue_global_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("ix_step_dequeue_global")
+                .table(StepProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Lane-scoped dequeue index
+// ---------------------------------------------------------------------------
+
+async fn create_dequeue_lane_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if is_postgres(manager) {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX IF NOT EXISTS ix_step_dequeue_lane \
+                 ON step_projection (lane, created_at, step_sequence) \
+                 WHERE status = 'pending' AND ready_state = 'ready'",
+            )
+            .await?;
+        return Ok(());
+    }
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_dequeue_lane")
+                .table(StepProjection::Table)
+                .col(StepProjection::Lane)
+                .col(StepProjection::Status)
+                .col(StepProjection::ReadyState)
+                .col(StepProjection::CreatedAt)
+                .col(StepProjection::StepSequence)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn drop_dequeue_lane_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("ix_step_dequeue_lane")
+                .table(StepProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Drop subsumed ix_step_status_created
+// ---------------------------------------------------------------------------
+
+async fn drop_subsumed_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .if_exists()
+                .name("ix_step_status_created")
+                .table(StepProjection::Table)
+                .to_owned(),
+        )
+        .await
+}
+
+async fn restore_subsumed_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_index(
+            Index::create()
+                .if_not_exists()
+                .name("ix_step_status_created")
+                .table(StepProjection::Table)
+                .col(StepProjection::Status)
+                .col(StepProjection::CreatedAt)
+                .to_owned(),
+        )
+        .await
+}
+
+fn is_postgres(manager: &SchemaManager<'_>) -> bool {
+    matches!(manager.get_database_backend(), sea_orm::DbBackend::Postgres)
+}
+
+// ---------------------------------------------------------------------------
+// Column identifiers
+// ---------------------------------------------------------------------------
+
+#[derive(DeriveIden)]
+enum StepProjection {
+    Table,
+    Status,
+    ReadyState,
+    CreatedAt,
+    StepSequence,
+    Lane,
+}

--- a/crates/tanren-store/src/migration/mod.rs
+++ b/crates/tanren-store/src/migration/mod.rs
@@ -22,3 +22,32 @@ impl MigratorTrait for Migrator {
         vec![Box::new(m_0001_init::Migration)]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::Database;
+
+    use super::*;
+
+    /// Round-trip `Migrator::up` and `Migrator::down` against a
+    /// fresh in-memory `SQLite` database. This is the only place
+    /// the down path is exercised — every other test runs on an
+    /// already-migrated database and never tears the schema back
+    /// down.
+    #[tokio::test]
+    async fn up_then_down_is_clean() {
+        let conn = Database::connect("sqlite::memory:").await.expect("connect");
+        Migrator::up(&conn, None).await.expect("up");
+        Migrator::down(&conn, None).await.expect("down");
+        // And back up again — the schema should be rebuildable after
+        // a full down.
+        Migrator::up(&conn, None).await.expect("up after down");
+    }
+
+    #[tokio::test]
+    async fn up_is_idempotent() {
+        let conn = Database::connect("sqlite::memory:").await.expect("connect");
+        Migrator::up(&conn, None).await.expect("first up");
+        Migrator::up(&conn, None).await.expect("second up");
+    }
+}

--- a/crates/tanren-store/src/migration/mod.rs
+++ b/crates/tanren-store/src/migration/mod.rs
@@ -9,6 +9,8 @@
 use sea_orm_migration::{MigrationTrait, MigratorTrait, async_trait};
 
 mod m_0001_init;
+mod m_0002_integrity;
+mod m_0003_dequeue_indexes;
 
 /// Master migrator for the store. Run against a live
 /// [`sea_orm::DatabaseConnection`] by
@@ -19,7 +21,11 @@ pub(crate) struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m_0001_init::Migration)]
+        vec![
+            Box::new(m_0001_init::Migration),
+            Box::new(m_0002_integrity::Migration),
+            Box::new(m_0003_dequeue_indexes::Migration),
+        ]
     }
 }
 

--- a/crates/tanren-store/src/migration/mod.rs
+++ b/crates/tanren-store/src/migration/mod.rs
@@ -1,0 +1,24 @@
+//! Schema migrations.
+//!
+//! The migration framework is backend-agnostic — each migration is a
+//! `MigrationTrait` that manipulates the schema through `SeaORM`'s
+//! `SchemaManager`. `SeaORM` tracks applied migrations in the
+//! `seaql_migrations` table, which makes `Migrator::up` idempotent:
+//! running it twice in a row is a no-op on the second call.
+
+use sea_orm_migration::{MigrationTrait, MigratorTrait, async_trait};
+
+mod m_0001_init;
+
+/// Master migrator for the store. Run against a live
+/// [`sea_orm::DatabaseConnection`] by
+/// [`Store::run_migrations`](crate::Store::run_migrations).
+#[derive(Debug)]
+pub(crate) struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m_0001_init::Migration)]
+    }
+}

--- a/crates/tanren-store/src/params.rs
+++ b/crates/tanren-store/src/params.rs
@@ -236,8 +236,8 @@ pub struct AckParams {
 ///
 /// Cancels every pending non-teardown step belonging to a dispatch
 /// and appends one `StepCancelled` envelope per cancelled row in
-/// the same transaction. Replaces the old bare
-/// `cancel_pending_steps(&DispatchId)` signature.
+/// the same transaction. The store mints the timestamp internally
+/// so the operation identifier is not caller-controlled.
 #[derive(Debug, Clone)]
 pub struct CancelPendingStepsParams {
     /// Owning dispatch.
@@ -247,8 +247,6 @@ pub struct CancelPendingStepsParams {
     pub actor: Option<ActorContext>,
     /// Human-readable reason.
     pub reason: Option<String>,
-    /// Timestamp for all generated `StepCancelled` envelopes.
-    pub timestamp: DateTime<Utc>,
 }
 
 /// Parameters for

--- a/crates/tanren-store/src/params.rs
+++ b/crates/tanren-store/src/params.rs
@@ -185,8 +185,14 @@ pub struct EnqueueStepParams {
 /// transaction. If `next_step` is `None`, only the completion half runs.
 #[derive(Debug, Clone)]
 pub struct AckAndEnqueueParams {
+    /// Owning dispatch — validated against the completion event payload.
+    pub dispatch_id: DispatchId,
     /// Step being completed.
     pub step_id: StepId,
+    /// Declared step type — validated against the completion event and
+    /// used as a WHERE filter on the projection UPDATE to prevent
+    /// `step_type` divergence between the event log and the projection.
+    pub step_type: StepType,
     /// Result payload stored on the step projection row.
     pub result: StepResult,
     /// `StepCompleted` envelope appended co-transactionally.
@@ -199,6 +205,14 @@ pub struct AckAndEnqueueParams {
 /// Parameters for [`JobQueue::nack`](crate::JobQueue::nack).
 #[derive(Debug, Clone)]
 pub struct NackParams {
+    /// Owning dispatch — validated against the event payload.
+    pub dispatch_id: DispatchId,
+    /// Step being failed or retried.
+    pub step_id: StepId,
+    /// Declared step type — validated against the failure event and
+    /// used as a WHERE filter on the projection UPDATE to prevent
+    /// `step_type` divergence between the event log and the projection.
+    pub step_type: StepType,
     /// Human-readable error text stored on the step row.
     pub error: String,
     /// Typed classification (transient / fatal / ambiguous).
@@ -223,8 +237,14 @@ pub struct NackParams {
 /// companion event.
 #[derive(Debug, Clone)]
 pub struct AckParams {
+    /// Owning dispatch — validated against the event payload.
+    pub dispatch_id: DispatchId,
     /// Step being completed.
     pub step_id: StepId,
+    /// Declared step type — validated against the completion event and
+    /// used as a WHERE filter on the projection UPDATE to prevent
+    /// `step_type` divergence between the event log and the projection.
+    pub step_type: StepType,
     /// Result payload stored on the step projection row.
     pub result: StepResult,
     /// `StepCompleted` envelope appended co-transactionally.

--- a/crates/tanren-store/src/params.rs
+++ b/crates/tanren-store/src/params.rs
@@ -1,0 +1,241 @@
+//! Filter and parameter types used by the store traits.
+//!
+//! These types intentionally live in `tanren-store` rather than
+//! `tanren-domain`: they are persistence concerns (pagination cursors,
+//! dequeue knobs, co-transactional event bundles) that the domain
+//! layer has no opinion on. Domain types are reused verbatim inside
+//! them — the store never invents a duplicate identifier type.
+//!
+//! # Co-transactionality contract
+//!
+//! Any param struct whose name ends in `Params` and that contains an
+//! [`EventEnvelope`] field promises that the store will append the
+//! event inside the same transaction as the projection write it
+//! describes. Callers therefore build the envelope once (with the
+//! correct `event_id`, `timestamp`, and `entity_ref`) and hand it to
+//! the store — the store never mints events on its own.
+
+use chrono::{DateTime, Utc};
+use tanren_domain::{
+    ActorContext, DispatchId, DispatchMode, DispatchSnapshot, DispatchStatus, EntityKind,
+    EntityRef, ErrorClass, EventEnvelope, GraphRevision, Lane, StepId, StepPayload, StepReadyState,
+    StepResult, StepType, UserId,
+};
+
+// ---------------------------------------------------------------------------
+// Query filters
+// ---------------------------------------------------------------------------
+
+/// Default page size for paginated queries.
+pub const DEFAULT_QUERY_LIMIT: u64 = 100;
+
+/// Filter passed to [`EventStore::query_events`](crate::EventStore::query_events).
+///
+/// Fields use `Option` for "unfiltered on this dimension". `limit`
+/// defaults to [`DEFAULT_QUERY_LIMIT`]; `offset` defaults to `0`. Each
+/// filter dimension is backed by an index on the `events` table — see
+/// `migration::m_0001_init`.
+#[derive(Debug, Clone, Default)]
+pub struct EventFilter {
+    /// Restrict to events whose routing root matches this entity.
+    pub entity_ref: Option<EntityRef>,
+    /// Restrict to events whose routing root is in this set (OR).
+    pub entity_refs: Option<Vec<EntityRef>>,
+    /// Restrict to events of a given entity kind.
+    pub entity_kind: Option<EntityKind>,
+    /// Restrict to a specific `DomainEvent` variant tag (`snake_case`).
+    pub event_type: Option<String>,
+    /// Earliest event timestamp (inclusive).
+    pub since: Option<DateTime<Utc>>,
+    /// Latest event timestamp (exclusive).
+    pub until: Option<DateTime<Utc>>,
+    /// Max rows to return.
+    pub limit: u64,
+    /// Zero-based offset into the result set.
+    pub offset: u64,
+}
+
+impl EventFilter {
+    /// Construct an empty filter with the default limit and zero offset.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entity_ref: None,
+            entity_refs: None,
+            entity_kind: None,
+            event_type: None,
+            since: None,
+            until: None,
+            limit: DEFAULT_QUERY_LIMIT,
+            offset: 0,
+        }
+    }
+}
+
+/// Filter passed to [`StateStore::query_dispatches`](crate::StateStore::query_dispatches).
+///
+/// Every optional dimension corresponds to an index on
+/// `dispatch_projection`; see `migration::m_0001_init`.
+#[derive(Debug, Clone, Default)]
+pub struct DispatchFilter {
+    /// Restrict to dispatches in this status.
+    pub status: Option<DispatchStatus>,
+    /// Restrict to dispatches routed to this lane.
+    pub lane: Option<Lane>,
+    /// Restrict to dispatches for a particular project (exact match).
+    pub project: Option<String>,
+    /// Restrict to dispatches submitted by a particular user.
+    pub user_id: Option<UserId>,
+    /// Earliest dispatch creation time (inclusive).
+    pub since: Option<DateTime<Utc>>,
+    /// Latest dispatch creation time (exclusive).
+    pub until: Option<DateTime<Utc>>,
+    /// Max rows to return.
+    pub limit: u64,
+    /// Zero-based offset into the result set.
+    pub offset: u64,
+}
+
+impl DispatchFilter {
+    /// Construct an empty filter with the default limit and zero offset.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            status: None,
+            lane: None,
+            project: None,
+            user_id: None,
+            since: None,
+            until: None,
+            limit: DEFAULT_QUERY_LIMIT,
+            offset: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Queue params
+// ---------------------------------------------------------------------------
+
+/// Parameters for [`JobQueue::dequeue`](crate::JobQueue::dequeue).
+#[derive(Debug, Clone)]
+pub struct DequeueParams {
+    /// Opaque identifier for the worker claiming the step. Stored on
+    /// the step projection row for crash recovery.
+    pub worker_id: String,
+    /// Lane to restrict the claim to. `None` means any lane.
+    pub lane: Option<Lane>,
+    /// Maximum number of steps that may be simultaneously in
+    /// `status='running'` for the given lane filter. The dequeue is a
+    /// no-op if the running count already meets or exceeds this.
+    pub max_concurrent: u64,
+}
+
+/// A step successfully claimed from the queue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueuedStep {
+    /// Step identifier.
+    pub step_id: StepId,
+    /// Owning dispatch.
+    pub dispatch_id: DispatchId,
+    /// Declared step type (provision / execute / teardown / `dry_run`).
+    pub step_type: StepType,
+    /// Monotonic sequence number within the dispatch.
+    pub step_sequence: u32,
+    /// Lane the step is pinned to, or `None` for free-floating.
+    pub lane: Option<Lane>,
+    /// Full step payload to hand to the worker.
+    pub payload: StepPayload,
+}
+
+/// Parameters for [`JobQueue::enqueue_step`](crate::JobQueue::enqueue_step).
+///
+/// Pairs with a `StepEnqueued` envelope appended co-transactionally by
+/// `ack_and_enqueue` and `enqueue_step`.
+#[derive(Debug, Clone)]
+pub struct EnqueueStepParams {
+    /// Owning dispatch.
+    pub dispatch_id: DispatchId,
+    /// Step identifier.
+    pub step_id: StepId,
+    /// Declared step type.
+    pub step_type: StepType,
+    /// Monotonic sequence number within the dispatch.
+    pub step_sequence: u32,
+    /// Lane the step is pinned to, if any.
+    pub lane: Option<Lane>,
+    /// Dependency list — other steps whose completion unblocks this one.
+    pub depends_on: Vec<StepId>,
+    /// Graph revision this step belongs to.
+    pub graph_revision: GraphRevision,
+    /// Full step payload.
+    pub payload: StepPayload,
+    /// Initial ready state — `Ready` if `depends_on` is empty, else `Blocked`.
+    pub ready_state: StepReadyState,
+    /// `StepEnqueued` envelope appended co-transactionally. Callers
+    /// build this with the same `dispatch_id` / `step_id`; the store
+    /// does not re-derive it.
+    pub enqueue_event: EventEnvelope,
+}
+
+/// Parameters for [`JobQueue::ack_and_enqueue`](crate::JobQueue::ack_and_enqueue).
+///
+/// Completes the current step **and** enqueues its successor — plus the
+/// two envelopes that describe both transitions — in a single
+/// transaction. If `next_step` is `None`, only the completion half runs.
+#[derive(Debug, Clone)]
+pub struct AckAndEnqueueParams {
+    /// Step being completed.
+    pub step_id: StepId,
+    /// Result payload stored on the step projection row.
+    pub result: StepResult,
+    /// `StepCompleted` envelope appended co-transactionally.
+    pub completion_event: EventEnvelope,
+    /// Optional successor step — if present, its row is inserted and
+    /// its enqueue envelope is appended in the same transaction.
+    pub next_step: Option<EnqueueStepParams>,
+}
+
+/// Parameters for [`JobQueue::nack`](crate::JobQueue::nack).
+#[derive(Debug, Clone)]
+pub struct NackParams {
+    /// Human-readable error text stored on the step row.
+    pub error: String,
+    /// Typed classification (transient / fatal / ambiguous).
+    pub error_class: ErrorClass,
+    /// If true, the step is reset to `pending` with an incremented
+    /// `retry_count`. If false, it is marked `failed`.
+    pub retry: bool,
+    /// `StepFailed` envelope appended co-transactionally.
+    pub failure_event: EventEnvelope,
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch projection params
+// ---------------------------------------------------------------------------
+
+/// Parameters for
+/// [`StateStore::create_dispatch_projection`](crate::StateStore::create_dispatch_projection).
+///
+/// Creates the projection row and appends the companion
+/// `DispatchCreated` envelope in one transaction.
+#[derive(Debug, Clone)]
+pub struct CreateDispatchParams {
+    /// Dispatch identifier.
+    pub dispatch_id: DispatchId,
+    /// Mode (auto / manual).
+    pub mode: DispatchMode,
+    /// Execution lane.
+    pub lane: Lane,
+    /// Snapshot of the dispatch configuration at creation time.
+    pub dispatch: DispatchSnapshot,
+    /// Actor context (org/user/team/project scope).
+    pub actor: ActorContext,
+    /// Graph revision this dispatch was planned against.
+    pub graph_revision: GraphRevision,
+    /// Creation timestamp — also used for the projection row's
+    /// `created_at` and `updated_at` fields.
+    pub created_at: DateTime<Utc>,
+    /// `DispatchCreated` envelope appended co-transactionally.
+    pub creation_event: EventEnvelope,
+}

--- a/crates/tanren-store/src/params.rs
+++ b/crates/tanren-store/src/params.rs
@@ -18,8 +18,8 @@
 use chrono::{DateTime, Utc};
 use tanren_domain::{
     ActorContext, DispatchId, DispatchMode, DispatchSnapshot, DispatchStatus, EntityKind,
-    EntityRef, ErrorClass, EventEnvelope, GraphRevision, Lane, StepId, StepPayload, StepReadyState,
-    StepResult, StepType, UserId,
+    EntityRef, ErrorClass, EventEnvelope, GraphRevision, Lane, Outcome, StepId, StepPayload,
+    StepReadyState, StepResult, StepType, UserId,
 };
 
 // ---------------------------------------------------------------------------
@@ -213,6 +213,62 @@ pub struct NackParams {
 // ---------------------------------------------------------------------------
 // Dispatch projection params
 // ---------------------------------------------------------------------------
+
+/// Parameters for [`JobQueue::ack`](crate::JobQueue::ack).
+///
+/// Completes the given step and appends the caller-supplied
+/// `StepCompleted` envelope co-transactionally. Replaces the old
+/// bare `ack(&StepId, &StepResult)` signature so that every
+/// projection-mutating method co-transactionally appends its
+/// companion event.
+#[derive(Debug, Clone)]
+pub struct AckParams {
+    /// Step being completed.
+    pub step_id: StepId,
+    /// Result payload stored on the step projection row.
+    pub result: StepResult,
+    /// `StepCompleted` envelope appended co-transactionally.
+    pub completion_event: EventEnvelope,
+}
+
+/// Parameters for
+/// [`JobQueue::cancel_pending_steps`](crate::JobQueue::cancel_pending_steps).
+///
+/// Cancels every pending non-teardown step belonging to a dispatch
+/// and appends one `StepCancelled` envelope per cancelled row in
+/// the same transaction. Replaces the old bare
+/// `cancel_pending_steps(&DispatchId)` signature.
+#[derive(Debug, Clone)]
+pub struct CancelPendingStepsParams {
+    /// Owning dispatch.
+    pub dispatch_id: DispatchId,
+    /// Actor initiating the cancellation (written to each
+    /// `StepCancelled` event).
+    pub actor: Option<ActorContext>,
+    /// Human-readable reason.
+    pub reason: Option<String>,
+    /// Timestamp for all generated `StepCancelled` envelopes.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Parameters for
+/// [`StateStore::update_dispatch_status`](crate::StateStore::update_dispatch_status).
+///
+/// Updates the dispatch projection row and appends the caller-
+/// supplied lifecycle event co-transactionally. The store validates
+/// that the event's `entity_ref` matches `EntityRef::Dispatch(dispatch_id)`
+/// before committing.
+#[derive(Debug, Clone)]
+pub struct UpdateDispatchStatusParams {
+    /// Dispatch identifier.
+    pub dispatch_id: DispatchId,
+    /// New status.
+    pub status: DispatchStatus,
+    /// Terminal outcome, if any.
+    pub outcome: Option<Outcome>,
+    /// The lifecycle event to append co-transactionally.
+    pub status_event: EventEnvelope,
+}
 
 /// Parameters for
 /// [`StateStore::create_dispatch_projection`](crate::StateStore::create_dispatch_projection).

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -68,15 +68,10 @@ impl StateStore for Store {
     async fn query_dispatches(&self, filter: &DispatchFilter) -> StoreResult<Vec<DispatchView>> {
         let mut query = dispatch_projection::Entity::find();
         if let Some(status) = filter.status {
-            query = query.filter(
-                dispatch_projection::Column::Status
-                    .eq(dispatch_converters::status_to_string(status)),
-            );
+            query = query.filter(dispatch_projection::Column::Status.eq(status.to_string()));
         }
         if let Some(lane) = filter.lane {
-            query = query.filter(
-                dispatch_projection::Column::Lane.eq(dispatch_converters::lane_to_string(lane)),
-            );
+            query = query.filter(dispatch_projection::Column::Lane.eq(lane.to_string()));
         }
         if let Some(ref project) = filter.project {
             query = query.filter(dispatch_projection::Column::Project.eq(project.as_str()));
@@ -126,13 +121,11 @@ impl StateStore for Store {
     }
 
     async fn count_running_steps(&self, lane: Option<&Lane>) -> StoreResult<u64> {
-        let mut query = step_projection::Entity::find().filter(step_projection::Column::Status.eq(
-            step_converters::step_status_to_string(tanren_domain::StepStatus::Running),
-        ));
+        let mut query = step_projection::Entity::find().filter(
+            step_projection::Column::Status.eq(tanren_domain::StepStatus::Running.to_string()),
+        );
         if let Some(lane) = lane {
-            query = query.filter(
-                step_projection::Column::Lane.eq(dispatch_converters::lane_to_string(*lane)),
-            );
+            query = query.filter(step_projection::Column::Lane.eq(lane.to_string()));
         }
         Ok(query.count(self.conn()).await?)
     }
@@ -166,8 +159,8 @@ impl StateStore for Store {
         let now = Utc::now();
         let update = dispatch_projection::ActiveModel {
             dispatch_id: Set(id.into_uuid()),
-            status: Set(dispatch_converters::status_to_string(status).to_owned()),
-            outcome: Set(outcome.map(|o| dispatch_converters::outcome_to_string(o).to_owned())),
+            status: Set(status.to_string()),
+            outcome: Set(outcome.map(|o| o.to_string())),
             updated_at: Set(now),
             ..Default::default()
         };

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -12,14 +12,14 @@ use sea_orm::{
     ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect, TransactionTrait,
 };
-use tanren_domain::{DispatchId, DispatchStatus, DispatchView, Lane, Outcome, StepId, StepView};
+use tanren_domain::{DispatchId, DispatchView, EntityRef, Lane, StepId, StepView};
 
 use crate::converters::{
     dispatch as dispatch_converters, events as event_converters, step as step_converters,
 };
-use crate::entity::{dispatch_projection, step_projection};
+use crate::entity::{dispatch_projection, events, step_projection};
 use crate::errors::{StoreError, StoreResult};
-use crate::params::{CreateDispatchParams, DispatchFilter};
+use crate::params::{CreateDispatchParams, DispatchFilter, UpdateDispatchStatusParams};
 use crate::store::Store;
 
 /// Projection read / write interface for dispatches and steps.
@@ -47,13 +47,10 @@ pub trait StateStore: Send + Sync {
     async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()>;
 
     /// Update a dispatch's status (and, for terminal transitions,
-    /// its outcome). `updated_at` is set to the current wall clock.
-    async fn update_dispatch_status(
-        &self,
-        id: &DispatchId,
-        status: DispatchStatus,
-        outcome: Option<Outcome>,
-    ) -> StoreResult<()>;
+    /// its outcome) and append the companion lifecycle event
+    /// co-transactionally. `updated_at` is set to the current wall
+    /// clock.
+    async fn update_dispatch_status(&self, params: UpdateDispatchStatusParams) -> StoreResult<()>;
 }
 
 #[async_trait]
@@ -140,9 +137,7 @@ impl StateStore for Store {
                     dispatch_projection::Entity::insert(projection)
                         .exec(txn)
                         .await?;
-                    crate::entity::events::Entity::insert(event_model)
-                        .exec(txn)
-                        .await?;
+                    events::Entity::insert(event_model).exec(txn).await?;
                     Ok(())
                 })
             })
@@ -150,30 +145,47 @@ impl StateStore for Store {
         Ok(())
     }
 
-    async fn update_dispatch_status(
-        &self,
-        id: &DispatchId,
-        status: DispatchStatus,
-        outcome: Option<Outcome>,
-    ) -> StoreResult<()> {
+    async fn update_dispatch_status(&self, params: UpdateDispatchStatusParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(
+            &params.status_event,
+            EntityRef::Dispatch(params.dispatch_id),
+        )?;
+
         let now = Utc::now();
-        let update = dispatch_projection::ActiveModel {
-            dispatch_id: Set(id.into_uuid()),
-            status: Set(status.to_string()),
-            outcome: Set(outcome.map(|o| o.to_string())),
-            updated_at: Set(now),
-            ..Default::default()
-        };
-        let result = dispatch_projection::Entity::update(update)
-            .filter(dispatch_projection::Column::DispatchId.eq(id.into_uuid()))
-            .exec(self.conn())
-            .await;
-        match result {
-            Ok(_) => Ok(()),
-            Err(sea_orm::DbErr::RecordNotUpdated) => Err(StoreError::NotFound {
-                entity: format!("dispatch {id}"),
-            }),
-            Err(err) => Err(err.into()),
-        }
+        let event_model = event_converters::envelope_to_active_model(&params.status_event)?;
+        let id = params.dispatch_id;
+        let id_uuid = id.into_uuid();
+        let status = params.status;
+        let outcome = params.outcome;
+
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    let update = dispatch_projection::ActiveModel {
+                        dispatch_id: Set(id_uuid),
+                        status: Set(status.to_string()),
+                        outcome: Set(outcome.map(|o| o.to_string())),
+                        updated_at: Set(now),
+                        ..Default::default()
+                    };
+                    let result = dispatch_projection::Entity::update(update)
+                        .filter(dispatch_projection::Column::DispatchId.eq(id_uuid))
+                        .exec(txn)
+                        .await;
+                    match result {
+                        Ok(_) => {}
+                        Err(sea_orm::DbErr::RecordNotUpdated) => {
+                            return Err(StoreError::NotFound {
+                                entity: format!("dispatch {id}"),
+                            });
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
+                    events::Entity::insert(event_model).exec(txn).await?;
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
     }
 }

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -12,7 +12,7 @@ use sea_orm::{
     ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect, TransactionTrait,
 };
-use tanren_domain::{DispatchId, DispatchView, EntityRef, Lane, StepId, StepView};
+use tanren_domain::{DispatchId, DispatchView, Lane, StepId, StepView};
 
 use crate::converters::{
     dispatch as dispatch_converters, events as event_converters, step as step_converters,
@@ -128,6 +128,7 @@ impl StateStore for Store {
     }
 
     async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()> {
+        event_converters::validate_envelope_entity_ref(&params.creation_event)?;
         let projection = dispatch_converters::params_to_active_model(&params)?;
         let event_model = event_converters::envelope_to_active_model(&params.creation_event)?;
 
@@ -146,10 +147,7 @@ impl StateStore for Store {
     }
 
     async fn update_dispatch_status(&self, params: UpdateDispatchStatusParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(
-            &params.status_event,
-            EntityRef::Dispatch(params.dispatch_id),
-        )?;
+        event_converters::validate_envelope_entity_ref(&params.status_event)?;
 
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.status_event)?;

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -128,7 +128,11 @@ impl StateStore for Store {
     }
 
     async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.creation_event)?;
+        event_converters::validate_dispatch_event(
+            &params.creation_event,
+            params.dispatch_id,
+            "dispatch_created",
+        )?;
         let projection = dispatch_converters::params_to_active_model(&params)?;
         let event_model = event_converters::envelope_to_active_model(&params.creation_event)?;
 
@@ -147,7 +151,11 @@ impl StateStore for Store {
     }
 
     async fn update_dispatch_status(&self, params: UpdateDispatchStatusParams) -> StoreResult<()> {
-        event_converters::validate_envelope_entity_ref(&params.status_event)?;
+        event_converters::validate_dispatch_event(
+            &params.status_event,
+            params.dispatch_id,
+            event_converters::dispatch_status_event_tag(params.status),
+        )?;
 
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.status_event)?;

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -9,13 +9,13 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::{
-    ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, TransactionTrait,
+    ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
+    TransactionTrait, sea_query::Expr,
 };
 use tanren_domain::{DispatchId, DispatchView, Lane, StepId, StepView};
 
 use crate::converters::{
-    dispatch as dispatch_converters, events as event_converters, step as step_converters,
+    dispatch as dispatch_converters, events as event_converters, step as step_converters, validate,
 };
 use crate::entity::{dispatch_projection, events, step_projection};
 use crate::errors::{StoreError, StoreResult};
@@ -128,11 +128,7 @@ impl StateStore for Store {
     }
 
     async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()> {
-        event_converters::validate_dispatch_event(
-            &params.creation_event,
-            params.dispatch_id,
-            "dispatch_created",
-        )?;
+        validate::validate_create_dispatch(&params)?;
         let projection = dispatch_converters::params_to_active_model(&params)?;
         let event_model = event_converters::envelope_to_active_model(&params.creation_event)?;
 
@@ -151,11 +147,7 @@ impl StateStore for Store {
     }
 
     async fn update_dispatch_status(&self, params: UpdateDispatchStatusParams) -> StoreResult<()> {
-        event_converters::validate_dispatch_event(
-            &params.status_event,
-            params.dispatch_id,
-            event_converters::dispatch_status_event_tag(params.status),
-        )?;
+        validate::validate_update_dispatch_status(&params)?;
 
         let now = Utc::now();
         let event_model = event_converters::envelope_to_active_model(&params.status_event)?;
@@ -167,25 +159,44 @@ impl StateStore for Store {
         self.conn()
             .transaction::<_, (), StoreError>(move |txn| {
                 Box::pin(async move {
-                    let update = dispatch_projection::ActiveModel {
-                        dispatch_id: Set(id_uuid),
-                        status: Set(status.to_string()),
-                        outcome: Set(outcome.map(|o| o.to_string())),
-                        updated_at: Set(now),
-                        ..Default::default()
-                    };
-                    let result = dispatch_projection::Entity::update(update)
+                    // Fetch current row to enforce lifecycle transitions.
+                    let row = dispatch_projection::Entity::find_by_id(id_uuid)
+                        .one(txn)
+                        .await?;
+                    let row = row.ok_or_else(|| StoreError::NotFound {
+                        entity: format!("dispatch {id}"),
+                    })?;
+                    let current = dispatch_converters::parse_status(&row.status)?;
+                    if !current.can_transition_to(status) {
+                        return Err(StoreError::InvalidTransition {
+                            entity: format!("dispatch {id}"),
+                            from: current.to_string(),
+                            to: status.to_string(),
+                        });
+                    }
+
+                    // CAS: only update if the status still matches
+                    // what we read, preventing concurrent callers
+                    // from both succeeding.
+                    let result = dispatch_projection::Entity::update_many()
+                        .col_expr(
+                            dispatch_projection::Column::Status,
+                            Expr::value(status.to_string()),
+                        )
+                        .col_expr(
+                            dispatch_projection::Column::Outcome,
+                            Expr::value(outcome.map(|o| o.to_string())),
+                        )
+                        .col_expr(dispatch_projection::Column::UpdatedAt, Expr::value(now))
                         .filter(dispatch_projection::Column::DispatchId.eq(id_uuid))
+                        .filter(dispatch_projection::Column::Status.eq(current.to_string()))
                         .exec(txn)
-                        .await;
-                    match result {
-                        Ok(_) => {}
-                        Err(sea_orm::DbErr::RecordNotUpdated) => {
-                            return Err(StoreError::NotFound {
-                                entity: format!("dispatch {id}"),
-                            });
-                        }
-                        Err(err) => return Err(err.into()),
+                        .await?;
+                    if result.rows_affected == 0 {
+                        return Err(StoreError::Conflict(format!(
+                            "dispatch {id} status changed concurrently \
+                             from {current}"
+                        )));
                     }
                     events::Entity::insert(event_model).exec(txn).await?;
                     Ok(())

--- a/crates/tanren-store/src/state_store.rs
+++ b/crates/tanren-store/src/state_store.rs
@@ -1,0 +1,186 @@
+//! [`StateStore`] trait and its implementation on [`Store`].
+//!
+//! All queries in this module go through `SeaORM`'s entity API and
+//! use indexed columns. Projection writes that follow an event append
+//! run co-transactionally with the event insert — the caller hands
+//! the store an [`EventEnvelope`] via the param struct and the store
+//! appends it inside the same transaction closure.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
+    QuerySelect, TransactionTrait,
+};
+use tanren_domain::{DispatchId, DispatchStatus, DispatchView, Lane, Outcome, StepId, StepView};
+
+use crate::converters::{
+    dispatch as dispatch_converters, events as event_converters, step as step_converters,
+};
+use crate::entity::{dispatch_projection, step_projection};
+use crate::errors::{StoreError, StoreResult};
+use crate::params::{CreateDispatchParams, DispatchFilter};
+use crate::store::Store;
+
+/// Projection read / write interface for dispatches and steps.
+#[async_trait]
+pub trait StateStore: Send + Sync {
+    /// Look up a dispatch by id.
+    async fn get_dispatch(&self, id: &DispatchId) -> StoreResult<Option<DispatchView>>;
+
+    /// Query dispatches by filter dimensions (status, lane, user, etc.).
+    async fn query_dispatches(&self, filter: &DispatchFilter) -> StoreResult<Vec<DispatchView>>;
+
+    /// Look up a single step by id.
+    async fn get_step(&self, id: &StepId) -> StoreResult<Option<StepView>>;
+
+    /// Return all steps for a dispatch, ordered by `step_sequence`.
+    async fn get_steps_for_dispatch(&self, dispatch_id: &DispatchId) -> StoreResult<Vec<StepView>>;
+
+    /// Count steps currently in `status = 'running'`, optionally
+    /// restricted to a lane. Used by the scheduler to enforce lane
+    /// concurrency caps outside the dequeue fast path.
+    async fn count_running_steps(&self, lane: Option<&Lane>) -> StoreResult<u64>;
+
+    /// Insert the initial projection row for a newly-created dispatch
+    /// and append its `DispatchCreated` event in one transaction.
+    async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()>;
+
+    /// Update a dispatch's status (and, for terminal transitions,
+    /// its outcome). `updated_at` is set to the current wall clock.
+    async fn update_dispatch_status(
+        &self,
+        id: &DispatchId,
+        status: DispatchStatus,
+        outcome: Option<Outcome>,
+    ) -> StoreResult<()>;
+}
+
+#[async_trait]
+impl StateStore for Store {
+    async fn get_dispatch(&self, id: &DispatchId) -> StoreResult<Option<DispatchView>> {
+        let row = dispatch_projection::Entity::find_by_id(id.into_uuid())
+            .one(self.conn())
+            .await?;
+        row.map(dispatch_converters::model_to_view).transpose()
+    }
+
+    async fn query_dispatches(&self, filter: &DispatchFilter) -> StoreResult<Vec<DispatchView>> {
+        let mut query = dispatch_projection::Entity::find();
+        if let Some(status) = filter.status {
+            query = query.filter(
+                dispatch_projection::Column::Status
+                    .eq(dispatch_converters::status_to_string(status)),
+            );
+        }
+        if let Some(lane) = filter.lane {
+            query = query.filter(
+                dispatch_projection::Column::Lane.eq(dispatch_converters::lane_to_string(lane)),
+            );
+        }
+        if let Some(ref project) = filter.project {
+            query = query.filter(dispatch_projection::Column::Project.eq(project.as_str()));
+        }
+        if let Some(user_id) = filter.user_id {
+            query = query.filter(dispatch_projection::Column::UserId.eq(user_id.into_uuid()));
+        }
+        if let Some(since) = filter.since {
+            query = query.filter(dispatch_projection::Column::CreatedAt.gte(since));
+        }
+        if let Some(until) = filter.until {
+            query = query.filter(dispatch_projection::Column::CreatedAt.lt(until));
+        }
+
+        let rows = query
+            .order_by_desc(dispatch_projection::Column::CreatedAt)
+            .limit(filter.limit)
+            .offset(filter.offset)
+            .all(self.conn())
+            .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(dispatch_converters::model_to_view(row)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_step(&self, id: &StepId) -> StoreResult<Option<StepView>> {
+        let row = step_projection::Entity::find_by_id(id.into_uuid())
+            .one(self.conn())
+            .await?;
+        row.map(step_converters::model_to_view).transpose()
+    }
+
+    async fn get_steps_for_dispatch(&self, dispatch_id: &DispatchId) -> StoreResult<Vec<StepView>> {
+        let rows = step_projection::Entity::find()
+            .filter(step_projection::Column::DispatchId.eq(dispatch_id.into_uuid()))
+            .order_by_asc(step_projection::Column::StepSequence)
+            .all(self.conn())
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(step_converters::model_to_view(row)?);
+        }
+        Ok(out)
+    }
+
+    async fn count_running_steps(&self, lane: Option<&Lane>) -> StoreResult<u64> {
+        let mut query = step_projection::Entity::find().filter(step_projection::Column::Status.eq(
+            step_converters::step_status_to_string(tanren_domain::StepStatus::Running),
+        ));
+        if let Some(lane) = lane {
+            query = query.filter(
+                step_projection::Column::Lane.eq(dispatch_converters::lane_to_string(*lane)),
+            );
+        }
+        Ok(query.count(self.conn()).await?)
+    }
+
+    async fn create_dispatch_projection(&self, params: CreateDispatchParams) -> StoreResult<()> {
+        let projection = dispatch_converters::params_to_active_model(&params)?;
+        let event_model = event_converters::envelope_to_active_model(&params.creation_event)?;
+
+        self.conn()
+            .transaction::<_, (), StoreError>(move |txn| {
+                Box::pin(async move {
+                    dispatch_projection::Entity::insert(projection)
+                        .exec(txn)
+                        .await?;
+                    crate::entity::events::Entity::insert(event_model)
+                        .exec(txn)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn update_dispatch_status(
+        &self,
+        id: &DispatchId,
+        status: DispatchStatus,
+        outcome: Option<Outcome>,
+    ) -> StoreResult<()> {
+        let now = Utc::now();
+        let update = dispatch_projection::ActiveModel {
+            dispatch_id: Set(id.into_uuid()),
+            status: Set(dispatch_converters::status_to_string(status).to_owned()),
+            outcome: Set(outcome.map(|o| dispatch_converters::outcome_to_string(o).to_owned())),
+            updated_at: Set(now),
+            ..Default::default()
+        };
+        let result = dispatch_projection::Entity::update(update)
+            .filter(dispatch_projection::Column::DispatchId.eq(id.into_uuid()))
+            .exec(self.conn())
+            .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(sea_orm::DbErr::RecordNotUpdated) => Err(StoreError::NotFound {
+                entity: format!("dispatch {id}"),
+            }),
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/crates/tanren-store/src/store.rs
+++ b/crates/tanren-store/src/store.rs
@@ -11,7 +11,7 @@
 use sea_orm::{DatabaseConnection, DbErr};
 use sea_orm_migration::MigratorTrait;
 
-use crate::connection;
+use crate::connection::{self, ConnectConfig};
 use crate::errors::{StoreError, StoreResult};
 use crate::migration::Migrator;
 
@@ -38,6 +38,16 @@ impl Store {
     /// unreachable host, authentication failure).
     pub async fn new(database_url: &str) -> StoreResult<Self> {
         let conn = connection::connect(database_url).await?;
+        Ok(Self { conn })
+    }
+
+    /// Open a connection with explicit pool sizing and timeout knobs.
+    ///
+    /// # Errors
+    ///
+    /// Returns any connection error raised by `SeaORM`.
+    pub async fn new_with_config(database_url: &str, config: &ConnectConfig) -> StoreResult<Self> {
+        let conn = connection::connect_with_config(database_url, config).await?;
         Ok(Self { conn })
     }
 

--- a/crates/tanren-store/src/store.rs
+++ b/crates/tanren-store/src/store.rs
@@ -1,0 +1,75 @@
+//! Unified [`Store`] struct — one [`DatabaseConnection`] threaded
+//! through every trait impl.
+//!
+//! The three traits ([`EventStore`](crate::EventStore),
+//! [`JobQueue`](crate::JobQueue),
+//! [`StateStore`](crate::StateStore)) are implemented for `Store` in
+//! their respective modules. This file only holds the struct
+//! definition, the constructor, the migration runner, and a
+//! crate-internal accessor for the underlying connection.
+
+use sea_orm::{DatabaseConnection, DbErr};
+use sea_orm_migration::MigratorTrait;
+
+use crate::connection;
+use crate::errors::{StoreError, StoreResult};
+use crate::migration::Migrator;
+
+/// Backend-agnostic store handle. Cheap to clone — the inner
+/// [`DatabaseConnection`] is itself a shared pool handle.
+#[derive(Clone, Debug)]
+pub struct Store {
+    conn: DatabaseConnection,
+}
+
+impl Store {
+    /// Open a connection to the given database URL. Does **not** run
+    /// migrations — call [`Store::run_migrations`] separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns any connection error raised by `SeaORM` (bad URL,
+    /// unreachable host, authentication failure).
+    pub async fn new(database_url: &str) -> StoreResult<Self> {
+        let conn = connection::connect(database_url).await?;
+        Ok(Self { conn })
+    }
+
+    /// Wrap an existing [`DatabaseConnection`]. Useful for tests that
+    /// already hold a mock or in-memory connection.
+    #[must_use]
+    pub fn from_connection(conn: DatabaseConnection) -> Self {
+        Self { conn }
+    }
+
+    /// Apply every pending schema migration.
+    ///
+    /// `SeaORM` tracks applied migrations in the `seaql_migrations`
+    /// table, so this is idempotent — calling it twice in a row is a
+    /// no-op on the second call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Migration`] if the migrator rejects the
+    /// schema (e.g., partially-applied state from an aborted run).
+    pub async fn run_migrations(&self) -> StoreResult<()> {
+        Migrator::up(&self.conn, None)
+            .await
+            .map_err(|err: DbErr| StoreError::Migration(err.to_string()))
+    }
+
+    /// Close the underlying connection pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns any driver error raised during shutdown.
+    pub async fn close(self) -> StoreResult<()> {
+        self.conn.close().await.map_err(StoreError::from)
+    }
+
+    /// Accessor for the underlying connection. Used internally by the
+    /// trait implementations.
+    pub(crate) fn conn(&self) -> &DatabaseConnection {
+        &self.conn
+    }
+}

--- a/crates/tanren-store/src/store.rs
+++ b/crates/tanren-store/src/store.rs
@@ -51,6 +51,21 @@ impl Store {
         Ok(Self { conn })
     }
 
+    /// Open a connection **and** apply all pending migrations.
+    ///
+    /// This is the recommended entrypoint for production use.
+    /// Equivalent to calling [`Store::new`] followed by
+    /// [`Store::run_migrations`].
+    ///
+    /// # Errors
+    ///
+    /// Returns connection errors or migration failures.
+    pub async fn open_and_migrate(database_url: &str) -> StoreResult<Self> {
+        let store = Self::new(database_url).await?;
+        store.run_migrations().await?;
+        Ok(store)
+    }
+
     /// Wrap an existing [`DatabaseConnection`]. Useful for tests that
     /// already hold a mock or in-memory connection.
     #[must_use]
@@ -123,5 +138,13 @@ mod tests {
         // surfaces as `StoreError::Database`.
         let result = Store::new("gopher://nowhere").await;
         assert!(matches!(result, Err(StoreError::Database(_))));
+    }
+
+    #[tokio::test]
+    async fn open_and_migrate_creates_usable_store() {
+        let store = Store::open_and_migrate("sqlite::memory:")
+            .await
+            .expect("open_and_migrate");
+        assert_eq!(store.conn().get_database_backend(), DbBackend::Sqlite);
     }
 }

--- a/crates/tanren-store/src/store.rs
+++ b/crates/tanren-store/src/store.rs
@@ -15,9 +15,15 @@ use crate::connection;
 use crate::errors::{StoreError, StoreResult};
 use crate::migration::Migrator;
 
-/// Backend-agnostic store handle. Cheap to clone — the inner
-/// [`DatabaseConnection`] is itself a shared pool handle.
-#[derive(Clone, Debug)]
+/// Backend-agnostic store handle.
+///
+/// Wrap in [`std::sync::Arc`] if you need to share it across tasks.
+/// We deliberately do not derive [`Clone`] because `SeaORM`'s
+/// [`DatabaseConnection`] is not `Clone` when the `mock` feature is
+/// active (which the store enables in dev-dependencies for unit
+/// tests). Since Lane 0.4 will share `Store` via `Arc` anyway, the
+/// lost convenience is minimal.
+#[derive(Debug)]
 pub struct Store {
     conn: DatabaseConnection,
 }
@@ -71,5 +77,41 @@ impl Store {
     /// trait implementations.
     pub(crate) fn conn(&self) -> &DatabaseConnection {
         &self.conn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, DbBackend, MockDatabase};
+
+    use super::*;
+
+    #[test]
+    fn from_connection_wraps_an_existing_handle() {
+        let conn = MockDatabase::new(DbBackend::Postgres).into_connection();
+        let store = Store::from_connection(conn);
+        // `conn` is a valid handle — the crate-internal accessor
+        // returns a reference we can inspect.
+        assert_eq!(
+            store.conn().get_database_backend(),
+            DbBackend::Postgres,
+            "Store::from_connection must preserve the underlying backend"
+        );
+    }
+
+    #[test]
+    fn from_connection_preserves_sqlite_backend() {
+        let conn = MockDatabase::new(DbBackend::Sqlite).into_connection();
+        let store = Store::from_connection(conn);
+        assert_eq!(store.conn().get_database_backend(), DbBackend::Sqlite);
+    }
+
+    #[tokio::test]
+    async fn new_rejects_obviously_invalid_url() {
+        // Not a `sqlite:` or `postgres:` scheme — `SeaORM` rejects
+        // the URL in its URL parser, returning a `DbErr`. The error
+        // surfaces as `StoreError::Database`.
+        let result = Store::new("gopher://nowhere").await;
+        assert!(matches!(result, Err(StoreError::Database(_))));
     }
 }

--- a/crates/tanren-store/tests/common/mod.rs
+++ b/crates/tanren-store/tests/common/mod.rs
@@ -23,8 +23,8 @@ use tanren_domain::{
     TimeoutSecs, UserId,
 };
 use tanren_store::{
-    AckAndEnqueueParams, CreateDispatchParams, DequeueParams, EnqueueStepParams, JobQueue,
-    StateStore, Store, StoreResult,
+    AckAndEnqueueParams, AckParams, CancelPendingStepsParams, CreateDispatchParams, DequeueParams,
+    EnqueueStepParams, JobQueue, StateStore, Store, StoreResult, UpdateDispatchStatusParams,
 };
 use uuid::Uuid;
 
@@ -285,6 +285,74 @@ pub(crate) fn ack_and_enqueue_execute(
         result,
         completion_event,
         next_step: Some(next),
+    }
+}
+
+/// Build an [`AckParams`] wrapping a step completion.
+pub(crate) fn ack_params(
+    dispatch_id: DispatchId,
+    step_id: StepId,
+    step_type: StepType,
+    result: StepResult,
+) -> AckParams {
+    let completion_event = step_completed_event(dispatch_id, step_id, step_type, &result);
+    AckParams {
+        step_id,
+        result,
+        completion_event,
+    }
+}
+
+/// Build [`CancelPendingStepsParams`] for a dispatch.
+pub(crate) fn cancel_pending_steps_params(dispatch_id: DispatchId) -> CancelPendingStepsParams {
+    CancelPendingStepsParams {
+        dispatch_id,
+        actor: None,
+        reason: None,
+        timestamp: Utc::now(),
+    }
+}
+
+/// Build [`UpdateDispatchStatusParams`] for a status transition.
+pub(crate) fn update_dispatch_status_params(
+    dispatch_id: DispatchId,
+    status: DispatchStatus,
+    outcome: Option<Outcome>,
+) -> UpdateDispatchStatusParams {
+    let payload = match status {
+        DispatchStatus::Pending | DispatchStatus::Running => {
+            DomainEvent::DispatchStarted { dispatch_id }
+        }
+        DispatchStatus::Completed => DomainEvent::DispatchCompleted {
+            dispatch_id,
+            outcome: outcome.unwrap_or(Outcome::Success),
+            total_duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+        },
+        DispatchStatus::Failed => DomainEvent::DispatchFailed {
+            dispatch_id,
+            outcome: outcome.unwrap_or(Outcome::Fail),
+            failed_step_id: None,
+            failed_step_type: None,
+            error: "test failure".to_owned(),
+        },
+        DispatchStatus::Cancelled => DomainEvent::DispatchCancelled {
+            dispatch_id,
+            actor: actor(),
+            reason: None,
+        },
+    };
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Dispatch(dispatch_id),
+        payload,
+    };
+    UpdateDispatchStatusParams {
+        dispatch_id,
+        status,
+        outcome,
+        status_event: event,
     }
 }
 

--- a/crates/tanren-store/tests/common/mod.rs
+++ b/crates/tanren-store/tests/common/mod.rs
@@ -302,7 +302,6 @@ pub(crate) fn cancel_pending_steps_params(dispatch_id: DispatchId) -> CancelPend
         dispatch_id,
         actor: None,
         reason: None,
-        timestamp: Utc::now(),
     }
 }
 

--- a/crates/tanren-store/tests/common/mod.rs
+++ b/crates/tanren-store/tests/common/mod.rs
@@ -1,0 +1,346 @@
+//! Shared fixture helpers for the integration test suites.
+//!
+//! This module is `mod common;` in each integration test binary.
+//! It intentionally does **not** declare tests itself — it only
+//! provides builders for `tanren-domain` values and the typed param
+//! structs that the store's traits consume. Each integration binary
+//! (`sqlite_integration`, `postgres_integration`) runs the same set
+//! of `#[tokio::test]` functions against a freshly-created
+//! `tanren_store::Store`.
+//!
+//! The helpers favor determinism over realism: timestamps are taken
+//! from `chrono::Utc::now()`, UUIDs from `uuid::Uuid::now_v7()`, and
+//! every envelope is built from raw domain constructors so the
+//! integration tests do not depend on any orchestrator or planner
+//! logic that doesn't exist yet.
+
+use chrono::{DateTime, Utc};
+use tanren_domain::{
+    ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
+    DispatchStatus, DomainEvent, EntityRef, EventEnvelope, EventId, ExecutePayload, ExecuteResult,
+    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, ProvisionPayload,
+    ProvisionResult, SCHEMA_VERSION, StepId, StepPayload, StepReadyState, StepResult, StepType,
+    TimeoutSecs, UserId,
+};
+use tanren_store::{
+    AckAndEnqueueParams, CreateDispatchParams, DequeueParams, EnqueueStepParams, JobQueue,
+    StateStore, Store, StoreResult,
+};
+use uuid::Uuid;
+
+/// Build a canonical [`DispatchSnapshot`] for tests.
+pub(crate) fn snapshot(project: &str) -> DispatchSnapshot {
+    DispatchSnapshot {
+        project: NonEmptyString::try_new(project.to_owned()).expect("project"),
+        phase: Phase::DoTask,
+        cli: Cli::Claude,
+        auth_mode: AuthMode::ApiKey,
+        branch: NonEmptyString::try_new("main".to_owned()).expect("branch"),
+        spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("spec"),
+        workflow_id: NonEmptyString::try_new("wf-1".to_owned()).expect("wf"),
+        timeout: TimeoutSecs::try_new(60).expect("timeout"),
+        environment_profile: NonEmptyString::try_new("default".to_owned()).expect("prof"),
+        gate_cmd: None,
+        context: None,
+        model: None,
+        project_env: ConfigKeys::default(),
+        required_secrets: vec![],
+        preserve_on_failure: false,
+        created_at: Utc::now(),
+    }
+}
+
+/// Build a canonical [`ActorContext`] for tests.
+pub(crate) fn actor() -> ActorContext {
+    ActorContext {
+        org_id: OrgId::new(),
+        user_id: UserId::new(),
+        team_id: None,
+        api_key_id: None,
+        project_id: None,
+    }
+}
+
+/// Build a [`CreateDispatchParams`] with a fresh dispatch id and a
+/// canonical `DispatchCreated` envelope.
+pub(crate) fn create_dispatch_params(
+    project: &str,
+    actor: ActorContext,
+    lane: Lane,
+) -> CreateDispatchParams {
+    let dispatch_id = DispatchId::new();
+    let snap = snapshot(project);
+    let created_at = Utc::now();
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: created_at,
+        entity_ref: EntityRef::Dispatch(dispatch_id),
+        payload: DomainEvent::DispatchCreated {
+            dispatch_id,
+            dispatch: Box::new(snap.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: actor.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    };
+    CreateDispatchParams {
+        dispatch_id,
+        mode: DispatchMode::Manual,
+        lane,
+        dispatch: snap,
+        actor,
+        graph_revision: GraphRevision::INITIAL,
+        created_at,
+        creation_event: event,
+    }
+}
+
+/// Build an [`EnqueueStepParams`] pointing at `dispatch_id` with the
+/// given type and sequence. Includes a `StepEnqueued` envelope.
+pub(crate) fn enqueue_step_params(
+    dispatch_id: DispatchId,
+    step_id: StepId,
+    step_type: StepType,
+    step_sequence: u32,
+    lane: Option<Lane>,
+    payload: StepPayload,
+) -> EnqueueStepParams {
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type,
+            step_sequence,
+            lane,
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+        },
+    };
+    EnqueueStepParams {
+        dispatch_id,
+        step_id,
+        step_type,
+        step_sequence,
+        lane,
+        depends_on: vec![],
+        graph_revision: GraphRevision::INITIAL,
+        payload,
+        ready_state: StepReadyState::Ready,
+        enqueue_event: event,
+    }
+}
+
+/// Build a `StepCompleted` envelope matching the given result.
+pub(crate) fn step_completed_event(
+    dispatch_id: DispatchId,
+    step_id: StepId,
+    step_type: StepType,
+    result: &StepResult,
+) -> EventEnvelope {
+    EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepCompleted {
+            dispatch_id,
+            step_id,
+            step_type,
+            duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+            result_payload: Box::new(result.clone()),
+        },
+    }
+}
+
+/// A canonical `StepResult::Provision` for tests.
+pub(crate) fn provision_result() -> StepResult {
+    StepResult::Provision(Box::new(ProvisionResult {
+        handle: tanren_domain::EnvironmentHandle {
+            id: NonEmptyString::try_new("handle-1".to_owned()).expect("handle"),
+            runtime_type: NonEmptyString::try_new("local".to_owned()).expect("runtime"),
+        },
+    }))
+}
+
+/// A canonical `StepPayload::Provision` for tests.
+pub(crate) fn provision_payload(snap: DispatchSnapshot) -> StepPayload {
+    StepPayload::Provision(Box::new(ProvisionPayload { dispatch: snap }))
+}
+
+/// A canonical `StepPayload::Execute` for tests.
+pub(crate) fn execute_payload(snap: DispatchSnapshot) -> StepPayload {
+    StepPayload::Execute(Box::new(ExecutePayload {
+        dispatch: snap,
+        handle: tanren_domain::EnvironmentHandle {
+            id: NonEmptyString::try_new("handle-1".to_owned()).expect("handle"),
+            runtime_type: NonEmptyString::try_new("local".to_owned()).expect("runtime"),
+        },
+    }))
+}
+
+/// A canonical `StepResult::Execute` for tests.
+pub(crate) fn execute_result() -> StepResult {
+    StepResult::Execute(Box::new(ExecuteResult {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: FiniteF64::try_new(1.5).expect("finite"),
+        gate_output: None,
+        tail_output: None,
+        stderr_tail: None,
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    }))
+}
+
+/// Convenience: create a dispatch projection and return its id.
+pub(crate) async fn create_dispatch(
+    store: &Store,
+    project: &str,
+    actor: ActorContext,
+    lane: Lane,
+) -> StoreResult<DispatchId> {
+    let params = create_dispatch_params(project, actor, lane);
+    let id = params.dispatch_id;
+    store.create_dispatch_projection(params).await?;
+    Ok(id)
+}
+
+/// Seed a dispatch with `count` pending execute-lane steps. Returns
+/// the vector of generated step ids in insertion order.
+pub(crate) async fn seed_steps(
+    store: &Store,
+    dispatch_id: DispatchId,
+    snap: &DispatchSnapshot,
+    lane: Lane,
+    count: u32,
+) -> StoreResult<Vec<StepId>> {
+    let mut ids = Vec::with_capacity(count as usize);
+    for seq in 0..count {
+        let step_id = StepId::new();
+        let params = enqueue_step_params(
+            dispatch_id,
+            step_id,
+            StepType::Execute,
+            seq,
+            Some(lane),
+            execute_payload(snap.clone()),
+        );
+        store.enqueue_step(params).await?;
+        ids.push(step_id);
+    }
+    Ok(ids)
+}
+
+/// Attempt a dequeue with the given knobs — helper so tests don't
+/// repeat the param construction.
+pub(crate) async fn try_dequeue(
+    store: &Store,
+    worker_id: &str,
+    lane: Option<Lane>,
+    max_concurrent: u64,
+) -> StoreResult<Option<tanren_store::QueuedStep>> {
+    store
+        .dequeue(DequeueParams {
+            worker_id: worker_id.to_owned(),
+            lane,
+            max_concurrent,
+        })
+        .await
+}
+
+/// Build an `AckAndEnqueueParams` that ACKs `step_id` with an execute
+/// result and enqueues a successor step with the same dispatch id.
+pub(crate) fn ack_and_enqueue_execute(
+    dispatch_id: DispatchId,
+    ack_step_id: StepId,
+    ack_step_type: StepType,
+    snap: &DispatchSnapshot,
+    next_step_id: StepId,
+    next_seq: u32,
+    next_lane: Option<Lane>,
+) -> AckAndEnqueueParams {
+    let result = execute_result();
+    let completion_event = step_completed_event(dispatch_id, ack_step_id, ack_step_type, &result);
+    let next = enqueue_step_params(
+        dispatch_id,
+        next_step_id,
+        StepType::Execute,
+        next_seq,
+        next_lane,
+        execute_payload(snap.clone()),
+    );
+    AckAndEnqueueParams {
+        step_id: ack_step_id,
+        result,
+        completion_event,
+        next_step: Some(next),
+    }
+}
+
+/// Build a creation params whose `dispatch_id` equals `existing` — the
+/// unique-constraint violation is the trigger for rollback tests.
+pub(crate) fn duplicate_create_params(
+    existing: DispatchId,
+    actor: ActorContext,
+    lane: Lane,
+) -> CreateDispatchParams {
+    let snap = snapshot("clashing");
+    let created_at = Utc::now();
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: created_at,
+        entity_ref: EntityRef::Dispatch(existing),
+        payload: DomainEvent::DispatchCreated {
+            dispatch_id: existing,
+            dispatch: Box::new(snap.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: actor.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    };
+    CreateDispatchParams {
+        dispatch_id: existing,
+        mode: DispatchMode::Manual,
+        lane,
+        dispatch: snap,
+        actor,
+        graph_revision: GraphRevision::INITIAL,
+        created_at,
+        creation_event: event,
+    }
+}
+
+/// Return the current server-side wall clock inside a transaction
+/// (wrapped in a helper so the caller doesn't need to import chrono
+/// just to get `Utc::now()`).
+pub(crate) fn now() -> DateTime<Utc> {
+    Utc::now()
+}
+
+/// Assert that the given dispatch projection exists and has the
+/// expected status.
+pub(crate) async fn assert_dispatch_status(
+    store: &Store,
+    dispatch_id: &DispatchId,
+    expected: DispatchStatus,
+) {
+    let view = store
+        .get_dispatch(dispatch_id)
+        .await
+        .expect("get dispatch")
+        .expect("dispatch should exist");
+    assert_eq!(view.status, expected);
+}

--- a/crates/tanren-store/tests/common/mod.rs
+++ b/crates/tanren-store/tests/common/mod.rs
@@ -217,9 +217,10 @@ pub(crate) async fn seed_steps(
     snap: &DispatchSnapshot,
     lane: Lane,
     count: u32,
+    start_seq: u32,
 ) -> StoreResult<Vec<StepId>> {
     let mut ids = Vec::with_capacity(count as usize);
-    for seq in 0..count {
+    for seq in start_seq..(start_seq + count) {
         let step_id = StepId::new();
         let params = enqueue_step_params(
             dispatch_id,
@@ -274,7 +275,9 @@ pub(crate) fn ack_and_enqueue_execute(
         execute_payload(snap.clone()),
     );
     AckAndEnqueueParams {
+        dispatch_id,
         step_id: ack_step_id,
+        step_type: ack_step_type,
         result,
         completion_event,
         next_step: Some(next),
@@ -290,7 +293,9 @@ pub(crate) fn ack_params(
 ) -> AckParams {
     let completion_event = step_completed_event(dispatch_id, step_id, step_type, &result);
     AckParams {
+        dispatch_id,
         step_id,
+        step_type,
         result,
         completion_event,
     }
@@ -312,9 +317,10 @@ pub(crate) fn update_dispatch_status_params(
     outcome: Option<Outcome>,
 ) -> UpdateDispatchStatusParams {
     let payload = match status {
-        DispatchStatus::Pending | DispatchStatus::Running => {
-            DomainEvent::DispatchStarted { dispatch_id }
-        }
+        DispatchStatus::Pending => unreachable!(
+            "update_dispatch_status_params must not be called with Pending — Pending is only set at creation"
+        ),
+        DispatchStatus::Running => DomainEvent::DispatchStarted { dispatch_id },
         DispatchStatus::Completed => DomainEvent::DispatchCompleted {
             dispatch_id,
             outcome: outcome.unwrap_or(Outcome::Success),

--- a/crates/tanren-store/tests/common/mod.rs
+++ b/crates/tanren-store/tests/common/mod.rs
@@ -17,10 +17,9 @@
 use chrono::{DateTime, Utc};
 use tanren_domain::{
     ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
-    DispatchStatus, DomainEvent, EntityRef, EventEnvelope, EventId, ExecutePayload, ExecuteResult,
-    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, ProvisionPayload,
-    ProvisionResult, SCHEMA_VERSION, StepId, StepPayload, StepReadyState, StepResult, StepType,
-    TimeoutSecs, UserId,
+    DispatchStatus, DomainEvent, EventEnvelope, EventId, ExecutePayload, ExecuteResult, FiniteF64,
+    GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, ProvisionPayload, ProvisionResult,
+    StepId, StepPayload, StepReadyState, StepResult, StepType, TimeoutSecs, UserId,
 };
 use tanren_store::{
     AckAndEnqueueParams, AckParams, CancelPendingStepsParams, CreateDispatchParams, DequeueParams,
@@ -71,12 +70,10 @@ pub(crate) fn create_dispatch_params(
     let dispatch_id = DispatchId::new();
     let snap = snapshot(project);
     let created_at = Utc::now();
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: created_at,
-        entity_ref: EntityRef::Dispatch(dispatch_id),
-        payload: DomainEvent::DispatchCreated {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        created_at,
+        DomainEvent::DispatchCreated {
             dispatch_id,
             dispatch: Box::new(snap.clone()),
             mode: DispatchMode::Manual,
@@ -84,7 +81,7 @@ pub(crate) fn create_dispatch_params(
             actor: actor.clone(),
             graph_revision: GraphRevision::INITIAL,
         },
-    };
+    );
     CreateDispatchParams {
         dispatch_id,
         mode: DispatchMode::Manual,
@@ -107,12 +104,10 @@ pub(crate) fn enqueue_step_params(
     lane: Option<Lane>,
     payload: StepPayload,
 ) -> EnqueueStepParams {
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepEnqueued {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepEnqueued {
             dispatch_id,
             step_id,
             step_type,
@@ -121,7 +116,7 @@ pub(crate) fn enqueue_step_params(
             depends_on: vec![],
             graph_revision: GraphRevision::INITIAL,
         },
-    };
+    );
     EnqueueStepParams {
         dispatch_id,
         step_id,
@@ -143,19 +138,17 @@ pub(crate) fn step_completed_event(
     step_type: StepType,
     result: &StepResult,
 ) -> EventEnvelope {
-    EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepCompleted {
+    EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepCompleted {
             dispatch_id,
             step_id,
             step_type,
             duration_secs: FiniteF64::try_new(1.0).expect("finite"),
             result_payload: Box::new(result.clone()),
         },
-    }
+    )
 }
 
 /// A canonical `StepResult::Provision` for tests.
@@ -341,13 +334,7 @@ pub(crate) fn update_dispatch_status_params(
             reason: None,
         },
     };
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Dispatch(dispatch_id),
-        payload,
-    };
+    let event = EventEnvelope::new(EventId::from_uuid(Uuid::now_v7()), Utc::now(), payload);
     UpdateDispatchStatusParams {
         dispatch_id,
         status,
@@ -365,12 +352,10 @@ pub(crate) fn duplicate_create_params(
 ) -> CreateDispatchParams {
     let snap = snapshot("clashing");
     let created_at = Utc::now();
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: created_at,
-        entity_ref: EntityRef::Dispatch(existing),
-        payload: DomainEvent::DispatchCreated {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        created_at,
+        DomainEvent::DispatchCreated {
             dispatch_id: existing,
             dispatch: Box::new(snap.clone()),
             mode: DispatchMode::Manual,
@@ -378,7 +363,7 @@ pub(crate) fn duplicate_create_params(
             actor: actor.clone(),
             graph_revision: GraphRevision::INITIAL,
         },
-    };
+    );
     CreateDispatchParams {
         dispatch_id: existing,
         mode: DispatchMode::Manual,

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -32,7 +32,7 @@ use common::{
     enqueue_step_params, execute_payload, execute_result, now, provision_payload, provision_result,
     seed_steps, snapshot, step_completed_event, try_dequeue, update_dispatch_status_params,
 };
-use tanren_domain::{DispatchStatus, DomainEvent, EntityRef, Lane, StepId, StepPayload, StepType};
+use tanren_domain::{DispatchStatus, DomainEvent, Lane, StepId, StepPayload, StepType};
 use tanren_store::{EventFilter, EventStore, JobQueue, StateStore, Store};
 use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
@@ -191,13 +191,11 @@ async fn full_lifecycle_passes_on_postgres() {
 
     // 8. Build a DispatchStarted envelope inline using `now()` to
     //    exercise that helper.
-    let started = tanren_domain::EventEnvelope {
-        schema_version: tanren_domain::SCHEMA_VERSION,
-        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
-        timestamp: now(),
-        entity_ref: EntityRef::Dispatch(id),
-        payload: DomainEvent::DispatchStarted { dispatch_id: id },
-    };
+    let started = tanren_domain::EventEnvelope::new(
+        tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        now(),
+        DomainEvent::DispatchStarted { dispatch_id: id },
+    );
     store.append(&started).await.expect("append started");
 
     let events = store

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -134,7 +134,7 @@ async fn full_lifecycle_passes_on_postgres() {
     tokio::time::sleep(Duration::from_millis(10)).await;
 
     // 4. Seed a couple of execute steps via the seed_steps helper.
-    let _seeded = seed_steps(store, id, &snap, Lane::Impl, 2)
+    let _seeded = seed_steps(store, id, &snap, Lane::Impl, 2, 1)
         .await
         .expect("seed");
 
@@ -227,7 +227,7 @@ async fn dispatch_status_and_cancel_on_postgres() {
         .await
         .expect("create");
     // Seed some steps so cancel has work to do.
-    let _ = seed_steps(store, id, &snap, Lane::Impl, 3)
+    let _ = seed_steps(store, id, &snap, Lane::Impl, 3, 0)
         .await
         .expect("seed");
 

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -1,0 +1,304 @@
+//! Postgres-backed integration tests for `tanren-store`.
+//!
+//! Gated behind the `postgres-integration` cargo feature so it does
+//! not run on every local `cargo nextest run`. Each test either
+//! spins up a fresh `testcontainers::Postgres` container or
+//! connects to `TANREN_TEST_POSTGRES_URL` (for CI where a service
+//! container is already running). Tests share no state — each call
+//! to [`postgres_store`] migrates a fresh schema.
+//!
+//! The most important test in this file is [`dequeue_is_race_safe`],
+//! which exercises the `FOR UPDATE SKIP LOCKED` path that `SQLite`
+//! cannot reproduce and is the single most critical correctness
+//! guarantee the store provides.
+
+#![cfg(feature = "postgres-integration")]
+
+mod common;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use common::{
+    ack_and_enqueue_execute, actor, assert_dispatch_status, create_dispatch,
+    create_dispatch_params, duplicate_create_params, enqueue_step_params, execute_payload,
+    execute_result, now, provision_payload, provision_result, seed_steps, snapshot,
+    step_completed_event, try_dequeue,
+};
+use tanren_domain::{DispatchStatus, DomainEvent, EntityRef, Lane, StepId, StepPayload, StepType};
+use tanren_store::{EventFilter, EventStore, JobQueue, StateStore, Store};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+
+/// Container handle + connected store. Keep both around — dropping
+/// the container shuts down the database.
+struct Fixture {
+    _container: Option<ContainerAsync<PostgresImage>>,
+    store: Store,
+}
+
+/// Acquire a running Postgres and migrate a fresh schema. Uses
+/// `TANREN_TEST_POSTGRES_URL` when set (CI path); otherwise spins up
+/// a testcontainer.
+async fn postgres_fixture() -> Fixture {
+    if let Ok(url) = std::env::var("TANREN_TEST_POSTGRES_URL") {
+        // Tests share the same database when running against CI's
+        // service container; reset the `public` schema before
+        // migrating so each test starts clean.
+        reset_schema(&url).await;
+        let store = migrate_fresh(&url).await;
+        Fixture {
+            _container: None,
+            store,
+        }
+    } else {
+        let container = PostgresImage::default()
+            .start()
+            .await
+            .expect("start postgres container");
+        let host = container.get_host().await.expect("host");
+        let port = container.get_host_port_ipv4(5432).await.expect("port");
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        let store = migrate_fresh(&url).await;
+        Fixture {
+            _container: Some(container),
+            store,
+        }
+    }
+}
+
+async fn migrate_fresh(url: &str) -> Store {
+    let store = Store::new(url).await.expect("connect to postgres");
+    store.run_migrations().await.expect("run migrations");
+    store
+}
+
+async fn reset_schema(url: &str) {
+    use sea_orm::{ConnectionTrait, Database};
+    let conn = Database::connect(url).await.expect("bootstrap connect");
+    conn.execute_unprepared("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+        .await
+        .expect("reset schema");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn full_lifecycle_passes_on_postgres() {
+    let fixture = postgres_fixture().await;
+    let store = &fixture.store;
+    let snap = snapshot("alpha");
+    let actor_ctx = actor();
+    let dup_actor = actor_ctx.clone();
+
+    // 1. create_dispatch helper + get_dispatch + assert_dispatch_status
+    let id = create_dispatch(store, "alpha", actor_ctx, Lane::Impl)
+        .await
+        .expect("create");
+    assert_dispatch_status(store, &id, DispatchStatus::Pending).await;
+
+    // 2. Duplicate create must fail cleanly without corrupting state.
+    assert!(
+        store
+            .create_dispatch_projection(duplicate_create_params(id, dup_actor, Lane::Impl))
+            .await
+            .is_err()
+    );
+
+    // 3. Seed a few pending steps via the seed_steps helper.
+    let _seeded = seed_steps(store, id, &snap, Lane::Impl, 2)
+        .await
+        .expect("seed");
+
+    // 4. Enqueue one more via the explicit builder using a
+    //    provision payload (exercises provision_payload and enqueue
+    //    params).
+    let provision_step = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            provision_step,
+            StepType::Provision,
+            99,
+            Some(Lane::Impl),
+            provision_payload(snap.clone()),
+        ))
+        .await
+        .expect("provision enqueue");
+
+    // 5. Dequeue the provision step, then ack it with
+    //    provision_result so both provision_result and ack paths
+    //    are exercised.
+    let claimed = try_dequeue(store, "worker-prov", Some(Lane::Impl), 99)
+        .await
+        .expect("dequeue")
+        .expect("claim");
+    assert!(matches!(claimed.payload, StepPayload::Provision(_)));
+    store
+        .ack(&claimed.step_id, &provision_result())
+        .await
+        .expect("ack provision");
+
+    // 6. Pick one execute step, hand it off via ack_and_enqueue.
+    let execute_step = try_dequeue(store, "worker-exec", Some(Lane::Impl), 99)
+        .await
+        .expect("dequeue")
+        .expect("claim");
+    let next_step = StepId::new();
+    store
+        .ack_and_enqueue(ack_and_enqueue_execute(
+            id,
+            execute_step.step_id,
+            StepType::Execute,
+            &snap,
+            next_step,
+            42,
+            Some(Lane::Impl),
+        ))
+        .await
+        .expect("ack_and_enqueue");
+
+    // 7. Append a StepCompleted envelope via the helper and verify
+    //    it lands.
+    let standalone_completed = step_completed_event(
+        id,
+        execute_step.step_id,
+        StepType::Execute,
+        &execute_result(),
+    );
+    store
+        .append(&standalone_completed)
+        .await
+        .expect("append completed");
+
+    // 8. Build a DispatchStarted envelope inline using `now()` to
+    //    exercise that helper.
+    let started = tanren_domain::EventEnvelope {
+        schema_version: tanren_domain::SCHEMA_VERSION,
+        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        timestamp: now(),
+        entity_ref: EntityRef::Dispatch(id),
+        payload: DomainEvent::DispatchStarted { dispatch_id: id },
+    };
+    store.append(&started).await.expect("append started");
+
+    let events = store
+        .query_events(&EventFilter {
+            limit: 100,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("query");
+    assert!(events.total_count >= 6);
+
+    // Ensure `create_dispatch_params` is still directly invokable in
+    // isolation (exercised above through `create_dispatch`, but
+    // clippy wants an explicit reference so the helper isn't pruned).
+    let _params = create_dispatch_params("second", actor(), Lane::Audit);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn dequeue_is_race_safe() {
+    let fixture = postgres_fixture().await;
+    let store = Arc::new(fixture.store);
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+
+    // Seed 5 pending execute-lane steps.
+    let mut seeded = Vec::new();
+    for seq in 0..5 {
+        let step_id = StepId::new();
+        store
+            .enqueue_step(enqueue_step_params(
+                id,
+                step_id,
+                StepType::Execute,
+                seq,
+                Some(Lane::Impl),
+                execute_payload(snap.clone()),
+            ))
+            .await
+            .expect("enqueue");
+        seeded.push(step_id);
+    }
+
+    // Spawn 20 concurrent dequeues with max_concurrent = 5. Exactly
+    // 5 must succeed; no step may be claimed twice.
+    let mut handles = Vec::new();
+    for n in 0..20 {
+        let store = Arc::clone(&store);
+        let worker_id = format!("worker-{n}");
+        handles.push(tokio::spawn(async move {
+            try_dequeue(&store, &worker_id, Some(Lane::Impl), 5)
+                .await
+                .expect("dequeue")
+        }));
+    }
+
+    let mut claimed: Vec<StepId> = Vec::new();
+    for handle in handles {
+        if let Some(queued) = handle.await.expect("join") {
+            claimed.push(queued.step_id);
+        }
+    }
+
+    assert_eq!(
+        claimed.len(),
+        5,
+        "exactly 5 claims should have been awarded"
+    );
+    let unique: HashSet<_> = claimed.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        claimed.len(),
+        "no step should be claimed by two workers"
+    );
+    for claimed_id in &claimed {
+        assert!(
+            seeded.contains(claimed_id),
+            "claim must be one of the seeded steps"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dequeue_respects_max_concurrent_one() {
+    let fixture = postgres_fixture().await;
+    let store = Arc::new(fixture.store);
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    for seq in 0..5 {
+        store
+            .enqueue_step(enqueue_step_params(
+                id,
+                StepId::new(),
+                StepType::Execute,
+                seq,
+                Some(Lane::Impl),
+                execute_payload(snap.clone()),
+            ))
+            .await
+            .expect("enqueue");
+    }
+
+    let mut handles = Vec::new();
+    for n in 0..10 {
+        let store = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            try_dequeue(&store, &format!("w{n}"), Some(Lane::Impl), 1)
+                .await
+                .expect("dequeue")
+        }));
+    }
+
+    let mut claimed = 0;
+    for handle in handles {
+        if handle.await.expect("join").is_some() {
+            claimed += 1;
+        }
+    }
+    assert_eq!(claimed, 1, "max_concurrent=1 allows exactly one claim");
+}

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -27,10 +27,10 @@ use std::time::Duration;
 // instance in parallel.
 
 use common::{
-    ack_and_enqueue_execute, actor, assert_dispatch_status, create_dispatch,
-    create_dispatch_params, duplicate_create_params, enqueue_step_params, execute_payload,
-    execute_result, now, provision_payload, provision_result, seed_steps, snapshot,
-    step_completed_event, try_dequeue,
+    ack_and_enqueue_execute, ack_params, actor, assert_dispatch_status,
+    cancel_pending_steps_params, create_dispatch, create_dispatch_params, duplicate_create_params,
+    enqueue_step_params, execute_payload, execute_result, now, provision_payload, provision_result,
+    seed_steps, snapshot, step_completed_event, try_dequeue, update_dispatch_status_params,
 };
 use tanren_domain::{DispatchStatus, DomainEvent, EntityRef, Lane, StepId, StepPayload, StepType};
 use tanren_store::{EventFilter, EventStore, JobQueue, StateStore, Store};
@@ -148,7 +148,12 @@ async fn full_lifecycle_passes_on_postgres() {
     assert_eq!(claimed.step_id, provision_step);
     assert!(matches!(claimed.payload, StepPayload::Provision(_)));
     store
-        .ack(&claimed.step_id, &provision_result())
+        .ack(ack_params(
+            id,
+            claimed.step_id,
+            StepType::Provision,
+            provision_result(),
+        ))
         .await
         .expect("ack provision");
 
@@ -202,12 +207,47 @@ async fn full_lifecycle_passes_on_postgres() {
         })
         .await
         .expect("query");
-    assert!(events.total_count >= 6);
+    // Dequeue now mints StepDequeued events, ack now appends
+    // StepCompleted co-transactionally, so the total is higher.
+    assert!(events.total_count >= 8);
 
     // Ensure `create_dispatch_params` is still directly invokable in
     // isolation (exercised above through `create_dispatch`, but
     // clippy wants an explicit reference so the helper isn't pruned).
     let _params = create_dispatch_params("second", actor(), Lane::Audit);
+}
+
+/// Exercises `update_dispatch_status` and `cancel_pending_steps` on
+/// `Postgres` — both must append their companion events
+/// co-transactionally.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dispatch_status_and_cancel_on_postgres() {
+    let fixture = postgres_fixture().await;
+    let store = &fixture.store;
+    let snap = snapshot("beta");
+    let id = create_dispatch(store, "beta", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    // Seed some steps so cancel has work to do.
+    let _ = seed_steps(store, id, &snap, Lane::Impl, 3)
+        .await
+        .expect("seed");
+
+    store
+        .update_dispatch_status(update_dispatch_status_params(
+            id,
+            DispatchStatus::Running,
+            None,
+        ))
+        .await
+        .expect("update status");
+    assert_dispatch_status(store, &id, DispatchStatus::Running).await;
+
+    let cancelled = store
+        .cancel_pending_steps(cancel_pending_steps_params(id))
+        .await
+        .expect("cancel");
+    assert_eq!(cancelled, 3);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -18,6 +18,13 @@ mod common;
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
+
+// Nextest serializes this binary via the `postgres-integration`
+// test group in `.config/nextest.toml`. Running tests one at a
+// time sidesteps pg_catalog races when multiple tests all drop +
+// recreate the `public` schema against the same `Postgres`
+// instance in parallel.
 
 use common::{
     ack_and_enqueue_execute, actor, assert_dispatch_status, create_dispatch,
@@ -44,8 +51,9 @@ struct Fixture {
 async fn postgres_fixture() -> Fixture {
     if let Ok(url) = std::env::var("TANREN_TEST_POSTGRES_URL") {
         // Tests share the same database when running against CI's
-        // service container; reset the `public` schema before
-        // migrating so each test starts clean.
+        // service container; the nextest `postgres-integration`
+        // test group enforces serial execution, so it is safe to
+        // drop + recreate the `public` schema between tests.
         reset_schema(&url).await;
         let store = migrate_fresh(&url).await;
         Fixture {
@@ -104,34 +112,40 @@ async fn full_lifecycle_passes_on_postgres() {
             .is_err()
     );
 
-    // 3. Seed a few pending steps via the seed_steps helper.
-    let _seeded = seed_steps(store, id, &snap, Lane::Impl, 2)
-        .await
-        .expect("seed");
-
-    // 4. Enqueue one more via the explicit builder using a
-    //    provision payload (exercises provision_payload and enqueue
-    //    params).
+    // 3. Enqueue the provision step first (sequence 0). The dequeue
+    //    order is `created_at ASC, step_sequence ASC`, so enqueuing
+    //    provision before the execute seeds guarantees it is the
+    //    first row claimed.
     let provision_step = StepId::new();
     store
         .enqueue_step(enqueue_step_params(
             id,
             provision_step,
             StepType::Provision,
-            99,
+            0,
             Some(Lane::Impl),
             provision_payload(snap.clone()),
         ))
         .await
         .expect("provision enqueue");
+    // A small sleep guarantees the following execute seeds have
+    // observably-later `created_at` timestamps, independent of
+    // clock resolution.
+    tokio::time::sleep(Duration::from_millis(10)).await;
 
-    // 5. Dequeue the provision step, then ack it with
+    // 4. Seed a couple of execute steps via the seed_steps helper.
+    let _seeded = seed_steps(store, id, &snap, Lane::Impl, 2)
+        .await
+        .expect("seed");
+
+    // 5. First dequeue returns the provision step. Ack it with
     //    provision_result so both provision_result and ack paths
     //    are exercised.
     let claimed = try_dequeue(store, "worker-prov", Some(Lane::Impl), 99)
         .await
         .expect("dequeue")
         .expect("claim");
+    assert_eq!(claimed.step_id, provision_step);
     assert!(matches!(claimed.payload, StepPayload::Provision(_)));
     store
         .ack(&claimed.step_id, &provision_result())
@@ -301,4 +315,63 @@ async fn dequeue_respects_max_concurrent_one() {
         }
     }
     assert_eq!(claimed, 1, "max_concurrent=1 allows exactly one claim");
+}
+
+/// B-01 regression: `dequeue(None)` counts running rows across ALL
+/// lanes while `dequeue(Some(Impl))` counts only impl rows. With
+/// a per-lane advisory lock this was a race; the global lock must
+/// prevent over-claiming when these two call shapes are mixed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn cross_lane_dequeue_respects_global_cap() {
+    let fixture = postgres_fixture().await;
+    let store = Arc::new(fixture.store);
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+
+    // Seed 3 steps in the Impl lane.
+    for seq in 0..3 {
+        store
+            .enqueue_step(enqueue_step_params(
+                id,
+                StepId::new(),
+                StepType::Execute,
+                seq,
+                Some(Lane::Impl),
+                execute_payload(snap.clone()),
+            ))
+            .await
+            .expect("enqueue");
+    }
+
+    // Spawn 10 workers: half call dequeue(None, max_concurrent=1),
+    // half call dequeue(Some(Impl), max_concurrent=1). With the
+    // global lock, the total running count across the entire step
+    // table never exceeds 1, because both call shapes share the
+    // same serialization point.
+    let mut handles = Vec::new();
+    for n in 0..10 {
+        let store = Arc::clone(&store);
+        let lane = if n % 2 == 0 { None } else { Some(Lane::Impl) };
+        handles.push(tokio::spawn(async move {
+            try_dequeue(&store, &format!("w{n}"), lane, 1)
+                .await
+                .expect("dequeue")
+        }));
+    }
+
+    let mut claimed = 0;
+    for handle in handles {
+        if handle.await.expect("join").is_some() {
+            claimed += 1;
+        }
+    }
+    // `max_concurrent=1` means at most 1 step should be in
+    // `running` state. All concurrent callers see the same cap
+    // because the advisory lock serializes them.
+    assert_eq!(
+        claimed, 1,
+        "cross-lane max_concurrent=1 must still allow exactly one claim"
+    );
 }

--- a/crates/tanren-store/tests/postgres_integration.rs
+++ b/crates/tanren-store/tests/postgres_integration.rs
@@ -356,9 +356,12 @@ async fn dequeue_respects_max_concurrent_one() {
 }
 
 /// B-01 regression: `dequeue(None)` counts running rows across ALL
-/// lanes while `dequeue(Some(Impl))` counts only impl rows. With
-/// a per-lane advisory lock this was a race; the global lock must
-/// prevent over-claiming when these two call shapes are mixed.
+/// lanes while `dequeue(Some(Impl))` counts only impl rows. The
+/// hierarchical advisory lock scheme handles this: `lane=None` takes
+/// an exclusive lock on the global key, which conflicts with the
+/// shared lock lane-specific dequeues hold. This test mixes
+/// `dequeue(None)` and `dequeue(Some(Impl))` concurrently and
+/// asserts `max_concurrent=1` is respected.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn cross_lane_dequeue_respects_global_cap() {
     let fixture = postgres_fixture().await;
@@ -368,7 +371,6 @@ async fn cross_lane_dequeue_respects_global_cap() {
         .await
         .expect("create");
 
-    // Seed 3 steps in the Impl lane.
     for seq in 0..3 {
         store
             .enqueue_step(enqueue_step_params(
@@ -383,11 +385,9 @@ async fn cross_lane_dequeue_respects_global_cap() {
             .expect("enqueue");
     }
 
-    // Spawn 10 workers: half call dequeue(None, max_concurrent=1),
-    // half call dequeue(Some(Impl), max_concurrent=1). With the
-    // global lock, the total running count across the entire step
-    // table never exceeds 1, because both call shapes share the
-    // same serialization point.
+    // Half call dequeue(None), half call dequeue(Some(Impl)).
+    // The hierarchical lock serializes None against Impl (exclusive
+    // global vs shared global), so `max_concurrent=1` is respected.
     let mut handles = Vec::new();
     for n in 0..10 {
         let store = Arc::clone(&store);
@@ -405,11 +405,81 @@ async fn cross_lane_dequeue_respects_global_cap() {
             claimed += 1;
         }
     }
-    // `max_concurrent=1` means at most 1 step should be in
-    // `running` state. All concurrent callers see the same cap
-    // because the advisory lock serializes them.
     assert_eq!(
         claimed, 1,
         "cross-lane max_concurrent=1 must still allow exactly one claim"
+    );
+}
+
+/// Scalability property: lane-specific dequeues for different lanes
+/// can proceed in parallel under the hierarchical lock scheme. Each
+/// lane holds its own exclusive lock + a shared global lock; since
+/// the global lock is shared, different lanes do not block each
+/// other. This test seeds steps in both `Impl` and `Audit` lanes
+/// and asserts that all steps in both lanes are claimed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn different_lanes_dequeue_in_parallel() {
+    let fixture = postgres_fixture().await;
+    let store = Arc::new(fixture.store);
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+
+    // Seed 3 steps in Impl, 3 in Audit.
+    for seq in 0..3_u32 {
+        store
+            .enqueue_step(enqueue_step_params(
+                id,
+                StepId::new(),
+                StepType::Execute,
+                seq,
+                Some(Lane::Impl),
+                execute_payload(snap.clone()),
+            ))
+            .await
+            .expect("enqueue impl");
+        store
+            .enqueue_step(enqueue_step_params(
+                id,
+                StepId::new(),
+                StepType::Execute,
+                10 + seq,
+                Some(Lane::Audit),
+                execute_payload(snap.clone()),
+            ))
+            .await
+            .expect("enqueue audit");
+    }
+
+    // Spawn workers: half for Impl, half for Audit, each with
+    // max_concurrent=3 (enough to drain the lane).
+    let mut handles = Vec::new();
+    for n in 0..10 {
+        let store = Arc::clone(&store);
+        let lane = if n % 2 == 0 {
+            Some(Lane::Impl)
+        } else {
+            Some(Lane::Audit)
+        };
+        handles.push(tokio::spawn(async move {
+            try_dequeue(&store, &format!("w{n}"), lane, 3)
+                .await
+                .expect("dequeue")
+        }));
+    }
+
+    let mut claimed = 0;
+    for handle in handles {
+        if handle.await.expect("join").is_some() {
+            claimed += 1;
+        }
+    }
+    // Both lanes should be fully drained (3 impl + 3 audit = 6).
+    // If the locks serialized across lanes, some workers would time
+    // out or fail to claim; all 6 must succeed.
+    assert_eq!(
+        claimed, 6,
+        "different lanes must dequeue in parallel: expected 6 total claims"
     );
 }

--- a/crates/tanren-store/tests/sqlite_audit_fixes.rs
+++ b/crates/tanren-store/tests/sqlite_audit_fixes.rs
@@ -1,0 +1,404 @@
+//! Regression tests for audit findings B-01, I-01, I-02, and S-02.
+//!
+//! Self-contained helpers (no `mod common;`) to avoid dead-code
+//! warnings from shared helpers this binary doesn't exercise.
+
+use chrono::Utc;
+use tanren_domain::{
+    ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DomainEvent,
+    EnvironmentHandle, ErrorClass, EventEnvelope, EventId, ExecutePayload, ExecuteResult,
+    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, StepId, StepPayload,
+    StepReadyState, StepResult, StepStatus, StepType, TimeoutSecs, UserId,
+};
+use tanren_store::{
+    AckAndEnqueueParams, AckParams, CreateDispatchParams, DequeueParams, EnqueueStepParams,
+    JobQueue, NackParams, QueuedStep, StateStore, Store, StoreError, StoreResult,
+};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Minimal fixture helpers
+// ---------------------------------------------------------------------------
+
+async fn fresh_store() -> Store {
+    let store = Store::new("sqlite::memory:").await.expect("connect");
+    store.run_migrations().await.expect("migrate");
+    store
+}
+
+fn snap() -> tanren_domain::DispatchSnapshot {
+    tanren_domain::DispatchSnapshot {
+        project: NonEmptyString::try_new("alpha".to_owned()).expect("p"),
+        phase: Phase::DoTask,
+        cli: Cli::Claude,
+        auth_mode: AuthMode::ApiKey,
+        branch: NonEmptyString::try_new("main".to_owned()).expect("b"),
+        spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("s"),
+        workflow_id: NonEmptyString::try_new("wf-1".to_owned()).expect("w"),
+        timeout: TimeoutSecs::try_new(60).expect("t"),
+        environment_profile: NonEmptyString::try_new("default".to_owned()).expect("e"),
+        gate_cmd: None,
+        context: None,
+        model: None,
+        project_env: ConfigKeys::default(),
+        required_secrets: vec![],
+        preserve_on_failure: false,
+        created_at: Utc::now(),
+    }
+}
+
+fn actor() -> ActorContext {
+    ActorContext {
+        org_id: OrgId::new(),
+        user_id: UserId::new(),
+        team_id: None,
+        api_key_id: None,
+        project_id: None,
+    }
+}
+
+fn handle() -> EnvironmentHandle {
+    EnvironmentHandle {
+        id: NonEmptyString::try_new("h-1".to_owned()).expect("h"),
+        runtime_type: NonEmptyString::try_new("local".to_owned()).expect("r"),
+    }
+}
+
+fn exec_payload() -> StepPayload {
+    StepPayload::Execute(Box::new(ExecutePayload {
+        dispatch: snap(),
+        handle: handle(),
+    }))
+}
+
+fn exec_result() -> StepResult {
+    StepResult::Execute(Box::new(ExecuteResult {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: FiniteF64::try_new(1.5).expect("f"),
+        gate_output: None,
+        tail_output: None,
+        stderr_tail: None,
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    }))
+}
+
+async fn create_dispatch(store: &Store, _project: &str, lane: Lane) -> StoreResult<DispatchId> {
+    let id = DispatchId::new();
+    let s = snap();
+    let act = actor();
+    let now = Utc::now();
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        now,
+        DomainEvent::DispatchCreated {
+            dispatch_id: id,
+            dispatch: Box::new(s.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: act.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    store
+        .create_dispatch_projection(CreateDispatchParams {
+            dispatch_id: id,
+            mode: DispatchMode::Manual,
+            lane,
+            dispatch: s,
+            actor: act,
+            graph_revision: GraphRevision::INITIAL,
+            created_at: now,
+            creation_event: event,
+        })
+        .await?;
+    Ok(id)
+}
+
+fn enqueue_params(
+    dispatch_id: DispatchId,
+    step_id: StepId,
+    seq: u32,
+    lane: Option<Lane>,
+) -> EnqueueStepParams {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            step_sequence: seq,
+            lane,
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    EnqueueStepParams {
+        dispatch_id,
+        step_id,
+        step_type: StepType::Execute,
+        step_sequence: seq,
+        lane,
+        depends_on: vec![],
+        graph_revision: GraphRevision::INITIAL,
+        payload: exec_payload(),
+        ready_state: StepReadyState::Ready,
+        enqueue_event: event,
+    }
+}
+
+async fn dequeue(store: &Store, lane: Option<Lane>) -> StoreResult<Option<QueuedStep>> {
+    store
+        .dequeue(DequeueParams {
+            worker_id: "w1".to_owned(),
+            lane,
+            max_concurrent: 10,
+        })
+        .await
+}
+
+fn completed_event(dispatch_id: DispatchId, step_id: StepId, result: &StepResult) -> EventEnvelope {
+    EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepCompleted {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            duration_secs: FiniteF64::try_new(1.0).expect("f"),
+            result_payload: Box::new(result.clone()),
+        },
+    )
+}
+
+fn nack(dispatch_id: DispatchId, step_id: StepId, error: &str, retry: bool) -> NackParams {
+    let failure_event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepFailed {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            error: error.to_owned(),
+            error_class: ErrorClass::Transient,
+            retry_count: u32::from(retry),
+            duration_secs: FiniteF64::try_new(0.5).expect("f"),
+        },
+    );
+    NackParams {
+        dispatch_id,
+        step_id,
+        step_type: StepType::Execute,
+        error: error.to_owned(),
+        error_class: ErrorClass::Transient,
+        retry,
+        failure_event,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// B-01: cross-dispatch ack_and_enqueue must be rejected
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cross_dispatch_ack_and_enqueue_rejected() {
+    let store = fresh_store().await;
+    let id_a = create_dispatch(&store, "alpha", Lane::Impl)
+        .await
+        .expect("A");
+    let id_b = create_dispatch(&store, "beta", Lane::Impl)
+        .await
+        .expect("B");
+
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_params(id_a, step_id, 0, Some(Lane::Impl)))
+        .await
+        .expect("enqueue");
+    let _ = dequeue(&store, Some(Lane::Impl)).await.expect("dequeue");
+
+    let result = exec_result();
+    let completion = completed_event(id_a, step_id, &result);
+    let next_for_b = enqueue_params(id_b, StepId::new(), 0, Some(Lane::Impl));
+    let params = AckAndEnqueueParams {
+        dispatch_id: id_a,
+        step_id,
+        step_type: StepType::Execute,
+        result,
+        completion_event: completion,
+        next_step: Some(next_for_b),
+    };
+
+    let err = store
+        .ack_and_enqueue(params)
+        .await
+        .expect_err("cross-dispatch must be rejected");
+    assert!(
+        matches!(err, StoreError::Conversion { .. }),
+        "expected Conversion, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// I-01: nack(retry=true) must clear error; ack after retry must stay clean
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn nack_retry_clears_error() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, "alpha", Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_params(id, step_id, 0, Some(Lane::Impl)))
+        .await
+        .expect("enqueue");
+    let _ = dequeue(&store, Some(Lane::Impl)).await.expect("dequeue");
+
+    store
+        .nack(nack(id, step_id, "boom", true))
+        .await
+        .expect("nack");
+
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Pending);
+    assert!(view.error.is_none(), "retry=true must clear error");
+}
+
+#[tokio::test]
+async fn ack_clears_error_after_retry_cycle() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, "alpha", Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_params(id, step_id, 0, Some(Lane::Impl)))
+        .await
+        .expect("enqueue");
+
+    // First attempt: dequeue -> nack(retry)
+    let _ = dequeue(&store, Some(Lane::Impl)).await.expect("d1");
+    store
+        .nack(nack(id, step_id, "transient", true))
+        .await
+        .expect("nack");
+
+    // Second attempt: dequeue -> ack
+    let _ = dequeue(&store, Some(Lane::Impl)).await.expect("d2");
+    let result = exec_result();
+    let completion = completed_event(id, step_id, &result);
+    store
+        .ack(AckParams {
+            dispatch_id: id,
+            step_id,
+            step_type: StepType::Execute,
+            result,
+            completion_event: completion,
+        })
+        .await
+        .expect("ack");
+
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Completed);
+    assert!(view.error.is_none(), "ack must clear error");
+}
+
+// ---------------------------------------------------------------------------
+// S-02: dequeue returns None when all steps are blocked
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dequeue_returns_none_when_all_blocked() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, "alpha", Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    let mut params = enqueue_params(id, step_id, 0, Some(Lane::Impl));
+    params.ready_state = StepReadyState::Blocked;
+    store.enqueue_step(params).await.expect("enqueue");
+
+    let result = dequeue(&store, Some(Lane::Impl)).await.expect("dequeue");
+    assert!(result.is_none(), "blocked step must not be dequeued");
+}
+
+// ---------------------------------------------------------------------------
+// S-02: ack_and_enqueue rolls back on constraint violation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ack_and_enqueue_rolls_back_on_constraint_violation() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, "alpha", Lane::Impl)
+        .await
+        .expect("create");
+
+    let s0 = StepId::new();
+    let s1 = StepId::new();
+    store
+        .enqueue_step(enqueue_params(id, s0, 0, Some(Lane::Impl)))
+        .await
+        .expect("enqueue s0");
+    store
+        .enqueue_step(enqueue_params(id, s1, 1, Some(Lane::Impl)))
+        .await
+        .expect("enqueue s1");
+
+    let _ = dequeue(&store, Some(Lane::Impl)).await.expect("dequeue");
+
+    // Ack s0 and try to enqueue at sequence 1 (already taken by s1).
+    let result = exec_result();
+    let completion = completed_event(id, s0, &result);
+    let dup_next = enqueue_params(id, StepId::new(), 1, Some(Lane::Impl));
+    let params = AckAndEnqueueParams {
+        dispatch_id: id,
+        step_id: s0,
+        step_type: StepType::Execute,
+        result,
+        completion_event: completion,
+        next_step: Some(dup_next),
+    };
+
+    store
+        .ack_and_enqueue(params)
+        .await
+        .expect_err("duplicate sequence must fail");
+
+    // The original step must still be Running — the tx rolled back.
+    let view = store.get_step(&s0).await.expect("get").expect("exists");
+    assert_eq!(
+        view.status,
+        StepStatus::Running,
+        "step must remain Running after rollback"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// I-03: Store::open_and_migrate triple-apply is idempotent
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn triple_migration_is_idempotent() {
+    let store = Store::open_and_migrate("sqlite::memory:")
+        .await
+        .expect("first open");
+    store.run_migrations().await.expect("second apply");
+    store.run_migrations().await.expect("third apply");
+}

--- a/crates/tanren-store/tests/sqlite_dequeue.rs
+++ b/crates/tanren-store/tests/sqlite_dequeue.rs
@@ -1,0 +1,353 @@
+//! Dequeue and recovery edge-case tests on `SQLite`.
+//!
+//! These exercises supplement the broader integration suite with
+//! targeted coverage for the dequeue path, lane filtering,
+//! `max_concurrent` enforcement, stale-step recovery (including
+//! `NULL` heartbeats), CAS-safe dispatch status updates, and
+//! impossible-state rejection.
+//!
+//! This file defines its own minimal helpers rather than importing
+//! the shared `common` module to avoid dead-code warnings from
+//! unused shared helpers.
+
+use chrono::Utc;
+use tanren_domain::{
+    ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
+    DispatchStatus, DomainEvent, EnvironmentHandle, EventEnvelope, EventId, ExecutePayload,
+    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, StepId, StepPayload,
+    StepReadyState, StepType, TimeoutSecs, UserId,
+};
+use tanren_store::{
+    DequeueParams, EnqueueStepParams, JobQueue, QueuedStep, StateStore, Store, StoreError,
+    StoreResult, UpdateDispatchStatusParams,
+};
+use uuid::Uuid;
+
+// ---- minimal helpers -------------------------------------------------------
+
+async fn fresh_store() -> Store {
+    let store = Store::new("sqlite::memory:").await.expect("connect");
+    store.run_migrations().await.expect("migrate");
+    store
+}
+
+fn snap() -> DispatchSnapshot {
+    DispatchSnapshot {
+        project: NonEmptyString::try_new("test".to_owned()).expect("project"),
+        phase: Phase::DoTask,
+        cli: Cli::Claude,
+        auth_mode: AuthMode::ApiKey,
+        branch: NonEmptyString::try_new("main".to_owned()).expect("branch"),
+        spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("spec"),
+        workflow_id: NonEmptyString::try_new("wf-1".to_owned()).expect("wf"),
+        timeout: TimeoutSecs::try_new(60).expect("timeout"),
+        environment_profile: NonEmptyString::try_new("default".to_owned()).expect("prof"),
+        gate_cmd: None,
+        context: None,
+        model: None,
+        project_env: ConfigKeys::default(),
+        required_secrets: vec![],
+        preserve_on_failure: false,
+        created_at: Utc::now(),
+    }
+}
+
+fn actor() -> ActorContext {
+    ActorContext {
+        org_id: OrgId::new(),
+        user_id: UserId::new(),
+        team_id: None,
+        api_key_id: None,
+        project_id: None,
+    }
+}
+
+async fn create_dispatch(store: &Store, lane: Lane) -> StoreResult<DispatchId> {
+    let id = DispatchId::new();
+    let s = snap();
+    let a = actor();
+    let created_at = Utc::now();
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        created_at,
+        DomainEvent::DispatchCreated {
+            dispatch_id: id,
+            dispatch: Box::new(s.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: a.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    store
+        .create_dispatch_projection(tanren_store::CreateDispatchParams {
+            dispatch_id: id,
+            mode: DispatchMode::Manual,
+            lane,
+            dispatch: s,
+            actor: a,
+            graph_revision: GraphRevision::INITIAL,
+            created_at,
+            creation_event: event,
+        })
+        .await?;
+    Ok(id)
+}
+
+fn enqueue_params(dispatch_id: DispatchId, seq: u32, lane: Lane) -> EnqueueStepParams {
+    let step_id = StepId::new();
+    let s = snap();
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            step_sequence: seq,
+            lane: Some(lane),
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    EnqueueStepParams {
+        dispatch_id,
+        step_id,
+        step_type: StepType::Execute,
+        step_sequence: seq,
+        lane: Some(lane),
+        depends_on: vec![],
+        graph_revision: GraphRevision::INITIAL,
+        payload: StepPayload::Execute(Box::new(ExecutePayload {
+            dispatch: s,
+            handle: EnvironmentHandle {
+                id: NonEmptyString::try_new("h-1".to_owned()).expect("handle"),
+                runtime_type: NonEmptyString::try_new("local".to_owned()).expect("rt"),
+            },
+        })),
+        ready_state: StepReadyState::Ready,
+        enqueue_event: event,
+    }
+}
+
+async fn dequeue(
+    store: &Store,
+    worker: &str,
+    lane: Option<Lane>,
+    max: u64,
+) -> StoreResult<Option<QueuedStep>> {
+    store
+        .dequeue(DequeueParams {
+            worker_id: worker.to_owned(),
+            lane,
+            max_concurrent: max,
+        })
+        .await
+}
+
+fn status_params(
+    id: DispatchId,
+    status: DispatchStatus,
+    outcome: Option<Outcome>,
+) -> UpdateDispatchStatusParams {
+    let payload = match status {
+        DispatchStatus::Pending => unreachable!("test helper"),
+        DispatchStatus::Running => DomainEvent::DispatchStarted { dispatch_id: id },
+        DispatchStatus::Completed => DomainEvent::DispatchCompleted {
+            dispatch_id: id,
+            outcome: outcome.unwrap_or(Outcome::Success),
+            total_duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+        },
+        DispatchStatus::Failed => DomainEvent::DispatchFailed {
+            dispatch_id: id,
+            outcome: outcome.unwrap_or(Outcome::Fail),
+            failed_step_id: None,
+            failed_step_type: None,
+            error: "test".to_owned(),
+        },
+        DispatchStatus::Cancelled => DomainEvent::DispatchCancelled {
+            dispatch_id: id,
+            actor: actor(),
+            reason: None,
+        },
+    };
+    let event = EventEnvelope::new(EventId::from_uuid(Uuid::now_v7()), Utc::now(), payload);
+    UpdateDispatchStatusParams {
+        dispatch_id: id,
+        status,
+        outcome,
+        status_event: event,
+    }
+}
+
+// ---- dequeue edge cases ---------------------------------------------------
+
+#[tokio::test]
+async fn dequeue_returns_none_when_no_pending_steps() {
+    let store = fresh_store().await;
+    let _id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let result = dequeue(&store, "w-1", Some(Lane::Impl), 10)
+        .await
+        .expect("dequeue");
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn dequeue_returns_none_at_max_concurrent() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    store
+        .enqueue_step(enqueue_params(id, 0, Lane::Impl))
+        .await
+        .expect("enqueue 0");
+    store
+        .enqueue_step(enqueue_params(id, 1, Lane::Impl))
+        .await
+        .expect("enqueue 1");
+
+    let first = dequeue(&store, "w-1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue first");
+    assert!(first.is_some(), "first dequeue should succeed");
+
+    let second = dequeue(&store, "w-2", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue second");
+    assert!(second.is_none(), "second dequeue should return None");
+}
+
+#[tokio::test]
+async fn dequeue_respects_lane_filter() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    store
+        .enqueue_step(enqueue_params(id, 0, Lane::Impl))
+        .await
+        .expect("enqueue impl");
+    let audit_params = enqueue_params(id, 1, Lane::Audit);
+    let audit_step = audit_params.step_id;
+    store
+        .enqueue_step(audit_params)
+        .await
+        .expect("enqueue audit");
+
+    let claimed = dequeue(&store, "w-1", Some(Lane::Audit), 10)
+        .await
+        .expect("dequeue audit");
+    let claimed = claimed.expect("audit-lane dequeue should succeed");
+    assert_eq!(claimed.step_id, audit_step);
+
+    let none = dequeue(&store, "w-2", Some(Lane::Audit), 10)
+        .await
+        .expect("dequeue audit again");
+    assert!(none.is_none());
+}
+
+// ---- stale-step recovery --------------------------------------------------
+
+#[tokio::test]
+async fn recover_null_heartbeat_steps() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    store
+        .enqueue_step(enqueue_params(id, 0, Lane::Impl))
+        .await
+        .expect("enqueue");
+
+    let claimed = dequeue(&store, "w-1", Some(Lane::Impl), 10)
+        .await
+        .expect("dequeue");
+    assert!(claimed.is_some());
+
+    // Heartbeat is NULL (never called heartbeat_step). Recovery
+    // with timeout=0 must reclaim the step.
+    let recovered = store.recover_stale_steps(0).await.expect("recover");
+    assert_eq!(recovered, 1, "NULL-heartbeat step must be recovered");
+}
+
+// ---- CAS dispatch status --------------------------------------------------
+
+#[tokio::test]
+async fn cas_dispatch_status_conflict() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    store
+        .update_dispatch_status(status_params(id, DispatchStatus::Running, None))
+        .await
+        .expect("pending -> running");
+
+    // Running -> Running is not a valid transition.
+    let err = store
+        .update_dispatch_status(status_params(id, DispatchStatus::Running, None))
+        .await
+        .expect_err("duplicate Running transition must fail");
+    assert!(
+        matches!(err, StoreError::InvalidTransition { .. }),
+        "expected InvalidTransition, got {err:?}"
+    );
+}
+
+// ---- impossible-state rejection -------------------------------------------
+
+#[tokio::test]
+async fn started_with_outcome_rejected() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::DispatchStarted { dispatch_id: id },
+    );
+    let params = UpdateDispatchStatusParams {
+        dispatch_id: id,
+        status: DispatchStatus::Running,
+        outcome: Some(Outcome::Success),
+        status_event: event,
+    };
+    let err = store
+        .update_dispatch_status(params)
+        .await
+        .expect_err("started with outcome must be rejected");
+    assert!(
+        matches!(err, StoreError::Conversion { .. }),
+        "expected Conversion, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_with_outcome_rejected() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    store
+        .update_dispatch_status(status_params(id, DispatchStatus::Running, None))
+        .await
+        .expect("pending -> running");
+
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::DispatchCancelled {
+            dispatch_id: id,
+            actor: actor(),
+            reason: None,
+        },
+    );
+    let params = UpdateDispatchStatusParams {
+        dispatch_id: id,
+        status: DispatchStatus::Cancelled,
+        outcome: Some(Outcome::Success),
+        status_event: event,
+    };
+    let err = store
+        .update_dispatch_status(params)
+        .await
+        .expect_err("cancelled with outcome must be rejected");
+    assert!(
+        matches!(err, StoreError::Conversion { .. }),
+        "expected Conversion, got {err:?}"
+    );
+}

--- a/crates/tanren-store/tests/sqlite_integration.rs
+++ b/crates/tanren-store/tests/sqlite_integration.rs
@@ -119,13 +119,11 @@ async fn event_append_query_and_filter() {
         .await
         .expect("create");
 
-    let started = tanren_domain::EventEnvelope {
-        schema_version: tanren_domain::SCHEMA_VERSION,
-        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
-        timestamp: now(),
-        entity_ref: EntityRef::Dispatch(dispatch_id),
-        payload: DomainEvent::DispatchStarted { dispatch_id },
-    };
+    let started = tanren_domain::EventEnvelope::new(
+        tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        now(),
+        DomainEvent::DispatchStarted { dispatch_id },
+    );
     let completed = step_completed_event(
         dispatch_id,
         StepId::new(),
@@ -146,7 +144,7 @@ async fn event_append_query_and_filter() {
         })
         .await
         .expect("by ref");
-    assert_eq!(by_ref.total_count, 2); // creation + started (step event is on Step ref)
+    assert_eq!(by_ref.total_count, 3); // creation + started + completed (all route to Dispatch)
     assert!(!by_ref.has_more);
     let ids: Vec<_> = by_ref.events.iter().map(|e| e.event_id).collect();
     assert!(ids.contains(&creation_event_id));
@@ -160,7 +158,7 @@ async fn event_append_query_and_filter() {
         })
         .await
         .expect("by kind");
-    assert_eq!(by_kind.total_count, 2);
+    assert_eq!(by_kind.total_count, 3);
 
     let by_type = store
         .query_events(&EventFilter {
@@ -424,12 +422,10 @@ async fn nack_retry_resets_to_pending_and_bumps_count() {
         .await
         .expect("dequeue");
 
-    let failure_event = tanren_domain::EventEnvelope {
-        schema_version: tanren_domain::SCHEMA_VERSION,
-        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
-        timestamp: now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepFailed {
+    let failure_event = tanren_domain::EventEnvelope::new(
+        tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        now(),
+        DomainEvent::StepFailed {
             dispatch_id: id,
             step_id,
             step_type: StepType::Execute,
@@ -438,7 +434,7 @@ async fn nack_retry_resets_to_pending_and_bumps_count() {
             retry_count: 1,
             duration_secs: tanren_domain::FiniteF64::try_new(0.5).expect("finite"),
         },
-    };
+    );
     store
         .nack(
             &step_id,

--- a/crates/tanren-store/tests/sqlite_integration.rs
+++ b/crates/tanren-store/tests/sqlite_integration.rs
@@ -360,7 +360,7 @@ async fn cancel_pending_steps_excludes_teardown() {
     let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
         .await
         .expect("create");
-    let _ = seed_steps(&store, id, &snap, Lane::Impl, 3)
+    let _ = seed_steps(&store, id, &snap, Lane::Impl, 3, 0)
         .await
         .expect("seed");
     let teardown_id = StepId::new();
@@ -436,15 +436,15 @@ async fn nack_retry_resets_to_pending_and_bumps_count() {
         },
     );
     store
-        .nack(
-            &step_id,
-            NackParams {
-                error: "boom".to_owned(),
-                error_class: tanren_domain::ErrorClass::Transient,
-                retry: true,
-                failure_event,
-            },
-        )
+        .nack(NackParams {
+            dispatch_id: id,
+            step_id,
+            step_type: StepType::Execute,
+            error: "boom".to_owned(),
+            error_class: tanren_domain::ErrorClass::Transient,
+            retry: true,
+            failure_event,
+        })
         .await
         .expect("nack");
 
@@ -455,7 +455,7 @@ async fn nack_retry_resets_to_pending_and_bumps_count() {
         .expect("exists");
     assert_eq!(view.status, StepStatus::Pending);
     assert_eq!(view.retry_count, 1);
-    assert_eq!(view.error.as_deref(), Some("boom"));
+    assert!(view.error.is_none(), "retry=true must clear error");
 }
 
 #[tokio::test]

--- a/crates/tanren-store/tests/sqlite_integration.rs
+++ b/crates/tanren-store/tests/sqlite_integration.rs
@@ -1,0 +1,497 @@
+//! `SQLite`-backed integration tests for `tanren-store`.
+//!
+//! Every test creates a fresh `sqlite::memory:` database, applies
+//! migrations, and exercises the traits end-to-end. `SQLite` cannot
+//! exercise row-level locking (`FOR UPDATE SKIP LOCKED`), so the
+//! Postgres-only concurrency test lives in `postgres_integration.rs`.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{
+    ack_and_enqueue_execute, actor, assert_dispatch_status, create_dispatch,
+    create_dispatch_params, duplicate_create_params, enqueue_step_params, execute_payload,
+    execute_result, now, provision_payload, provision_result, seed_steps, snapshot,
+    step_completed_event, try_dequeue,
+};
+use tanren_domain::{
+    DispatchStatus, DomainEvent, EntityKind, EntityRef, Lane, Outcome, StepId, StepPayload,
+    StepStatus, StepType,
+};
+use tanren_store::{
+    DispatchFilter, EventFilter, EventStore, JobQueue, NackParams, StateStore, Store,
+};
+
+/// Build a fresh in-memory `SQLite`-backed `Store`. Kept local to
+/// this binary so the common module stays backend-agnostic.
+async fn fresh_store() -> Store {
+    let store = Store::new("sqlite::memory:").await.expect("connect");
+    store.run_migrations().await.expect("migrate");
+    store
+}
+
+#[tokio::test]
+async fn dispatch_create_get_and_status_lifecycle() {
+    let store = fresh_store().await;
+    // Migrations are idempotent — a second run is a no-op. (`fresh_store`
+    // already ran them once.) `now()` keeps the helper exercised.
+    store.run_migrations().await.expect("second migration run");
+    let _ = now();
+
+    let actor_ctx = actor();
+    let user_id = actor_ctx.user_id;
+    let id = create_dispatch(&store, "alpha", actor_ctx, Lane::Impl)
+        .await
+        .expect("create");
+
+    let view = store.get_dispatch(&id).await.expect("get").expect("exists");
+    assert_eq!(view.dispatch_id, id);
+    assert_eq!(view.status, DispatchStatus::Pending);
+    assert_eq!(view.lane, Lane::Impl);
+    assert_eq!(view.actor.user_id, user_id);
+
+    store
+        .update_dispatch_status(&id, DispatchStatus::Running, None)
+        .await
+        .expect("running");
+    assert_dispatch_status(&store, &id, DispatchStatus::Running).await;
+    store
+        .update_dispatch_status(&id, DispatchStatus::Completed, Some(Outcome::Success))
+        .await
+        .expect("completed");
+    let view = store.get_dispatch(&id).await.expect("get").expect("exists");
+    assert_eq!(view.status, DispatchStatus::Completed);
+    assert_eq!(view.outcome, Some(Outcome::Success));
+}
+
+#[tokio::test]
+async fn query_dispatches_filters_by_lane_and_user() {
+    let store = fresh_store().await;
+    let actor_a = actor();
+    let actor_b = actor();
+    let actor_b_user = actor_b.user_id;
+    let id_a = create_dispatch(&store, "alpha", actor_a, Lane::Impl)
+        .await
+        .expect("a");
+    let _b = create_dispatch(&store, "alpha", actor_b, Lane::Audit)
+        .await
+        .expect("b");
+
+    let by_lane = store
+        .query_dispatches(&DispatchFilter {
+            lane: Some(Lane::Impl),
+            limit: 10,
+            ..DispatchFilter::new()
+        })
+        .await
+        .expect("by lane");
+    assert_eq!(by_lane.len(), 1);
+    assert_eq!(by_lane[0].dispatch_id, id_a);
+
+    let by_user = store
+        .query_dispatches(&DispatchFilter {
+            user_id: Some(actor_b_user),
+            limit: 10,
+            ..DispatchFilter::new()
+        })
+        .await
+        .expect("by user");
+    assert_eq!(by_user.len(), 1);
+    assert_eq!(by_user[0].actor.user_id, actor_b_user);
+}
+
+#[tokio::test]
+async fn event_append_query_and_filter() {
+    let store = fresh_store().await;
+    let params = create_dispatch_params("alpha", actor(), Lane::Impl);
+    let creation_event_id = params.creation_event.event_id;
+    let dispatch_id = params.dispatch_id;
+    store
+        .create_dispatch_projection(params)
+        .await
+        .expect("create");
+
+    let started = tanren_domain::EventEnvelope {
+        schema_version: tanren_domain::SCHEMA_VERSION,
+        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        timestamp: now(),
+        entity_ref: EntityRef::Dispatch(dispatch_id),
+        payload: DomainEvent::DispatchStarted { dispatch_id },
+    };
+    let completed = step_completed_event(
+        dispatch_id,
+        StepId::new(),
+        StepType::Execute,
+        &execute_result(),
+    );
+    store
+        .append_batch(&[started.clone(), completed.clone()])
+        .await
+        .expect("batch");
+    store.append_batch(&[]).await.expect("empty batch");
+
+    let by_ref = store
+        .query_events(&EventFilter {
+            entity_ref: Some(EntityRef::Dispatch(dispatch_id)),
+            limit: 10,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("by ref");
+    assert_eq!(by_ref.total_count, 2); // creation + started (step event is on Step ref)
+    assert!(!by_ref.has_more);
+    let ids: Vec<_> = by_ref.events.iter().map(|e| e.event_id).collect();
+    assert!(ids.contains(&creation_event_id));
+    assert!(ids.contains(&started.event_id));
+
+    let by_kind = store
+        .query_events(&EventFilter {
+            entity_kind: Some(EntityKind::Dispatch),
+            limit: 10,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("by kind");
+    assert_eq!(by_kind.total_count, 2);
+
+    let by_type = store
+        .query_events(&EventFilter {
+            event_type: Some("step_completed".to_owned()),
+            limit: 10,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("by type");
+    assert_eq!(by_type.total_count, 1);
+}
+
+#[tokio::test]
+async fn enqueue_dequeue_ack_lifecycle() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            step_id,
+            StepType::Provision,
+            0,
+            Some(Lane::Impl),
+            provision_payload(snap),
+        ))
+        .await
+        .expect("enqueue");
+
+    let claimed = try_dequeue(&store, "w1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue")
+        .expect("claim");
+    assert_eq!(claimed.step_id, step_id);
+    assert!(matches!(claimed.payload, StepPayload::Provision(_)));
+
+    let none = try_dequeue(&store, "w2", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue");
+    assert!(none.is_none(), "max_concurrent saturated");
+
+    store.ack(&step_id, &provision_result()).await.expect("ack");
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Completed);
+    assert!(view.result.is_some());
+
+    let count = store
+        .count_running_steps(Some(&Lane::Impl))
+        .await
+        .expect("count");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn ack_and_enqueue_is_atomic() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let step_a = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            step_a,
+            StepType::Execute,
+            0,
+            Some(Lane::Impl),
+            execute_payload(snap.clone()),
+        ))
+        .await
+        .expect("enqueue a");
+    let _ = try_dequeue(&store, "w1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue");
+
+    let step_b = StepId::new();
+    store
+        .ack_and_enqueue(ack_and_enqueue_execute(
+            id,
+            step_a,
+            StepType::Execute,
+            &snap,
+            step_b,
+            1,
+            Some(Lane::Impl),
+        ))
+        .await
+        .expect("ack_and_enqueue");
+
+    let view_a = store
+        .get_step(&step_a)
+        .await
+        .expect("get a")
+        .expect("a exists");
+    assert_eq!(view_a.status, StepStatus::Completed);
+    let view_b = store
+        .get_step(&step_b)
+        .await
+        .expect("get b")
+        .expect("b exists");
+    assert_eq!(view_b.status, StepStatus::Pending);
+
+    // 1 create + 1 enqueue(a) + 1 completion(a) + 1 enqueue(b) = 4
+    let events = store
+        .query_events(&EventFilter {
+            limit: 100,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("query");
+    assert_eq!(events.total_count, 4);
+}
+
+#[tokio::test]
+async fn ack_and_enqueue_rolls_back_on_pk_collision() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let step_a = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            step_a,
+            StepType::Execute,
+            0,
+            Some(Lane::Impl),
+            execute_payload(snap.clone()),
+        ))
+        .await
+        .expect("enqueue a");
+    let _ = try_dequeue(&store, "w1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue");
+
+    // Trigger a PK collision by making the "next step" reuse step_a's id.
+    let mut params = ack_and_enqueue_execute(
+        id,
+        step_a,
+        StepType::Execute,
+        &snap,
+        step_a,
+        1,
+        Some(Lane::Impl),
+    );
+    if let Some(ref mut next) = params.next_step {
+        next.step_id = step_a;
+        next.enqueue_event = enqueue_step_params(
+            id,
+            step_a,
+            StepType::Execute,
+            1,
+            Some(Lane::Impl),
+            execute_payload(snap.clone()),
+        )
+        .enqueue_event;
+    }
+    assert!(store.ack_and_enqueue(params).await.is_err());
+
+    let view = store.get_step(&step_a).await.expect("get").expect("exists");
+    assert_eq!(
+        view.status,
+        StepStatus::Running,
+        "ack must have rolled back"
+    );
+
+    let events = store
+        .query_events(&EventFilter {
+            event_type: Some("step_completed".to_owned()),
+            limit: 10,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("query");
+    assert_eq!(events.total_count, 0);
+}
+
+#[tokio::test]
+async fn cancel_pending_steps_excludes_teardown() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let _ = seed_steps(&store, id, &snap, Lane::Impl, 3)
+        .await
+        .expect("seed");
+    let teardown_id = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            teardown_id,
+            StepType::Teardown,
+            10,
+            Some(Lane::Impl),
+            StepPayload::Teardown(Box::new(tanren_domain::TeardownPayload {
+                dispatch: snap,
+                handle: tanren_domain::EnvironmentHandle {
+                    id: tanren_domain::NonEmptyString::try_new("h".to_owned()).expect("h"),
+                    runtime_type: tanren_domain::NonEmptyString::try_new("local".to_owned())
+                        .expect("r"),
+                },
+                preserve: false,
+            })),
+        ))
+        .await
+        .expect("teardown enqueue");
+
+    assert_eq!(store.cancel_pending_steps(&id).await.expect("cancel"), 3);
+    let tv = store
+        .get_step(&teardown_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(tv.status, StepStatus::Pending);
+}
+
+#[tokio::test]
+async fn nack_retry_resets_to_pending_and_bumps_count() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            step_id,
+            StepType::Execute,
+            0,
+            Some(Lane::Impl),
+            execute_payload(snap),
+        ))
+        .await
+        .expect("enqueue");
+    let _ = try_dequeue(&store, "w1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue");
+
+    let failure_event = tanren_domain::EventEnvelope {
+        schema_version: tanren_domain::SCHEMA_VERSION,
+        event_id: tanren_domain::EventId::from_uuid(uuid::Uuid::now_v7()),
+        timestamp: now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepFailed {
+            dispatch_id: id,
+            step_id,
+            step_type: StepType::Execute,
+            error: "boom".to_owned(),
+            error_class: tanren_domain::ErrorClass::Transient,
+            retry_count: 1,
+            duration_secs: tanren_domain::FiniteF64::try_new(0.5).expect("finite"),
+        },
+    };
+    store
+        .nack(
+            &step_id,
+            NackParams {
+                error: "boom".to_owned(),
+                error_class: tanren_domain::ErrorClass::Transient,
+                retry: true,
+                failure_event,
+            },
+        )
+        .await
+        .expect("nack");
+
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Pending);
+    assert_eq!(view.retry_count, 1);
+    assert_eq!(view.error.as_deref(), Some("boom"));
+}
+
+#[tokio::test]
+async fn recover_stale_steps_resets_long_running() {
+    let store = fresh_store().await;
+    let snap = snapshot("alpha");
+    let id = create_dispatch(&store, "alpha", actor(), Lane::Impl)
+        .await
+        .expect("create");
+    let step_id = StepId::new();
+    store
+        .enqueue_step(enqueue_step_params(
+            id,
+            step_id,
+            StepType::Execute,
+            0,
+            Some(Lane::Impl),
+            execute_payload(snap),
+        ))
+        .await
+        .expect("enqueue");
+    let _ = try_dequeue(&store, "w1", Some(Lane::Impl), 1)
+        .await
+        .expect("dequeue");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(store.recover_stale_steps(0).await.expect("recover"), 1);
+
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Pending);
+    assert!(view.worker_id.is_none());
+}
+
+#[tokio::test]
+async fn duplicate_dispatch_fails_cleanly() {
+    let store = fresh_store().await;
+    let actor_ctx = actor();
+    let dup_actor = actor_ctx.clone();
+    let id = create_dispatch(&store, "alpha", actor_ctx, Lane::Impl)
+        .await
+        .expect("first");
+    let result = store
+        .create_dispatch_projection(duplicate_create_params(id, dup_actor, Lane::Impl))
+        .await;
+    assert!(result.is_err(), "duplicate should fail");
+    let view = store
+        .get_dispatch(&id)
+        .await
+        .expect("get")
+        .expect("still exists");
+    assert_eq!(view.status, DispatchStatus::Pending);
+}

--- a/crates/tanren-store/tests/sqlite_integration.rs
+++ b/crates/tanren-store/tests/sqlite_integration.rs
@@ -1,19 +1,14 @@
 //! `SQLite`-backed integration tests for `tanren-store`.
-//!
-//! Every test creates a fresh `sqlite::memory:` database, applies
-//! migrations, and exercises the traits end-to-end. `SQLite` cannot
-//! exercise row-level locking (`FOR UPDATE SKIP LOCKED`), so the
-//! Postgres-only concurrency test lives in `postgres_integration.rs`.
 
 mod common;
 
 use std::time::Duration;
 
 use common::{
-    ack_and_enqueue_execute, actor, assert_dispatch_status, create_dispatch,
-    create_dispatch_params, duplicate_create_params, enqueue_step_params, execute_payload,
-    execute_result, now, provision_payload, provision_result, seed_steps, snapshot,
-    step_completed_event, try_dequeue,
+    ack_and_enqueue_execute, ack_params, actor, assert_dispatch_status,
+    cancel_pending_steps_params, create_dispatch, create_dispatch_params, duplicate_create_params,
+    enqueue_step_params, execute_payload, execute_result, now, provision_payload, provision_result,
+    seed_steps, snapshot, step_completed_event, try_dequeue, update_dispatch_status_params,
 };
 use tanren_domain::{
     DispatchStatus, DomainEvent, EntityKind, EntityRef, Lane, Outcome, StepId, StepPayload,
@@ -34,16 +29,20 @@ async fn fresh_store() -> Store {
 #[tokio::test]
 async fn dispatch_create_get_and_status_lifecycle() {
     let store = fresh_store().await;
-    // Migrations are idempotent — a second run is a no-op. (`fresh_store`
-    // already ran them once.) `now()` keeps the helper exercised.
-    store.run_migrations().await.expect("second migration run");
+    store.run_migrations().await.expect("idempotent");
     let _ = now();
-
     let actor_ctx = actor();
     let user_id = actor_ctx.user_id;
+    let dup_actor = actor_ctx.clone();
     let id = create_dispatch(&store, "alpha", actor_ctx, Lane::Impl)
         .await
         .expect("create");
+    assert!(
+        store
+            .create_dispatch_projection(duplicate_create_params(id, dup_actor, Lane::Impl))
+            .await
+            .is_err()
+    );
 
     let view = store.get_dispatch(&id).await.expect("get").expect("exists");
     assert_eq!(view.dispatch_id, id);
@@ -52,12 +51,20 @@ async fn dispatch_create_get_and_status_lifecycle() {
     assert_eq!(view.actor.user_id, user_id);
 
     store
-        .update_dispatch_status(&id, DispatchStatus::Running, None)
+        .update_dispatch_status(update_dispatch_status_params(
+            id,
+            DispatchStatus::Running,
+            None,
+        ))
         .await
         .expect("running");
     assert_dispatch_status(&store, &id, DispatchStatus::Running).await;
     store
-        .update_dispatch_status(&id, DispatchStatus::Completed, Some(Outcome::Success))
+        .update_dispatch_status(update_dispatch_status_params(
+            id,
+            DispatchStatus::Completed,
+            Some(Outcome::Success),
+        ))
         .await
         .expect("completed");
     let view = store.get_dispatch(&id).await.expect("get").expect("exists");
@@ -198,7 +205,15 @@ async fn enqueue_dequeue_ack_lifecycle() {
         .expect("dequeue");
     assert!(none.is_none(), "max_concurrent saturated");
 
-    store.ack(&step_id, &provision_result()).await.expect("ack");
+    store
+        .ack(ack_params(
+            id,
+            step_id,
+            StepType::Provision,
+            provision_result(),
+        ))
+        .await
+        .expect("ack");
     let view = store
         .get_step(&step_id)
         .await
@@ -264,7 +279,7 @@ async fn ack_and_enqueue_is_atomic() {
         .expect("b exists");
     assert_eq!(view_b.status, StepStatus::Pending);
 
-    // 1 create + 1 enqueue(a) + 1 completion(a) + 1 enqueue(b) = 4
+    // 1 create + 1 enqueue(a) + 1 dequeue(a) + 1 completion(a) + 1 enqueue(b) = 5
     let events = store
         .query_events(&EventFilter {
             limit: 100,
@@ -272,7 +287,7 @@ async fn ack_and_enqueue_is_atomic() {
         })
         .await
         .expect("query");
-    assert_eq!(events.total_count, 4);
+    assert_eq!(events.total_count, 5);
 }
 
 #[tokio::test]
@@ -371,7 +386,13 @@ async fn cancel_pending_steps_excludes_teardown() {
         .await
         .expect("teardown enqueue");
 
-    assert_eq!(store.cancel_pending_steps(&id).await.expect("cancel"), 3);
+    assert_eq!(
+        store
+            .cancel_pending_steps(cancel_pending_steps_params(id))
+            .await
+            .expect("cancel"),
+        3
+    );
     let tv = store
         .get_step(&teardown_id)
         .await
@@ -474,24 +495,4 @@ async fn recover_stale_steps_resets_long_running() {
         .expect("exists");
     assert_eq!(view.status, StepStatus::Pending);
     assert!(view.worker_id.is_none());
-}
-
-#[tokio::test]
-async fn duplicate_dispatch_fails_cleanly() {
-    let store = fresh_store().await;
-    let actor_ctx = actor();
-    let dup_actor = actor_ctx.clone();
-    let id = create_dispatch(&store, "alpha", actor_ctx, Lane::Impl)
-        .await
-        .expect("first");
-    let result = store
-        .create_dispatch_projection(duplicate_create_params(id, dup_actor, Lane::Impl))
-        .await;
-    assert!(result.is_err(), "duplicate should fail");
-    let view = store
-        .get_dispatch(&id)
-        .await
-        .expect("get")
-        .expect("still exists");
-    assert_eq!(view.status, DispatchStatus::Pending);
 }

--- a/crates/tanren-store/tests/sqlite_integrity.rs
+++ b/crates/tanren-store/tests/sqlite_integrity.rs
@@ -1,0 +1,268 @@
+//! Integrity enforcement tests — audit-fix deltas for P1 and P2
+//! findings: dispatch lifecycle enforcement, orphan step prevention,
+//! duplicate step sequence rejection.
+
+use chrono::Utc;
+use tanren_domain::{
+    ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
+    DomainEvent, EnvironmentHandle, EventEnvelope, EventId, ExecutePayload, FiniteF64,
+    GraphRevision, Lane, NonEmptyString, OrgId, Outcome, Phase, StepId, StepPayload,
+    StepReadyState, StepType, TimeoutSecs, UserId,
+};
+use tanren_store::{
+    CreateDispatchParams, EnqueueStepParams, JobQueue, StateStore, Store, StoreError,
+    UpdateDispatchStatusParams,
+};
+use uuid::Uuid;
+
+async fn fresh_store() -> Store {
+    let store = Store::new("sqlite::memory:").await.expect("connect");
+    store.run_migrations().await.expect("migrate");
+    store
+}
+
+fn snapshot() -> DispatchSnapshot {
+    DispatchSnapshot {
+        project: NonEmptyString::try_new("alpha".to_owned()).expect("p"),
+        phase: Phase::DoTask,
+        cli: Cli::Claude,
+        auth_mode: AuthMode::ApiKey,
+        branch: NonEmptyString::try_new("main".to_owned()).expect("b"),
+        spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("s"),
+        workflow_id: NonEmptyString::try_new("wf".to_owned()).expect("w"),
+        timeout: TimeoutSecs::try_new(60).expect("t"),
+        environment_profile: NonEmptyString::try_new("d".to_owned()).expect("e"),
+        gate_cmd: None,
+        context: None,
+        model: None,
+        project_env: ConfigKeys::default(),
+        required_secrets: vec![],
+        preserve_on_failure: false,
+        created_at: Utc::now(),
+    }
+}
+
+fn actor() -> ActorContext {
+    ActorContext {
+        org_id: OrgId::new(),
+        user_id: UserId::new(),
+        team_id: None,
+        api_key_id: None,
+        project_id: None,
+    }
+}
+
+async fn create_dispatch(store: &Store, lane: Lane) -> DispatchId {
+    let snap = snapshot();
+    let a = actor();
+    let dispatch_id = DispatchId::new();
+    let created_at = Utc::now();
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        created_at,
+        DomainEvent::DispatchCreated {
+            dispatch_id,
+            dispatch: Box::new(snap.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: a.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    store
+        .create_dispatch_projection(CreateDispatchParams {
+            dispatch_id,
+            mode: DispatchMode::Manual,
+            lane,
+            dispatch: snap,
+            actor: a,
+            graph_revision: GraphRevision::INITIAL,
+            created_at,
+            creation_event: event,
+        })
+        .await
+        .expect("create dispatch");
+    dispatch_id
+}
+
+fn execute_payload() -> StepPayload {
+    StepPayload::Execute(Box::new(ExecutePayload {
+        dispatch: snapshot(),
+        handle: EnvironmentHandle {
+            id: NonEmptyString::try_new("h".to_owned()).expect("h"),
+            runtime_type: NonEmptyString::try_new("local".to_owned()).expect("rt"),
+        },
+    }))
+}
+
+fn enqueue_params(
+    dispatch_id: DispatchId,
+    step_type: StepType,
+    step_sequence: u32,
+    lane: Lane,
+) -> EnqueueStepParams {
+    let step_id = StepId::new();
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type,
+            step_sequence,
+            lane: Some(lane),
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+        },
+    );
+    EnqueueStepParams {
+        dispatch_id,
+        step_id,
+        step_type,
+        step_sequence,
+        lane: Some(lane),
+        depends_on: vec![],
+        graph_revision: GraphRevision::INITIAL,
+        payload: execute_payload(),
+        ready_state: StepReadyState::Ready,
+        enqueue_event: event,
+    }
+}
+
+fn status_params(
+    dispatch_id: DispatchId,
+    status: tanren_domain::DispatchStatus,
+    outcome: Option<Outcome>,
+) -> UpdateDispatchStatusParams {
+    let payload = match status {
+        tanren_domain::DispatchStatus::Running => DomainEvent::DispatchStarted { dispatch_id },
+        tanren_domain::DispatchStatus::Completed => DomainEvent::DispatchCompleted {
+            dispatch_id,
+            outcome: outcome.unwrap_or(Outcome::Success),
+            total_duration_secs: FiniteF64::try_new(1.0).expect("f"),
+        },
+        tanren_domain::DispatchStatus::Failed => DomainEvent::DispatchFailed {
+            dispatch_id,
+            outcome: outcome.unwrap_or(Outcome::Fail),
+            failed_step_id: None,
+            failed_step_type: None,
+            error: "test failure".to_owned(),
+        },
+        tanren_domain::DispatchStatus::Cancelled => DomainEvent::DispatchCancelled {
+            dispatch_id,
+            actor: actor(),
+            reason: None,
+        },
+        tanren_domain::DispatchStatus::Pending => {
+            unreachable!("status_params must not be called with Pending")
+        }
+    };
+    let event = EventEnvelope::new(EventId::from_uuid(Uuid::now_v7()), Utc::now(), payload);
+    UpdateDispatchStatusParams {
+        dispatch_id,
+        status,
+        outcome,
+        status_event: event,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch lifecycle enforcement (P1)
+// ---------------------------------------------------------------------------
+
+/// `Pending -> Completed` is not legal — only `Pending -> Running`
+/// and `Pending -> Cancelled` are allowed.
+#[tokio::test]
+async fn dispatch_rejects_illegal_transition() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await;
+
+    let err = store
+        .update_dispatch_status(status_params(
+            id,
+            tanren_domain::DispatchStatus::Completed,
+            Some(Outcome::Success),
+        ))
+        .await
+        .expect_err("Pending -> Completed must fail");
+    assert!(matches!(err, StoreError::InvalidTransition { .. }));
+}
+
+/// Terminal states must not allow any outgoing transitions.
+#[tokio::test]
+async fn dispatch_rejects_terminal_rewrite() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await;
+
+    store
+        .update_dispatch_status(status_params(
+            id,
+            tanren_domain::DispatchStatus::Running,
+            None,
+        ))
+        .await
+        .expect("Pending -> Running");
+    store
+        .update_dispatch_status(status_params(
+            id,
+            tanren_domain::DispatchStatus::Completed,
+            Some(Outcome::Success),
+        ))
+        .await
+        .expect("Running -> Completed");
+
+    let err = store
+        .update_dispatch_status(status_params(
+            id,
+            tanren_domain::DispatchStatus::Running,
+            None,
+        ))
+        .await
+        .expect_err("Completed -> Running must fail");
+    assert!(matches!(err, StoreError::InvalidTransition { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Orphan step prevention (P1)
+// ---------------------------------------------------------------------------
+
+/// Enqueuing a step against a nonexistent dispatch must fail.
+#[tokio::test]
+async fn enqueue_step_rejects_orphan_dispatch() {
+    let store = fresh_store().await;
+    let fake_id = DispatchId::new();
+    let params = enqueue_params(fake_id, StepType::Execute, 0, Lane::Impl);
+    let err = store
+        .enqueue_step(params)
+        .await
+        .expect_err("orphan step must fail");
+    assert!(
+        matches!(err, StoreError::NotFound { .. }),
+        "expected NotFound, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate step sequence prevention (P2)
+// ---------------------------------------------------------------------------
+
+/// Two steps with the same `(dispatch_id, step_sequence)` must fail.
+#[tokio::test]
+async fn duplicate_step_sequence_rejected() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await;
+
+    store
+        .enqueue_step(enqueue_params(id, StepType::Execute, 0, Lane::Impl))
+        .await
+        .expect("first enqueue");
+
+    let err = store
+        .enqueue_step(enqueue_params(id, StepType::Provision, 0, Lane::Impl))
+        .await
+        .expect_err("duplicate step_sequence must fail");
+    assert!(
+        matches!(err, StoreError::Database(_)),
+        "expected Database error, got {err:?}"
+    );
+}

--- a/crates/tanren-store/tests/sqlite_liveness.rs
+++ b/crates/tanren-store/tests/sqlite_liveness.rs
@@ -13,8 +13,8 @@ use chrono::Utc;
 use tanren_domain::{
     ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
     DomainEvent, EntityRef, EnvironmentHandle, ErrorClass, EventEnvelope, EventId, ExecutePayload,
-    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Phase, SCHEMA_VERSION, StepId,
-    StepPayload, StepReadyState, StepStatus, StepType, TimeoutSecs, UserId,
+    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Phase, StepId, StepPayload,
+    StepReadyState, StepStatus, StepType, TimeoutSecs, UserId,
 };
 use tanren_store::{
     CreateDispatchParams, DequeueParams, EnqueueStepParams, EventFilter, EventStore, JobQueue,
@@ -64,12 +64,10 @@ async fn create_dispatch(store: &Store, lane: Lane) -> StoreResult<DispatchId> {
     let actor_ctx = actor();
     let dispatch_id = DispatchId::new();
     let created_at = Utc::now();
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: created_at,
-        entity_ref: EntityRef::Dispatch(dispatch_id),
-        payload: DomainEvent::DispatchCreated {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        created_at,
+        DomainEvent::DispatchCreated {
             dispatch_id,
             dispatch: Box::new(snap.clone()),
             mode: DispatchMode::Manual,
@@ -77,7 +75,7 @@ async fn create_dispatch(store: &Store, lane: Lane) -> StoreResult<DispatchId> {
             actor: actor_ctx.clone(),
             graph_revision: GraphRevision::INITIAL,
         },
-    };
+    );
     store
         .create_dispatch_projection(CreateDispatchParams {
             dispatch_id,
@@ -109,12 +107,10 @@ async fn enqueue_execute_step(
     lane: Lane,
 ) -> StoreResult<StepId> {
     let step_id = StepId::new();
-    let event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepEnqueued {
+    let event = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepEnqueued {
             dispatch_id,
             step_id,
             step_type: StepType::Execute,
@@ -123,7 +119,7 @@ async fn enqueue_execute_step(
             depends_on: vec![],
             graph_revision: GraphRevision::INITIAL,
         },
-    };
+    );
     store
         .enqueue_step(EnqueueStepParams {
             dispatch_id,
@@ -155,12 +151,10 @@ async fn claim_step(store: &Store, step_id: StepId) -> StoreResult<()> {
 }
 
 fn failure_envelope(dispatch_id: DispatchId, step_id: StepId) -> EventEnvelope {
-    EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id),
-        payload: DomainEvent::StepFailed {
+    EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepFailed {
             dispatch_id,
             step_id,
             step_type: StepType::Execute,
@@ -169,7 +163,7 @@ fn failure_envelope(dispatch_id: DispatchId, step_id: StepId) -> EventEnvelope {
             retry_count: 1,
             duration_secs: FiniteF64::try_new(0.5).expect("finite"),
         },
-    }
+    )
 }
 
 /// B-02: a step that is still receiving heartbeats must not be
@@ -297,64 +291,51 @@ async fn nack_rejects_pending_step() {
     assert_eq!(failures.total_count, 0);
 }
 
-/// I-05: when `entity_ref` is `Some(Dispatch(uuid_x))` and there
-/// exists a step event whose `entity_id` is also `uuid_x` (same UUID,
-/// different kind), only the dispatch event should be returned.
-/// Before the fix, the query filtered only on `entity_id` and would
-/// match both.
+/// I-05: filtering by `entity_ref = Dispatch(uuid_a)` must not
+/// return events that belong to `Dispatch(uuid_b)`. All domain
+/// events route to `EntityRef::Dispatch(dispatch_id)` via
+/// `entity_root()`, so the real discrimination axis is always
+/// between different dispatch UUIDs.
 #[tokio::test]
-async fn entity_ref_filter_distinguishes_kinds_with_same_uuid() {
+async fn entity_ref_filter_distinguishes_different_dispatches() {
     let store = fresh_store().await;
-    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
-
-    // Fabricate a step event whose entity_id happens to share the
-    // dispatch_id's UUID — pathological but not impossible when
-    // IDs are externally-supplied in future.
-    let shared_uuid = id.into_uuid();
-    let step_id_same_uuid = StepId::from_uuid(shared_uuid);
-
-    let dispatch_event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Dispatch(id),
-        payload: DomainEvent::DispatchStarted { dispatch_id: id },
-    };
-    let step_event = EventEnvelope {
-        schema_version: SCHEMA_VERSION,
-        event_id: EventId::from_uuid(Uuid::now_v7()),
-        timestamp: Utc::now(),
-        entity_ref: EntityRef::Step(step_id_same_uuid),
-        payload: DomainEvent::StepDequeued {
-            dispatch_id: id,
-            step_id: step_id_same_uuid,
-            worker_id: "test-worker".to_owned(),
-        },
-    };
-    store
-        .append(&dispatch_event)
+    let id_a = create_dispatch(&store, Lane::Impl).await.expect("create a");
+    let id_b = create_dispatch(&store, Lane::Audit)
         .await
-        .expect("append dispatch");
-    store.append(&step_event).await.expect("append step");
+        .expect("create b");
 
-    // Filter by typed Dispatch ref — must exclude the step event.
+    // Append an extra event on each dispatch so there is more than
+    // just the creation event to count.
+    let event_a = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::DispatchStarted { dispatch_id: id_a },
+    );
+    let event_b = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::DispatchStarted { dispatch_id: id_b },
+    );
+    store.append(&event_a).await.expect("append a");
+    store.append(&event_b).await.expect("append b");
+
+    // Filter by Dispatch(id_a) — must exclude all id_b events.
     let result = store
         .query_events(&EventFilter {
-            entity_ref: Some(EntityRef::Dispatch(id)),
+            entity_ref: Some(EntityRef::Dispatch(id_a)),
             limit: 100,
             ..EventFilter::new()
         })
         .await
         .expect("query");
 
-    // The creation event (from create_dispatch) + the DispatchStarted
-    // we just appended = 2. The StepDequeued must NOT be included.
+    // creation(a) + DispatchStarted(a) = 2
     assert_eq!(result.total_count, 2);
     for e in &result.events {
         assert_eq!(
-            e.entity_ref.kind(),
-            tanren_domain::EntityKind::Dispatch,
-            "step event must not appear in dispatch-filtered results"
+            e.entity_ref,
+            EntityRef::Dispatch(id_a),
+            "events for dispatch_b must not appear in dispatch_a-filtered results"
         );
     }
 }

--- a/crates/tanren-store/tests/sqlite_liveness.rs
+++ b/crates/tanren-store/tests/sqlite_liveness.rs
@@ -1,0 +1,360 @@
+//! `SQLite`-backed integration tests for the audit-fix deltas —
+//! heartbeat / recovery (B-02), `nack` state-machine enforcement
+//! (I-01), and typed entity-ref filtering (I-05).
+//!
+//! This binary intentionally does **not** include `common/mod.rs`:
+//! each integration binary ships its own copy of `common`, and
+//! helpers that only one binary uses become dead-code warnings. The
+//! tests here only need a handful of builders, so we inline them.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use tanren_domain::{
+    ActorContext, AuthMode, Cli, ConfigKeys, DispatchId, DispatchMode, DispatchSnapshot,
+    DomainEvent, EntityRef, EnvironmentHandle, ErrorClass, EventEnvelope, EventId, ExecutePayload,
+    FiniteF64, GraphRevision, Lane, NonEmptyString, OrgId, Phase, SCHEMA_VERSION, StepId,
+    StepPayload, StepReadyState, StepStatus, StepType, TimeoutSecs, UserId,
+};
+use tanren_store::{
+    CreateDispatchParams, DequeueParams, EnqueueStepParams, EventFilter, EventStore, JobQueue,
+    NackParams, StateStore, Store, StoreError, StoreResult,
+};
+use uuid::Uuid;
+
+async fn fresh_store() -> Store {
+    let store = Store::new("sqlite::memory:").await.expect("connect");
+    store.run_migrations().await.expect("migrate");
+    store
+}
+
+fn snapshot(project: &str) -> DispatchSnapshot {
+    DispatchSnapshot {
+        project: NonEmptyString::try_new(project.to_owned()).expect("project"),
+        phase: Phase::DoTask,
+        cli: Cli::Claude,
+        auth_mode: AuthMode::ApiKey,
+        branch: NonEmptyString::try_new("main".to_owned()).expect("branch"),
+        spec_folder: NonEmptyString::try_new("spec".to_owned()).expect("spec"),
+        workflow_id: NonEmptyString::try_new("wf".to_owned()).expect("wf"),
+        timeout: TimeoutSecs::try_new(60).expect("timeout"),
+        environment_profile: NonEmptyString::try_new("p".to_owned()).expect("profile"),
+        gate_cmd: None,
+        context: None,
+        model: None,
+        project_env: ConfigKeys::default(),
+        required_secrets: vec![],
+        preserve_on_failure: false,
+        created_at: Utc::now(),
+    }
+}
+
+fn actor() -> ActorContext {
+    ActorContext {
+        org_id: OrgId::new(),
+        user_id: UserId::new(),
+        team_id: None,
+        api_key_id: None,
+        project_id: None,
+    }
+}
+
+async fn create_dispatch(store: &Store, lane: Lane) -> StoreResult<DispatchId> {
+    let snap = snapshot("alpha");
+    let actor_ctx = actor();
+    let dispatch_id = DispatchId::new();
+    let created_at = Utc::now();
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: created_at,
+        entity_ref: EntityRef::Dispatch(dispatch_id),
+        payload: DomainEvent::DispatchCreated {
+            dispatch_id,
+            dispatch: Box::new(snap.clone()),
+            mode: DispatchMode::Manual,
+            lane,
+            actor: actor_ctx.clone(),
+            graph_revision: GraphRevision::INITIAL,
+        },
+    };
+    store
+        .create_dispatch_projection(CreateDispatchParams {
+            dispatch_id,
+            mode: DispatchMode::Manual,
+            lane,
+            dispatch: snap,
+            actor: actor_ctx,
+            graph_revision: GraphRevision::INITIAL,
+            created_at,
+            creation_event: event,
+        })
+        .await?;
+    Ok(dispatch_id)
+}
+
+fn execute_payload() -> StepPayload {
+    StepPayload::Execute(Box::new(ExecutePayload {
+        dispatch: snapshot("alpha"),
+        handle: EnvironmentHandle {
+            id: NonEmptyString::try_new("h".to_owned()).expect("h"),
+            runtime_type: NonEmptyString::try_new("local".to_owned()).expect("runtime"),
+        },
+    }))
+}
+
+async fn enqueue_execute_step(
+    store: &Store,
+    dispatch_id: DispatchId,
+    lane: Lane,
+) -> StoreResult<StepId> {
+    let step_id = StepId::new();
+    let event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepEnqueued {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            step_sequence: 0,
+            lane: Some(lane),
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+        },
+    };
+    store
+        .enqueue_step(EnqueueStepParams {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            step_sequence: 0,
+            lane: Some(lane),
+            depends_on: vec![],
+            graph_revision: GraphRevision::INITIAL,
+            payload: execute_payload(),
+            ready_state: StepReadyState::Ready,
+            enqueue_event: event,
+        })
+        .await?;
+    Ok(step_id)
+}
+
+async fn claim_step(store: &Store, step_id: StepId) -> StoreResult<()> {
+    let claimed = store
+        .dequeue(DequeueParams {
+            worker_id: "w1".to_owned(),
+            lane: Some(Lane::Impl),
+            max_concurrent: 1,
+        })
+        .await?
+        .expect("dequeue");
+    assert_eq!(claimed.step_id, step_id);
+    Ok(())
+}
+
+fn failure_envelope(dispatch_id: DispatchId, step_id: StepId) -> EventEnvelope {
+    EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id),
+        payload: DomainEvent::StepFailed {
+            dispatch_id,
+            step_id,
+            step_type: StepType::Execute,
+            error: "boom".to_owned(),
+            error_class: ErrorClass::Transient,
+            retry_count: 1,
+            duration_secs: FiniteF64::try_new(0.5).expect("finite"),
+        },
+    }
+}
+
+/// B-02: a step that is still receiving heartbeats must not be
+/// reclaimed by `recover_stale_steps`, even if the recovery
+/// threshold has elapsed since the initial claim. This is the core
+/// correctness property the audit flagged as missing.
+#[tokio::test]
+async fn heartbeat_protects_live_steps_from_recovery() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+    claim_step(&store, step_id).await.expect("claim");
+
+    // Simulate a worker making progress on a long-running step by
+    // refreshing the heartbeat across time.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    store.heartbeat_step(&step_id).await.expect("heartbeat 1");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    store.heartbeat_step(&step_id).await.expect("heartbeat 2");
+
+    // With threshold=3600s, the heartbeat is vastly newer than the
+    // cutoff, so the recovery pass must leave the step alone.
+    let recovered = store.recover_stale_steps(3600).await.expect("recover");
+    assert_eq!(recovered, 0, "live-worker step must not be reclaimed");
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Running);
+    assert_eq!(view.worker_id.as_deref(), Some("w1"));
+}
+
+/// B-02: a dead worker (no heartbeat after claim) does get reclaimed
+/// once the recovery threshold elapses. Counterpart to the test
+/// above.
+#[tokio::test]
+async fn recover_reclaims_steps_that_miss_heartbeats() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+    claim_step(&store, step_id).await.expect("claim");
+
+    // No heartbeat calls. After the threshold passes, the row is
+    // stale and recover_stale_steps(0) claims it.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let recovered = store.recover_stale_steps(0).await.expect("recover");
+    assert_eq!(recovered, 1);
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Pending);
+    assert!(view.worker_id.is_none());
+}
+
+/// B-02: heartbeat on a non-running step is rejected with
+/// `InvalidTransition`. Workers should never call heartbeat on a
+/// completed or cancelled step, so surfacing it as an error is the
+/// right signal.
+#[tokio::test]
+async fn heartbeat_rejects_pending_step() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+
+    let err = store
+        .heartbeat_step(&step_id)
+        .await
+        .expect_err("heartbeat on pending should fail");
+    assert!(matches!(err, StoreError::InvalidTransition { .. }));
+}
+
+/// I-01: `nack` on a pending step must fail — the domain step state
+/// machine only permits `Running -> Failed|Pending(retry)|Cancelled`,
+/// and the previous implementation did not enforce this. The nack
+/// must report `InvalidTransition` and leave the row untouched.
+#[tokio::test]
+async fn nack_rejects_pending_step() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+
+    let err = store
+        .nack(
+            &step_id,
+            NackParams {
+                error: "should reject".to_owned(),
+                error_class: ErrorClass::Transient,
+                retry: false,
+                failure_event: failure_envelope(id, step_id),
+            },
+        )
+        .await
+        .expect_err("nack on pending should fail");
+    assert!(matches!(err, StoreError::InvalidTransition { .. }));
+
+    // Step row is unchanged — still pending, no error set, no event
+    // appended (the failure envelope was supposed to land only
+    // co-transactionally with the state change).
+    let view = store
+        .get_step(&step_id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(view.status, StepStatus::Pending);
+    assert!(view.error.is_none());
+    let failures = store
+        .query_events(&EventFilter {
+            event_type: Some("step_failed".to_owned()),
+            limit: 10,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("query");
+    assert_eq!(failures.total_count, 0);
+}
+
+/// I-05: when `entity_ref` is `Some(Dispatch(uuid_x))` and there
+/// exists a step event whose `entity_id` is also `uuid_x` (same UUID,
+/// different kind), only the dispatch event should be returned.
+/// Before the fix, the query filtered only on `entity_id` and would
+/// match both.
+#[tokio::test]
+async fn entity_ref_filter_distinguishes_kinds_with_same_uuid() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    // Fabricate a step event whose entity_id happens to share the
+    // dispatch_id's UUID — pathological but not impossible when
+    // IDs are externally-supplied in future.
+    let shared_uuid = id.into_uuid();
+    let step_id_same_uuid = StepId::from_uuid(shared_uuid);
+
+    let dispatch_event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Dispatch(id),
+        payload: DomainEvent::DispatchStarted { dispatch_id: id },
+    };
+    let step_event = EventEnvelope {
+        schema_version: SCHEMA_VERSION,
+        event_id: EventId::from_uuid(Uuid::now_v7()),
+        timestamp: Utc::now(),
+        entity_ref: EntityRef::Step(step_id_same_uuid),
+        payload: DomainEvent::StepDequeued {
+            dispatch_id: id,
+            step_id: step_id_same_uuid,
+            worker_id: "test-worker".to_owned(),
+        },
+    };
+    store
+        .append(&dispatch_event)
+        .await
+        .expect("append dispatch");
+    store.append(&step_event).await.expect("append step");
+
+    // Filter by typed Dispatch ref — must exclude the step event.
+    let result = store
+        .query_events(&EventFilter {
+            entity_ref: Some(EntityRef::Dispatch(id)),
+            limit: 100,
+            ..EventFilter::new()
+        })
+        .await
+        .expect("query");
+
+    // The creation event (from create_dispatch) + the DispatchStarted
+    // we just appended = 2. The StepDequeued must NOT be included.
+    assert_eq!(result.total_count, 2);
+    for e in &result.events {
+        assert_eq!(
+            e.entity_ref.kind(),
+            tanren_domain::EntityKind::Dispatch,
+            "step event must not appear in dispatch-filtered results"
+        );
+    }
+}

--- a/crates/tanren-store/tests/sqlite_liveness.rs
+++ b/crates/tanren-store/tests/sqlite_liveness.rs
@@ -257,15 +257,15 @@ async fn nack_rejects_pending_step() {
         .expect("enqueue");
 
     let err = store
-        .nack(
-            &step_id,
-            NackParams {
-                error: "should reject".to_owned(),
-                error_class: ErrorClass::Transient,
-                retry: false,
-                failure_event: failure_envelope(id, step_id),
-            },
-        )
+        .nack(NackParams {
+            dispatch_id: id,
+            step_id,
+            step_type: StepType::Execute,
+            error: "boom".to_owned(),
+            error_class: ErrorClass::Transient,
+            retry: false,
+            failure_event: failure_envelope(id, step_id),
+        })
         .await
         .expect_err("nack on pending should fail");
     assert!(matches!(err, StoreError::InvalidTransition { .. }));
@@ -366,7 +366,9 @@ async fn ack_rejects_wrong_event_variant() {
     );
     let err = store
         .ack(tanren_store::AckParams {
+            dispatch_id: id,
             step_id,
+            step_type: StepType::Execute,
             result: tanren_domain::StepResult::Execute(Box::new(tanren_domain::ExecuteResult {
                 outcome: tanren_domain::Outcome::Success,
                 signal: None,
@@ -430,7 +432,9 @@ async fn ack_rejects_wrong_step_id_in_envelope() {
     );
     let err = store
         .ack(tanren_store::AckParams {
+            dispatch_id: id,
             step_id,
+            step_type: StepType::Execute,
             result: tanren_domain::StepResult::Execute(Box::new(tanren_domain::ExecuteResult {
                 outcome: tanren_domain::Outcome::Success,
                 signal: None,

--- a/crates/tanren-store/tests/sqlite_liveness.rs
+++ b/crates/tanren-store/tests/sqlite_liveness.rs
@@ -339,3 +339,144 @@ async fn entity_ref_filter_distinguishes_different_dispatches() {
         );
     }
 }
+
+/// Semantic validation: `ack` with a `StepFailed` envelope (wrong
+/// variant) must be rejected before any write occurs.
+#[tokio::test]
+async fn ack_rejects_wrong_event_variant() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+    claim_step(&store, step_id).await.expect("claim");
+
+    let wrong = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepFailed {
+            dispatch_id: id,
+            step_id,
+            step_type: StepType::Execute,
+            error: "oops".to_owned(),
+            error_class: ErrorClass::Fatal,
+            retry_count: 0,
+            duration_secs: FiniteF64::try_new(0.1).expect("finite"),
+        },
+    );
+    let err = store
+        .ack(tanren_store::AckParams {
+            step_id,
+            result: tanren_domain::StepResult::Execute(Box::new(tanren_domain::ExecuteResult {
+                outcome: tanren_domain::Outcome::Success,
+                signal: None,
+                exit_code: Some(0),
+                duration_secs: FiniteF64::try_new(1.0).expect("f"),
+                gate_output: None,
+                tail_output: None,
+                stderr_tail: None,
+                pushed: false,
+                plan_hash: None,
+                unchecked_tasks: 0,
+                spec_modified: false,
+                findings: vec![],
+                token_usage: None,
+            })),
+            completion_event: wrong,
+        })
+        .await
+        .expect_err("wrong variant must be rejected");
+    assert!(matches!(err, StoreError::Conversion { .. }));
+}
+
+/// Semantic validation: `ack` with the correct variant but wrong
+/// `step_id` in the envelope payload must be rejected.
+#[tokio::test]
+async fn ack_rejects_wrong_step_id_in_envelope() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+    let step_id = enqueue_execute_step(&store, id, Lane::Impl)
+        .await
+        .expect("enqueue");
+    claim_step(&store, step_id).await.expect("claim");
+
+    let other_step = StepId::new();
+    let wrong = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::StepCompleted {
+            dispatch_id: id,
+            step_id: other_step, // wrong!
+            step_type: StepType::Execute,
+            duration_secs: FiniteF64::try_new(1.0).expect("f"),
+            result_payload: Box::new(tanren_domain::StepResult::Execute(Box::new(
+                tanren_domain::ExecuteResult {
+                    outcome: tanren_domain::Outcome::Success,
+                    signal: None,
+                    exit_code: Some(0),
+                    duration_secs: FiniteF64::try_new(1.0).expect("f"),
+                    gate_output: None,
+                    tail_output: None,
+                    stderr_tail: None,
+                    pushed: false,
+                    plan_hash: None,
+                    unchecked_tasks: 0,
+                    spec_modified: false,
+                    findings: vec![],
+                    token_usage: None,
+                },
+            ))),
+        },
+    );
+    let err = store
+        .ack(tanren_store::AckParams {
+            step_id,
+            result: tanren_domain::StepResult::Execute(Box::new(tanren_domain::ExecuteResult {
+                outcome: tanren_domain::Outcome::Success,
+                signal: None,
+                exit_code: Some(0),
+                duration_secs: FiniteF64::try_new(1.0).expect("f"),
+                gate_output: None,
+                tail_output: None,
+                stderr_tail: None,
+                pushed: false,
+                plan_hash: None,
+                unchecked_tasks: 0,
+                spec_modified: false,
+                findings: vec![],
+                token_usage: None,
+            })),
+            completion_event: wrong,
+        })
+        .await
+        .expect_err("wrong step_id must be rejected");
+    assert!(matches!(err, StoreError::Conversion { .. }));
+}
+
+/// Semantic validation: `update_dispatch_status(Running)` with a
+/// `DispatchCompleted` envelope must be rejected.
+#[tokio::test]
+async fn update_dispatch_status_rejects_variant_mismatch() {
+    let store = fresh_store().await;
+    let id = create_dispatch(&store, Lane::Impl).await.expect("create");
+
+    let wrong = EventEnvelope::new(
+        EventId::from_uuid(Uuid::now_v7()),
+        Utc::now(),
+        DomainEvent::DispatchCompleted {
+            dispatch_id: id,
+            outcome: tanren_domain::Outcome::Success,
+            total_duration_secs: FiniteF64::try_new(1.0).expect("f"),
+        },
+    );
+    let err = store
+        .update_dispatch_status(tanren_store::UpdateDispatchStatusParams {
+            dispatch_id: id,
+            status: tanren_domain::DispatchStatus::Running,
+            outcome: None,
+            status_event: wrong,
+        })
+        .await
+        .expect_err("status/variant mismatch must be rejected");
+    assert!(matches!(err, StoreError::Conversion { .. }));
+}

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,8 @@ registries = []
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Workspace path deps parse as wildcard version requirements — this is expected
+allow-wildcard-paths = true
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,20 @@ feature-depth = 1
 
 # Security advisories — deny known vulnerabilities
 [advisories]
-ignore = []
+ignore = [
+  # RUSTSEC-2025-0111: `tokio-tar` PAX extended header handling bug
+  # (CVE-2025-62518). Pulled in transitively by `testcontainers`,
+  # which `tanren-store` uses only as a dev-dependency for the
+  # Postgres integration test suite. It is never present in any
+  # production binary. Upstream has no fix; the suggested replacement
+  # (`astral-tokio-tar`) has not yet been adopted by testcontainers.
+  "RUSTSEC-2025-0111",
+  # RUSTSEC-2025-0134: `rustls-pemfile` is unmaintained. Pulled in
+  # transitively through SeaORM's rustls feature flags. The crate
+  # still functions correctly; this is an unmaintained notice, not
+  # a vulnerability. Remove when SeaORM upgrades to a successor.
+  "RUSTSEC-2025-0134",
+]
 
 # License policy — permissive licenses only
 [licenses]
@@ -24,6 +37,10 @@ allow = [
   "BSL-1.0",
   "CC0-1.0",
   "OpenSSL",
+  # Used by `webpki-roots`, pulled in transitively through SeaORM's
+  # rustls-tls feature flags. CDLA-Permissive-2.0 is a permissive
+  # data-sharing license comparable to MIT/Apache in intent.
+  "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 exceptions = []

--- a/docs/rewrite/ORIENTATION.md
+++ b/docs/rewrite/ORIENTATION.md
@@ -1,0 +1,319 @@
+# Tanren 2.0 — Coordinator Orientation
+
+You are a high-level coordinator agent for the Tanren 2.0 clean-room Rust
+rewrite. You track project state, dispatch implementation/audit agents,
+keep the planning canon in sync with reality, and surface blockers. You
+**do not write production code directly** — you hand tasks to focused
+agents via the briefs documented below.
+
+This file is a pointer deck, not a tutorial. Everything referenced here
+lives in the repo. Follow the links for depth.
+
+---
+
+## 1. Mission — 60 seconds
+
+- **What Tanren is:** An agent orchestration control plane for software
+  delivery. Decides what work happens, in what order, on which substrate,
+  under which policy constraints. Multi-interface (CLI / API / MCP / TUI)
+  over one canonical domain contract.
+- **Why a rewrite:** The Python system (still live on `master`) proved
+  the concept but accumulated cross-interface drift, step-centric
+  orchestration (not planner-native), and fragmented policy/governance.
+  Rust rewrite is a clean-room redesign around the intent — not a port.
+- **First consumer:** Forgeclaw. The contract surface is designed so
+  Forgeclaw can consume tanren through `tanren-app-services` + the
+  API binary without coupling to internals.
+- **Target audience:** solo developers, community projects, enterprise
+  teams — the same architecture must scale across all three.
+
+**Required reading for context** (in order):
+1. `docs/rewrite/MOTIVATIONS.md` — what's wrong with the Python system, why Rust
+2. `docs/rewrite/HLD.md` — high-level architecture, control + execution planes
+3. `docs/rewrite/DESIGN_PRINCIPLES.md` — the 10 decision rules — **treat as law**
+4. `docs/rewrite/CRATE_GUIDE.md` — workspace topology, dependency DAG, linking rules
+5. `docs/rewrite/CONTAINER_SYSTEM.md` — unified execution lease lifecycle
+6. `docs/rewrite/RUST_STACK.md` — library/tool choices
+7. `docs/rewrite/ROADMAP.md` — phased delivery plan (Phase 0 → 6)
+
+---
+
+## 2. Current Position
+
+**Branch model:**
+- `master` — Python codebase, still the production tanren
+- `rewrite/tanren-2-foundation` — Rust rewrite integration branch
+- `lane-*` — feature branches off the foundation for each lane
+
+**Phase 0 (Foundation) status:**
+
+| Lane | Crate(s) | Status | Notes |
+|------|----------|--------|-------|
+| 0.1  | workspace scaffold | ✅ merged | just tooling, lints, CI |
+| 0.2  | `tanren-domain` | ✅ merged, audit-certified | 164 tests, SeaORM `Value` round-trip verified |
+| 0.3  | `tanren-store` | 🔵 in progress on `lane-0.3` | SeaORM-based, briefs written |
+| 0.4  | `tanren-{contract,policy,orchestrator,app-services,observability}` + `tanren-cli` | ⏳ blocked on 0.2 (not 0.3 — can start in parallel with 0.3) | briefs written |
+
+The first end-to-end milestone lands when 0.3 + 0.4 converge: the CLI
+creates a dispatch, store it, and reads it back via the real store
+implementation.
+
+**Phase 1+ is sketched, not planned in depth.** Stubs exist at:
+- `docs/rewrite/tasks/LANE-1.1-HARNESS.md` — harness contract + output redaction
+- `docs/rewrite/tasks/LANE-1.2-RUNTIME.md` — runtime substrate + `runtime_type` typing
+- `docs/rewrite/tasks/LANE-2.1-PLANNING-GRAPH.md` — graph revision enforcement + non-dispatch events
+
+These stubs carry forward unresolved items from earlier audits — they
+are notes for when those phases begin, not ready-to-dispatch briefs.
+
+---
+
+## 3. The Canon
+
+Organized by purpose. Read lazily — fetch a file when a task needs it.
+
+### Planning docs (`docs/rewrite/`)
+- `MOTIVATIONS.md`, `HLD.md`, `DESIGN_PRINCIPLES.md`, `CRATE_GUIDE.md`,
+  `CONTAINER_SYSTEM.md`, `RUST_STACK.md`, `ROADMAP.md`, `README.md` —
+  the strategic canon. **Don't modify without a user-initiated decision.**
+
+### Lane briefs (`docs/rewrite/tasks/`)
+
+Each lane has three files:
+
+| Suffix | Audience | Purpose |
+|--------|----------|---------|
+| `-<NAME>.md` (e.g. `LANE-0.3-STORE.md`) | Reference | Full spec — schemas, trait shapes, constraints |
+| `-BRIEF.md` | Implementation agent | Concise handoff: scope, deliverables, "done when" |
+| `-AUDIT.md` | Audit agent | Audit dimensions, process, output format |
+
+Current lane briefs:
+- `LANE-0.2-DOMAIN.md` + `LANE-0.2-BRIEF.md` + `LANE-0.2-AUDIT.md` + `LANE-0.2-AUDIT-FINAL.md`
+- `LANE-0.3-STORE.md` + `LANE-0.3-BRIEF.md` + `LANE-0.3-AUDIT.md`
+- `LANE-0.4-CLI-WIRING.md` (full spec only — concise briefs pending)
+- `ADDON-SEAORM.md` — delta brief explaining the sqlx→SeaORM shift
+- `README.md` — lane execution order and parallelization strategy
+
+When you dispatch an implementation agent, hand them the `-BRIEF.md`.
+When you dispatch an audit agent, hand them the `-AUDIT.md`. Both should
+read the full `-<NAME>.md` spec plus linked planning docs as referenced
+in the brief.
+
+### Working conventions
+- `CLAUDE.md` — Rust conventions, quality rules, dependency DAG enforcement
+  rules. **Every implementation agent must read this.**
+- `justfile` — single task runner; `just ci` is the quality gate
+- `Cargo.toml` (workspace root) — strict lint policy (`[workspace.lints]`),
+  centralized dep pinning
+- `deny.toml` — license allowlist, advisory ignore list with justifications
+- `.github/workflows/rust-ci.yml` — CI mirror of `just ci` plus Postgres
+  integration job
+
+### Reference for conceptual parity (Python)
+The Python system in `packages/tanren-core/` and `services/` exists for
+**conceptual reference only** — read it to understand *what* tanren does
+operationally, never to port code. The Rust implementation is a redesign,
+not a translation. Agents that try to port Python files literally are
+working against the project's intent.
+
+---
+
+## 4. Working Model — How Lanes Happen
+
+```
+Plan canon (docs/rewrite/*.md)
+        │
+        ▼
+Lane spec   (docs/rewrite/tasks/LANE-X.Y-<NAME>.md)
+        │
+        ├── BRIEF.md ──────▶ Implementation agent ──▶ code on lane-X.Y branch
+        │                                                    │
+        │                                                    ▼
+        └── AUDIT.md ──────▶ Audit agent ──────▶ verdict (approve / follow-up / reject)
+                                                            │
+                                            ┌───────────────┴───────────────┐
+                                            │                               │
+                                       approved                       rejected
+                                            │                               │
+                                            ▼                               ▼
+                                  merge lane → foundation           re-dispatch
+                                  (--no-ff, preserve boundary)
+```
+
+**The coordinator's job at each stage:**
+
+1. **Before dispatch:** Verify the brief exists and references the right
+   canon. If any context is missing, write it before dispatching.
+2. **During implementation:** Do not micromanage. The agent has the
+   brief. If they ask for clarification, check the canon first — the
+   answer is usually there.
+3. **Before audit:** Verify `just ci` is green on the lane branch. If
+   not, the lane isn't ready and the audit should be deferred.
+4. **During audit:** Let the auditor apply the brief's dimensions.
+   Don't defend the implementation.
+5. **After audit:** If APPROVE → merge with `git merge --no-ff lane-X.Y`
+   and push. If follow-up → open the follow-up tasks and re-dispatch.
+   If reject → relay the blockers to the implementation agent.
+6. **After merge:** Delete the lane branch locally, create the next lane
+   branch off the foundation tip.
+
+**Parallelization rules** (from `docs/rewrite/tasks/README.md`):
+- Lane 0.2 blocked everything (domain foundation)
+- Lane 0.3 and Lane 0.4 can run in parallel — they depend on domain,
+  not on each other
+- Within a phase, lanes run in parallel worktrees when dependencies allow
+- Integration happens at phase boundaries
+
+---
+
+## 5. Quality Rules — Non-Negotiables
+
+These live in `CLAUDE.md` but must never be negotiated:
+
+- **No `unsafe`** — forbidden at workspace level
+- **No `unwrap` / `panic!` / `todo!` / `unimplemented!`** in library code
+- **No `println!` / `eprintln!` / `dbg!`** — use `tracing`
+- **No inline `#[allow()]` / `#[expect()]`** — relax lints at the crate's
+  `[lints.clippy]` section in `Cargo.toml` with a comment if needed
+- **Max 500 lines per `.rs` file** — enforced by `just check-lines`
+- **Max 100 lines per function** — enforced by clippy
+- **`thiserror` in libraries, `anyhow` only in binaries**
+- **Secrets use `secrecy::Secret<T>`** — never log, serialize, or Debug
+- **Dependencies pinned in workspace `[workspace.dependencies]`** — crates
+  reference with `dep.workspace = true`
+
+**Gate:** `just ci` green across the full workspace. This runs fmt, lint,
+deny, check-lines, check-suppression, test, doc, machete. All must pass
+before a lane can be considered audit-ready.
+
+---
+
+## 6. Decisions Already Made — Do Not Re-Litigate
+
+These were settled earlier and shouldn't be reopened without a user-
+initiated decision. Agents who try to re-open them are wasting context.
+
+1. **SeaORM, not raw sqlx.** Rationale in `docs/rewrite/tasks/ADDON-SEAORM.md`.
+   Handles JSON dialect split (TEXT/JSONB), migration DDL per backend,
+   compile-time checking. Raw SQL escape hatch exists for the dequeue
+   claim path only.
+2. **Both SQLite and Postgres must work.** SQLite = dev/solo, Postgres =
+   team/enterprise. Never assume one backend.
+3. **Envelope timestamp is authoritative.** `DomainEvent` variants no
+   longer carry independent timestamps — the envelope is the single
+   source of truth. (Lane 0.2 audit finding B, resolved.)
+4. **Single-path dispatch termination** (Lane 0.2 audit finding F,
+   carried into Lane 0.4 orchestrator spec):
+   - `DispatchCompleted` only for `Outcome::Success`
+   - `DispatchFailed` for `Fail | Blocked | Error | Timeout`
+   - `DispatchCancelled` only for user-initiated cancellation
+5. **`tanren-domain` is the only crate with no internal dependencies.**
+   Every other crate may depend on domain; domain depends on nothing
+   in the workspace.
+6. **Linking rules from `CRATE_GUIDE.md`** are enforced. Interface
+   binaries only depend on `app-services` + `contract` (+ runtime/harness
+   for composition wiring). Only `tanren-store` owns SQL. Policy returns
+   typed decisions, never transport errors.
+7. **Output redaction is a harness-side responsibility** (Lane 0.2
+   finding E). Domain fields like `tail_output`, `stderr_tail`, and
+   `gate_output` are captured verbatim; Phase 1 harness adapters must
+   redact before producing an `ExecuteResult`.
+8. **`deny.toml` advisory ignores** are documented with reasoning
+   inline. Current ignores: `RUSTSEC-2025-0111` (tokio-tar, dev-only
+   testcontainers), `RUSTSEC-2025-0134` (rustls-pemfile unmaintained,
+   transitive through SeaORM). Do not add new ignores without
+   justification in the same commit.
+
+---
+
+## 7. Your Role as Coordinator
+
+You are responsible for:
+
+- **Knowing the current lane state** — which lane is implementing,
+  which is auditing, which is merged. Use `git branch` and
+  `git log --oneline` against `rewrite/tanren-2-foundation` to verify.
+- **Dispatching the right agent with the right brief.** Implementation
+  gets `*-BRIEF.md`. Audit gets `*-AUDIT.md`. Neither gets Python code.
+- **Tracking unresolved items from past audits.** Carry them forward
+  into later lane briefs. The Phase 1+ stubs (`LANE-1.1-HARNESS.md`,
+  `LANE-1.2-RUNTIME.md`, `LANE-2.1-PLANNING-GRAPH.md`) are where
+  audit follow-ups live until their phase begins.
+- **Keeping `docs/rewrite/tasks/README.md` in sync** with lane status
+  (✅ merged, 🔵 in progress, ⏳ blocked).
+- **Surfacing blockers to the user.** If `just ci` stays red for more
+  than one agent turnaround, escalate. If an audit finding contradicts
+  a planning doc, escalate. If a decision needs to be re-opened,
+  escalate — don't re-litigate on your own.
+- **Running the merge choreography** when audits approve: merge with
+  `--no-ff`, push, delete local lane branch, create next lane branch
+  from the new foundation tip.
+
+You are **not** responsible for:
+- Writing production code (delegate to implementation agents)
+- Running the audit dimensions yourself (delegate to audit agents)
+- Deciding strategic direction (that's the user)
+- Rewriting planning docs (canon changes need user approval)
+
+---
+
+## 8. Danger Zone
+
+Stop and ask the user before doing any of these:
+
+- Modifying anything in `docs/rewrite/*.md` outside `tasks/` (the
+  strategic canon)
+- Modifying `CLAUDE.md` conventions
+- Modifying `deny.toml`, `justfile`, or `.github/workflows/` in a way
+  that changes the quality gate
+- Merging a lane that has not passed audit
+- Force-pushing to `rewrite/tanren-2-foundation`
+- Deleting any branch other than a lane branch that has been fully
+  merged and verified
+- Touching the Python codebase (`packages/`, `services/`, `tests/`)
+- Adding a new workspace dependency not already in
+  `[workspace.dependencies]`
+- Re-opening any decision in Section 6
+
+---
+
+## 9. Quick Reference Commands
+
+```bash
+# Verify current state
+git branch --show-current
+git log --oneline rewrite/tanren-2-foundation..HEAD
+
+# Run the quality gate locally
+just ci
+
+# Run tests with coverage for a specific crate
+cargo llvm-cov nextest -p tanren-<name> --summary-only
+
+# Start a Postgres integration test run (requires running Postgres)
+cargo nextest run -p tanren-store --features postgres-integration
+
+# Merge an approved lane (from foundation branch)
+git checkout rewrite/tanren-2-foundation
+git merge --no-ff lane-X.Y -m "Merge lane-X.Y: <summary>"
+git push origin rewrite/tanren-2-foundation
+
+# Create the next lane branch
+git checkout -b lane-X.Y+1
+```
+
+---
+
+## Handoff
+
+When handing tasks to sub-agents, your briefing should always:
+
+1. Identify the lane and phase
+2. Link the `-BRIEF.md` or `-AUDIT.md` file
+3. Note any cross-lane dependencies or prior audit findings
+4. Remind them to read `CLAUDE.md` before writing code
+5. Remind them that `just ci` must pass before they declare done
+
+You do not need to explain the mission, the architecture, or the
+conventions — that's what this orientation file is for, and they should
+read it as their first action if they haven't already.

--- a/docs/rewrite/tasks/LANE-0.3-AUDIT.md
+++ b/docs/rewrite/tasks/LANE-0.3-AUDIT.md
@@ -1,0 +1,319 @@
+# Lane 0.3 — Store Core — Audit Brief
+
+## Role
+
+You are auditing the `tanren-store` crate implementation. This crate owns
+**all database access in the workspace** — SQL, migrations, transactions,
+and race-safety. A bug here corrupts data, double-executes work, or leaks
+secrets. You are the last line of defense before Lane 0.4 consumes this
+store through the real trait implementations.
+
+You must not rubber-stamp. The store layer has subtle correctness
+requirements (atomic dequeue, transactional ack_and_enqueue, migration
+idempotency) that typical code review misses. This audit exists to
+catch those specifically.
+
+## Required Reading
+
+Before auditing, read these in order:
+
+1. `docs/rewrite/tasks/LANE-0.3-STORE.md` — the implementation spec
+2. `docs/rewrite/tasks/LANE-0.3-BRIEF.md` — the agent handoff with
+   "done when" checklist
+3. `docs/rewrite/tasks/ADDON-SEAORM.md` — why SeaORM, what it does and
+   doesn't abstract away
+4. `docs/rewrite/DESIGN_PRINCIPLES.md` — decision rules
+5. `docs/rewrite/CRATE_GUIDE.md` — linking rules
+6. `CLAUDE.md` — workspace quality conventions
+7. Skim `crates/tanren-domain/src/lib.rs` exports — the store converts
+   to/from these types
+
+## Audit Dimensions
+
+### 1. Spec Fidelity — Intent, Not Letter
+
+The spec tells the agent *what* to build. You are checking whether the
+implementation honors the deeper intent from the planning docs:
+
+- **Event-sourced durability, projection-driven read performance.**
+  Events are the source of truth; projections are derived. Does the
+  implementation treat events as canonical? Are projections only
+  updated through event append transactions, never independently?
+- **No scan-heavy operational paths.** Every operational query should
+  use an index. Run `EXPLAIN QUERY PLAN` (SQLite) or `EXPLAIN ANALYZE`
+  (Postgres) on at least: `get_dispatch`, `get_steps_for_dispatch`,
+  `count_running_steps`, `query_dispatches` with a status filter.
+  Full table scans on any of these are a blocker.
+- **Single backend abstraction, documented escape hatches.** Raw SQL is
+  permitted only where SeaORM's entity API cannot express the query
+  (the `dequeue` claim path). Anywhere else raw SQL appears, it should
+  be justified in a comment. Ad-hoc raw SQL for "convenience" is a
+  regression.
+- **No domain logic in the store.** The store persists and queries. It
+  does not decide. Things like "should this dispatch be cancelled" or
+  "is this guard violated" belong in the orchestrator (Lane 0.4) and
+  use domain functions. If the store calls `check_execute_guards` or
+  similar, that is a layering violation.
+
+### 2. Correctness
+
+- **State machine fidelity.** Reads and writes must preserve the
+  lifecycle enums exactly as domain defines them. String coercion
+  (e.g., `status.to_string()` on write, parse on read) is a common
+  bug vector. Verify roundtrip correctness by reading back every
+  write and comparing to the input. Snapshot tests at the SQL layer
+  are helpful here.
+- **Event payload round-trip.** Events stored as JSON must come back
+  equal to what went in. Check that the converter uses
+  `serde_json::to_value` / `from_value` (not `to_string` / `from_str`)
+  so the SeaORM entity path matches what the Lane 0.2 audit certified.
+- **Sequence numbering.** If the store assigns `step_sequence`
+  values, they must be monotonic per dispatch and gap-free under normal
+  operation. Verify with a test that creates a dispatch, enqueues
+  several steps, and reads back the sequence.
+- **Projection consistency with events.** After appending a
+  `DispatchCreated` event, `get_dispatch` must return the new
+  dispatch immediately in the same transaction. After appending a
+  `StepCompleted` event via `ack`, `get_step` must reflect the new
+  status.
+
+### 3. Race Safety — The Critical Section
+
+This is the most important dimension. Most store bugs hide here.
+
+- **`dequeue` atomicity.** The TOCTOU hazard is: read
+  `count(status='running' AND lane=X)`, decide to claim, mark
+  `status='running'`. Between read and mark, another worker can claim
+  the same slot. Verify the implementation uses a single transaction
+  with proper isolation:
+  - **Postgres path:** `SELECT ... FOR UPDATE SKIP LOCKED` is the
+    correct idiom. The `UPDATE ... WHERE step_id = (subquery)` pattern
+    with `FOR UPDATE SKIP LOCKED` inside the subquery is canonical.
+    Any other pattern (separate SELECT then UPDATE, no row-level lock,
+    `SERIALIZABLE` without `SKIP LOCKED`) is suspect.
+  - **SQLite path:** SQLite has no row-level locks. The correct
+    approach is `BEGIN IMMEDIATE` + `busy_timeout` to force
+    single-writer serialization on the database, plus the count check
+    and update in one transaction. If the code uses `BEGIN DEFERRED`
+    or no explicit `BEGIN IMMEDIATE`, flag it.
+- **Concurrency test actually tests concurrency.** Check that a
+  concurrency test exists and that it meaningfully exercises the race.
+  A test that spawns two tasks serially does nothing; a test that
+  spawns N tasks with `tokio::spawn` and then awaits all of them
+  against Postgres is correct. Verify the test:
+  - Runs against Postgres (SQLite can't exercise row-level locking)
+  - Spawns ≥ 10 concurrent claim attempts
+  - Asserts that the number of successful claims equals the number
+    of available slots (not more, not less)
+  - Asserts that no step is claimed by two workers
+- **`ack_and_enqueue` atomicity.** The implementation must do:
+  1. Update current step `status='completed'`, store result
+  2. Insert next step row
+  3. Append `StepCompleted` event
+  4. Append `StepEnqueued` event
+  — all in **one** `db.transaction::<_, _, StoreError>(...)` closure.
+  Any separation is a bug. Verify by reading the code path and
+  confirming a single transaction boundary. Simulate a failure mid-op
+  in a test (e.g., inject an error after step 2) and confirm no
+  partial state remains.
+- **`cancel_pending_steps` ordering.** When cancelling pending steps,
+  teardown steps should be excluded (per domain guard rules). Verify
+  the query filter explicitly excludes `step_type='teardown'`.
+- **Crash recovery.** `recover_stale_steps(timeout_secs)` must reset
+  running steps older than the threshold back to pending without
+  clobbering steps a live worker is still processing. Check the
+  heartbeat / updated_at logic and verify with a test.
+
+### 4. Transaction Boundaries
+
+- **Every method that writes and reads in the same operation uses a
+  transaction.** Common bugs: append event outside the projection-update
+  transaction; ack step but insert next step in a separate await.
+- **Error paths roll back cleanly.** If any step in a transaction
+  returns an error, the entire transaction must roll back. SeaORM's
+  `db.transaction::<_, _, StoreError>(|txn| ...)` does this correctly
+  if the closure returns `Err`. Verify there are no manual commit
+  calls that bypass the closure's automatic rollback on error.
+- **No silent commit-on-drop.** Check that no `Transaction` handle is
+  held across an `await` without being either committed or dropped in
+  an error path. Silent commit-on-drop is a common footgun with some
+  async DB clients; SeaORM's pattern avoids this but verify the code
+  uses the closure-based API, not the manual `begin()` / `commit()`
+  pattern, unless there's a documented reason.
+
+### 5. Migration Lifecycle
+
+- **Idempotency.** Running `run_migrations` twice must be a no-op on
+  the second call. Verify the migration framework uses a
+  `seaql_migrations` table (SeaORM's default) or equivalent version
+  tracking. Verify with a test that applies migrations twice and
+  asserts no error and no schema drift.
+- **Fresh DB works on both backends.** Create a fresh SQLite `:memory:`
+  DB, apply migrations, verify the expected tables exist. Same for
+  Postgres via testcontainers.
+- **Schema matches entity definitions.** For every entity in
+  `entity/`, verify the migration creates a column matching the entity
+  type. A common bug: entity declares `Uuid` but migration creates
+  `string()`. This compiles but fails at runtime on the first insert.
+- **JsonBinary column type.** Verify the `payload` columns use
+  `json_binary()` in the migration (not `json()` or `text()`). This is
+  the piece that delivers JSONB on Postgres and TEXT on SQLite.
+
+### 6. Performance
+
+- **Indexes match query patterns.** For each query in the code, identify
+  the `WHERE` / `ORDER BY` columns and verify a matching index exists
+  in the migration. The spec required indexes are listed — verify each
+  is present. Extra indexes are fine; missing ones are a blocker.
+- **No N+1 queries.** `get_steps_for_dispatch` should be one query, not
+  one query per step. Verify by inspection.
+- **Batch append.** `append_batch` should use a single transaction or
+  a multi-row insert, not append events one at a time in a loop.
+  Verify by inspection.
+- **Connection pool sizing.** SeaORM's `ConnectOptions` should set
+  reasonable `min_connections` / `max_connections` / `idle_timeout`
+  defaults. If the code uses SeaORM's defaults, note that in the
+  report. If it sets custom values, verify they are justified.
+
+### 7. Security
+
+- **No secret leakage in error messages.** `StoreError` variants must
+  not embed raw SQL, connection strings, or query parameters that
+  could contain user-provided values. Check each `#[error(...)]`
+  format string and each `From<DbErr>` conversion.
+- **No secret leakage in logs.** If the store uses `tracing` (it
+  should not heavily instrument in Phase 0), verify no span records
+  event payloads or dispatch snapshots with `Debug` formatting. The
+  Lane 0.2 audit verified `ConfigEnv::Debug` redacts values, but
+  the store could still log the full `DispatchSnapshot` which has
+  `ConfigKeys` (names only, safe) — verify this has not regressed.
+- **Parameterized queries only.** Every raw SQL string must use
+  parameter placeholders (`$1`, `$2` for Postgres; `?` for SQLite)
+  and pass values through `Statement::from_sql_and_values`. String
+  interpolation of user data into SQL is SQL injection, blocker.
+- **No stored credentials.** The store should never persist raw
+  secret values. Events should only contain names (`required_secrets:
+  Vec<String>`) never values. Verify by grepping for likely secret
+  field names and confirming they don't appear in any insert path.
+
+### 8. Maintainability
+
+- **No file over 500 lines, no function over 100.** Run
+  `just check-lines`. A store implementation tends to grow long — if
+  a single file is approaching the limit, it should have been split.
+- **Entity definitions are authoritative.** Columns in `entity/events.rs`
+  must match columns created in `migration/m_0001_init.rs`. Drift
+  here is a runtime landmine. A good pattern: one integration test
+  that round-trips every entity through a fresh DB.
+- **Converters are symmetric.** For every `From<Model> for DomainType`
+  there should be a corresponding `impl From<DomainType> for ActiveModel`
+  (or `TryFrom` if fallible). Asymmetric converters are a smell.
+- **No inline `#[allow]`.** `just check-suppression` must pass.
+- **Doc comments on every public item.** SeaORM entity code is
+  boilerplate-heavy but the trait impls and converters should have
+  `///` doc comments explaining non-obvious choices.
+
+### 9. Testing Quality
+
+- **Three tiers actually implemented.** `MockDatabase` unit tests,
+  SQLite in-memory integration tests, and Postgres testcontainers
+  integration tests all exist. Verify by running each tier explicitly:
+  - `cargo nextest run -p tanren-store` (default tier)
+  - `cargo nextest run -p tanren-store --features postgres-integration`
+    (Postgres tier, requires running Postgres)
+- **Test coverage is meaningful, not just numbers.** Run
+  `cargo llvm-cov nextest -p tanren-store --summary-only`. Target
+  is ≥ 85% line coverage. Flag coverage gaps in the trait method
+  implementations specifically — a 70% overall with 50% coverage on
+  `JobQueue::dequeue` is worse than 80% with 100% on dequeue.
+- **Regression tests cover the prior-audit risks.** Verify the
+  implementation has explicit tests for:
+  - Double-claim prevention under concurrent dequeue
+  - `ack_and_enqueue` atomic rollback on mid-op failure
+  - Migration double-apply idempotency
+  - Event round-trip through `serde_json::Value` (not string)
+
+### 10. Scalability and Extensibility
+
+- **Adding a new event variant.** If a new `DomainEvent` variant is
+  added in Lane 0.2 (or later), how much of this store breaks? Ideally
+  zero — the event payload is `serde_json::Value` and the store
+  doesn't care what's inside. Verify by inspection.
+- **Adding a new step type.** Same question for `StepType`. The store
+  persists the discriminant string and the full payload JSON —
+  adding a variant should require no store changes.
+- **Adding a new projection table.** When Phase 3 adds user/apikey
+  projections, how invasive is it? The answer should be: add a new
+  entity module, add a new migration, add store methods. No existing
+  code should need to change. Verify the current module boundaries
+  support this cleanly.
+
+## Audit Process
+
+1. Check out the branch under review. Confirm you're on `lane-0.3` or
+   its successor (`git branch --show-current`).
+2. Run `just ci`. It must pass. Stop and report if it doesn't.
+3. Run `cargo nextest run -p tanren-store` (default SQLite tier).
+4. Start a Postgres container and run `cargo nextest run -p tanren-store
+   --features postgres-integration`. Verify the Postgres tier passes.
+5. Run `cargo llvm-cov nextest -p tanren-store --summary-only` and
+   record the coverage numbers per file.
+6. Walk through each audit dimension above. For each concrete check,
+   read the relevant code and either verify it or produce a finding.
+7. Pay special attention to Dimension 3 (Race Safety) and Dimension 4
+   (Transaction Boundaries) — these are the highest-risk areas.
+8. Produce the output report.
+
+## Output Format
+
+Deliver findings in three sections.
+
+### Section 1 — Verification Results
+
+A table of the ten audit dimensions with a one-line verdict and any
+blocker/issue/suggestion findings referenced by ID:
+
+```
+Dimension                  | Verdict      | Findings
+1. Spec Fidelity            | PASS         | —
+2. Correctness              | PASS         | S-02
+3. Race Safety              | CONCERNS     | B-01, I-03
+4. Transaction Boundaries   | PASS         | —
+5. Migration Lifecycle      | PASS         | —
+6. Performance              | CONCERNS     | I-04
+7. Security                 | PASS         | —
+8. Maintainability          | PASS         | S-05
+9. Testing Quality          | PASS         | —
+10. Scalability             | PASS         | —
+```
+
+### Section 2 — Findings
+
+Each finding formatted as:
+
+```
+### [BLOCKER|ISSUE|SUGGESTION] ID — Short title
+
+**Dimension:** Race Safety / Correctness / etc.
+**Location:** crates/tanren-store/src/job_queue.rs:142
+**Finding:** Description of what's wrong and why it matters.
+**Reproduction:** (for blockers) Concrete steps or test case that
+demonstrates the issue.
+**Fix:** Concrete fix or direction.
+```
+
+Use IDs: `B-NN` for blockers, `I-NN` for issues, `S-NN` for suggestions.
+
+### Section 3 — Recommendation
+
+One of:
+
+- **APPROVE for merge** — no blockers, store is production-ready for
+  Phase 0 scope. Any issues are follow-ups, not gates.
+- **APPROVE with follow-up** — no blockers, but specific fixes should
+  land before Lane 0.4 integration. List them.
+- **REJECT** — one or more blockers. List them and describe the fix
+  path. Lane 0.3 must re-audit before merge.
+
+Include coverage numbers and the pass/fail status of each test tier as
+an appendix to the recommendation.

--- a/docs/rewrite/tasks/LANE-0.3-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-0.3-BRIEF.md
@@ -1,0 +1,110 @@
+# Lane 0.3 — Store Core — Agent Brief
+
+## Task
+
+Implement the event-sourced persistence layer in `crates/tanren-store`. This
+crate owns **all SQL, all migrations, and all transactional semantics**. No
+other crate in the workspace should contain database queries.
+
+## Full Spec
+
+Read `docs/rewrite/tasks/LANE-0.3-STORE.md` completely before starting. It
+contains the complete schema, trait definitions, migration structure, and
+test tier requirements. Also read `docs/rewrite/tasks/ADDON-SEAORM.md` for
+the rationale behind using SeaORM instead of raw sqlx — the key takeaway is
+that SeaORM handles JSON dialect differences (TEXT on SQLite, JSONB on
+Postgres) and backend-agnostic migration DDL, but you must still drop to
+raw SQL for the atomic dequeue claim path.
+
+## Key Context
+
+- **Clean-room rewrite, not a port.** The Python store in
+  `packages/tanren-core/src/tanren_core/store/` exists for conceptual
+  reference only. Design for Rust's type system and SeaORM's entity API.
+- **Domain types are frozen.** `tanren-domain` is merged and stable. You
+  depend on it, never modify it. All entity → domain mapping lives in
+  `crates/tanren-store/src/converters.rs`.
+- **Both backends must work.** SQLite is the dev/solo target, Postgres is
+  the production target. Every migration, every query, every transaction
+  must work on both. SeaORM's entity API handles most of this; the
+  exception is `JobQueue::dequeue` which has backend-specific paths.
+- **Workspace quality rules apply.** Read `CLAUDE.md`. No
+  `unwrap`/`todo`/`panic`, no inline `#[allow()]`, max 500 lines per file,
+  max 100 lines per function. `thiserror` in the library, never `anyhow`.
+  Run `just ci` before considering the work done.
+- **Domain compatibility already certified.** `EventEnvelope` round-trips
+  through `serde_json::Value` (verified in Lane 0.2 audit). You can
+  serialize/deserialize freely.
+
+## Deliverable Modules
+
+| Module | Contents |
+|--------|----------|
+| `connection.rs` | `connect(url) -> DatabaseConnection` + startup migration runner |
+| `migration/` | SeaORM `MigrationTrait` impls for events + dispatch_projection + step_projection |
+| `entity/` | One file per table with `DeriveEntityModel` — `events.rs`, `dispatch_projection.rs`, `step_projection.rs`, `mod.rs` |
+| `converters.rs` | `From`/`TryFrom` between entity `Model`s and domain types |
+| `event_store.rs` | `EventStore` trait + impl using entity API |
+| `job_queue.rs` | `JobQueue` trait + impl; raw-SQL dequeue branches on `DbBackend` |
+| `state_store.rs` | `StateStore` trait + impl for dispatch/step projection queries |
+| `store.rs` | Unified `Store` struct implementing all three traits over one `DatabaseConnection` |
+| `errors.rs` | `StoreError` enum (thiserror), with `From<DbErr>` and domain-error mapping |
+
+## Critical Correctness Requirements
+
+1. **Atomic dequeue.** `JobQueue::dequeue` must be race-safe under concurrent
+   workers. Postgres path uses `SELECT … FOR UPDATE SKIP LOCKED`, SQLite path
+   uses a serializable transaction with `busy_timeout`. Must check
+   `count(status='running' AND lane=X) < max_concurrent` and claim the step
+   in a **single transaction** to prevent TOCTOU.
+
+2. **Atomic ack_and_enqueue.** Updating the current step's status +
+   appending completion events + inserting the next step's row + appending
+   `StepEnqueued` must happen in one transaction. Partial success is a bug.
+
+3. **Event append + projection update are co-transactional.** When the
+   store emits a `DispatchCreated` event and creates the dispatch
+   projection row, both happen in the same transaction or neither does.
+
+4. **Migration idempotency.** `run_migrations` applied twice in a row must
+   be a no-op on the second call.
+
+5. **No scan-heavy hot paths.** Every operational query (get_dispatch,
+   get_steps_for_dispatch, count_running_steps, query_dispatches with
+   filters) must use an index. Check `EXPLAIN` on both backends.
+
+## Testing Strategy
+
+Follow the tier model from the spec:
+
+| Tier | Backend | Framework |
+|------|---------|-----------|
+| Unit | None | `sea_orm::MockDatabase` for trait logic |
+| Integration (dev) | SQLite `:memory:` | `sea_orm::Database::connect("sqlite::memory:")` |
+| Integration (prod) | Postgres real | `testcontainers-modules::postgres::Postgres`, gated behind `postgres-integration` feature |
+| Concurrency | Postgres real | testcontainers — SQLite cannot exercise `FOR UPDATE SKIP LOCKED` |
+
+Minimum test coverage:
+- Every trait method on both backends (SQLite + Postgres integration)
+- Round-trip: append events → query events → verify identical
+- Race test: spawn N concurrent dequeue tasks on Postgres, assert no double-claim
+- Transaction test: `ack_and_enqueue` with a simulated failure mid-op does not leave partial state
+- Migration test: apply migrations to fresh DB, verify schema; apply again, verify no-op
+
+## Done When
+
+1. `just ci` passes (full workspace)
+2. Integration tests pass on both SQLite and Postgres (via `cargo nextest run -p tanren-store --features postgres-integration` with a running Postgres)
+3. All three traits (`EventStore`, `JobQueue`, `StateStore`) are implemented on the unified `Store`
+4. Migration framework applies cleanly to a fresh SQLite DB and a fresh Postgres DB
+5. Dequeue is race-safe under concurrent access (verify with the concurrency test)
+6. `ack_and_enqueue` is fully atomic (verify with the transaction test)
+7. `cargo doc -p tanren-store` builds with no warnings
+8. No `unwrap()`, `todo!()`, `panic!()` in any code path
+
+## Out of Scope
+
+- User and API key projection tables (Phase 3 — policy lane)
+- VM assignment table (Phase 1 — runtime lane)
+- Observability instrumentation (Phase 5)
+- Read-model optimizations beyond what the base schema requires (Phase 5)

--- a/docs/rewrite/tasks/LANE-0.4-AUDIT.md
+++ b/docs/rewrite/tasks/LANE-0.4-AUDIT.md
@@ -1,0 +1,84 @@
+# Lane 0.4 — Contract, App-Services, and CLI Skeleton — Audit Brief
+
+## Role
+
+You are auditing the first vertical slice of Tanren 2.0. This lane is
+where architectural drift can re-enter the rewrite: interface crates can
+accidentally own business logic, orchestrator code can leak transport
+concerns, and binaries can bypass the application layer. Your job is to
+verify the lane proves the contract-first architecture rather than merely
+making the CLI "work somehow."
+
+## Required Reading
+
+Read these before auditing:
+
+1. `docs/rewrite/tasks/LANE-0.4-CLI-WIRING.md`
+2. `docs/rewrite/tasks/LANE-0.4-BRIEF.md`
+3. `docs/rewrite/DESIGN_PRINCIPLES.md`
+4. `docs/rewrite/CRATE_GUIDE.md`
+5. `CLAUDE.md`
+
+Skim public exports of:
+
+- `crates/tanren-domain`
+- `crates/tanren-store`
+- `crates/tanren-contract`
+- `crates/tanren-orchestrator`
+- `crates/tanren-app-services`
+
+## Audit Dimensions
+
+### 1. Architecture Fidelity
+
+- `tanren-contract` is serialization/schema only.
+- `tanren-policy` returns typed decisions, not transport errors.
+- `tanren-orchestrator` owns lifecycle sequencing and store coordination.
+- `tanren-app-services` maps inputs/outputs and errors; it does not re-implement orchestration.
+- `tanren-cli` is thin: argument parsing, dependency wiring, JSON output.
+
+Any inversion here is a blocker because it recreates the drift the rewrite exists to remove.
+
+### 2. Store Boundary Discipline
+
+- Lane 0.4 consumes `tanren-store` only through public traits / param structs / `Store` construction.
+- No SQL, entity imports, migration imports, or row-shape assumptions appear outside `tanren-store`.
+- No code bypasses the co-transactional store APIs by appending raw events directly.
+
+### 3. Lifecycle Correctness
+
+- `create_dispatch` creates the projection, emits `DispatchCreated`, and enqueues the initial step through the store contract.
+- `cancel_dispatch` cancels pending steps, updates status, and emits `DispatchCancelled`.
+- The orchestrator enforces the single-path terminal-event rule:
+  - `DispatchCompleted` only for `Outcome::Success`
+  - `DispatchFailed` for all other non-cancel terminal outcomes
+  - `DispatchCancelled` only for user-initiated cancellation
+
+### 4. Error Mapping
+
+- Domain/store/policy errors are converted into stable contract error responses.
+- The CLI prints deterministic JSON on success and failure.
+- Libraries use `thiserror`; `anyhow` appears only in binaries.
+
+### 5. Test Quality
+
+- Contract serde round-trip tests exist.
+- Orchestrator tests cover create/get/list/cancel behavior and terminal-event emission.
+- CLI integration tests exercise the full SQLite path: create → get → list → cancel.
+- `just ci` is green across the workspace.
+
+## Audit Process
+
+1. Confirm the branch under review is the lane-0.4 branch.
+2. Run `just ci`.
+3. Inspect crate boundaries and dependency direction.
+4. Run the CLI integration tests and confirm they hit the real store path on SQLite.
+5. Verify no transport logic leaked into orchestrator and no orchestration logic leaked into the CLI.
+
+## Approve When
+
+- The vertical slice works end to end on SQLite.
+- Crate boundaries from `CRATE_GUIDE.md` remain intact.
+- Terminal-event emission is single-path and explicitly tested.
+- Errors are typed and stable at the contract boundary.
+- `just ci` passes with no suppressions or layering regressions.

--- a/docs/rewrite/tasks/LANE-0.4-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-0.4-BRIEF.md
@@ -1,0 +1,87 @@
+# Lane 0.4 — Contract, App-Services, and CLI Skeleton — Agent Brief
+
+## Task
+
+Implement the first end-to-end vertical slice of Tanren 2.0 across the
+contract, policy, orchestrator, app-services, observability, and CLI
+crates. The goal is to prove the contract-first pipeline: create a
+dispatch, persist it through the store traits, and read it back through
+the CLI.
+
+## Full Spec
+
+Read `docs/rewrite/tasks/LANE-0.4-CLI-WIRING.md` completely before
+starting. Also read:
+
+1. `docs/rewrite/DESIGN_PRINCIPLES.md`
+2. `docs/rewrite/CRATE_GUIDE.md`
+3. `CLAUDE.md`
+
+Lane 0.3 is now the real persistence boundary. Treat its public traits
+and param types as the store contract; do not bypass them with SQL or
+new persistence helpers.
+
+## Key Context
+
+- **Clean-room rewrite, not a port.** Python CLI/API/orchestration code is
+  conceptual reference only.
+- **Domain is frozen.** `tanren-domain` is merged and stable.
+- **Store is real.** `tanren-store` owns all SQL and persistence semantics.
+  Lane 0.4 must call it through traits and param structs, not by reaching
+  into entities or migrations.
+- **Contract-first means interface-safe types.** `tanren-contract`
+  defines request/response types; `tanren-app-services` maps to/from
+  domain types; binaries stay transport-specific.
+- **No runtime execution yet.** This lane wires dispatch creation,
+  query, list, and cancel only. No harness or environment execution
+  belongs here.
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| `tanren-contract` | Interface-safe request/response/error types with serde round-trip tests |
+| `tanren-policy` | Minimal typed pass-through policy skeleton |
+| `tanren-orchestrator` | Dispatch creation/query/list/cancel flow over `EventStore + JobQueue + StateStore` |
+| `tanren-app-services` | Service layer mapping contract types to domain/use-case calls |
+| `tanren-observability` | Minimal tracing bootstrap used by binaries |
+| `bin/tanren-cli` | Clap CLI implementing `dispatch create/get/list/cancel` |
+
+## Non-Negotiables
+
+1. **Thin binaries.** `tanren-cli` parses args, builds dependencies, and prints JSON. Business logic stays in app-services/orchestrator.
+2. **No store leakage.** Lane 0.4 must not import `tanren_store::entity`, migrations, or raw SQL.
+3. **Single-path unsuccessful termination.** The orchestrator emits:
+   - `DispatchCompleted` only for `Outcome::Success`
+   - `DispatchFailed` for `Fail | Blocked | Error | Timeout`
+   - `DispatchCancelled` only for user-initiated cancellation
+4. **Typed error mapping.** Libraries use `thiserror`; the CLI binary may use `anyhow`.
+5. **Trait-based wiring.** Orchestrator/service code is generic over store traits or accepts trait objects; do not hardcode SQLite logic into use cases.
+
+## Implementation Order
+
+1. Define contract request/response/error shapes.
+2. Implement the minimal policy skeleton.
+3. Implement orchestrator create/get/list/cancel against the store traits.
+4. Implement app-services mapping and error translation.
+5. Add observability bootstrap.
+6. Wire the CLI binary to the real `Store`.
+7. Add end-to-end CLI tests against SQLite.
+
+## Done When
+
+1. `tanren dispatch create` succeeds against a fresh SQLite database.
+2. `tanren dispatch get` returns the created dispatch.
+3. `tanren dispatch list` shows the dispatch.
+4. `tanren dispatch cancel` transitions to `Cancelled`.
+5. Orchestrator tests verify the terminal-event emission rule.
+6. Contract types round-trip via serde.
+7. CLI integration tests cover create → get → list → cancel.
+8. `just ci` passes across the full workspace.
+
+## Out of Scope
+
+- Runtime / harness execution
+- Planner-native graph scheduling
+- Auth, quotas, and placement policy beyond the minimal skeleton
+- API, MCP, or TUI transport wiring

--- a/docs/rewrite/tasks/README.md
+++ b/docs/rewrite/tasks/README.md
@@ -2,17 +2,26 @@
 
 ## Phase 0: Foundation
 
+### Current Status
+
+| Lane | Crate(s) | Status | Notes |
+|------|----------|--------|-------|
+| 0.1 | workspace scaffold | ✅ merged | just tooling, lints, CI |
+| 0.2 | `tanren-domain` | ✅ merged, audit-certified | canonical domain model frozen for downstream lanes |
+| 0.3 | `tanren-store` | ✅ implemented, audit-approved, pending merge | real store is ready for foundation integration |
+| 0.4 | `tanren-contract`, `tanren-policy`, `tanren-orchestrator`, `tanren-app-services`, `tanren-observability`, `tanren-cli` | 🔵 ready to start | concise implementation + audit briefs now present |
+
 ### Execution Order
 
 ```
 Lane 0.1 (Workspace Scaffold) ✅ COMPLETE
          │
          ▼
-Lane 0.2 (Domain Model)       ← START HERE — sequential, blocks everything
+Lane 0.2 (Domain Model) ✅ merged
          │
          ├────────────────────┐
          ▼                    ▼
-Lane 0.3 (Store Core)    Lane 0.4 (Contract + CLI Wiring)
+Lane 0.3 (Store Core) ✅ ready to merge    Lane 0.4 (Contract + CLI Wiring) 🔵 ready to start
          │                    │
          └────────┬───────────┘
                   ▼
@@ -21,12 +30,12 @@ Lane 0.3 (Store Core)    Lane 0.4 (Contract + CLI Wiring)
 
 ### Lane Details
 
-| Lane | Crate(s) | Depends On | Brief |
-|------|----------|------------|-------|
+| Lane | Crate(s) | Depends On | Status | Brief |
+|------|----------|------------|--------|-------|
 | 0.1 | workspace | — | ✅ Complete: scaffold, just, CI, lints |
-| 0.2 | `tanren-domain` | 0.1 | [LANE-0.2-DOMAIN.md](LANE-0.2-DOMAIN.md) |
-| 0.3 | `tanren-store` | 0.2 | [LANE-0.3-STORE.md](LANE-0.3-STORE.md) |
-| 0.4 | `tanren-contract`, `tanren-policy`, `tanren-orchestrator`, `tanren-app-services`, `tanren-observability`, `tanren-cli` | 0.2 | [LANE-0.4-CLI-WIRING.md](LANE-0.4-CLI-WIRING.md) |
+| 0.2 | `tanren-domain` | 0.1 | ✅ merged, audit-certified | [LANE-0.2-DOMAIN.md](LANE-0.2-DOMAIN.md) |
+| 0.3 | `tanren-store` | 0.2 | ✅ implemented, audit-approved, pending merge | [LANE-0.3-STORE.md](LANE-0.3-STORE.md) |
+| 0.4 | `tanren-contract`, `tanren-policy`, `tanren-orchestrator`, `tanren-app-services`, `tanren-observability`, `tanren-cli` | 0.2 | 🔵 ready to start | [LANE-0.4-CLI-WIRING.md](LANE-0.4-CLI-WIRING.md) |
 
 ### First Milestone Exit Criteria
 
@@ -42,11 +51,17 @@ All of the following must be true:
 
 ### Parallelization Strategy
 
-**Lane 0.2** runs first with one agent. Once domain types compile and tests pass,
-**Lane 0.3** and **Lane 0.4** launch in parallel worktrees:
+**Lane 0.2** ran first with one agent. With domain merged, **Lane 0.3**
+and **Lane 0.4** can proceed in parallel worktrees:
 
 - Lane 0.3 agent works in `crates/tanren-store/` — needs domain types but not CLI/contract
 - Lane 0.4 agent works in `crates/tanren-{contract,policy,orchestrator,app-services,observability}/` and `bin/tanren-cli/` — needs domain types but can mock store traits
+
+Dispatch rules:
+
+- Implementation agents get `LANE-0.4-BRIEF.md` plus the full spec
+- Audit agents get `LANE-0.4-AUDIT.md` plus the full spec
+- Lane 0.4 should target `rewrite/tanren-2-foundation` tip after lane 0.3 merges, but it can begin on a parallel lane branch immediately against the same domain foundation
 
 Integration happens when both lanes merge: the CLI binary connects to the real store.
 

--- a/justfile
+++ b/justfile
@@ -148,7 +148,7 @@ build:
 
 # Type-check all workspace crates
 check:
-    @{{ cargo }} check --workspace --all-targets --quiet
+    @{{ cargo }} check --workspace --all-targets --features tanren-store/test-hooks --quiet
 
 # ============================================================================
 # Test
@@ -156,11 +156,11 @@ check:
 
 # Run all tests via nextest (pass extra args after --)
 test *args:
-    @{{ cargo }} nextest run --workspace --no-tests=pass {{ args }}
+    @{{ cargo }} nextest run --workspace --no-tests=pass --features tanren-store/test-hooks {{ args }}
 
 # Generate code coverage report (lcov)
 coverage:
-    @{{ cargo }} llvm-cov nextest --workspace --lcov --output-path lcov.info --no-tests=pass
+    @{{ cargo }} llvm-cov nextest --workspace --features tanren-store/test-hooks --lcov --output-path lcov.info --no-tests=pass
     @echo "Coverage report: lcov.info"
 
 # ============================================================================
@@ -169,7 +169,7 @@ coverage:
 
 # Run clippy with deny warnings
 lint:
-    @{{ cargo }} clippy --workspace --all-targets --quiet -- -D warnings
+    @{{ cargo }} clippy --workspace --all-targets --features tanren-store/test-hooks --quiet -- -D warnings
 
 # Glob for Rust workspace TOML files (excludes Python pyproject.toml)
 toml_globs := "Cargo.toml bin/*/Cargo.toml crates/*/Cargo.toml .cargo/*.toml .config/*.toml rust-toolchain.toml clippy.toml taplo.toml deny.toml .rustfmt.toml lefthook.yml"
@@ -188,7 +188,7 @@ fmt-fix:
 fix:
     @{{ cargo }} fmt
     @RUST_LOG=error taplo fmt {{ toml_globs }}
-    @{{ cargo }} clippy --workspace --all-targets --fix --allow-dirty --allow-staged --quiet -- -D warnings
+    @{{ cargo }} clippy --workspace --all-targets --features tanren-store/test-hooks --fix --allow-dirty --allow-staged --quiet -- -D warnings
 
 # ============================================================================
 # Audit & Analysis
@@ -229,6 +229,56 @@ check-lines:
     done < <(find crates/ bin/ -name '*.rs' -print0)
     if [[ "$failed" -eq 1 ]]; then exit 1; fi
     echo "All files within line limit."
+
+# Enforce crate dependency layering (foundation crates must not depend on capability crates)
+check-deps:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Checking crate dependency layering..."
+
+    # Foundation crates: domain logic, no I/O, no orchestration
+    foundation=(
+        "tanren-domain"
+        "tanren-contract"
+        "tanren-policy"
+        "tanren-observability"
+    )
+
+    # Capability crates: these must NOT be depended upon by foundation crates
+    capability=(
+        "tanren-store"
+        "tanren-planner"
+        "tanren-scheduler"
+        "tanren-orchestrator"
+        "tanren-app-services"
+        "tanren-runtime"
+        "tanren-runtime-local"
+        "tanren-runtime-docker"
+        "tanren-runtime-remote"
+        "tanren-harness-claude"
+        "tanren-harness-codex"
+        "tanren-harness-opencode"
+    )
+
+    failed=0
+    metadata=$({{ cargo }} metadata --format-version 1 --no-deps 2>/dev/null)
+
+    for fnd in "${foundation[@]}"; do
+        deps=$(echo "$metadata" \
+            | jq -r ".packages[] | select(.name == \"$fnd\") | .dependencies[].name" 2>/dev/null || true)
+        for cap in "${capability[@]}"; do
+            if echo "$deps" | grep -qx "$cap"; then
+                echo "FAIL: foundation crate '$fnd' depends on capability crate '$cap'"
+                failed=1
+            fi
+        done
+    done
+
+    if [[ "$failed" -eq 1 ]]; then
+        echo "Crate layering violation detected. Foundation crates must not depend on capability crates."
+        exit 1
+    fi
+    echo "Crate layering rules pass."
 
 # Prohibit inline lint suppression (#[allow/expect])
 check-suppression:
@@ -272,5 +322,5 @@ clean:
 # ============================================================================
 
 # Run full CI check locally
-ci: fmt lint deny check-lines check-suppression test doc machete
+ci: fmt lint check check-lines check-suppression check-deps deny test doc machete
     @echo "==> All CI checks passed!"

--- a/profiles/rust-cargo/architecture/crate-layering.md
+++ b/profiles/rust-cargo/architecture/crate-layering.md
@@ -1,0 +1,72 @@
+# Crate Layering
+
+Enforce dependency direction. Core never depends on infrastructure. Infrastructure never depends on API/CLI. Validate with `just check-deps`.
+
+```
+# ✓ Good: Correct dependency direction
+┌─────────────┐     ┌──────────────┐     ┌──────────────┐
+│  bin/api     │────▶│  orchestrator│────▶│   domain     │
+│  bin/cli     │     │  store       │     │   policy     │
+└─────────────┘     └──────────────┘     └──────────────┘
+   Binaries            Infrastructure        Foundation
+   (anyhow)            (thiserror)           (thiserror)
+```
+
+```toml
+# ✓ Good: Domain crate has zero infrastructure deps
+# crates/myapp-domain/Cargo.toml
+[dependencies]
+serde = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+# No sqlx, no reqwest, no tokio — pure domain logic
+```
+
+```toml
+# ✗ Bad: Domain importing infrastructure
+# crates/myapp-domain/Cargo.toml
+[dependencies]
+sqlx = { workspace = true }    # Database driver in domain!
+reqwest = { workspace = true } # HTTP client in domain!
+```
+
+**Layering rules:**
+
+| Rule | Description |
+|------|-------------|
+| Core rule | Domain crate never imports from any other workspace crate |
+| Storage rule | Only store crate owns SQL and query details |
+| Transport rule | Binaries depend on app-services + contract (+ runtime for wiring) |
+| Policy rule | Policy returns typed decisions, never transport-layer errors |
+| Runtime rule | Runtime/harness crates never own policy decisions |
+| Observability rule | No crate emits unstructured logs without correlation context |
+
+**Automated enforcement with `check-deps`:**
+
+```bash
+# justfile recipe
+check-deps:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    foundation=("myapp-domain" "myapp-policy" "myapp-contract")
+    capability=("myapp-orchestrator" "myapp-store")
+    for cap in "${capability[@]}"; do
+        deps=$(cargo metadata --format-version 1 \
+            | jq -r ".packages[] | select(.name == \"$cap\") | .dependencies[].name")
+        for found in "${foundation[@]}"; do
+            # Foundation crates must not depend on capability crates
+            # (reverse direction check)
+        done
+    done
+    echo "check-deps: all layering rules pass"
+```
+
+**Rules:**
+- Foundation crates: domain types, policies, contracts — zero I/O dependencies
+- Capability crates: orchestration, storage, runtime — implement traits from foundation
+- Binary crates: composition wiring — depend on capability + foundation
+- Validate layering in CI via `just check-deps` in quality-gates job
+- Add `check-deps` to the `ci` gate for all projects with 3+ crates
+
+**Why:** Enforced layering prevents accidental coupling that makes crates untestable in isolation. A domain crate that imports `sqlx` can no longer be tested without a database. Automated checks catch violations before code review.

--- a/profiles/rust-cargo/architecture/id-formats.md
+++ b/profiles/rust-cargo/architecture/id-formats.md
@@ -1,0 +1,80 @@
+# ID Formats
+
+Use UUIDv7 for all internal identifiers. Wrap in domain newtypes to prevent cross-type confusion. Store as TEXT in SQLite, UUID in PostgreSQL.
+
+```rust
+// ✓ Good: Domain ID newtype
+use uuid::Uuid;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DispatchId(Uuid);
+
+impl DispatchId {
+    /// Create a new time-ordered ID.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
+
+impl fmt::Display for DispatchId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<Uuid> for DispatchId {
+    fn from(id: Uuid) -> Self { Self(id) }
+}
+
+impl AsRef<Uuid> for DispatchId {
+    fn as_ref(&self) -> &Uuid { &self.0 }
+}
+```
+
+```rust
+// ✓ Good: Type safety prevents misuse
+fn assign(dispatch_id: DispatchId, agent_id: AgentId) -> Result<()>;
+
+// Compile error: can't pass AgentId where DispatchId is expected
+assign(agent_id, dispatch_id);  // Error!
+```
+
+```rust
+// ✗ Bad: Raw types
+fn assign(dispatch_id: Uuid, agent_id: Uuid) -> Result<()>;
+// Easy to swap arguments — compiles but wrong
+assign(agent_id_value, dispatch_id_value);  // Compiles! Bug.
+```
+
+```rust
+// ✗ Bad: String IDs
+fn assign(dispatch_id: &str, agent_id: &str) -> Result<()>;
+// No type safety, no format validation, easy to pass garbage
+```
+
+**UUIDv7 properties:**
+- Time-ordered: IDs sort chronologically without a separate timestamp column
+- Globally unique: no coordination needed across distributed systems
+- 128-bit: sufficient entropy for any scale
+- Created via `Uuid::now_v7()` (requires `uuid` crate with `v7` feature)
+
+**Database storage:**
+
+| Database | Column Type | Rationale |
+|----------|-------------|-----------|
+| SQLite | `TEXT` | No native UUID type; TEXT preserves human readability |
+| PostgreSQL | `UUID` | Native type with indexing optimizations |
+
+**Rules:**
+- Every domain entity gets its own ID newtype: `UserId`, `TaskId`, `AgentId`, etc.
+- All IDs created via `Uuid::now_v7()` — never v4 (random, not sortable)
+- Derive `Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize`
+- Use `#[serde(transparent)]` for clean JSON serialization
+- Implement `Display`, `From<Uuid>`, `AsRef<Uuid>`
+- Never use auto-increment integers for primary keys
+
+**Why:** Newtypes make ID misuse a compile error rather than a runtime bug. UUIDv7 combines time-ordering (efficient indexing, natural sort) with global uniqueness (no sequence coordination). The type system enforces correct usage across crate boundaries.

--- a/profiles/rust-cargo/architecture/naming-conventions.md
+++ b/profiles/rust-cargo/architecture/naming-conventions.md
@@ -1,0 +1,81 @@
+# Cross-Layer Naming Conventions
+
+Consistent naming across Rust modules, types, database schema, and API surfaces. Each layer follows its natural convention.
+
+```rust
+// ✓ Good: Consistent naming across layers
+
+// Module: snake_case
+mod task_dispatch;
+
+// Type: PascalCase
+pub struct TaskDispatch { /* ... */ }
+
+// Error: {Domain}Error
+pub enum DispatchError {
+    AgentUnavailable { agent_id: AgentId },
+    BudgetExhausted { budget_id: BudgetId },
+}
+
+// Function: snake_case, verb-first
+pub fn create_dispatch(cmd: CreateDispatchCommand) -> Result<TaskDispatch, DispatchError>;
+pub fn validate_budget(budget_id: BudgetId) -> Result<Budget, PolicyError>;
+pub fn is_active(&self) -> bool;  // Predicate: is_/has_/can_ prefix
+```
+
+**Database naming:**
+
+```sql
+-- ✓ Good: snake_case tables and columns (matches Rust convention)
+CREATE TABLE task_dispatches (
+    id          TEXT PRIMARY KEY,
+    agent_id    TEXT NOT NULL,
+    status      TEXT NOT NULL,
+    created_at  TEXT NOT NULL
+);
+```
+
+**API naming:**
+
+```
+# ✓ Good: kebab-case paths, snake_case JSON fields
+POST /api/v1/task-dispatches
+GET  /api/v1/task-dispatches/{id}
+
+{
+    "agent_id": "01234567-...",
+    "task_status": "pending",
+    "created_at": "2025-01-15T09:00:00Z"
+}
+```
+
+**Serde configuration:**
+
+```rust
+// ✓ Good: Explicit serde rename for API consistency
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+```
+
+**Summary:**
+
+| Layer | Convention | Example |
+|-------|-----------|---------|
+| Crate names | `kebab-case` | `myapp-domain` |
+| Modules/files | `snake_case` | `task_dispatch.rs` |
+| Types/traits | `PascalCase` | `TaskDispatch` |
+| Functions | `snake_case` | `create_dispatch()` |
+| Constants | `SCREAMING_SNAKE_CASE` | `MAX_RETRY_COUNT` |
+| Error types | `{Domain}Error` | `DispatchError` |
+| Feature flags | `kebab-case` | `postgres-integration` |
+| DB tables/columns | `snake_case` | `task_dispatches` |
+| API paths | `kebab-case` | `/task-dispatches` |
+| JSON fields | `snake_case` | `agent_id` |
+
+**Why:** Predictable naming reduces cognitive load. Developers can infer the name of a table from its Rust type, or an API path from a module name, without looking it up.

--- a/profiles/rust-cargo/architecture/secrets-handling.md
+++ b/profiles/rust-cargo/architecture/secrets-handling.md
@@ -1,0 +1,76 @@
+# Secrets Handling
+
+Wrap all secrets in `secrecy::Secret<T>`. Never log, serialize, or display raw secret values. Expose only at the point of use.
+
+```rust
+// ✓ Good: Secret-wrapped configuration
+use secrecy::{ExposeSecret, Secret};
+
+#[derive(Debug)]  // Debug output shows Secret([REDACTED])
+pub struct DatabaseConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: Secret<String>,  // Wrapped
+}
+
+pub struct ApiConfig {
+    pub endpoint: String,
+    pub api_key: Secret<String>,   // Wrapped
+    pub webhook_secret: Secret<String>,  // Wrapped
+}
+```
+
+```rust
+// ✓ Good: Expose only at point of use
+fn connect(config: &DatabaseConfig) -> Result<Pool> {
+    let url = format!(
+        "postgres://{}:{}@{}:{}/app",
+        config.username,
+        config.password.expose_secret(),  // Exposed here only
+        config.host,
+        config.port,
+    );
+    Pool::connect(&url).await
+}
+```
+
+```rust
+// ✓ Good: Safe to log structs containing secrets
+tracing::info!(?config, "connecting to database");
+// Output: config=DatabaseConfig { host: "db.example.com", port: 5432,
+//         username: "app", password: Secret([REDACTED]) }
+```
+
+```rust
+// ✗ Bad: Raw secret in struct
+pub struct ApiConfig {
+    pub api_key: String,  // Exposed in Debug, logs, error messages
+}
+
+// ✗ Bad: Logging raw secret
+tracing::info!("connecting with key {}", api_key);
+
+// ✗ Bad: Serializing secret to JSON
+#[derive(Serialize)]
+pub struct Config {
+    pub api_key: String,  // Will appear in JSON output
+}
+```
+
+**What to wrap:**
+- API keys and tokens
+- Database passwords and connection strings
+- Webhook secrets and signing keys
+- OAuth client secrets
+- Any credential or authentication material
+
+**Rules:**
+- Use `secrecy::Secret<String>` (or `Secret<Vec<u8>>` for binary secrets)
+- `Secret<T>` implements `Debug` as `Secret([REDACTED])` — safe to derive `Debug` on containing structs
+- Call `.expose_secret()` only at the point where the raw value is needed (HTTP header, connection string)
+- Never implement `Display`, `Serialize`, or `ToString` on types that expose raw secrets
+- Never pass raw secret values to `tracing` fields or format strings
+- Use `secrecy::zeroize` feature if you need memory scrubbing after use
+
+**Why:** `Secret<T>` makes accidental credential exposure a compile-time or at minimum a visible code-review concern rather than a silent runtime leak. The type system prevents secrets from appearing in logs, error messages, serialized output, and debug displays.

--- a/profiles/rust-cargo/architecture/thin-binary-crate.md
+++ b/profiles/rust-cargo/architecture/thin-binary-crate.md
@@ -1,0 +1,70 @@
+# Thin Binary Crate
+
+Binary crates (`main.rs`) are thin orchestration layers. Parse args, initialize tracing, build the dependency graph, delegate to library crates, handle top-level errors. No business logic.
+
+```rust
+// ✓ Good: Thin main.rs (~30 lines)
+use anyhow::{Context, Result};
+use clap::Parser;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+    #[arg(long, default_value = "8080")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .json()
+        .init();
+
+    let cli = Cli::parse();
+
+    let store = myapp_store::SqliteStore::connect(&cli.database_url)
+        .await
+        .context("failed to connect to database")?;
+
+    let service = myapp_orchestrator::Service::new(store);
+
+    myapp_api::serve(service, cli.port)
+        .await
+        .context("server exited with error")
+}
+```
+
+```rust
+// ✗ Bad: Business logic in main.rs
+#[tokio::main]
+async fn main() -> Result<()> {
+    // ... 300 lines of request handling, validation,
+    // database queries, error formatting, retries ...
+}
+```
+
+**What belongs in `main.rs`:**
+- CLI argument parsing (clap)
+- Tracing/logging initialization
+- Configuration loading
+- Dependency graph construction (wiring implementations to traits)
+- Top-level error handling with `anyhow`
+- Signal handling (graceful shutdown)
+
+**What does NOT belong in `main.rs`:**
+- Business logic or domain rules
+- Data transformation or validation
+- Database queries or HTTP request handling
+- Retry logic or error recovery
+- Any function longer than ~20 lines
+
+**Rules:**
+- Binary crates use `anyhow::Result` for the main return type
+- All logic lives in library crates, binary crates just wire and run
+- Binary crates should be under 100 lines total (often under 50)
+- Binary crates depend on `app-services` or `orchestrator` + concrete infrastructure crates
+
+**Why:** Thin binaries keep all testable logic in library crates where it can be unit-tested without spinning up a full server. Multiple binaries (API, CLI, daemon) can share the same library crates with different wiring.

--- a/profiles/rust-cargo/architecture/trait-based-abstraction.md
+++ b/profiles/rust-cargo/architecture/trait-based-abstraction.md
@@ -1,0 +1,66 @@
+# Trait-Based Abstraction
+
+Access infrastructure through traits defined in core crates. Never import concrete implementations in domain logic. Wire implementations via constructor injection.
+
+```rust
+// ✓ Good: Port trait in domain crate
+// crates/myapp-domain/src/ports.rs
+#[async_trait]
+pub trait EventStore: Send + Sync {
+    async fn append(&self, events: &[Event]) -> Result<(), StoreError>;
+    async fn replay(&self, stream_id: StreamId) -> Result<Vec<Event>, StoreError>;
+}
+
+#[async_trait]
+pub trait Notifier: Send + Sync {
+    async fn notify(&self, notification: Notification) -> Result<(), NotifyError>;
+}
+```
+
+```rust
+// ✓ Good: Adapter implementation in infrastructure crate
+// crates/myapp-store/src/sqlite.rs
+use myapp_domain::ports::EventStore;
+
+pub struct SqliteEventStore { pool: SqlitePool }
+
+#[async_trait]
+impl EventStore for SqliteEventStore {
+    async fn append(&self, events: &[Event]) -> Result<(), StoreError> {
+        // SQLite-specific implementation
+    }
+    // ...
+}
+```
+
+```rust
+// ✓ Good: Constructor injection in binary crate
+// bin/myapp-api/src/main.rs
+let store = SqliteEventStore::new(&config.database_url).await?;
+let notifier = WebhookNotifier::new(&config.webhook_url);
+let service = OrchestratorService::new(store, notifier);
+```
+
+```rust
+// ✗ Bad: Direct infrastructure import in domain
+// crates/myapp-domain/src/orchestrator.rs
+use sqlx::SqlitePool;  // Domain crate importing database driver!
+
+pub struct Orchestrator {
+    pool: SqlitePool,  // Concrete dependency in domain
+}
+```
+
+**Rules:**
+- Core/domain crate: defines port traits, domain types, business logic. Zero I/O dependencies.
+- Infrastructure crates: implement port traits with concrete backends (SQLite, Postgres, HTTP, etc.)
+- Binary crates: compose the dependency graph, inject implementations
+- Use `async_trait` for async trait methods (until native async traits stabilize fully)
+- Prefer `impl Trait` for constructor parameters; use `Box<dyn Trait>` when object safety requires it
+
+**Swapping implementations:**
+- Same trait, different backend: `SqliteEventStore` vs `PostgresEventStore`
+- Testing: inject mock implementations in tests, real implementations in production
+- No conditional compilation needed — the type system handles it
+
+**Why:** Trait-based abstraction enables swapping implementations without changing business logic. Domain crates stay pure and testable without database drivers or HTTP clients in their dependency tree. This is the Rust equivalent of ports-and-adapters architecture.

--- a/profiles/rust-cargo/architecture/workspace-layout.md
+++ b/profiles/rust-cargo/architecture/workspace-layout.md
@@ -1,0 +1,89 @@
+# Workspace Layout
+
+Use a Cargo workspace with a flat crate directory. Name crates `{project}-{domain}`. Every crate inherits workspace configuration.
+
+```
+# ✓ Good: Flat workspace layout
+Cargo.toml              # Workspace root
+rust-toolchain.toml
+justfile
+deny.toml
+clippy.toml
+taplo.toml
+.cargo/config.toml
+.config/nextest.toml
+lefthook.yml
+
+crates/
+  myapp-domain/         # Core entities, no external deps
+  myapp-store/          # Database adapters
+  myapp-policy/         # Authorization, budgets
+  myapp-orchestrator/   # Business logic engine
+
+bin/
+  myapp-api/            # HTTP server binary
+  myapp-cli/            # CLI binary
+```
+
+```toml
+# ✓ Good: Workspace root Cargo.toml
+[workspace]
+resolver = "2"
+members = [
+    "bin/myapp-api",
+    "bin/myapp-cli",
+    "crates/myapp-domain",
+    "crates/myapp-store",
+    "crates/myapp-policy",
+    "crates/myapp-orchestrator",
+]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+# All dependencies centralized here
+
+[workspace.lints.rust]
+# All lints centralized here
+```
+
+```toml
+# ✗ Bad: No workspace, standalone crates
+# Each crate has its own version, edition, lint config
+# Dependencies duplicated across Cargo.toml files
+```
+
+**Per-crate Cargo.toml template:**
+
+```toml
+[package]
+name = "myapp-domain"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Core domain entities and business rules"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }
+proptest = { workspace = true }
+```
+
+**Rules:**
+- Library crates in `crates/`, binary crates in `bin/` (or `apps/`)
+- All crates inherit workspace package config and lints
+- `publish = false` unless publishing to crates.io
+- Resolver `"2"` required for workspace dependencies feature
+- Source directories searched by `check-lines` and `check-suppression` must include both `crates/` and `bin/` (or `apps/`)
+
+**Why:** A workspace provides unified dependency management, shared lint configuration, and single-command builds. Flat crate layout keeps the project navigable as it grows.

--- a/profiles/rust-cargo/global/address-deprecations-immediately.md
+++ b/profiles/rust-cargo/global/address-deprecations-immediately.md
@@ -1,0 +1,44 @@
+# Address Deprecations Immediately
+
+Compiler warnings are errors. Never defer deprecation fixes. Never suppress with `#[allow(deprecated)]`.
+
+```rust
+// ✓ Good: Migrate to replacement API immediately
+use std::sync::LazyLock;
+
+static CONFIG: LazyLock<Config> = LazyLock::new(|| {
+    Config::from_env()
+});
+```
+
+```rust
+// ✗ Bad: Suppressing deprecation warning
+#[allow(deprecated)]
+use std::sync::lazy::SyncLazy; // Deprecated — use LazyLock
+```
+
+```rust
+// ✗ Bad: Ignoring compiler warnings
+// warning: use of deprecated function `old_api::connect`
+// --> src/db.rs:42:5
+// ... (left unfixed, "will get to it later")
+```
+
+**Rules:**
+- `RUSTFLAGS="-D warnings"` in CI — all warnings are errors
+- Clippy warnings are errors: `cargo clippy -- -D warnings`
+- Doc warnings are errors: `RUSTDOCFLAGS="-D warnings"`
+- When a dependency deprecates an API, migrate immediately in the same PR that updates the dep
+- When the Rust compiler deprecates a feature, migrate before the next toolchain bump
+
+**Toolchain updates:**
+- Update `rust-toolchain.toml` channel and MSRV proactively
+- Review Rust release notes for deprecations and new features
+- Migrate to new edition features when updating edition
+
+**Exceptions:**
+- Only when blocked on an upstream crate release that hasn't published the replacement yet
+- Track with a GitHub issue linking to the upstream issue
+- Never suppress — leave the warning visible as a reminder
+
+**Why:** Deferred deprecations accumulate into migration debt that compounds with each release. Addressing them immediately keeps the codebase on the latest stable APIs, reduces surprise breakage during toolchain upgrades, and ensures CI stays green without warning suppression.

--- a/profiles/rust-cargo/global/dependency-management.md
+++ b/profiles/rust-cargo/global/dependency-management.md
@@ -1,0 +1,66 @@
+# Dependency Management
+
+All dependencies pinned in workspace `[workspace.dependencies]`. Crates reference with `dep.workspace = true`. No version declarations in member crates.
+
+```toml
+# ✓ Good: Centralized workspace dependency
+# Root Cargo.toml
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+thiserror = "2"
+
+# Crate Cargo.toml
+[dependencies]
+serde = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+```
+
+```toml
+# ✗ Bad: Version declared in member crate
+[dependencies]
+serde = { version = "1.0.210", features = ["derive"] }
+tokio = "1.40"
+```
+
+**Per-crate Cargo.toml pattern:**
+
+```toml
+[package]
+name = "myapp-core"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+```
+
+**License policy (cargo-deny):**
+- Allowed: MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-3.0, Unicode-DFS-2016, Zlib, BSL-1.0, CC0-1.0, CDLA-Permissive-2.0, OpenSSL
+- No copyleft licenses (GPL, LGPL, AGPL, MPL-2.0)
+- `confidence-threshold = 0.8`
+
+**Source restrictions:**
+- `unknown-registry = "deny"` — crates.io only
+- `unknown-git = "deny"` — no git dependencies
+- `wildcards = "deny"` — no wildcard version specs
+- `allow-wildcard-paths = true` — workspace path deps parse as wildcard; this is expected
+
+**Advisory policy:**
+- Zero ignores for production dependencies
+- Dev-only transitive ignores permitted with documented justification in `deny.toml`
+- Security advisories addressed within 48 hours
+
+**Unused dependency detection:**
+- `cargo-machete` runs in CI to detect unused dependencies
+- Remove unused deps immediately — don't leave dead weight
+
+**Update strategy:**
+- Update dependencies proactively with `cargo update`
+- Review changelogs before major version bumps
+- Run `just ci` after every dependency update
+
+**Why:** Centralized dependency management prevents version conflicts, ensures consistent feature flags, and makes auditing tractable. Strict license and source policies protect against legal and supply-chain risks.

--- a/profiles/rust-cargo/global/just-ci-gate.md
+++ b/profiles/rust-cargo/global/just-ci-gate.md
@@ -1,0 +1,53 @@
+# Just CI Gate
+
+`just ci` is the single verification gate. All sub-gates must pass before merge. No exceptions, no overrides.
+
+```bash
+# ✓ Good: Full gate check before merge
+just ci   # Runs all gates in sequence
+
+# Individual gates:
+just fmt                 # Rust formatting + TOML formatting
+just lint                # Clippy with -D warnings
+just check               # cargo check --workspace --all-targets
+just check-lines         # Max 500 lines per .rs file
+just check-suppression   # No inline #[allow/expect]
+just check-deps          # Crate layering rules
+just deny                # License + advisory audit
+just test                # cargo nextest run
+just machete             # Unused dependency detection
+just doc                 # Build docs with -D warnings
+```
+
+```bash
+# ✗ Bad: Skipping gates or running partial checks
+cargo test               # Wrong test runner
+cargo clippy || true     # Silencing lint errors
+just test && just lint   # Missing other gates
+```
+
+**Task runner:**
+- Use `just` (not `make`) — cross-platform, declarative, no hidden state
+- Shell: `bash -euo pipefail` for fail-fast behavior
+- All recipes defined in `justfile` at workspace root
+
+**Pre-commit hooks (lefthook):**
+- `cargo fmt --check` — formatting
+- `cargo clippy --workspace --all-targets --quiet -- -D warnings` — linting
+- `taplo fmt --check <explicit-glob-list>` — TOML formatting
+- All three run in parallel via `lefthook.yml`
+
+**Bootstrap:**
+- `just bootstrap` installs all tools via `cargo-binstall` (with fallback to `cargo install --locked`)
+- Tools: cargo-nextest, cargo-deny, cargo-llvm-cov, cargo-machete, cargo-hack, cargo-insta, taplo, lefthook
+
+**CI pipeline (GitHub Actions):**
+- **check** job: fmt + taplo + clippy (ubuntu + macos matrix)
+- **test** job: nextest with `--profile ci` (ubuntu + macos matrix)
+- **coverage** job: llvm-cov to codecov (ubuntu)
+- **deny** job: cargo-deny-action (ubuntu)
+- **doc** job: `RUSTDOCFLAGS="-D warnings"` (ubuntu)
+- **machete** job: unused deps (ubuntu)
+- **quality-gates** job: check-lines + check-suppression + check-deps (ubuntu)
+
+**Why:** A single broken gate means broken code reaches the main branch. Running all gates locally with `just ci` before push catches issues before CI, keeping feedback loops fast.

--- a/profiles/rust-cargo/rust/edition-and-toolchain.md
+++ b/profiles/rust-cargo/rust/edition-and-toolchain.md
@@ -1,0 +1,74 @@
+# Edition and Toolchain
+
+Edition 2024, MSRV 1.85, stable channel. Toolchain pinned via `rust-toolchain.toml` checked into the repo.
+
+```toml
+# ✓ Good: rust-toolchain.toml
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
+```
+
+```toml
+# ✗ Bad: No toolchain file, or using nightly
+[toolchain]
+channel = "nightly"   # Unstable features break without warning
+```
+
+**Required config files:**
+
+```toml
+# rustfmt.toml — use defaults, only set edition
+edition = "2024"
+```
+
+```toml
+# clippy.toml — enforce function line limit
+too-many-lines-threshold = 100
+# doc-valid-idents is project-specific:
+# doc-valid-idents = ["SeaORM", "SQLite", "PostgreSQL", "UUIDv7"]
+```
+
+```toml
+# taplo.toml — TOML formatter
+[formatting]
+align_entries = false
+array_auto_expand = true
+array_auto_collapse = true
+```
+
+```toml
+# .cargo/config.toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[alias]
+t = "nextest run"
+c = "clippy --workspace --all-targets"
+
+[net]
+retry = 3
+```
+
+**Workspace package defaults:**
+
+```toml
+# Root Cargo.toml
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "MIT OR Apache-2.0"
+```
+
+**Notes:**
+- Mold linker on Linux provides significant link-time speedup; macOS uses default linker (already fast)
+- `llvm-tools-preview` component is required for `cargo-llvm-cov` coverage
+- `doc-valid-idents` in `clippy.toml` is project-specific — add domain acronyms as needed
+- `taplo fmt --check` uses an explicit glob list in CI/hooks to avoid missing TOML files
+
+**Why:** A pinned toolchain ensures every developer and CI runner uses the same compiler version, eliminating "works on my machine" issues. Edition 2024 enables the latest language features while MSRV 1.85 ensures broad compatibility.

--- a/profiles/rust-cargo/rust/error-handling.md
+++ b/profiles/rust-cargo/rust/error-handling.md
@@ -1,0 +1,65 @@
+# Error Handling
+
+Use `thiserror` in library crates for typed, structured errors. Use `anyhow` only in binary crates for top-level error propagation. Never panic.
+
+```rust
+// ✓ Good: Library crate with thiserror
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("record not found: {id}")]
+    NotFound { id: Uuid },
+    #[error("duplicate key: {key}")]
+    DuplicateKey { key: String },
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+}
+
+pub fn get_record(id: Uuid) -> Result<Record, StorageError> {
+    // ...
+}
+```
+
+```rust
+// ✓ Good: Binary crate with anyhow
+use anyhow::{Context, Result};
+
+fn main() -> Result<()> {
+    let config = Config::load()
+        .context("failed to load configuration")?;
+    run_server(config).await
+        .context("server exited with error")
+}
+```
+
+```rust
+// ✗ Bad: unwrap, expect, panic, todo
+let value = map.get("key").unwrap();           // Denied
+let conn = connect().expect("must connect");   // Denied
+panic!("unexpected state");                     // Denied
+todo!("implement later");                       // Denied
+```
+
+**Option handling:**
+
+```rust
+// ✓ Good: Convert Option to Result
+let user = users.get(&id)
+    .ok_or_else(|| AuthError::UserNotFound { id })?;
+
+// ✓ Good: Pattern match
+match config.optional_field {
+    Some(value) => process(value),
+    None => use_default(),
+}
+```
+
+**Rules:**
+- Library crates: define domain error enums with `#[derive(thiserror::Error)]`
+- Binary crates: use `anyhow::Result` with `.context()` for human-readable error chains
+- Never use `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, `unimplemented!()`
+- Use `#[from]` for automatic error conversion between crate boundaries
+- Prefer `?` over manual `match` on `Result` when the error type converts
+
+**Why:** Typed errors in libraries give callers the ability to match on specific failure modes. `anyhow` in binaries provides rich error context for debugging. Banning panics ensures the program degrades gracefully rather than crashing.

--- a/profiles/rust-cargo/rust/file-and-function-limits.md
+++ b/profiles/rust-cargo/rust/file-and-function-limits.md
@@ -1,0 +1,49 @@
+# File and Function Limits
+
+Maximum 500 lines per `.rs` file. Maximum 100 lines per function. No exceptions.
+
+```bash
+# ✓ Good: Well-structured module
+$ wc -l crates/myapp-core/src/dispatch.rs
+  187 crates/myapp-core/src/dispatch.rs    # Under 500
+
+# ✗ Bad: Monolithic file
+$ wc -l crates/myapp-core/src/engine.rs
+  823 crates/myapp-core/src/engine.rs      # Over 500 — split it
+```
+
+```rust
+// ✓ Good: Focused function under 100 lines
+fn validate_dispatch(cmd: &DispatchCommand) -> Result<ValidatedDispatch, ValidationError> {
+    let agent = resolve_agent(&cmd.agent_id)?;
+    let capabilities = check_capabilities(&agent, &cmd.requirements)?;
+    let budget = verify_budget(&cmd.budget_id, cmd.estimated_cost)?;
+    Ok(ValidatedDispatch { agent, capabilities, budget })
+}
+```
+
+```rust
+// ✗ Bad: 200-line function doing too many things
+fn process_everything(input: Input) -> Result<Output> {
+    // ... 200 lines of mixed validation, processing, formatting, logging ...
+}
+```
+
+**Refactoring strategies when hitting limits:**
+
+**File too long (>500 lines):**
+- Split into submodules: `dispatch/mod.rs`, `dispatch/validate.rs`, `dispatch/execute.rs`
+- Extract types into a separate `types.rs` or `models.rs` module
+- Move `#[cfg(test)]` module to a separate test file if it's large
+
+**Function too long (>100 lines):**
+- Extract helper functions with descriptive names
+- Use early returns to reduce nesting
+- Break into a pipeline of small transforms
+
+**Enforcement:**
+- `just check-lines` recipe scans all `.rs` files in source directories, fails if any exceed 500 lines
+- `clippy.toml` sets `too-many-lines-threshold = 100`, enforced by clippy `too_many_lines` lint
+- Both run in CI via the quality-gates job
+
+**Why:** Short files and functions are easier to navigate, review, and test. The 500/100 limits force modular design without being so restrictive that they cause artificial splitting. These limits catch organic growth before files become unwieldy.

--- a/profiles/rust-cargo/rust/internal-visibility-controls.md
+++ b/profiles/rust-cargo/rust/internal-visibility-controls.md
@@ -1,0 +1,251 @@
+# Internal Visibility Controls
+
+Every access restriction must be enforced by the compiler. If rustc doesn't reject the misuse, the restriction doesn't exist. Never rely on documentation, naming conventions, or social agreement to prevent incorrect access to internal methods.
+
+## Guiding Principle
+
+The compiler is the reviewer that never sleeps. A method that is `pub` **will** be called by a downstream crate eventually — regardless of doc comments, `#[doc(hidden)]`, `__` prefixes, or "do not use" warnings. The only mechanisms that actually prevent misuse are:
+
+1. **Rust's visibility system** (`pub(crate)`, private modules, selective re-exports)
+2. **Conditional compilation** (`#[cfg(feature = "...")]` with `required-features`)
+
+Everything else is a suggestion, not an enforcement.
+
+## Decision Tree
+
+When a method should not be part of the public API, follow this priority strictly:
+
+### 1. Redesign the public API (strongest)
+
+Ask: why does the test need internal access? Often the answer is that the public API is incomplete. A facade that delegates to `pub(crate)` operations while exposing a complete set of public methods eliminates the need for escape hatches entirely.
+
+```rust
+// ✓ Good: Facade with complete public API
+// No internal access needed — tests use the same API as production code
+pub struct Store { /* private fields */ }
+
+impl Store {
+    pub async fn append_message(&self, msg: &Message) -> Result<()> {
+        ops::messages::append(&self.db, msg).await  // pub(crate) delegation
+    }
+    pub async fn replay_stream(&self, id: StreamId) -> Result<Vec<Event>> {
+        ops::messages::replay(&self.db, id).await
+    }
+}
+```
+
+```rust
+// ✗ Bad: Incomplete public API that forces tests to reach inside
+pub struct Store { pub db: DatabaseConnection }  // Exposed internals
+```
+
+If the public API is sufficient, integration tests need nothing extra. This is the gold standard.
+
+### 2. `pub(crate)` + unit tests (strong)
+
+If the method is truly internal — called only within the crate — make it `pub(crate)`. Test it from `#[cfg(test)] mod tests` inside the crate, where `pub(crate)` methods are visible.
+
+```rust
+// ✓ Good: Internal method with crate-only visibility
+pub(crate) async fn dequeue_impl(db: &DatabaseConnection, lane: Lane) -> Result<Job> {
+    // Only callable within this crate — compiler enforces it
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dequeues_from_correct_lane() {
+        // Can call dequeue_impl here — same crate
+    }
+}
+```
+
+```rust
+// ✗ Bad: pub method with a "please don't call this" comment
+/// Internal — do not call from outside this crate.
+pub async fn dequeue_impl(/* ... */) { /* ... */ }  // Nothing stops them
+```
+
+Key constraint: integration tests in `tests/` are **external crate roots** — they cannot see `pub(crate)` methods. If the method must be tested from `tests/`, you need option 3.
+
+### 3. Feature-gated `pub` + `required-features` (pragmatic)
+
+When integration tests genuinely need internal access — test fixture seeding, raw data insertion, schema introspection, invariant-bypassing helpers — use a Cargo feature gate with three mandatory components:
+
+1. `#[cfg(feature = "test-hooks")]` on the impl block
+2. `[[test]]` entries with `required-features = ["test-hooks"]` in Cargo.toml
+3. `--features crate-name/test-hooks` in **every** justfile recipe and CI job that compiles test targets
+
+All three are required. Missing any one creates a gap.
+
+### 4. Never: `#[doc(hidden)]`, naming conventions, or comments
+
+These are not visibility mechanisms:
+
+| Approach | What it actually does | Prevents misuse? |
+|----------|----------------------|-----------------|
+| `#[doc(hidden)]` | Hides from `cargo doc` output | **No** — any crate can still call it |
+| `__` prefix | Signals "private" by convention | **No** — compiles and runs normally |
+| Doc comment "do not use" | Communicates intent to readers | **No** — has zero compile-time effect |
+| Renaming to `_unchecked` | Signals danger | **No** — still callable |
+
+The sole acceptable use of `#[doc(hidden)]` is satisfying lint requirements where macro-generated code forces `pub` visibility but the containing module is unexported:
+
+```rust
+// Acceptable: SeaORM entities need pub but module is private
+// lib.rs
+#[doc(hidden)]
+pub mod entity;  // pub for E0446, module unexported, types unreachable
+```
+
+## Feature Gate Pattern — Complete Implementation
+
+### Cargo.toml
+
+```toml
+[features]
+default = []
+# Exposes Store::append / Store::append_batch for integration tests.
+# Production code must NOT enable this — bypasses projection consistency.
+# Test binaries declare required-features so bare `cargo test` silently
+# skips them rather than failing to compile.
+test-hooks = []
+
+# Every test binary that calls gated methods MUST have an entry here.
+# Auto-discovered tests (no [[test]] entry) will FAIL TO COMPILE
+# without the feature — this is the single most common mistake.
+[[test]]
+name = "sqlite_integration"
+path = "tests/sqlite_integration.rs"
+required-features = ["test-hooks"]
+
+[[test]]
+name = "event_query"
+path = "tests/event_query.rs"
+required-features = ["test-hooks"]
+
+# Features can compose — postgres tests need both hooks and postgres
+[[test]]
+name = "postgres_integration"
+path = "tests/postgres_integration.rs"
+required-features = ["test-hooks", "postgres-integration"]
+```
+
+### Source code
+
+```rust
+/// Test-only escape hatches — gated behind the `test-hooks` feature.
+/// These methods are conditionally compiled out of production builds.
+#[cfg(feature = "test-hooks")]
+impl Store {
+    /// Append a single event. Bypasses projection consistency.
+    pub async fn append(&self, event: &EventEnvelope) -> Result<()> {
+        // Use fully-qualified paths for types only used in gated blocks
+        // to avoid unused-import warnings when the feature is off.
+        let model = tanren_domain::EventEnvelope::to_active_model(event);
+        // ...
+    }
+}
+```
+
+### Justfile — every recipe that compiles test targets
+
+```just
+# Scope the feature per-crate, not workspace-wide.
+# Workspace-wide --features test-hooks would silently activate a
+# test-hooks feature on ANY crate that defines one — a latent
+# cross-crate collision risk.
+
+check:
+    @{{ cargo }} check --workspace --all-targets --features myapp-store/test-hooks --quiet
+
+test *args:
+    @{{ cargo }} nextest run --workspace --features myapp-store/test-hooks {{ args }}
+
+coverage:
+    @{{ cargo }} llvm-cov nextest --workspace --features myapp-store/test-hooks --lcov --output-path lcov.info
+
+lint:
+    @{{ cargo }} clippy --workspace --all-targets --features myapp-store/test-hooks --quiet -- -D warnings
+
+fix:
+    @{{ cargo }} clippy --workspace --all-targets --features myapp-store/test-hooks --fix --allow-dirty --allow-staged --quiet -- -D warnings
+
+# doc does NOT get the feature — gated methods should be invisible in public docs
+doc:
+    @RUSTDOCFLAGS="-D warnings" {{ cargo }} doc --workspace --no-deps --quiet
+```
+
+### CI — must mirror justfile exactly
+
+```yaml
+# Clippy must also pass the feature. Without it, clippy skips
+# feature-gated test binaries (via required-features), meaning
+# the test code is never linted. Unlinted test code accumulates
+# warnings that only surface when someone runs clippy locally
+# with the feature enabled.
+- name: Run clippy
+  run: cargo clippy --workspace --all-targets --features myapp-store/test-hooks -- -D warnings
+
+- name: Run tests
+  run: cargo nextest run --workspace --features myapp-store/test-hooks --profile ci
+
+- name: Generate coverage
+  run: cargo llvm-cov nextest --workspace --features myapp-store/test-hooks --lcov --output-path lcov.info
+```
+
+## Why `required-features` is non-negotiable
+
+Without `required-features` on `[[test]]` entries:
+
+```
+$ cargo test                    # No --features flag
+error[E0599]: no method named `append` found for struct `Store`
+  --> tests/event_query.rs:42:11
+```
+
+With `required-features`:
+
+```
+$ cargo test                    # No --features flag
+# test binary "event_query" silently skipped — feature not enabled
+# All other tests compile and run normally
+```
+
+The difference: a hard compile error vs. graceful degradation. Any developer or CI job that runs bare `cargo test` hits an incomprehensible error without `required-features`. With it, the gated tests simply don't run — they require an explicit opt-in via `--features`.
+
+## Module-level encapsulation patterns
+
+Beyond method visibility, use module structure to minimize the public surface:
+
+```rust
+// ✓ Good: Private module with selective re-exports
+// lib.rs
+mod ops;           // private — nothing leaks
+mod entities;      // private — SeaORM models stay internal
+mod migrations;    // private — migration details stay internal
+
+pub use store::{Store, StoreBackend};     // facade only
+pub use error::{StoreError, RetryHint};   // error types
+pub use types::{ReplayCursor};            // value types
+```
+
+```rust
+// ✗ Bad: Public modules exposing internals
+pub mod ops;       // Every operation function is now public API
+pub mod entities;  // Every database model is now public API
+```
+
+**Rules:**
+- **Compiler enforcement only** — if rustc doesn't reject it, it's not restricted
+- **Feature name:** `test-hooks` (consistent across all projects in the workspace)
+- **Every test binary** using gated methods must have a `[[test]]` entry with `required-features`
+- **Justfile and CI must match** — every recipe and job that compiles test targets passes the feature, including clippy
+- **Scope per-crate:** `--features myapp-store/test-hooks` (never workspace-wide)
+- **`doc` excluded:** gated methods must not appear in public documentation
+- **`pub(crate)` is always preferred** over feature gates when the test can live inside the crate
+- **`#[doc(hidden)]` is never a visibility mechanism** — only acceptable for lint satisfaction on unexported modules
+
+**Why:** The cost of a compile-time error for misuse is zero — it's caught before the code runs, before the PR is opened, before the reviewer sees it. The cost of a runtime bug from calling an internal method that bypasses safety invariants is unbounded. Every access restriction that isn't compiler-enforced will eventually be violated.

--- a/profiles/rust-cargo/rust/naming-conventions.md
+++ b/profiles/rust-cargo/rust/naming-conventions.md
@@ -1,0 +1,72 @@
+# Naming Conventions
+
+Follow Rust naming conventions strictly. Use Conventional Commits with scope for all commit messages.
+
+```rust
+// ✓ Good: Rust naming standards
+mod task_scheduler;              // Module: snake_case
+pub struct TaskScheduler;        // Type: PascalCase
+pub trait Dispatchable;          // Trait: PascalCase
+pub fn schedule_task();          // Function: snake_case, verb-first
+const MAX_RETRY_COUNT: u32 = 5;  // Constant: SCREAMING_SNAKE_CASE
+let active_tasks = vec![];       // Variable: snake_case
+```
+
+```toml
+# ✓ Good: Crate naming in Cargo.toml
+[package]
+name = "myapp-scheduler"   # kebab-case in Cargo.toml
+```
+
+```rust
+// In Rust source, the crate name becomes snake_case:
+use myapp_scheduler::TaskScheduler;
+```
+
+```rust
+// ✗ Bad: Inconsistent naming
+pub struct taskScheduler;   // Types must be PascalCase
+pub fn ScheduleTask();      // Functions must be snake_case
+mod TaskScheduler;          // Modules must be snake_case
+```
+
+**Error type naming:**
+
+```rust
+// ✓ Good: {Domain}Error pattern
+pub enum AuthError { /* ... */ }
+pub enum StorageError { /* ... */ }
+pub enum SchedulerError { /* ... */ }
+
+// ✗ Bad: Generic or inconsistent
+pub enum Error { /* ... */ }       // Too generic for a library crate
+pub enum AuthFailure { /* ... */ } // Inconsistent suffix
+```
+
+**Feature flags:**
+
+```toml
+# ✓ Good: kebab-case features
+[features]
+postgres-integration = []
+test-hooks = []
+```
+
+**Conventional Commits:**
+
+```
+feat(scheduler): add priority-based lane selection
+fix(store): close TOCTOU race in dequeue
+refactor(domain): extract dispatch state machine
+test(policy): add budget exhaustion property tests
+docs(api): update OpenAPI schema for v2 endpoints
+chore: update workspace dependencies
+```
+
+**Rules:**
+- Commit messages must use Conventional Commits format: `type(scope): description`
+- Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`
+- Scope matches the crate name without the project prefix (e.g., `store` not `myapp-store`)
+- Description is lowercase, imperative mood, no period
+
+**Why:** Consistent naming reduces cognitive load and makes the codebase navigable. Conventional Commits enable automated changelogs and make git history scannable by domain area.

--- a/profiles/rust-cargo/rust/no-unsafe-no-debug-output.md
+++ b/profiles/rust-cargo/rust/no-unsafe-no-debug-output.md
@@ -1,0 +1,56 @@
+# No Unsafe, No Debug Output
+
+No `unsafe` code. No `println!`/`eprintln!`/`dbg!`. Use `tracing` for all observability. Wrap secrets with `secrecy::Secret<T>`.
+
+```rust
+// ✓ Good: Structured tracing with fields
+use tracing::{info, warn, instrument};
+
+#[instrument(skip(db), fields(user_id = %user_id))]
+pub async fn process_request(user_id: UserId, db: &Database) -> Result<Response> {
+    info!("processing request");
+    let result = db.query(user_id).await?;
+    if result.is_empty() {
+        warn!(user_id = %user_id, "no records found");
+    }
+    Ok(Response::from(result))
+}
+```
+
+```rust
+// ✗ Bad: Debug output
+println!("processing user {}", user_id);   // Denied: print_stdout
+eprintln!("error: {}", err);               // Denied: print_stderr
+dbg!(result);                               // Denied: dbg_macro
+```
+
+```rust
+// ✓ Good: Secret handling
+use secrecy::{ExposeSecret, Secret};
+
+pub struct ApiConfig {
+    pub endpoint: String,
+    pub api_key: Secret<String>,  // Debug shows Secret([REDACTED])
+}
+
+fn connect(config: &ApiConfig) -> Result<Client> {
+    // Expose only at point of use
+    let header = format!("Bearer {}", config.api_key.expose_secret());
+    Client::new(&config.endpoint, header)
+}
+```
+
+```rust
+// ✗ Bad: Raw secret in logs or fields
+tracing::info!("connecting with key {}", api_key);  // Leaks secret
+```
+
+**Rules:**
+- `unsafe_code = "forbid"` — cannot be overridden even with `#[allow]`
+- All observability through `tracing` crate with structured fields
+- Use `#[instrument]` for automatic span creation on async functions
+- `secrecy::Secret<T>` for API keys, tokens, passwords, connection strings
+- Never implement `Display` or `Serialize` that exposes raw secret values
+- `tracing-subscriber` with `env-filter` and `json` features for production output
+
+**Why:** `unsafe` eliminates a class of memory safety bugs. Structured tracing (vs println) enables filtering, correlation, and machine-parseable logs. Secret wrapping prevents accidental credential exposure in logs, error messages, and debug output.

--- a/profiles/rust-cargo/rust/type-safety-patterns.md
+++ b/profiles/rust-cargo/rust/type-safety-patterns.md
@@ -1,0 +1,79 @@
+# Type Safety Patterns
+
+Use newtypes for domain IDs. Use `uuid::Uuid` v7 for time-ordered identifiers. Leverage the type system to encode invariants at compile time.
+
+```rust
+// ✓ Good: Domain ID newtype
+use uuid::Uuid;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UserId(Uuid);
+
+impl UserId {
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
+
+impl fmt::Display for UserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<Uuid> for UserId {
+    fn from(id: Uuid) -> Self { Self(id) }
+}
+
+impl AsRef<Uuid> for UserId {
+    fn as_ref(&self) -> &Uuid { &self.0 }
+}
+```
+
+```rust
+// ✗ Bad: Raw types for domain concepts
+fn assign_task(user_id: String, task_id: String) { /* easy to swap args */ }
+fn set_amount(cents: i64) { /* is this cents? dollars? */ }
+```
+
+**Enums over strings:**
+
+```rust
+// ✓ Good: Enum for fixed value sets
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+// ✗ Bad: String for fixed values
+pub status: String  // "pending" | "running" — typo-prone, no exhaustiveness check
+```
+
+**Invariant encoding:**
+
+```rust
+// ✓ Good: Type-level invariants
+use std::num::NonZeroU32;
+
+pub struct RetryConfig {
+    pub max_retries: NonZeroU32,  // Cannot be zero by construction
+    pub timeout: Duration,
+}
+```
+
+**Rules:**
+- All domain IDs: newtype wrapping `Uuid`, created via `Uuid::now_v7()`
+- Derive `Debug, Clone, Copy, PartialEq, Eq, Hash` on ID newtypes
+- Implement `Display`, `From<Uuid>`, `AsRef<Uuid>`, `Serialize`/`Deserialize`
+- Use enums (not strings) for any value with a fixed set of variants
+- Use `NonZero*`, `NonEmpty<Vec<T>>`, and similar types to encode invariants
+- Prefer `#[serde(rename_all = "snake_case")]` on enums for consistent serialization
+
+**Why:** Newtypes prevent cross-type confusion at compile time (can't pass `UserId` where `OrderId` is expected). UUIDv7 provides time-ordered, globally-unique identifiers without coordination. Type-level invariants eliminate runtime validation for structurally impossible states.

--- a/profiles/rust-cargo/rust/workspace-lints.md
+++ b/profiles/rust-cargo/rust/workspace-lints.md
@@ -1,0 +1,71 @@
+# Workspace Lints
+
+All lints configured in workspace `[workspace.lints]` and inherited by every crate. No inline `#[allow]` or `#[expect]` attributes anywhere in source code.
+
+```toml
+# ✓ Good: Workspace-level lint configuration
+# Root Cargo.toml
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_debug_implementations = "warn"
+unreachable_pub = "warn"
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# Strict lint groups
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Hard denies — these are never acceptable
+unwrap_used = "deny"
+panic = "deny"
+todo = "deny"
+dbg_macro = "deny"
+print_stdout = "deny"
+print_stderr = "deny"
+unimplemented = "deny"
+
+# Prohibit inline suppression
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+
+# Pedantic overrides (too noisy for practical use)
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+```
+
+```toml
+# ✓ Good: Crate inherits workspace lints
+# crates/myapp-core/Cargo.toml
+[lints]
+workspace = true
+```
+
+```rust
+// ✗ Bad: Inline lint suppression
+#[allow(clippy::too_many_arguments)]  // Denied by allow_attributes
+fn process(a: i32, b: i32, c: i32, d: i32, e: i32) { /* ... */ }
+```
+
+**Relaxing a lint for a specific crate:**
+
+When a crate legitimately needs a lint relaxed (e.g., macro-generated code), override in that crate's `Cargo.toml` with a comment:
+
+```toml
+# crates/myapp-storage/Cargo.toml
+[lints.rust]
+unsafe_code = "forbid"
+# SeaORM DeriveEntityModel requires pub visibility on generated types
+unreachable_pub = "allow"
+```
+
+**Enforcement:**
+- `allow_attributes = "deny"` catches any inline `#[allow()]` in source
+- `just check-suppression` scans for `#[allow(`, `#[expect(`, `#![allow(` across all source directories
+- CI quality-gates job runs `check-suppression`
+
+**Why:** Centralized lint configuration ensures consistent code quality across all crates. Prohibiting inline suppression forces developers to justify relaxations at the crate level where they're visible during review, preventing lint erosion one `#[allow]` at a time.

--- a/profiles/rust-cargo/testing/mandatory-coverage.md
+++ b/profiles/rust-cargo/testing/mandatory-coverage.md
@@ -1,0 +1,51 @@
+# Mandatory Coverage
+
+Coverage is mandatory. Use `cargo-llvm-cov` for measurement. Tests must exercise behavior, not just construction.
+
+```bash
+# ✓ Good: Generate coverage report
+just coverage   # Runs: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
+```
+
+```rust
+// ✓ Good: Test that validates behavior
+#[test]
+fn rejects_expired_token() {
+    let token = Token::new(Utc::now() - Duration::hours(1));
+    let result = validate_token(&token);
+    assert!(matches!(result, Err(AuthError::TokenExpired { .. })));
+}
+```
+
+```rust
+// ✗ Bad: Test that only checks construction
+#[test]
+fn creates_config() {
+    let config = Config::default();
+    assert!(config.is_ok());  // Doesn't test any behavior
+}
+```
+
+**Rules:**
+- `cargo llvm-cov nextest` for coverage measurement (combines nextest with LLVM instrumentation)
+- Output as lcov for CI integration: `--lcov --output-path lcov.info`
+- Upload to Codecov (or equivalent) in CI for tracking trends
+- Tests must exercise:
+  - Happy path with expected output validation
+  - Error cases with specific error variant checks
+  - Edge cases (empty input, boundary values, concurrent access)
+- Coverage is a signal, not a target — 100% line coverage with shallow assertions is worse than 80% with deep behavioral tests
+
+**CI pipeline:**
+
+```yaml
+# GitHub Actions coverage job
+- name: Coverage
+  run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
+- name: Upload
+  uses: codecov/codecov-action@v4
+  with:
+    files: lcov.info
+```
+
+**Why:** Coverage measurement identifies untested code paths before they become production bugs. Behavioral testing (vs construction testing) ensures tests catch regressions in actual logic, not just compilation.

--- a/profiles/rust-cargo/testing/mock-boundaries.md
+++ b/profiles/rust-cargo/testing/mock-boundaries.md
@@ -1,0 +1,80 @@
+# Mock Boundaries
+
+Mock at trait boundaries only. Never mock standard library types or internal implementation details. Use dependency injection.
+
+```rust
+// ✓ Good: Define a trait for the external dependency
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+pub struct SystemClock;
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> { Utc::now() }
+}
+
+// In production: inject SystemClock
+// In tests: inject a mock
+pub struct Scheduler<C: Clock> {
+    clock: C,
+    // ...
+}
+```
+
+```rust
+// ✓ Good: Mock the trait in tests
+struct FixedClock(DateTime<Utc>);
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> { self.0 }
+}
+
+#[test]
+fn schedules_task_at_next_window() {
+    let clock = FixedClock(Utc.with_ymd_and_hms(2025, 1, 15, 9, 0, 0).unwrap());
+    let scheduler = Scheduler::new(clock);
+    let next = scheduler.next_window();
+    assert_eq!(next.hour(), 10);
+}
+```
+
+```rust
+// ✗ Bad: Mocking internals
+// Don't mock reqwest::Client directly — use wiremock instead
+// Don't mock std::fs functions — use a trait abstraction
+// Don't mock private helper functions
+```
+
+**Dependency injection patterns:**
+
+```rust
+// ✓ Good: Constructor injection with impl Trait
+pub fn new_service(
+    store: impl EventStore,
+    notifier: impl Notifier,
+    clock: impl Clock,
+) -> Service { /* ... */ }
+
+// ✓ Good: Constructor injection with dyn Trait (when needed for object safety)
+pub fn new_service(
+    store: Box<dyn EventStore>,
+) -> Service { /* ... */ }
+```
+
+**Per-tier mock rules:**
+- **Unit tests**: mock trait dependencies freely; focus on isolated logic
+- **Integration tests**: use real implementations where possible; wiremock for HTTP, in-memory databases
+- **Builder pattern for test data**: create test fixture factories, not mock objects
+
+```rust
+// ✓ Good: Test data factory
+fn test_dispatch() -> Dispatch {
+    Dispatch {
+        id: DispatchId::new(),
+        status: DispatchStatus::Pending,
+        created_at: Utc::now(),
+        ..Default::default()
+    }
+}
+```
+
+**Why:** Mocking at trait boundaries tests real behavior while isolating external dependencies. Mocking internals creates brittle tests that break on refactoring. Dependency injection keeps production code testable without test-specific conditional logic.

--- a/profiles/rust-cargo/testing/nextest-configuration.md
+++ b/profiles/rust-cargo/testing/nextest-configuration.md
@@ -1,0 +1,54 @@
+# Nextest Configuration
+
+Use `cargo-nextest` for all test execution. Never use `cargo test`. Configure default and CI profiles with timeouts and retry policies.
+
+```bash
+# ✓ Good: Run tests with nextest
+cargo nextest run              # Or: cargo t (alias)
+just test                      # Wrapper that uses nextest
+just test -p myapp-core        # Single crate
+
+# ✗ Bad: Using cargo test
+cargo test                     # Missing: parallel control, timeouts, output filtering
+```
+
+**Required `.config/nextest.toml`:**
+
+```toml
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 2 }
+failure-output = "immediate"
+success-output = "never"
+status-level = "slow"
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+status-level = "all"
+retries = 2
+slow-timeout = { period = "120s", terminate-after = 3 }
+```
+
+**Test groups for serialized database tests:**
+
+```toml
+[test-groups]
+postgres-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = "binary(postgres_integration)"
+test-group = "postgres-integration"
+
+[[profile.ci.overrides]]
+filter = "binary(postgres_integration)"
+test-group = "postgres-integration"
+```
+
+**Rules:**
+- Default profile: 60s slow-timeout, immediate failure output, hide success output
+- CI profile: 120s slow-timeout, 2 retries, no fail-fast (run all tests even after failure)
+- Database integration tests: serialize with `max-threads = 1` to prevent schema race conditions
+- SQLite tests remain parallel (separate database files per test)
+- CI runs with `cargo nextest run --profile ci`
+
+**Why:** Nextest provides parallel execution, structured output, timeout enforcement, and retry policies that `cargo test` lacks. Slow-timeout catches tests that hang or regress in performance. CI retries handle transient failures without masking real bugs.

--- a/profiles/rust-cargo/testing/no-test-skipping.md
+++ b/profiles/rust-cargo/testing/no-test-skipping.md
@@ -1,0 +1,56 @@
+# No Test Skipping
+
+Never use `#[ignore]` on tests. Tests either run and pass or don't exist yet. Zero skips allowed.
+
+```rust
+// ✓ Good: Test that runs and asserts
+#[test]
+fn parses_valid_config() {
+    let config = Config::parse(VALID_TOML).unwrap();
+    assert_eq!(config.max_retries, 3);
+}
+```
+
+```rust
+// ✗ Bad: Ignored test
+#[test]
+#[ignore]  // "too slow" — fix it or delete it
+fn test_full_pipeline() { /* ... */ }
+```
+
+```rust
+// ✗ Bad: Conditional skip
+#[test]
+fn test_with_postgres() {
+    if std::env::var("DATABASE_URL").is_err() {
+        return;  // Silent skip — hides untested code
+    }
+    // ...
+}
+```
+
+```rust
+// ✗ Bad: Feature-gated test exclusion
+#[cfg(feature = "expensive-tests")]
+#[test]
+fn test_expensive_operation() { /* ... */ }
+```
+
+**Rules:**
+- No `#[ignore]` attribute on any test
+- No early `return` based on environment detection
+- No feature-gated test exclusion (use separate test binaries or nextest filters instead)
+- Flaky tests: make deterministic or delete — never ignore
+- Slow tests: optimize or move to integration tier — never skip
+
+**Handling external dependencies:**
+- Database tests: use in-memory SQLite by default, gate Postgres behind a feature + separate CI job
+- HTTP tests: use `wiremock` for local mock servers
+- Time-dependent tests: inject a `Clock` trait, mock in tests
+
+**Enforcement:**
+- `just check-suppression` greps source directories for `#[ignore]`
+- CI quality-gates job fails on any `#[ignore]` occurrence
+- Code review catches conditional skips
+
+**Why:** Skipped tests are invisible failures. They accumulate silently, giving false confidence in test coverage. A test that doesn't run provides zero value and should either be fixed or removed.

--- a/profiles/rust-cargo/testing/test-timing-rules.md
+++ b/profiles/rust-cargo/testing/test-timing-rules.md
@@ -1,0 +1,56 @@
+# Test Timing Rules
+
+Enforce timing limits per tier. Unit tests under 250ms with no I/O. Integration tests under 5 seconds. Nextest slow-timeout catches violators.
+
+```rust
+// ✓ Good: Fast unit test — pure logic, no I/O
+#[test]
+fn validates_cron_expression() {
+    let result = CronExpr::parse("0 9 * * 1-5");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().next_fire().weekday(), Weekday::Mon);
+}
+// Runs in <1ms
+```
+
+```rust
+// ✗ Bad: Unit test with hidden I/O
+#[test]
+fn loads_config_from_disk() {
+    let config = Config::from_file("test_config.toml");  // File I/O in unit test
+    assert!(config.is_ok());
+}
+// Slow, flaky, depends on filesystem state
+```
+
+```rust
+// ✓ Good: Integration test with real service, bounded time
+#[tokio::test]
+async fn appends_event_to_store() {
+    let store = EventStore::in_memory().await.unwrap();
+    store.append(test_event()).await.unwrap();
+    let events = store.replay_all().await.unwrap();
+    assert_eq!(events.len(), 1);
+}
+// Runs in ~50ms with in-memory SQLite
+```
+
+**Timing limits:**
+
+| Tier | Max Time | I/O Allowed | Network Allowed |
+|------|----------|-------------|-----------------|
+| Unit | 250ms | No | No |
+| Integration | 5s | Yes | Yes (wiremock/testcontainers) |
+| Doc tests | 250ms | No | No |
+
+**Nextest enforcement:**
+- Default profile: `slow-timeout = { period = "60s", terminate-after = 2 }` — flags slow tests, kills after 2 periods
+- CI profile: `slow-timeout = { period = "120s", terminate-after = 3 }` — more lenient for CI runners
+
+**Refactoring slow tests:**
+- Extract I/O behind a trait, mock in unit tests
+- Use in-memory databases instead of file-backed
+- Reduce test data size while maintaining coverage
+- Parallelize independent assertions
+
+**Why:** Fast tests enable tight feedback loops. A test suite that runs in seconds gets run frequently; one that takes minutes gets skipped. Timing limits prevent gradual test suite slowdown that erodes developer productivity.

--- a/profiles/rust-cargo/testing/test-tooling.md
+++ b/profiles/rust-cargo/testing/test-tooling.md
@@ -1,0 +1,73 @@
+# Test Tooling
+
+Use `insta` for snapshot testing, `proptest` for property-based testing, and `wiremock` for HTTP mocking. Each tool has a specific purpose — use the right one.
+
+**Snapshot testing with insta:**
+
+```rust
+// ✓ Good: Snapshot test for complex output
+use insta::assert_yaml_snapshot;
+
+#[test]
+fn serializes_dispatch_event() {
+    let event = DispatchEvent::started(agent_id, task_id);
+    assert_yaml_snapshot!(event);
+}
+// Snapshot stored in snapshots/module__serializes_dispatch_event.snap
+// Review with: cargo insta review
+```
+
+**Property-based testing with proptest:**
+
+```rust
+// ✓ Good: Roundtrip property test
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn json_roundtrip(event in arb_event()) {
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: Event = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(event, decoded);
+    }
+}
+
+// Define strategies for domain types
+fn arb_event() -> impl Strategy<Value = Event> {
+    (arb_event_kind(), any::<u64>()).prop_map(|(kind, seq)| {
+        Event { kind, sequence: seq }
+    })
+}
+```
+
+**HTTP mocking with wiremock:**
+
+```rust
+// ✓ Good: Mock external API with wiremock
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::{method, path};
+
+#[tokio::test]
+async fn fetches_remote_config() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/config"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(test_config()))
+        .mount(&server)
+        .await;
+
+    let client = ConfigClient::new(&server.uri());
+    let config = client.fetch().await.unwrap();
+    assert_eq!(config.version, 2);
+}
+```
+
+**Rules:**
+- `insta`: use for serialized output, error messages, complex struct snapshots
+- `proptest`: use for parsing, serialization roundtrips, invariant validation
+- `wiremock`: use for HTTP mocking — prefer over trait-mocking for HTTP clients
+- `testcontainers`: use for database integration tests against real Postgres
+- Review insta snapshots with `cargo insta review` before committing
+- Define proptest strategies for all domain types used in property tests
+
+**Why:** Each tool targets a specific testing need. Snapshot tests catch unexpected output changes. Property tests find edge cases humans miss. wiremock tests HTTP integration without flaky network dependencies.

--- a/profiles/rust-cargo/testing/three-tier-test-structure.md
+++ b/profiles/rust-cargo/testing/three-tier-test-structure.md
@@ -1,0 +1,72 @@
+# Three-Tier Test Structure
+
+Tests organized into unit, integration, and doc tests following Rust's native test layout. Each tier has clear boundaries and timing limits.
+
+```
+crates/myapp-core/
+├── src/
+│   ├── dispatch.rs           # Source code
+│   └── dispatch.rs           # Unit tests at bottom: #[cfg(test)] mod tests
+├── tests/
+│   ├── dispatch_lifecycle.rs  # Integration tests: full public API
+│   └── common/
+│       └── mod.rs            # Shared test utilities
+```
+
+**Tier definitions:**
+
+**Unit tests** (`#[cfg(test)] mod tests` in source files):
+- Fast: <250ms per test
+- Mocks allowed and encouraged for external dependencies
+- No I/O, no network, no database
+- Test isolated logic, algorithms, and state transitions
+- Colocated with the code they test
+
+```rust
+// ✓ Good: Unit test at bottom of source file
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_dispatch_command() {
+        let cmd = DispatchCommand::builder()
+            .agent_id(AgentId::new())
+            .build();
+        assert!(cmd.validate().is_ok());
+    }
+}
+```
+
+**Integration tests** (`tests/` directory):
+- Moderate speed: <5s per test
+- Real services via wiremock or testcontainers
+- Test the crate's public API as an external consumer would
+- May use shared test utilities from `tests/common/mod.rs`
+
+```rust
+// ✓ Good: Integration test in tests/ directory
+// tests/event_append.rs
+use myapp_store::EventStore;
+
+#[tokio::test]
+async fn appends_and_replays_events() {
+    let store = EventStore::in_memory().await.unwrap();
+    store.append(test_event()).await.unwrap();
+    let events = store.replay(stream_id).await.unwrap();
+    assert_eq!(events.len(), 1);
+}
+```
+
+**Doc tests** (`///` examples in public API):
+- Minimal, focused on API usage
+- Must compile and run
+- Not a substitute for unit or integration tests
+
+**Rules:**
+- Unit tests live in `#[cfg(test)]` modules colocated with source (Rust convention)
+- Integration tests live in `tests/` at the crate root
+- Never place business logic in test helpers
+- Mirror module structure in integration test file naming
+
+**Why:** Rust's native test layout provides natural tier separation. Colocated unit tests keep test code close to the code it validates. Integration tests in `tests/` exercise the public API boundary, catching issues that unit tests miss.


### PR DESCRIPTION
## Summary
This finalizes the lane-0.3 store branch for merge into `rewrite/tanren-2-foundation` and adds the missing handoff material for lane 0.4.

## What changed
- hardens `tanren-store` invariants around event/payload validation, dispatch status transitions, dequeue semantics, and projection consistency
- adds integrity and dequeue-index migrations plus focused SQLite/Postgres regression coverage for audit follow-ups
- gates direct event append methods behind `tanren-store/test-hooks` so lane 0.4 consumes the store through the intended transactional APIs
- strengthens local/CI quality gates with crate-layering checks and consistent test-hook coverage
- adds `docs/rewrite/ORIENTATION.md`, `LANE-0.4-BRIEF.md`, `LANE-0.4-AUDIT.md`, and updates `docs/rewrite/tasks/README.md` so lane 0.4 can pick up immediately after merge
- adds the `profiles/rust-cargo/` standards profile that captures the Rust workspace conventions used by this rewrite

## Readiness assessment
I audited the implementation for lane-0.4 pickup and did not find a blocker.
- `tanren-store` now exposes a cleaner public surface for downstream callers
- invariant checks that used to be implicit are now explicit and regression-tested
- the coordinator/handoff gap for lane 0.4 is closed with a concise implementation brief and audit brief
- the branch is ready to merge into the rewrite integration branch

## Validation
- `just ci`

## Impact
Merging this PR should let lane 0.4 start from a stable store boundary and a complete handoff package, instead of depending on undocumented coordinator knowledge.