### PR TITLE
feat(runtime): harden lane 1.1 contract and redaction safeguards

### DIFF
--- a/.claude/commands/audit-spec.md
+++ b/.claude/commands/audit-spec.md
@@ -23,6 +23,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - audit.md (spec-scope narrative body)
+- behavior-map.md
 ---
 
 # audit-spec
@@ -40,23 +41,34 @@ spec) or `defer` (backlog for future specs via `triage-audits`).
 - Relevant standards (for context; compliance is `adhere-spec`).
 - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — effective pillar set for spec scope.
 - The spec's non-negotiables (from spec frontmatter).
+- `behavior-map.md`, linked scenarios, and demo outcomes.
 
 ## Responsibilities
 
 1. Review the full spec's diff against the spec's acceptance
    criteria, non-negotiables, and pillar expectations.
-2. For each finding: `add_finding` with severity, title,
+2. Verify behavior coverage integrity at spec scope:
+   - every shaped behavior is mapped
+   - mapped scenarios exist and pass
+   - deprecated behaviors are intentionally handled
+3. Verify mutation evidence quality at spec scope:
+   surviving mutants are triaged and mapped to concrete follow-up
+   actions when needed.
+4. Verify coverage-gap interpretation quality:
+   uncovered paths are classified as missing scenario vs dead/non-
+   scenario support code.
+5. For each finding: `add_finding` with severity, title,
    affected files/lines, source phase `audit-spec`, the pillar it
    relates to, and `attached_task` if it scopes to one. Cross-
    reference signposts to avoid duplicating known-deferred issues.
-3. For each applicable pillar: `record_rubric_score(pillar, score,
+6. For each applicable pillar: `record_rubric_score(pillar, score,
    rationale, supporting_finding_ids)`. Same invariants as
    `audit-task` (target 10, passing 7, findings required for gaps,
    `fix_now` required below passing).
-4. For each non-negotiable: `record_non_negotiable_compliance(name,
+7. For each non-negotiable: `record_non_negotiable_compliance(name,
    status, rationale)`.
-5. Write reasoning into the `audit.md` body.
-6. Call `report_phase_outcome`:
+8. Write reasoning into the `audit.md` body.
+9. Call `report_phase_outcome`:
    - `complete` if every pillar ≥ passing, every non-negotiable
      `pass`, demo passed, zero unaddressed `fix_now`.
    - `blocked` otherwise. Orchestrator materializes new tasks from

--- a/.claude/commands/audit-task.md
+++ b/.claude/commands/audit-task.md
@@ -21,6 +21,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - audit.md (task-scope narrative body)
+- behavior-map.md
 ---
 
 # audit-task
@@ -41,24 +42,33 @@ the orchestrator materializes new tasks from your `fix_now` findings.
   phase — `adhere-task`).
 - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — the effective pillar set (task scope).
 - Relevant signposts.
+- `behavior-map.md` and linked scenarios.
 
 ## Responsibilities
 
 1. Read the diff in full. Understand what changed and why.
-2. For each finding: call `add_finding` with severity
+2. Audit behavior traceability:
+   - behavior changes are mapped in `behavior-map.md`
+   - mapped scenarios exist and reflect implemented behavior
+   - scenario quality is adequate for claimed behavior
+3. Audit mutation quality evidence for touched behavior scope:
+   surviving mutants, if any, are explained or addressed.
+4. Audit coverage interpretation quality:
+   uncovered code is discussed as missing scenario vs dead/non-scenario code.
+5. For each finding: call `add_finding` with severity
    `fix_now` / `defer` / `note` / `question`, a descriptive title,
    affected files and line numbers, and the pillar it relates to.
    Cross-reference signposts: do not re-surface issues an existing
    signpost records as `deferred` or `architectural_constraint`.
-3. For each applicable pillar: call `record_rubric_score(pillar,
+6. For each applicable pillar: call `record_rubric_score(pillar,
    score, rationale, supporting_finding_ids)`.
    - Score 1–10 (target 10, passing 7).
    - `score < target` requires at least one linked finding.
    - `score < passing` requires at least one linked `fix_now`
      finding. Tool will reject invalid linkage.
-4. Write narrative reasoning into the body of `audit.md`
+7. Write narrative reasoning into the body of `audit.md`
    (task-scope section).
-5. Call `report_phase_outcome`:
+8. Call `report_phase_outcome`:
    - `complete` if all scores ≥ passing and zero `fix_now` findings
      remain. The `TaskAudited` guard will be recorded.
    - `blocked` if any `fix_now` findings are produced. The orchestrator

--- a/.claude/commands/discover-standards.md
+++ b/.claude/commands/discover-standards.md
@@ -23,7 +23,8 @@ produces_evidence:
 
 Interactively extract tribal knowledge from the codebase and codify
 it as standards files under `tanren/standards`. Each standard is
-one rule with clear applicability metadata.
+one rule with clear applicability metadata. Prefer behavior-first
+standards where testing strategy is in scope.
 
 ## Inputs (from your dispatch)
 
@@ -36,15 +37,20 @@ one rule with clear applicability metadata.
    none is supplied.
 2. Read representative files. Identify unusual, opinionated, or
    tribal patterns.
-3. For each candidate pattern the user selects, hold a full loop:
+3. If testing standards are in scope, explicitly probe for BDD
+   requirements:
+   - behavior inventory expectations
+   - scenario traceability expectations
+   - mutation and coverage interpretation policies
+4. For each candidate pattern the user selects, hold a full loop:
    ask clarifying questions one at a time (no batching), draft the
    standard, confirm, write the file. Filename:
    `tanren/standards/{category}/{kebab-slug}.md`.
-4. Frontmatter required on every standard: `name`, `category`,
+5. Frontmatter required on every standard: `name`, `category`,
    `applies_to` (globs), `applies_to_languages`,
    `applies_to_domains`, `importance` (low/medium/high/critical).
-5. Update `tanren/standards/index.yml` to include the new entry.
-6. `report_phase_outcome("complete", <N standards authored>)`.
+6. Update `tanren/standards/index.yml` to include the new entry.
+7. `report_phase_outcome("complete", <N standards authored>)`.
 
 ## Out of scope
 

--- a/.claude/commands/do-task.md
+++ b/.claude/commands/do-task.md
@@ -25,6 +25,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - signposts.md (narrative body)
+- behavior-map.md
 ---
 
 # do-task
@@ -42,25 +43,30 @@ workflow progression are Tanren-code's job.
 - The spec folder path.
 - Relevant standards (injected separately by Tanren-code; treat as
   context, not edits).
+- Existing `behavior-map.md` mapping.
 
 ## Responsibilities
 
 1. Call `start_task(task_id)` at session start (if not already
    transitioned).
 2. Implement only the supplied task. Do not touch unrelated files.
-3. Run `just check` before signalling complete. If
+3. If the task changes behavior, update `behavior-map.md` and the
+   mapped scenario files in the same task session.
+4. Run `just check` before signalling complete. If
    it fails on trivial issues (formatting, imports), self-fix and
    re-run. If it fails persistently, stop: emit a signpost and
    report `blocked` (Tanren-code will dispatch `investigate`).
-4. Record signposts for non-obvious issues you hit or decisions that
+5. Record signposts for non-obvious issues you hit or decisions that
    would surprise a future reader. Each signpost needs concrete
    evidence — error messages, file paths, command output.
-5. On successful implementation: call
+6. Treat behavior-changing code without behavior-map and scenario
+   updates as incomplete work.
+7. On successful implementation: call
    `complete_task(task_id, evidence_refs)` with the relevant file
    paths / commit refs. The `Implemented` transition is recorded by
    Tanren-code; the gate / audit / adherence guards run in parallel
    afterward.
-6. Call `report_phase_outcome("complete", …)`.
+8. Call `report_phase_outcome("complete", …)`.
 
 ## Verification
 

--- a/.claude/commands/investigate.md
+++ b/.claude/commands/investigate.md
@@ -52,23 +52,28 @@ resort — escalate to a blocker for `resolve-blockers`.
 
 1. Read the failure evidence in full. Distinguish root causes from
    symptoms. Do not modify code; this phase is read-only.
-2. Identify each root cause. For each, choose one action:
+2. Classify root causes explicitly. Include BDD-specific classes when
+   applicable:
+   - missing scenario for claimed behavior
+   - weak scenario (mutation survivor)
+   - behavior-map drift (implementation and mapping out of sync)
+   - acceptance criteria ambiguity
+   - environment drift
+3. For each root cause, choose one action:
    - **Task scope was wrong:** `revise_task(task_id,
-     revised_description, revised_acceptance, reason)`. Use this
-     when the acceptance criteria were ambiguous or incomplete.
+     revised_description, revised_acceptance, reason)`.
    - **A new fix scope is required:** `create_task(title,
      description, origin: Investigation { source_phase,
      source_task, loop_index }, acceptance_criteria)`.
    - **Task is infeasible:** `abandon_task(task_id, reason,
      replacements)` with at least one replacement.
    - **Cannot resolve autonomously:** `escalate_to_blocker(reason,
-     options)`. Use this only after attempting diagnosis and only
-     when a human judgment call is genuinely needed.
-3. Add `note` / `question` findings for observations that are not
+     options)`.
+4. Add `note` / `question` findings for observations that are not
    immediately actionable but might be useful to the next phase.
-4. Write a narrative for `investigation-report.json` (tool-generated
+5. Write a narrative for `investigation-report.json` (tool-generated
    from your calls; the narrative field is your prose).
-5. Call `report_phase_outcome("complete", <one-line summary>)`.
+6. Call `report_phase_outcome("complete", <one-line summary>)`.
 
 ## Verification
 

--- a/.claude/commands/run-demo.md
+++ b/.claude/commands/run-demo.md
@@ -22,35 +22,40 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - demo.md (narrative body)
+- behavior-map.md
 ---
 
 # run-demo
 
 ## Purpose
 
-Execute the demo steps authored in `shape-spec`. Record typed
-results per step. Emit findings for any observable that fails.
+Execute the demo steps authored in `shape-spec` as a user-visible
+behavior walkthrough. Demo execution is not a test-runner proxy.
+Record typed results per step and emit findings for failed observables.
 
 ## Inputs (from your dispatch)
 
 - The spec folder and its `demo.md` frontmatter (steps with
   `RUN` / `SKIP` modes, descriptions, expected observables).
 - The supplied demo environment (already probed by shape-spec).
+- `behavior-map.md` for step-to-behavior references.
 
 ## Responsibilities
 
 1. Execute every `RUN` step. `SKIP` steps are not executed; they do
    not contribute to pass/fail.
-2. For each executed step: call `append_demo_result(step_id,
+2. Each executed step must reference behavior IDs and expected
+   observables from the behavior map.
+3. For each executed step: call `append_demo_result(step_id,
    status, observed)` with `pass` or `fail` and the observed
    outcome.
-3. For each failure: call `add_finding` with `source_phase:
+4. For each failure: call `add_finding` with `source_phase:
    run-demo`, descriptive title, affected files (if applicable), and
-   severity `fix_now`. If the failure reveals a test gap (tests pass
-   but demo fails), add a `fix_now` finding that describes the
-   missing test.
-4. Add signposts for non-obvious root causes.
-5. Call `report_phase_outcome`:
+   severity `fix_now`. If the failure reveals a scenario gap (tests
+   pass but demo fails), add a `fix_now` finding describing the
+   missing or weak scenario.
+5. Add signposts for non-obvious root causes.
+6. Call `report_phase_outcome`:
    - `complete` if every `RUN` step passes and at least one `RUN`
      step exists.
    - `blocked` if any `RUN` step fails. Orchestrator will dispatch

--- a/.claude/commands/shape-spec.md
+++ b/.claude/commands/shape-spec.md
@@ -27,6 +27,7 @@ required_capabilities:
 produces_evidence:
 - spec.md (narrative body)
 - demo.md (narrative body)
+- behavior-map.md
 ---
 
 # shape-spec
@@ -35,8 +36,9 @@ produces_evidence:
 
 Shape a new spec interactively with the user. Establish scope,
 non-negotiables, acceptance criteria, a runnable demo plan, and an
-initial task breakdown. You do **not** create issues, branches, or
-PRs; Tanren-code owns all workflow mechanics.
+initial task breakdown. Behavior inventory is mandatory: define new,
+modified, and deprecated behaviors with stable behavior IDs and map
+them to scenarios and demo steps.
 
 ## Inputs (from your dispatch)
 
@@ -50,15 +52,20 @@ PRs; Tanren-code owns all workflow mechanics.
    acceptance criteria. Ask clarifying questions until there is zero
    ambiguity.
 2. Derive non-negotiables (hard constraints that must always hold).
-3. Design a runnable demo plan: concrete steps, each tagged `RUN`
-   or `SKIP`, with explicit expected observables. Probe the demo
-   environment *before* committing `RUN` tags — if a connection is
-   unavailable, mark `SKIP` with the reason.
-4. Break the work into ordered tasks with clear acceptance criteria.
-   Tasks should be independently verifiable.
-5. Emit every structured fact via tools (see below). Author the
-   narrative body of `spec.md` and the narrative portions of
-   `demo.md` as supporting prose.
+3. Build a behavior inventory with stable IDs for every new,
+   modified, and deprecated behavior in scope.
+4. Design a runnable demo plan: concrete steps, each tagged `RUN`
+   or `SKIP`, with explicit expected observables and linked behavior
+   IDs. Probe the demo environment *before* committing `RUN` tags —
+   if a connection is unavailable, mark `SKIP` with the reason.
+5. Create `behavior-map.md` in the spec folder, mapping each
+   behavior ID to planned feature/scenario IDs and demo step IDs.
+6. Break the work into ordered tasks with clear acceptance criteria.
+   Tasks should be independently verifiable and traceable to behavior
+   IDs.
+7. Emit every structured fact via tools (see below). Author the
+   narrative body of `spec.md`, `demo.md`, and `behavior-map.md` as
+   supporting prose.
 
 ## Emitting results
 
@@ -76,12 +83,9 @@ Call in this order:
    external GitHub issues
 6. `set_spec_base_branch` with the branch this spec will target
 7. `create_task` per planned task with stable ordering, typed
-   `origin: ShapeSpec`, and explicit acceptance criteria
+   `origin: ShapeSpec`, explicit acceptance criteria, and behavior
+   coverage intent
 8. `report_phase_outcome("complete", <short summary>)`
-
-The narrative body of `spec.md` captures motivation, background, and
-the scope conversation. The narrative body of `demo.md` captures the
-walkthrough story.
 
 ⚠ ORCHESTRATOR-OWNED ARTIFACT — DO NOT EDIT.
 plan.md and progress.json are generated from the typed task store.

--- a/.claude/commands/walk-spec.md
+++ b/.claude/commands/walk-spec.md
@@ -17,24 +17,26 @@ required_capabilities:
 - task.create
 - task.read
 - phase.outcome
-produces_evidence: []
+produces_evidence:
+- behavior-map.md
 ---
 
 # walk-spec
 
 ## Purpose
 
-The user's acceptance checkpoint. Walk through the demo live, confirm
-acceptance criteria are met, surface any last concerns, and signal
-completion. Tanren-code handles `pull request` creation, roadmap
-updates, and `GitHub` communication after you signal
-complete.
+The user's acceptance checkpoint. Walk through behavior outcomes live,
+confirm acceptance criteria are met, surface any last concerns, and
+signal completion. Tanren-code handles `pull request` creation,
+roadmap updates, and `GitHub` communication after you
+signal complete.
 
 ## Inputs (from your dispatch)
 
 - The fully-implemented spec (all tasks Complete, audits passed,
   demo passed).
-- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`.
+- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`, and
+  `behavior-map.md`.
 
 ## Responsibilities
 
@@ -43,8 +45,8 @@ complete.
    `report_phase_outcome("error", …)` immediately — walk-spec is
    not the place to fix unfinished work.
 2. Run `just ci` and confirm green.
-3. Present an implementation summary + acceptance-criteria proof to
-   the user. Keep it concise; the user has the diff and can read it.
+3. Present an implementation summary in behavior terms:
+   behavior IDs, mapped scenarios, and demo evidence.
 4. Walk through the demo step-by-step. For each step: explain,
    execute, show result, confirm before next.
 5. If a demo step fails during the walkthrough: STOP. Call

--- a/.codex/skills/audit-spec/SKILL.md
+++ b/.codex/skills/audit-spec/SKILL.md
@@ -24,6 +24,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - audit.md (spec-scope narrative body)
+- behavior-map.md
 ---
 
 # audit-spec
@@ -41,23 +42,34 @@ spec) or `defer` (backlog for future specs via `triage-audits`).
 - Relevant standards (for context; compliance is `adhere-spec`).
 - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — effective pillar set for spec scope.
 - The spec's non-negotiables (from spec frontmatter).
+- `behavior-map.md`, linked scenarios, and demo outcomes.
 
 ## Responsibilities
 
 1. Review the full spec's diff against the spec's acceptance
    criteria, non-negotiables, and pillar expectations.
-2. For each finding: `add_finding` with severity, title,
+2. Verify behavior coverage integrity at spec scope:
+   - every shaped behavior is mapped
+   - mapped scenarios exist and pass
+   - deprecated behaviors are intentionally handled
+3. Verify mutation evidence quality at spec scope:
+   surviving mutants are triaged and mapped to concrete follow-up
+   actions when needed.
+4. Verify coverage-gap interpretation quality:
+   uncovered paths are classified as missing scenario vs dead/non-
+   scenario support code.
+5. For each finding: `add_finding` with severity, title,
    affected files/lines, source phase `audit-spec`, the pillar it
    relates to, and `attached_task` if it scopes to one. Cross-
    reference signposts to avoid duplicating known-deferred issues.
-3. For each applicable pillar: `record_rubric_score(pillar, score,
+6. For each applicable pillar: `record_rubric_score(pillar, score,
    rationale, supporting_finding_ids)`. Same invariants as
    `audit-task` (target 10, passing 7, findings required for gaps,
    `fix_now` required below passing).
-4. For each non-negotiable: `record_non_negotiable_compliance(name,
+7. For each non-negotiable: `record_non_negotiable_compliance(name,
    status, rationale)`.
-5. Write reasoning into the `audit.md` body.
-6. Call `report_phase_outcome`:
+8. Write reasoning into the `audit.md` body.
+9. Call `report_phase_outcome`:
    - `complete` if every pillar ≥ passing, every non-negotiable
      `pass`, demo passed, zero unaddressed `fix_now`.
    - `blocked` otherwise. Orchestrator materializes new tasks from

--- a/.codex/skills/audit-task/SKILL.md
+++ b/.codex/skills/audit-task/SKILL.md
@@ -22,6 +22,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - audit.md (task-scope narrative body)
+- behavior-map.md
 ---
 
 # audit-task
@@ -42,24 +43,33 @@ the orchestrator materializes new tasks from your `fix_now` findings.
   phase — `adhere-task`).
 - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — the effective pillar set (task scope).
 - Relevant signposts.
+- `behavior-map.md` and linked scenarios.
 
 ## Responsibilities
 
 1. Read the diff in full. Understand what changed and why.
-2. For each finding: call `add_finding` with severity
+2. Audit behavior traceability:
+   - behavior changes are mapped in `behavior-map.md`
+   - mapped scenarios exist and reflect implemented behavior
+   - scenario quality is adequate for claimed behavior
+3. Audit mutation quality evidence for touched behavior scope:
+   surviving mutants, if any, are explained or addressed.
+4. Audit coverage interpretation quality:
+   uncovered code is discussed as missing scenario vs dead/non-scenario code.
+5. For each finding: call `add_finding` with severity
    `fix_now` / `defer` / `note` / `question`, a descriptive title,
    affected files and line numbers, and the pillar it relates to.
    Cross-reference signposts: do not re-surface issues an existing
    signpost records as `deferred` or `architectural_constraint`.
-3. For each applicable pillar: call `record_rubric_score(pillar,
+6. For each applicable pillar: call `record_rubric_score(pillar,
    score, rationale, supporting_finding_ids)`.
    - Score 1–10 (target 10, passing 7).
    - `score < target` requires at least one linked finding.
    - `score < passing` requires at least one linked `fix_now`
      finding. Tool will reject invalid linkage.
-4. Write narrative reasoning into the body of `audit.md`
+7. Write narrative reasoning into the body of `audit.md`
    (task-scope section).
-5. Call `report_phase_outcome`:
+8. Call `report_phase_outcome`:
    - `complete` if all scores ≥ passing and zero `fix_now` findings
      remain. The `TaskAudited` guard will be recorded.
    - `blocked` if any `fix_now` findings are produced. The orchestrator

--- a/.codex/skills/discover-standards/SKILL.md
+++ b/.codex/skills/discover-standards/SKILL.md
@@ -24,7 +24,8 @@ produces_evidence:
 
 Interactively extract tribal knowledge from the codebase and codify
 it as standards files under `tanren/standards`. Each standard is
-one rule with clear applicability metadata.
+one rule with clear applicability metadata. Prefer behavior-first
+standards where testing strategy is in scope.
 
 ## Inputs (from your dispatch)
 
@@ -37,15 +38,20 @@ one rule with clear applicability metadata.
    none is supplied.
 2. Read representative files. Identify unusual, opinionated, or
    tribal patterns.
-3. For each candidate pattern the user selects, hold a full loop:
+3. If testing standards are in scope, explicitly probe for BDD
+   requirements:
+   - behavior inventory expectations
+   - scenario traceability expectations
+   - mutation and coverage interpretation policies
+4. For each candidate pattern the user selects, hold a full loop:
    ask clarifying questions one at a time (no batching), draft the
    standard, confirm, write the file. Filename:
    `tanren/standards/{category}/{kebab-slug}.md`.
-4. Frontmatter required on every standard: `name`, `category`,
+5. Frontmatter required on every standard: `name`, `category`,
    `applies_to` (globs), `applies_to_languages`,
    `applies_to_domains`, `importance` (low/medium/high/critical).
-5. Update `tanren/standards/index.yml` to include the new entry.
-6. `report_phase_outcome("complete", <N standards authored>)`.
+6. Update `tanren/standards/index.yml` to include the new entry.
+7. `report_phase_outcome("complete", <N standards authored>)`.
 
 ## Out of scope
 

--- a/.codex/skills/do-task/SKILL.md
+++ b/.codex/skills/do-task/SKILL.md
@@ -26,6 +26,7 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - signposts.md (narrative body)
+- behavior-map.md
 ---
 
 # do-task
@@ -43,25 +44,30 @@ workflow progression are Tanren-code's job.
 - The spec folder path.
 - Relevant standards (injected separately by Tanren-code; treat as
   context, not edits).
+- Existing `behavior-map.md` mapping.
 
 ## Responsibilities
 
 1. Call `start_task(task_id)` at session start (if not already
    transitioned).
 2. Implement only the supplied task. Do not touch unrelated files.
-3. Run `just check` before signalling complete. If
+3. If the task changes behavior, update `behavior-map.md` and the
+   mapped scenario files in the same task session.
+4. Run `just check` before signalling complete. If
    it fails on trivial issues (formatting, imports), self-fix and
    re-run. If it fails persistently, stop: emit a signpost and
    report `blocked` (Tanren-code will dispatch `investigate`).
-4. Record signposts for non-obvious issues you hit or decisions that
+5. Record signposts for non-obvious issues you hit or decisions that
    would surprise a future reader. Each signpost needs concrete
    evidence — error messages, file paths, command output.
-5. On successful implementation: call
+6. Treat behavior-changing code without behavior-map and scenario
+   updates as incomplete work.
+7. On successful implementation: call
    `complete_task(task_id, evidence_refs)` with the relevant file
    paths / commit refs. The `Implemented` transition is recorded by
    Tanren-code; the gate / audit / adherence guards run in parallel
    afterward.
-6. Call `report_phase_outcome("complete", …)`.
+8. Call `report_phase_outcome("complete", …)`.
 
 ## Verification
 

--- a/.codex/skills/investigate/SKILL.md
+++ b/.codex/skills/investigate/SKILL.md
@@ -53,23 +53,28 @@ resort — escalate to a blocker for `resolve-blockers`.
 
 1. Read the failure evidence in full. Distinguish root causes from
    symptoms. Do not modify code; this phase is read-only.
-2. Identify each root cause. For each, choose one action:
+2. Classify root causes explicitly. Include BDD-specific classes when
+   applicable:
+   - missing scenario for claimed behavior
+   - weak scenario (mutation survivor)
+   - behavior-map drift (implementation and mapping out of sync)
+   - acceptance criteria ambiguity
+   - environment drift
+3. For each root cause, choose one action:
    - **Task scope was wrong:** `revise_task(task_id,
-     revised_description, revised_acceptance, reason)`. Use this
-     when the acceptance criteria were ambiguous or incomplete.
+     revised_description, revised_acceptance, reason)`.
    - **A new fix scope is required:** `create_task(title,
      description, origin: Investigation { source_phase,
      source_task, loop_index }, acceptance_criteria)`.
    - **Task is infeasible:** `abandon_task(task_id, reason,
      replacements)` with at least one replacement.
    - **Cannot resolve autonomously:** `escalate_to_blocker(reason,
-     options)`. Use this only after attempting diagnosis and only
-     when a human judgment call is genuinely needed.
-3. Add `note` / `question` findings for observations that are not
+     options)`.
+4. Add `note` / `question` findings for observations that are not
    immediately actionable but might be useful to the next phase.
-4. Write a narrative for `investigation-report.json` (tool-generated
+5. Write a narrative for `investigation-report.json` (tool-generated
    from your calls; the narrative field is your prose).
-5. Call `report_phase_outcome("complete", <one-line summary>)`.
+6. Call `report_phase_outcome("complete", <one-line summary>)`.
 
 ## Verification
 

--- a/.codex/skills/run-demo/SKILL.md
+++ b/.codex/skills/run-demo/SKILL.md
@@ -23,35 +23,40 @@ required_capabilities:
 - phase.outcome
 produces_evidence:
 - demo.md (narrative body)
+- behavior-map.md
 ---
 
 # run-demo
 
 ## Purpose
 
-Execute the demo steps authored in `shape-spec`. Record typed
-results per step. Emit findings for any observable that fails.
+Execute the demo steps authored in `shape-spec` as a user-visible
+behavior walkthrough. Demo execution is not a test-runner proxy.
+Record typed results per step and emit findings for failed observables.
 
 ## Inputs (from your dispatch)
 
 - The spec folder and its `demo.md` frontmatter (steps with
   `RUN` / `SKIP` modes, descriptions, expected observables).
 - The supplied demo environment (already probed by shape-spec).
+- `behavior-map.md` for step-to-behavior references.
 
 ## Responsibilities
 
 1. Execute every `RUN` step. `SKIP` steps are not executed; they do
    not contribute to pass/fail.
-2. For each executed step: call `append_demo_result(step_id,
+2. Each executed step must reference behavior IDs and expected
+   observables from the behavior map.
+3. For each executed step: call `append_demo_result(step_id,
    status, observed)` with `pass` or `fail` and the observed
    outcome.
-3. For each failure: call `add_finding` with `source_phase:
+4. For each failure: call `add_finding` with `source_phase:
    run-demo`, descriptive title, affected files (if applicable), and
-   severity `fix_now`. If the failure reveals a test gap (tests pass
-   but demo fails), add a `fix_now` finding that describes the
-   missing test.
-4. Add signposts for non-obvious root causes.
-5. Call `report_phase_outcome`:
+   severity `fix_now`. If the failure reveals a scenario gap (tests
+   pass but demo fails), add a `fix_now` finding describing the
+   missing or weak scenario.
+5. Add signposts for non-obvious root causes.
+6. Call `report_phase_outcome`:
    - `complete` if every `RUN` step passes and at least one `RUN`
      step exists.
    - `blocked` if any `RUN` step fails. Orchestrator will dispatch

--- a/.codex/skills/shape-spec/SKILL.md
+++ b/.codex/skills/shape-spec/SKILL.md
@@ -28,6 +28,7 @@ required_capabilities:
 produces_evidence:
 - spec.md (narrative body)
 - demo.md (narrative body)
+- behavior-map.md
 ---
 
 # shape-spec
@@ -36,8 +37,9 @@ produces_evidence:
 
 Shape a new spec interactively with the user. Establish scope,
 non-negotiables, acceptance criteria, a runnable demo plan, and an
-initial task breakdown. You do **not** create issues, branches, or
-PRs; Tanren-code owns all workflow mechanics.
+initial task breakdown. Behavior inventory is mandatory: define new,
+modified, and deprecated behaviors with stable behavior IDs and map
+them to scenarios and demo steps.
 
 ## Inputs (from your dispatch)
 
@@ -51,15 +53,20 @@ PRs; Tanren-code owns all workflow mechanics.
    acceptance criteria. Ask clarifying questions until there is zero
    ambiguity.
 2. Derive non-negotiables (hard constraints that must always hold).
-3. Design a runnable demo plan: concrete steps, each tagged `RUN`
-   or `SKIP`, with explicit expected observables. Probe the demo
-   environment *before* committing `RUN` tags — if a connection is
-   unavailable, mark `SKIP` with the reason.
-4. Break the work into ordered tasks with clear acceptance criteria.
-   Tasks should be independently verifiable.
-5. Emit every structured fact via tools (see below). Author the
-   narrative body of `spec.md` and the narrative portions of
-   `demo.md` as supporting prose.
+3. Build a behavior inventory with stable IDs for every new,
+   modified, and deprecated behavior in scope.
+4. Design a runnable demo plan: concrete steps, each tagged `RUN`
+   or `SKIP`, with explicit expected observables and linked behavior
+   IDs. Probe the demo environment *before* committing `RUN` tags —
+   if a connection is unavailable, mark `SKIP` with the reason.
+5. Create `behavior-map.md` in the spec folder, mapping each
+   behavior ID to planned feature/scenario IDs and demo step IDs.
+6. Break the work into ordered tasks with clear acceptance criteria.
+   Tasks should be independently verifiable and traceable to behavior
+   IDs.
+7. Emit every structured fact via tools (see below). Author the
+   narrative body of `spec.md`, `demo.md`, and `behavior-map.md` as
+   supporting prose.
 
 ## Emitting results
 
@@ -77,12 +84,9 @@ Call in this order:
    external GitHub issues
 6. `set_spec_base_branch` with the branch this spec will target
 7. `create_task` per planned task with stable ordering, typed
-   `origin: ShapeSpec`, and explicit acceptance criteria
+   `origin: ShapeSpec`, explicit acceptance criteria, and behavior
+   coverage intent
 8. `report_phase_outcome("complete", <short summary>)`
-
-The narrative body of `spec.md` captures motivation, background, and
-the scope conversation. The narrative body of `demo.md` captures the
-walkthrough story.
 
 ⚠ ORCHESTRATOR-OWNED ARTIFACT — DO NOT EDIT.
 plan.md and progress.json are generated from the typed task store.

--- a/.codex/skills/walk-spec/SKILL.md
+++ b/.codex/skills/walk-spec/SKILL.md
@@ -18,24 +18,26 @@ required_capabilities:
 - task.create
 - task.read
 - phase.outcome
-produces_evidence: []
+produces_evidence:
+- behavior-map.md
 ---
 
 # walk-spec
 
 ## Purpose
 
-The user's acceptance checkpoint. Walk through the demo live, confirm
-acceptance criteria are met, surface any last concerns, and signal
-completion. Tanren-code handles `pull request` creation, roadmap
-updates, and `GitHub` communication after you signal
-complete.
+The user's acceptance checkpoint. Walk through behavior outcomes live,
+confirm acceptance criteria are met, surface any last concerns, and
+signal completion. Tanren-code handles `pull request` creation,
+roadmap updates, and `GitHub` communication after you
+signal complete.
 
 ## Inputs (from your dispatch)
 
 - The fully-implemented spec (all tasks Complete, audits passed,
   demo passed).
-- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`.
+- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`, and
+  `behavior-map.md`.
 
 ## Responsibilities
 
@@ -44,8 +46,8 @@ complete.
    `report_phase_outcome("error", …)` immediately — walk-spec is
    not the place to fix unfinished work.
 2. Run `just ci` and confirm green.
-3. Present an implementation summary + acceptance-criteria proof to
-   the user. Keep it concise; the user has the diff and can read it.
+3. Present an implementation summary in behavior terms:
+   behavior IDs, mapped scenarios, and demo evidence.
 4. Walk through the demo step-by-step. For each step: explain,
    execute, show result, confirm before next.
 5. If a demo step fails during the walkthrough: STOP. Call

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -238,5 +238,8 @@ jobs:
       - name: Check local/workflow CI parity rules
         run: just check-ci-parity
 
+      - name: Check redaction perf regression thresholds
+        run: just check-redaction-perf
+
       - name: Check pinned Rust toolchain sync
         run: just check-rust-toolchain-sync

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -144,7 +144,15 @@ jobs:
         with:
           tool: cargo-nextest,cargo-llvm-cov
 
+      - name: Build tanren-mcp for workspace parity tests
+        run: cargo build -p tanren-mcp --locked --quiet
+
+      - name: Verify tanren-mcp test binary path
+        run: test -x "${{ github.workspace }}/target/debug/tanren-mcp"
+
       - name: Generate coverage
+        env:
+          TANREN_MCP_BIN: ${{ github.workspace }}/target/debug/tanren-mcp
         run: cargo llvm-cov nextest --workspace --features tanren-store/test-hooks,tanren-orchestrator/test-hooks --locked --lcov --output-path lcov.info --no-tests=pass
 
       - name: Upload coverage to Codecov

--- a/.opencode/commands/audit-spec.md
+++ b/.opencode/commands/audit-spec.md
@@ -20,23 +20,34 @@ template: |2
   - Relevant standards (for context; compliance is `adhere-spec`).
   - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — effective pillar set for spec scope.
   - The spec's non-negotiables (from spec frontmatter).
+  - `behavior-map.md`, linked scenarios, and demo outcomes.
 
   ## Responsibilities
 
   1. Review the full spec's diff against the spec's acceptance
      criteria, non-negotiables, and pillar expectations.
-  2. For each finding: `add_finding` with severity, title,
+  2. Verify behavior coverage integrity at spec scope:
+     - every shaped behavior is mapped
+     - mapped scenarios exist and pass
+     - deprecated behaviors are intentionally handled
+  3. Verify mutation evidence quality at spec scope:
+     surviving mutants are triaged and mapped to concrete follow-up
+     actions when needed.
+  4. Verify coverage-gap interpretation quality:
+     uncovered paths are classified as missing scenario vs dead/non-
+     scenario support code.
+  5. For each finding: `add_finding` with severity, title,
      affected files/lines, source phase `audit-spec`, the pillar it
      relates to, and `attached_task` if it scopes to one. Cross-
      reference signposts to avoid duplicating known-deferred issues.
-  3. For each applicable pillar: `record_rubric_score(pillar, score,
+  6. For each applicable pillar: `record_rubric_score(pillar, score,
      rationale, supporting_finding_ids)`. Same invariants as
      `audit-task` (target 10, passing 7, findings required for gaps,
      `fix_now` required below passing).
-  4. For each non-negotiable: `record_non_negotiable_compliance(name,
+  7. For each non-negotiable: `record_non_negotiable_compliance(name,
      status, rationale)`.
-  5. Write reasoning into the `audit.md` body.
-  6. Call `report_phase_outcome`:
+  8. Write reasoning into the `audit.md` body.
+  9. Call `report_phase_outcome`:
      - `complete` if every pillar ≥ passing, every non-negotiable
        `pass`, demo passed, zero unaddressed `fix_now`.
      - `blocked` otherwise. Orchestrator materializes new tasks from

--- a/.opencode/commands/audit-task.md
+++ b/.opencode/commands/audit-task.md
@@ -23,24 +23,33 @@ template: |2
     phase — `adhere-task`).
   - `completeness, performance, scalability, strictness, security, stability, maintainability, extensibility, elegance, style, relevance, modularity, documentation_complete` — the effective pillar set (task scope).
   - Relevant signposts.
+  - `behavior-map.md` and linked scenarios.
 
   ## Responsibilities
 
   1. Read the diff in full. Understand what changed and why.
-  2. For each finding: call `add_finding` with severity
+  2. Audit behavior traceability:
+     - behavior changes are mapped in `behavior-map.md`
+     - mapped scenarios exist and reflect implemented behavior
+     - scenario quality is adequate for claimed behavior
+  3. Audit mutation quality evidence for touched behavior scope:
+     surviving mutants, if any, are explained or addressed.
+  4. Audit coverage interpretation quality:
+     uncovered code is discussed as missing scenario vs dead/non-scenario code.
+  5. For each finding: call `add_finding` with severity
      `fix_now` / `defer` / `note` / `question`, a descriptive title,
      affected files and line numbers, and the pillar it relates to.
      Cross-reference signposts: do not re-surface issues an existing
      signpost records as `deferred` or `architectural_constraint`.
-  3. For each applicable pillar: call `record_rubric_score(pillar,
+  6. For each applicable pillar: call `record_rubric_score(pillar,
      score, rationale, supporting_finding_ids)`.
      - Score 1–10 (target 10, passing 7).
      - `score < target` requires at least one linked finding.
      - `score < passing` requires at least one linked `fix_now`
        finding. Tool will reject invalid linkage.
-  4. Write narrative reasoning into the body of `audit.md`
+  7. Write narrative reasoning into the body of `audit.md`
      (task-scope section).
-  5. Call `report_phase_outcome`:
+  8. Call `report_phase_outcome`:
      - `complete` if all scores ≥ passing and zero `fix_now` findings
        remain. The `TaskAudited` guard will be recorded.
      - `blocked` if any `fix_now` findings are produced. The orchestrator

--- a/.opencode/commands/discover-standards.md
+++ b/.opencode/commands/discover-standards.md
@@ -11,7 +11,8 @@ template: |2
 
   Interactively extract tribal knowledge from the codebase and codify
   it as standards files under `tanren/standards`. Each standard is
-  one rule with clear applicability metadata.
+  one rule with clear applicability metadata. Prefer behavior-first
+  standards where testing strategy is in scope.
 
   ## Inputs (from your dispatch)
 
@@ -24,15 +25,20 @@ template: |2
      none is supplied.
   2. Read representative files. Identify unusual, opinionated, or
      tribal patterns.
-  3. For each candidate pattern the user selects, hold a full loop:
+  3. If testing standards are in scope, explicitly probe for BDD
+     requirements:
+     - behavior inventory expectations
+     - scenario traceability expectations
+     - mutation and coverage interpretation policies
+  4. For each candidate pattern the user selects, hold a full loop:
      ask clarifying questions one at a time (no batching), draft the
      standard, confirm, write the file. Filename:
      `tanren/standards/{category}/{kebab-slug}.md`.
-  4. Frontmatter required on every standard: `name`, `category`,
+  5. Frontmatter required on every standard: `name`, `category`,
      `applies_to` (globs), `applies_to_languages`,
      `applies_to_domains`, `importance` (low/medium/high/critical).
-  5. Update `tanren/standards/index.yml` to include the new entry.
-  6. `report_phase_outcome("complete", <N standards authored>)`.
+  6. Update `tanren/standards/index.yml` to include the new entry.
+  7. `report_phase_outcome("complete", <N standards authored>)`.
 
   ## Out of scope
 

--- a/.opencode/commands/do-task.md
+++ b/.opencode/commands/do-task.md
@@ -20,25 +20,30 @@ template: |2
   - The spec folder path.
   - Relevant standards (injected separately by Tanren-code; treat as
     context, not edits).
+  - Existing `behavior-map.md` mapping.
 
   ## Responsibilities
 
   1. Call `start_task(task_id)` at session start (if not already
      transitioned).
   2. Implement only the supplied task. Do not touch unrelated files.
-  3. Run `just check` before signalling complete. If
+  3. If the task changes behavior, update `behavior-map.md` and the
+     mapped scenario files in the same task session.
+  4. Run `just check` before signalling complete. If
      it fails on trivial issues (formatting, imports), self-fix and
      re-run. If it fails persistently, stop: emit a signpost and
      report `blocked` (Tanren-code will dispatch `investigate`).
-  4. Record signposts for non-obvious issues you hit or decisions that
+  5. Record signposts for non-obvious issues you hit or decisions that
      would surprise a future reader. Each signpost needs concrete
      evidence — error messages, file paths, command output.
-  5. On successful implementation: call
+  6. Treat behavior-changing code without behavior-map and scenario
+     updates as incomplete work.
+  7. On successful implementation: call
      `complete_task(task_id, evidence_refs)` with the relevant file
      paths / commit refs. The `Implemented` transition is recorded by
      Tanren-code; the gate / audit / adherence guards run in parallel
      afterward.
-  6. Call `report_phase_outcome("complete", …)`.
+  8. Call `report_phase_outcome("complete", …)`.
 
   ## Verification
 

--- a/.opencode/commands/investigate.md
+++ b/.opencode/commands/investigate.md
@@ -29,23 +29,28 @@ template: |2
 
   1. Read the failure evidence in full. Distinguish root causes from
      symptoms. Do not modify code; this phase is read-only.
-  2. Identify each root cause. For each, choose one action:
+  2. Classify root causes explicitly. Include BDD-specific classes when
+     applicable:
+     - missing scenario for claimed behavior
+     - weak scenario (mutation survivor)
+     - behavior-map drift (implementation and mapping out of sync)
+     - acceptance criteria ambiguity
+     - environment drift
+  3. For each root cause, choose one action:
      - **Task scope was wrong:** `revise_task(task_id,
-       revised_description, revised_acceptance, reason)`. Use this
-       when the acceptance criteria were ambiguous or incomplete.
+       revised_description, revised_acceptance, reason)`.
      - **A new fix scope is required:** `create_task(title,
        description, origin: Investigation { source_phase,
        source_task, loop_index }, acceptance_criteria)`.
      - **Task is infeasible:** `abandon_task(task_id, reason,
        replacements)` with at least one replacement.
      - **Cannot resolve autonomously:** `escalate_to_blocker(reason,
-       options)`. Use this only after attempting diagnosis and only
-       when a human judgment call is genuinely needed.
-  3. Add `note` / `question` findings for observations that are not
+       options)`.
+  4. Add `note` / `question` findings for observations that are not
      immediately actionable but might be useful to the next phase.
-  4. Write a narrative for `investigation-report.json` (tool-generated
+  5. Write a narrative for `investigation-report.json` (tool-generated
      from your calls; the narrative field is your prose).
-  5. Call `report_phase_outcome("complete", <one-line summary>)`.
+  6. Call `report_phase_outcome("complete", <one-line summary>)`.
 
   ## Verification
 

--- a/.opencode/commands/run-demo.md
+++ b/.opencode/commands/run-demo.md
@@ -9,29 +9,33 @@ template: |2
 
   ## Purpose
 
-  Execute the demo steps authored in `shape-spec`. Record typed
-  results per step. Emit findings for any observable that fails.
+  Execute the demo steps authored in `shape-spec` as a user-visible
+  behavior walkthrough. Demo execution is not a test-runner proxy.
+  Record typed results per step and emit findings for failed observables.
 
   ## Inputs (from your dispatch)
 
   - The spec folder and its `demo.md` frontmatter (steps with
     `RUN` / `SKIP` modes, descriptions, expected observables).
   - The supplied demo environment (already probed by shape-spec).
+  - `behavior-map.md` for step-to-behavior references.
 
   ## Responsibilities
 
   1. Execute every `RUN` step. `SKIP` steps are not executed; they do
      not contribute to pass/fail.
-  2. For each executed step: call `append_demo_result(step_id,
+  2. Each executed step must reference behavior IDs and expected
+     observables from the behavior map.
+  3. For each executed step: call `append_demo_result(step_id,
      status, observed)` with `pass` or `fail` and the observed
      outcome.
-  3. For each failure: call `add_finding` with `source_phase:
+  4. For each failure: call `add_finding` with `source_phase:
      run-demo`, descriptive title, affected files (if applicable), and
-     severity `fix_now`. If the failure reveals a test gap (tests pass
-     but demo fails), add a `fix_now` finding that describes the
-     missing test.
-  4. Add signposts for non-obvious root causes.
-  5. Call `report_phase_outcome`:
+     severity `fix_now`. If the failure reveals a scenario gap (tests
+     pass but demo fails), add a `fix_now` finding describing the
+     missing or weak scenario.
+  5. Add signposts for non-obvious root causes.
+  6. Call `report_phase_outcome`:
      - `complete` if every `RUN` step passes and at least one `RUN`
        step exists.
      - `blocked` if any `RUN` step fails. Orchestrator will dispatch

--- a/.opencode/commands/shape-spec.md
+++ b/.opencode/commands/shape-spec.md
@@ -11,8 +11,9 @@ template: |2
 
   Shape a new spec interactively with the user. Establish scope,
   non-negotiables, acceptance criteria, a runnable demo plan, and an
-  initial task breakdown. You do **not** create issues, branches, or
-  PRs; Tanren-code owns all workflow mechanics.
+  initial task breakdown. Behavior inventory is mandatory: define new,
+  modified, and deprecated behaviors with stable behavior IDs and map
+  them to scenarios and demo steps.
 
   ## Inputs (from your dispatch)
 
@@ -26,15 +27,20 @@ template: |2
      acceptance criteria. Ask clarifying questions until there is zero
      ambiguity.
   2. Derive non-negotiables (hard constraints that must always hold).
-  3. Design a runnable demo plan: concrete steps, each tagged `RUN`
-     or `SKIP`, with explicit expected observables. Probe the demo
-     environment *before* committing `RUN` tags — if a connection is
-     unavailable, mark `SKIP` with the reason.
-  4. Break the work into ordered tasks with clear acceptance criteria.
-     Tasks should be independently verifiable.
-  5. Emit every structured fact via tools (see below). Author the
-     narrative body of `spec.md` and the narrative portions of
-     `demo.md` as supporting prose.
+  3. Build a behavior inventory with stable IDs for every new,
+     modified, and deprecated behavior in scope.
+  4. Design a runnable demo plan: concrete steps, each tagged `RUN`
+     or `SKIP`, with explicit expected observables and linked behavior
+     IDs. Probe the demo environment *before* committing `RUN` tags —
+     if a connection is unavailable, mark `SKIP` with the reason.
+  5. Create `behavior-map.md` in the spec folder, mapping each
+     behavior ID to planned feature/scenario IDs and demo step IDs.
+  6. Break the work into ordered tasks with clear acceptance criteria.
+     Tasks should be independently verifiable and traceable to behavior
+     IDs.
+  7. Emit every structured fact via tools (see below). Author the
+     narrative body of `spec.md`, `demo.md`, and `behavior-map.md` as
+     supporting prose.
 
   ## Emitting results
 
@@ -52,12 +58,9 @@ template: |2
      external GitHub issues
   6. `set_spec_base_branch` with the branch this spec will target
   7. `create_task` per planned task with stable ordering, typed
-     `origin: ShapeSpec`, and explicit acceptance criteria
+     `origin: ShapeSpec`, explicit acceptance criteria, and behavior
+     coverage intent
   8. `report_phase_outcome("complete", <short summary>)`
-
-  The narrative body of `spec.md` captures motivation, background, and
-  the scope conversation. The narrative body of `demo.md` captures the
-  walkthrough story.
 
   ⚠ ORCHESTRATOR-OWNED ARTIFACT — DO NOT EDIT.
   plan.md and progress.json are generated from the typed task store.

--- a/.opencode/commands/walk-spec.md
+++ b/.opencode/commands/walk-spec.md
@@ -9,17 +9,18 @@ template: |2
 
   ## Purpose
 
-  The user's acceptance checkpoint. Walk through the demo live, confirm
-  acceptance criteria are met, surface any last concerns, and signal
-  completion. Tanren-code handles `pull request` creation, roadmap
-  updates, and `GitHub` communication after you signal
-  complete.
+  The user's acceptance checkpoint. Walk through behavior outcomes live,
+  confirm acceptance criteria are met, surface any last concerns, and
+  signal completion. Tanren-code handles `pull request` creation,
+  roadmap updates, and `GitHub` communication after you
+  signal complete.
 
   ## Inputs (from your dispatch)
 
   - The fully-implemented spec (all tasks Complete, audits passed,
     demo passed).
-  - The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`.
+  - The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`, and
+    `behavior-map.md`.
 
   ## Responsibilities
 
@@ -28,8 +29,8 @@ template: |2
      `report_phase_outcome("error", …)` immediately — walk-spec is
      not the place to fix unfinished work.
   2. Run `just ci` and confirm green.
-  3. Present an implementation summary + acceptance-criteria proof to
-     the user. Keep it concise; the user has the diff and can read it.
+  3. Present an implementation summary in behavior terms:
+     behavior IDs, mapped scenarios, and demo evidence.
   4. Walk through the demo step-by-step. For each step: explain,
      execute, show result, confirm before next.
   5. If a demo step fails during the walkthrough: STOP. Call

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,6 +3098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,6 +3881,8 @@ name = "tanren-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "proptest",
+ "secrecy",
  "serde",
  "tanren-domain",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,6 +3884,7 @@ dependencies = [
  "proptest",
  "secrecy",
  "serde",
+ "serde_json",
  "tanren-domain",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,13 @@ dependencies = [
 [[package]]
 name = "tanren-runtime"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "tanren-domain",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "tanren-runtime-docker"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +560,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -687,6 +726,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +794,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1312,6 +1412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,10 +1850,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2082,6 +2213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2411,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,7 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2580,6 +2745,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2871,6 +3056,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3881,6 +4075,7 @@ name = "tanren-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "criterion",
  "proptest",
  "secrecy",
  "serde",
@@ -3974,7 +4169,7 @@ dependencies = [
  "ferroid",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -4066,6 +4261,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4508,6 +4713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4627,6 +4842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4679,6 +4904,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ alembic-check:
 	cd packages/tanren-core && uv run alembic upgrade head && uv run alembic check
 
 arch-check: import-check alembic-check
-	cargo clippy --workspace --all-targets --features tanren-store/test-hooks -- -D warnings
 
 check:
 	$(MAKE) format-check

--- a/commands/project/discover-standards.md
+++ b/commands/project/discover-standards.md
@@ -23,7 +23,8 @@ produces_evidence:
 
 Interactively extract tribal knowledge from the codebase and codify
 it as standards files under `{{STANDARDS_ROOT}}`. Each standard is
-one rule with clear applicability metadata.
+one rule with clear applicability metadata. Prefer behavior-first
+standards where testing strategy is in scope.
 
 ## Inputs (from your dispatch)
 
@@ -36,15 +37,20 @@ one rule with clear applicability metadata.
    none is supplied.
 2. Read representative files. Identify unusual, opinionated, or
    tribal patterns.
-3. For each candidate pattern the user selects, hold a full loop:
+3. If testing standards are in scope, explicitly probe for BDD
+   requirements:
+   - behavior inventory expectations
+   - scenario traceability expectations
+   - mutation and coverage interpretation policies
+4. For each candidate pattern the user selects, hold a full loop:
    ask clarifying questions one at a time (no batching), draft the
    standard, confirm, write the file. Filename:
    `{{STANDARDS_ROOT}}/{category}/{kebab-slug}.md`.
-4. Frontmatter required on every standard: `name`, `category`,
+5. Frontmatter required on every standard: `name`, `category`,
    `applies_to` (globs), `applies_to_languages`,
    `applies_to_domains`, `importance` (low/medium/high/critical).
-5. Update `{{STANDARDS_ROOT}}/index.yml` to include the new entry.
-6. `report_phase_outcome("complete", <N standards authored>)`.
+6. Update `{{STANDARDS_ROOT}}/index.yml` to include the new entry.
+7. `report_phase_outcome("complete", <N standards authored>)`.
 
 ## Out of scope
 

--- a/commands/spec/audit-spec.md
+++ b/commands/spec/audit-spec.md
@@ -23,6 +23,7 @@ required_capabilities:
   - phase.outcome
 produces_evidence:
   - audit.md (spec-scope narrative body)
+  - behavior-map.md
 ---
 
 # audit-spec
@@ -40,23 +41,34 @@ spec) or `defer` (backlog for future specs via `triage-audits`).
 - Relevant standards (for context; compliance is `adhere-spec`).
 - `{{PILLAR_LIST}}` — effective pillar set for spec scope.
 - The spec's non-negotiables (from spec frontmatter).
+- `behavior-map.md`, linked scenarios, and demo outcomes.
 
 ## Responsibilities
 
 1. Review the full spec's diff against the spec's acceptance
    criteria, non-negotiables, and pillar expectations.
-2. For each finding: `add_finding` with severity, title,
+2. Verify behavior coverage integrity at spec scope:
+   - every shaped behavior is mapped
+   - mapped scenarios exist and pass
+   - deprecated behaviors are intentionally handled
+3. Verify mutation evidence quality at spec scope:
+   surviving mutants are triaged and mapped to concrete follow-up
+   actions when needed.
+4. Verify coverage-gap interpretation quality:
+   uncovered paths are classified as missing scenario vs dead/non-
+   scenario support code.
+5. For each finding: `add_finding` with severity, title,
    affected files/lines, source phase `audit-spec`, the pillar it
    relates to, and `attached_task` if it scopes to one. Cross-
    reference signposts to avoid duplicating known-deferred issues.
-3. For each applicable pillar: `record_rubric_score(pillar, score,
+6. For each applicable pillar: `record_rubric_score(pillar, score,
    rationale, supporting_finding_ids)`. Same invariants as
    `audit-task` (target 10, passing 7, findings required for gaps,
    `fix_now` required below passing).
-4. For each non-negotiable: `record_non_negotiable_compliance(name,
+7. For each non-negotiable: `record_non_negotiable_compliance(name,
    status, rationale)`.
-5. Write reasoning into the `audit.md` body.
-6. Call `report_phase_outcome`:
+8. Write reasoning into the `audit.md` body.
+9. Call `report_phase_outcome`:
    - `complete` if every pillar ≥ passing, every non-negotiable
      `pass`, demo passed, zero unaddressed `fix_now`.
    - `blocked` otherwise. Orchestrator materializes new tasks from

--- a/commands/spec/audit-task.md
+++ b/commands/spec/audit-task.md
@@ -21,6 +21,7 @@ required_capabilities:
   - phase.outcome
 produces_evidence:
   - audit.md (task-scope narrative body)
+  - behavior-map.md
 ---
 
 # audit-task
@@ -41,24 +42,33 @@ the orchestrator materializes new tasks from your `fix_now` findings.
   phase — `adhere-task`).
 - `{{PILLAR_LIST}}` — the effective pillar set (task scope).
 - Relevant signposts.
+- `behavior-map.md` and linked scenarios.
 
 ## Responsibilities
 
 1. Read the diff in full. Understand what changed and why.
-2. For each finding: call `add_finding` with severity
+2. Audit behavior traceability:
+   - behavior changes are mapped in `behavior-map.md`
+   - mapped scenarios exist and reflect implemented behavior
+   - scenario quality is adequate for claimed behavior
+3. Audit mutation quality evidence for touched behavior scope:
+   surviving mutants, if any, are explained or addressed.
+4. Audit coverage interpretation quality:
+   uncovered code is discussed as missing scenario vs dead/non-scenario code.
+5. For each finding: call `add_finding` with severity
    `fix_now` / `defer` / `note` / `question`, a descriptive title,
    affected files and line numbers, and the pillar it relates to.
    Cross-reference signposts: do not re-surface issues an existing
    signpost records as `deferred` or `architectural_constraint`.
-3. For each applicable pillar: call `record_rubric_score(pillar,
+6. For each applicable pillar: call `record_rubric_score(pillar,
    score, rationale, supporting_finding_ids)`.
    - Score 1–10 (target 10, passing 7).
    - `score < target` requires at least one linked finding.
    - `score < passing` requires at least one linked `fix_now`
      finding. Tool will reject invalid linkage.
-4. Write narrative reasoning into the body of `audit.md`
+7. Write narrative reasoning into the body of `audit.md`
    (task-scope section).
-5. Call `report_phase_outcome`:
+8. Call `report_phase_outcome`:
    - `complete` if all scores ≥ passing and zero `fix_now` findings
      remain. The `TaskAudited` guard will be recorded.
    - `blocked` if any `fix_now` findings are produced. The orchestrator

--- a/commands/spec/do-task.md
+++ b/commands/spec/do-task.md
@@ -25,6 +25,7 @@ required_capabilities:
   - phase.outcome
 produces_evidence:
   - signposts.md (narrative body)
+  - behavior-map.md
 ---
 
 # do-task
@@ -42,25 +43,30 @@ workflow progression are Tanren-code's job.
 - The spec folder path.
 - Relevant standards (injected separately by Tanren-code; treat as
   context, not edits).
+- Existing `behavior-map.md` mapping.
 
 ## Responsibilities
 
 1. Call `start_task(task_id)` at session start (if not already
    transitioned).
 2. Implement only the supplied task. Do not touch unrelated files.
-3. Run `{{TASK_VERIFICATION_HOOK}}` before signalling complete. If
+3. If the task changes behavior, update `behavior-map.md` and the
+   mapped scenario files in the same task session.
+4. Run `{{TASK_VERIFICATION_HOOK}}` before signalling complete. If
    it fails on trivial issues (formatting, imports), self-fix and
    re-run. If it fails persistently, stop: emit a signpost and
    report `blocked` (Tanren-code will dispatch `investigate`).
-4. Record signposts for non-obvious issues you hit or decisions that
+5. Record signposts for non-obvious issues you hit or decisions that
    would surprise a future reader. Each signpost needs concrete
    evidence — error messages, file paths, command output.
-5. On successful implementation: call
+6. Treat behavior-changing code without behavior-map and scenario
+   updates as incomplete work.
+7. On successful implementation: call
    `complete_task(task_id, evidence_refs)` with the relevant file
    paths / commit refs. The `Implemented` transition is recorded by
    Tanren-code; the gate / audit / adherence guards run in parallel
    afterward.
-6. Call `report_phase_outcome("complete", …)`.
+8. Call `report_phase_outcome("complete", …)`.
 
 ## Verification
 

--- a/commands/spec/investigate.md
+++ b/commands/spec/investigate.md
@@ -52,23 +52,28 @@ resort — escalate to a blocker for `resolve-blockers`.
 
 1. Read the failure evidence in full. Distinguish root causes from
    symptoms. Do not modify code; this phase is read-only.
-2. Identify each root cause. For each, choose one action:
+2. Classify root causes explicitly. Include BDD-specific classes when
+   applicable:
+   - missing scenario for claimed behavior
+   - weak scenario (mutation survivor)
+   - behavior-map drift (implementation and mapping out of sync)
+   - acceptance criteria ambiguity
+   - environment drift
+3. For each root cause, choose one action:
    - **Task scope was wrong:** `revise_task(task_id,
-     revised_description, revised_acceptance, reason)`. Use this
-     when the acceptance criteria were ambiguous or incomplete.
+     revised_description, revised_acceptance, reason)`.
    - **A new fix scope is required:** `create_task(title,
      description, origin: Investigation { source_phase,
      source_task, loop_index }, acceptance_criteria)`.
    - **Task is infeasible:** `abandon_task(task_id, reason,
      replacements)` with at least one replacement.
    - **Cannot resolve autonomously:** `escalate_to_blocker(reason,
-     options)`. Use this only after attempting diagnosis and only
-     when a human judgment call is genuinely needed.
-3. Add `note` / `question` findings for observations that are not
+     options)`.
+4. Add `note` / `question` findings for observations that are not
    immediately actionable but might be useful to the next phase.
-4. Write a narrative for `investigation-report.json` (tool-generated
+5. Write a narrative for `investigation-report.json` (tool-generated
    from your calls; the narrative field is your prose).
-5. Call `report_phase_outcome("complete", <one-line summary>)`.
+6. Call `report_phase_outcome("complete", <one-line summary>)`.
 
 ## Verification
 

--- a/commands/spec/run-demo.md
+++ b/commands/spec/run-demo.md
@@ -22,35 +22,40 @@ required_capabilities:
   - phase.outcome
 produces_evidence:
   - demo.md (narrative body)
+  - behavior-map.md
 ---
 
 # run-demo
 
 ## Purpose
 
-Execute the demo steps authored in `shape-spec`. Record typed
-results per step. Emit findings for any observable that fails.
+Execute the demo steps authored in `shape-spec` as a user-visible
+behavior walkthrough. Demo execution is not a test-runner proxy.
+Record typed results per step and emit findings for failed observables.
 
 ## Inputs (from your dispatch)
 
 - The spec folder and its `demo.md` frontmatter (steps with
   `RUN` / `SKIP` modes, descriptions, expected observables).
 - The supplied demo environment (already probed by shape-spec).
+- `behavior-map.md` for step-to-behavior references.
 
 ## Responsibilities
 
 1. Execute every `RUN` step. `SKIP` steps are not executed; they do
    not contribute to pass/fail.
-2. For each executed step: call `append_demo_result(step_id,
+2. Each executed step must reference behavior IDs and expected
+   observables from the behavior map.
+3. For each executed step: call `append_demo_result(step_id,
    status, observed)` with `pass` or `fail` and the observed
    outcome.
-3. For each failure: call `add_finding` with `source_phase:
+4. For each failure: call `add_finding` with `source_phase:
    run-demo`, descriptive title, affected files (if applicable), and
-   severity `fix_now`. If the failure reveals a test gap (tests pass
-   but demo fails), add a `fix_now` finding that describes the
-   missing test.
-4. Add signposts for non-obvious root causes.
-5. Call `report_phase_outcome`:
+   severity `fix_now`. If the failure reveals a scenario gap (tests
+   pass but demo fails), add a `fix_now` finding describing the
+   missing or weak scenario.
+5. Add signposts for non-obvious root causes.
+6. Call `report_phase_outcome`:
    - `complete` if every `RUN` step passes and at least one `RUN`
      step exists.
    - `blocked` if any `RUN` step fails. Orchestrator will dispatch

--- a/commands/spec/shape-spec.md
+++ b/commands/spec/shape-spec.md
@@ -27,6 +27,7 @@ required_capabilities:
 produces_evidence:
   - spec.md (narrative body)
   - demo.md (narrative body)
+  - behavior-map.md
 ---
 
 # shape-spec
@@ -35,8 +36,9 @@ produces_evidence:
 
 Shape a new spec interactively with the user. Establish scope,
 non-negotiables, acceptance criteria, a runnable demo plan, and an
-initial task breakdown. You do **not** create issues, branches, or
-PRs; Tanren-code owns all workflow mechanics.
+initial task breakdown. Behavior inventory is mandatory: define new,
+modified, and deprecated behaviors with stable behavior IDs and map
+them to scenarios and demo steps.
 
 ## Inputs (from your dispatch)
 
@@ -50,15 +52,20 @@ PRs; Tanren-code owns all workflow mechanics.
    acceptance criteria. Ask clarifying questions until there is zero
    ambiguity.
 2. Derive non-negotiables (hard constraints that must always hold).
-3. Design a runnable demo plan: concrete steps, each tagged `RUN`
-   or `SKIP`, with explicit expected observables. Probe the demo
-   environment *before* committing `RUN` tags — if a connection is
-   unavailable, mark `SKIP` with the reason.
-4. Break the work into ordered tasks with clear acceptance criteria.
-   Tasks should be independently verifiable.
-5. Emit every structured fact via tools (see below). Author the
-   narrative body of `spec.md` and the narrative portions of
-   `demo.md` as supporting prose.
+3. Build a behavior inventory with stable IDs for every new,
+   modified, and deprecated behavior in scope.
+4. Design a runnable demo plan: concrete steps, each tagged `RUN`
+   or `SKIP`, with explicit expected observables and linked behavior
+   IDs. Probe the demo environment *before* committing `RUN` tags —
+   if a connection is unavailable, mark `SKIP` with the reason.
+5. Create `behavior-map.md` in the spec folder, mapping each
+   behavior ID to planned feature/scenario IDs and demo step IDs.
+6. Break the work into ordered tasks with clear acceptance criteria.
+   Tasks should be independently verifiable and traceable to behavior
+   IDs.
+7. Emit every structured fact via tools (see below). Author the
+   narrative body of `spec.md`, `demo.md`, and `behavior-map.md` as
+   supporting prose.
 
 ## Emitting results
 
@@ -76,12 +83,9 @@ Call in this order:
    external {{ISSUE_REF_NOUN}}s
 6. `set_spec_base_branch` with the branch this spec will target
 7. `create_task` per planned task with stable ordering, typed
-   `origin: ShapeSpec`, and explicit acceptance criteria
+   `origin: ShapeSpec`, explicit acceptance criteria, and behavior
+   coverage intent
 8. `report_phase_outcome("complete", <short summary>)`
-
-The narrative body of `spec.md` captures motivation, background, and
-the scope conversation. The narrative body of `demo.md` captures the
-walkthrough story.
 
 {{READONLY_ARTIFACT_BANNER}}
 

--- a/commands/spec/walk-spec.md
+++ b/commands/spec/walk-spec.md
@@ -17,24 +17,26 @@ required_capabilities:
   - task.create
   - task.read
   - phase.outcome
-produces_evidence: []
+produces_evidence:
+  - behavior-map.md
 ---
 
 # walk-spec
 
 ## Purpose
 
-The user's acceptance checkpoint. Walk through the demo live, confirm
-acceptance criteria are met, surface any last concerns, and signal
-completion. Tanren-code handles `{{PR_NOUN}}` creation, roadmap
-updates, and `{{ISSUE_PROVIDER}}` communication after you signal
-complete.
+The user's acceptance checkpoint. Walk through behavior outcomes live,
+confirm acceptance criteria are met, surface any last concerns, and
+signal completion. Tanren-code handles `{{PR_NOUN}}` creation,
+roadmap updates, and `{{ISSUE_PROVIDER}}` communication after you
+signal complete.
 
 ## Inputs (from your dispatch)
 
 - The fully-implemented spec (all tasks Complete, audits passed,
   demo passed).
-- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`.
+- The spec's `spec.md`, `plan.md`, `demo.md`, `audit.md`, and
+  `behavior-map.md`.
 
 ## Responsibilities
 
@@ -43,8 +45,8 @@ complete.
    `report_phase_outcome("error", …)` immediately — walk-spec is
    not the place to fix unfinished work.
 2. Run `{{SPEC_VERIFICATION_HOOK}}` and confirm green.
-3. Present an implementation summary + acceptance-criteria proof to
-   the user. Keep it concise; the user has the diff and can read it.
+3. Present an implementation summary in behavior terms:
+   behavior IDs, mapped scenarios, and demo evidence.
 4. Walk through the demo step-by-step. For each step: explain,
    execute, show result, confirm before next.
 5. If a demo step fails during the walkthrough: STOP. Call

--- a/crates/tanren-domain/src/commands.rs
+++ b/crates/tanren-domain/src/commands.rs
@@ -107,9 +107,10 @@ pub struct LeaseCapabilities {
     /// `"remote"`). This is deliberately a string rather than a typed
     /// enum so third-party runtime adapters can introduce new tags
     /// without changing the domain crate. TODO(phase-1): re-evaluate
-    /// in `LANE-1.2-RUNTIME.md` once the built-in runtime set is
-    /// stable — a `RuntimeKind::{Local, Docker, DooD, Remote,
-    /// Custom(String)}` enum may be worth the coupling.
+    /// after `LANE-1.3-ENV-CONTRACT.md` and `LANE-1.4-ENV-ADAPTERS.md`
+    /// settle the built-in runtime taxonomy — a
+    /// `RuntimeKind::{Local, Docker, DooD, Remote, Custom(String)}`
+    /// enum may be worth the coupling.
     pub runtime_type: NonEmptyString,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_limits: Option<ResourceLimits>,

--- a/crates/tanren-orchestrator/tests/dispatch_lifecycle.rs
+++ b/crates/tanren-orchestrator/tests/dispatch_lifecycle.rs
@@ -68,6 +68,7 @@ async fn get_nonexistent_dispatch_returns_none() {
 }
 
 #[tokio::test]
+#[cfg(feature = "test-hooks")]
 async fn create_dispatch_enqueues_provision_step() {
     let orch = setup().await;
     let actor = sample_actor();

--- a/crates/tanren-runtime/Cargo.toml
+++ b/crates/tanren-runtime/Cargo.toml
@@ -12,9 +12,11 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tanren-domain = { path = "../tanren-domain" }
 
 [dev-dependencies]
+proptest.workspace = true
 tokio.workspace = true

--- a/crates/tanren-runtime/Cargo.toml
+++ b/crates/tanren-runtime/Cargo.toml
@@ -19,4 +19,5 @@ tanren-domain = { path = "../tanren-domain" }
 
 [dev-dependencies]
 proptest.workspace = true
+serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tanren-runtime/Cargo.toml
+++ b/crates/tanren-runtime/Cargo.toml
@@ -18,6 +18,11 @@ thiserror.workspace = true
 tanren-domain = { path = "../tanren-domain" }
 
 [dev-dependencies]
+criterion = "0.5"
 proptest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+
+[[bench]]
+name = "redaction"
+harness = false

--- a/crates/tanren-runtime/Cargo.toml
+++ b/crates/tanren-runtime/Cargo.toml
@@ -11,5 +11,10 @@ description = "Runtime trait contracts — harness and environment lease abstrac
 workspace = true
 
 [dependencies]
+async-trait.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tanren-domain = { path = "../tanren-domain" }
 
 [dev-dependencies]
+tokio.workspace = true

--- a/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
+++ b/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
@@ -28,4 +28,7 @@ uv run python scripts/check_redaction_perf.py
 ```
 
 The checker reads Criterion outputs under `target/criterion` and fails when any
-scenario mean exceeds its threshold budget.
+scenario violates either:
+
+1. relative regression budget (`max_regression_pct` from locked baseline mean)
+2. absolute mean ceiling (`max_mean_ns`)

--- a/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
+++ b/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
@@ -1,0 +1,28 @@
+# Redaction Benchmark Baseline Scenarios
+
+This file defines the fixed benchmark scenario set for `benches/redaction.rs`.
+It is the baseline artifact used for regression comparisons across runs.
+
+## Scenarios
+
+1. `redaction/large_output`
+- ~8k repeated lines with bearer + assignment secrets across all channels.
+- Validates throughput and allocation behavior under large payload redaction.
+
+2. `redaction/many_secret_hints`
+- 200 explicit secret values + 50 required secret keys.
+- Validates matcher scale when hint lists are large.
+
+3. `redaction/prefix_density/{10,50,200}`
+- Varying token-prefix list sizes with dense prefixed token payloads.
+- Validates scanner scaling as policy prefix set grows.
+
+## Usage
+
+Run locally:
+
+```bash
+cargo bench -p tanren-runtime --bench redaction
+```
+
+Compare resulting Criterion output directories between commits for regressions.

--- a/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
+++ b/crates/tanren-runtime/benches/baselines/redaction-scenarios.md
@@ -2,6 +2,7 @@
 
 This file defines the fixed benchmark scenario set for `benches/redaction.rs`.
 It is the baseline artifact used for regression comparisons across runs.
+`redaction-thresholds.json` is the machine-enforced CI budget for these scenarios.
 
 ## Scenarios
 
@@ -23,6 +24,8 @@ Run locally:
 
 ```bash
 cargo bench -p tanren-runtime --bench redaction
+uv run python scripts/check_redaction_perf.py
 ```
 
-Compare resulting Criterion output directories between commits for regressions.
+The checker reads Criterion outputs under `target/criterion` and fails when any
+scenario mean exceeds its threshold budget.

--- a/crates/tanren-runtime/benches/baselines/redaction-thresholds.json
+++ b/crates/tanren-runtime/benches/baselines/redaction-thresholds.json
@@ -1,10 +1,26 @@
 {
   "unit": "mean_nanoseconds",
+  "max_regression_pct": 10.0,
   "scenarios": {
-    "redaction/large_output": 120000000,
-    "redaction/many_secret_hints": 3000000,
-    "redaction/prefix_density/10": 450000,
-    "redaction/prefix_density/50": 500000,
-    "redaction/prefix_density/200": 900000
+    "redaction/large_output": {
+      "baseline_mean_ns": 47000000,
+      "max_mean_ns": 55000000
+    },
+    "redaction/many_secret_hints": {
+      "baseline_mean_ns": 1200000,
+      "max_mean_ns": 1500000
+    },
+    "redaction/prefix_density/10": {
+      "baseline_mean_ns": 200000,
+      "max_mean_ns": 260000
+    },
+    "redaction/prefix_density/50": {
+      "baseline_mean_ns": 210000,
+      "max_mean_ns": 280000
+    },
+    "redaction/prefix_density/200": {
+      "baseline_mean_ns": 270000,
+      "max_mean_ns": 360000
+    }
   }
 }

--- a/crates/tanren-runtime/benches/baselines/redaction-thresholds.json
+++ b/crates/tanren-runtime/benches/baselines/redaction-thresholds.json
@@ -1,0 +1,10 @@
+{
+  "unit": "mean_nanoseconds",
+  "scenarios": {
+    "redaction/large_output": 120000000,
+    "redaction/many_secret_hints": 3000000,
+    "redaction/prefix_density/10": 450000,
+    "redaction/prefix_density/50": 500000,
+    "redaction/prefix_density/200": 900000
+  }
+}

--- a/crates/tanren-runtime/benches/redaction.rs
+++ b/crates/tanren-runtime/benches/redaction.rs
@@ -91,14 +91,19 @@ fn bench_many_secrets(c: &mut Criterion) {
 fn bench_many_policy_prefixes(c: &mut Criterion) {
     let mut group = c.benchmark_group("redaction/prefix_density");
     for prefix_count in [10_usize, 50, 200] {
-        let policy = RedactionPolicy {
-            min_token_len: 8,
-            min_secret_fragment_len: 6,
-            sensitive_key_names: vec!["api_key".to_owned(), "token".to_owned()],
-            token_prefixes: (0..prefix_count)
-                .map(|idx| format!("p{idx:03}_"))
-                .collect::<Vec<_>>(),
-            max_persistable_channel_bytes: 256 * 1024,
+        let Ok(policy) = RedactionPolicy::builder()
+            .min_token_len(8)
+            .min_secret_fragment_len(6)
+            .sensitive_key_names(vec!["api_key".to_owned(), "token".to_owned()])
+            .token_prefixes(
+                (0..prefix_count)
+                    .map(|idx| format!("p{idx:03}_"))
+                    .collect::<Vec<_>>(),
+            )
+            .max_persistable_channel_bytes(256 * 1024)
+            .build()
+        else {
+            continue;
         };
         let redactor = DefaultOutputRedactor::new(policy);
         let mut payload = String::new();

--- a/crates/tanren-runtime/benches/redaction.rs
+++ b/crates/tanren-runtime/benches/redaction.rs
@@ -1,0 +1,135 @@
+use std::fmt::Write as _;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use tanren_domain::{FiniteF64, Outcome};
+use tanren_runtime::{
+    DefaultOutputRedactor, OutputRedactor, RawExecutionOutput, RedactionHints, RedactionPolicy,
+    RedactionSecret, SecretName,
+};
+
+fn base_output(
+    gate_output: String,
+    tail_output: String,
+    stderr_tail: String,
+) -> RawExecutionOutput {
+    RawExecutionOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+        gate_output: Some(gate_output),
+        tail_output: Some(tail_output),
+        stderr_tail: Some(stderr_tail),
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: Vec::new(),
+        token_usage: None,
+    }
+}
+
+fn bench_large_output(c: &mut Criterion) {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("sk-live-secret-value-123")],
+    };
+
+    let repeated =
+        "Authorization: Bearer sk-live-secret-value-123 API_TOKEN=sk-live-secret-value-123 SAFE\n"
+            .repeat(8_000);
+    let output = base_output(repeated.clone(), repeated.clone(), repeated);
+
+    c.bench_function("redaction/large_output", |b| {
+        b.iter_batched(
+            || output.clone(),
+            |raw| {
+                let result = redactor.redact_with_audit(raw, &hints);
+                let _ = black_box(result);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn bench_many_secrets(c: &mut Criterion) {
+    let redactor = DefaultOutputRedactor::default();
+    let secret_values = (0..200)
+        .map(|idx| RedactionSecret::from(format!("secret-{idx:04}-value-abcdefghijkl")))
+        .collect::<Vec<_>>();
+    let required_secret_names = (0..50)
+        .map(|idx| SecretName::try_new(format!("TOKEN_{idx:02}")).expect("secret name"))
+        .collect::<Vec<_>>();
+    let hints = RedactionHints {
+        required_secret_names,
+        secret_values,
+    };
+
+    let mut payload = String::new();
+    for idx in 0..200 {
+        let _ = write!(
+            payload,
+            "TOKEN_{:02}=secret-{idx:04}-value-abcdefghijkl ",
+            idx % 50
+        );
+    }
+    let output = base_output(payload.clone(), payload.clone(), payload);
+
+    c.bench_function("redaction/many_secret_hints", |b| {
+        b.iter_batched(
+            || output.clone(),
+            |raw| {
+                let result = redactor.redact_with_audit(raw, &hints);
+                let _ = black_box(result);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn bench_many_policy_prefixes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redaction/prefix_density");
+    for prefix_count in [10_usize, 50, 200] {
+        let policy = RedactionPolicy {
+            min_token_len: 8,
+            min_secret_fragment_len: 6,
+            sensitive_key_names: vec!["api_key".to_owned(), "token".to_owned()],
+            token_prefixes: (0..prefix_count)
+                .map(|idx| format!("p{idx:03}_"))
+                .collect::<Vec<_>>(),
+            max_persistable_channel_bytes: 256 * 1024,
+        };
+        let redactor = DefaultOutputRedactor::new(policy);
+        let mut payload = String::new();
+        for idx in 0..800 {
+            let _ = write!(payload, "p{:03}_TOKEN_VALUE_{idx:04} ", idx % prefix_count);
+        }
+        let output = base_output(payload.clone(), payload.clone(), payload);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(prefix_count),
+            &output,
+            |b, raw| {
+                b.iter_batched(
+                    || raw.clone(),
+                    |input| {
+                        let result = redactor.redact_with_audit(input, &RedactionHints::default());
+                        let _ = black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn benches(c: &mut Criterion) {
+    bench_large_output(c);
+    bench_many_secrets(c);
+    bench_many_policy_prefixes(c);
+}
+
+criterion_group!(redaction_benches, benches);
+criterion_main!(redaction_benches);

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+
+use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
+use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
+use crate::failure::HarnessFailure;
+use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
+
+/// Events emitted by the contract wrapper and adapters during execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HarnessExecutionEvent {
+    PreflightAccepted,
+    PreflightDenied(CompatibilityDenialKind),
+    AdapterInvoked,
+    PersistableOutputReady,
+}
+
+/// Observer for execution events.
+pub trait HarnessObserver: Send {
+    fn on_event(&mut self, event: HarnessExecutionEvent);
+}
+
+/// Result returned by concrete adapter implementations before redaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecutionSignal {
+    pub output: RawExecutionOutput,
+    pub provider_run_id: Option<String>,
+    pub session_resumed: bool,
+}
+
+/// Adapter trait for provider-specific harness integrations.
+#[async_trait]
+pub trait HarnessAdapter: Send + Sync {
+    fn adapter_name(&self) -> &'static str;
+
+    fn capabilities(&self) -> HarnessCapabilities;
+
+    /// Execute one request and return raw output prior to redaction.
+    ///
+    /// # Errors
+    /// Returns [`HarnessFailure`] if the provider returns a terminal failure.
+    async fn execute(
+        &self,
+        request: &HarnessExecutionRequest,
+        observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, HarnessFailure>;
+}
+
+/// Contract-level failures surfaced to orchestrator/worker layers.
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessContractError {
+    #[error(transparent)]
+    CompatibilityDenied(#[from] CompatibilityDenial),
+    #[error(transparent)]
+    AdapterFailure(#[from] HarnessFailure),
+    #[error(transparent)]
+    Redaction(#[from] RedactionError),
+    #[error("redaction leak detected in persistable output")]
+    RedactionLeakDetected,
+}
+
+/// Execute through the contract wrapper:
+/// 1. capability preflight
+/// 2. adapter execution
+/// 3. redaction before persistence
+/// 4. leak-check on known secret material
+///
+/// # Errors
+/// Returns [`HarnessContractError`] for any failed stage.
+pub async fn execute_with_contract(
+    adapter: &dyn HarnessAdapter,
+    request: &HarnessExecutionRequest,
+    redactor: &dyn OutputRedactor,
+    hints: &RedactionHints,
+    observer: &mut dyn HarnessObserver,
+) -> Result<HarnessExecutionResult, HarnessContractError> {
+    adapter
+        .capabilities()
+        .ensure_admissible(&request.requirements)
+        .map_err(|err| {
+            observer.on_event(HarnessExecutionEvent::PreflightDenied(err.kind));
+            HarnessContractError::CompatibilityDenied(err)
+        })?;
+    observer.on_event(HarnessExecutionEvent::PreflightAccepted);
+    observer.on_event(HarnessExecutionEvent::AdapterInvoked);
+
+    let signal = adapter.execute(request, observer).await?;
+    let output = redactor.redact(signal.output, hints)?;
+    if redactor.has_known_secret_leak(&output, hints) {
+        return Err(HarnessContractError::RedactionLeakDetected);
+    }
+    observer.on_event(HarnessExecutionEvent::PersistableOutputReady);
+    Ok(HarnessExecutionResult {
+        output,
+        provider_run_id: signal.provider_run_id,
+        session_resumed: signal.session_resumed,
+    })
+}

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
 use crate::failure::HarnessFailure;
-use crate::redaction::{OutputRedactor, RedactionError};
+use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError};
 
 /// Events emitted by the contract wrapper and adapters during execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +69,15 @@ pub enum HarnessContractError {
 pub async fn execute_with_contract(
     adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
+    observer: &mut dyn HarnessObserver,
+) -> Result<HarnessExecutionResult, HarnessContractError> {
+    let redactor = DefaultOutputRedactor::default();
+    execute_with_contract_internal(adapter, request, &redactor, observer).await
+}
+
+async fn execute_with_contract_internal(
+    adapter: &dyn HarnessAdapter,
+    request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
@@ -95,3 +104,16 @@ pub async fn execute_with_contract(
         session_resumed: signal.session_resumed,
     })
 }
+
+#[cfg(test)]
+pub(crate) async fn execute_with_contract_for_tests(
+    adapter: &dyn HarnessAdapter,
+    request: &HarnessExecutionRequest,
+    redactor: &dyn OutputRedactor,
+    observer: &mut dyn HarnessObserver,
+) -> Result<HarnessExecutionResult, HarnessContractError> {
+    execute_with_contract_internal(adapter, request, redactor, observer).await
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -4,8 +4,10 @@ use std::sync::{Arc, OnceLock};
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
-use crate::failure::{HarnessFailure, ProviderFailure, ProviderIdentifier};
-use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints};
+use crate::failure::{HarnessFailure, ProviderFailure, ProviderIdentifier, ProviderRunId};
+use crate::redaction::{
+    DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHintBoundsError, RedactionHints,
+};
 
 /// Events emitted by the contract wrapper and adapters during execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,7 +83,7 @@ impl ContractCallToken {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionSignal {
     pub output: RawExecutionOutput,
-    pub provider_run_id: Option<String>,
+    pub provider_run_id: Option<ProviderRunId>,
     pub session_resumed: bool,
 }
 
@@ -173,6 +175,8 @@ pub enum HarnessContractError {
     #[error(transparent)]
     CompatibilityDenied(#[from] CompatibilityDenial),
     #[error(transparent)]
+    InvalidRedactionHints(#[from] RedactionHintBoundsError),
+    #[error(transparent)]
     AdapterFailure(#[from] HarnessFailure),
     #[error("unsafe provider metadata in `{field}`: {violation}")]
     UnsafeProviderMetadata {
@@ -181,6 +185,8 @@ pub enum HarnessContractError {
     },
     #[error(transparent)]
     Redaction(#[from] RedactionError),
+    #[error("redaction leak detected while sanitizing adapter failure payload")]
+    FailurePathRedactionLeakDetected,
     #[error("redaction leak detected in persistable output")]
     RedactionLeakDetected,
 }
@@ -209,7 +215,7 @@ async fn execute_with_contract_internal(
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
-    let hints = request.redaction_hints();
+    let hints = request.redaction_hints()?;
     adapter
         .capabilities()
         .ensure_admissible(&request.requirements)
@@ -280,9 +286,7 @@ fn sanitize_provider_failure(
     )
     .map_err(HarnessContractError::Redaction)?;
     if sanitized.audit.has_any_leak() {
-        return Err(HarnessContractError::Redaction(
-            RedactionError::PolicyViolation,
-        ));
+        return Err(HarnessContractError::FailurePathRedactionLeakDetected);
     }
     failure.message = sanitized
         .output
@@ -315,13 +319,7 @@ fn sanitize_provider_identifier(
         return Ok(None);
     };
 
-    let candidate = sanitize_metadata_value(
-        field,
-        raw_identifier.as_str(),
-        ProviderIdentifier::MAX_LEN,
-        redactor,
-        hints,
-    )?;
+    let candidate = sanitize_metadata_value(field, raw_identifier.as_str(), redactor, hints)?;
     let parsed = ProviderIdentifier::try_new(candidate).map_err(|_| {
         HarnessContractError::UnsafeProviderMetadata {
             field,
@@ -332,30 +330,28 @@ fn sanitize_provider_identifier(
 }
 
 fn sanitize_provider_run_id(
-    provider_run_id: Option<String>,
+    provider_run_id: Option<ProviderRunId>,
     redactor: &dyn OutputRedactor,
     hints: &RedactionHints,
-) -> Result<Option<String>, HarnessContractError> {
-    const MAX_PROVIDER_RUN_ID_LEN: usize = 128;
-
+) -> Result<Option<ProviderRunId>, HarnessContractError> {
     let Some(raw_value) = provider_run_id else {
         return Ok(None);
     };
 
-    let candidate = sanitize_metadata_value(
-        "provider_run_id",
-        &raw_value,
-        MAX_PROVIDER_RUN_ID_LEN,
-        redactor,
-        hints,
-    )?;
-    Ok(Some(candidate))
+    let candidate =
+        sanitize_metadata_value("provider_run_id", raw_value.as_str(), redactor, hints)?;
+    let parsed = ProviderRunId::try_new(candidate).map_err(|_| {
+        HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::InvalidFormat,
+        }
+    })?;
+    Ok(Some(parsed))
 }
 
 fn sanitize_metadata_value(
     field: &'static str,
     raw_value: &str,
-    max_len: usize,
     redactor: &dyn OutputRedactor,
     hints: &RedactionHints,
 ) -> Result<String, HarnessContractError> {
@@ -383,22 +379,7 @@ fn sanitize_metadata_value(
         });
     }
 
-    if !is_valid_provider_metadata_value(&candidate, max_len) {
-        return Err(HarnessContractError::UnsafeProviderMetadata {
-            field,
-            violation: ProviderMetadataViolation::InvalidFormat,
-        });
-    }
-
     Ok(candidate)
-}
-
-fn is_valid_provider_metadata_value(value: &str, max_len: usize) -> bool {
-    !value.is_empty()
-        && value.len() <= max_len
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
 }
 
 fn sanitize_failure_payload(

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -3,8 +3,11 @@ use std::sync::OnceLock;
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
-use crate::failure::{HarnessFailure, ProviderFailure, classify_provider_failure};
-use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError};
+use crate::failure::{
+    HarnessFailure, ProviderFailure, TerminalFailureCodeError, classify_provider_failure,
+    ensure_terminal_failure_code,
+};
+use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints};
 
 /// Events emitted by the contract wrapper and adapters during execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +52,33 @@ pub trait HarnessObserver: Send {
     fn on_event(&mut self, event: HarnessExecutionEvent);
 }
 
+mod call_token {
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) struct Seal;
+}
+
+/// Contract-owned proof token required to invoke adapter execution.
+///
+/// This type is intentionally unconstructable outside crate internals.
+///
+/// ```compile_fail
+/// use tanren_runtime::ContractCallToken;
+///
+/// let _token = ContractCallToken { };
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ContractCallToken {
+    _seal: call_token::Seal,
+}
+
+impl ContractCallToken {
+    pub(crate) const fn new() -> Self {
+        Self {
+            _seal: call_token::Seal,
+        }
+    }
+}
+
 /// Result returned by concrete adapter implementations before redaction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionSignal {
@@ -72,7 +102,18 @@ pub trait HarnessAdapter: Send + Sync {
         &self,
         request: &HarnessExecutionRequest,
         observer: &mut dyn HarnessObserver,
+        token: ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderMetadataViolation {
+    #[error("metadata value was redacted or mutated during sanitization")]
+    RedactedOrMutated,
+    #[error("metadata value violates the allowed format")]
+    InvalidFormat,
+    #[error("metadata value triggered redaction leak detection")]
+    LeakDetected,
 }
 
 /// Contract-level failures surfaced to orchestrator/worker layers.
@@ -82,6 +123,13 @@ pub enum HarnessContractError {
     CompatibilityDenied(#[from] CompatibilityDenial),
     #[error(transparent)]
     AdapterFailure(#[from] HarnessFailure),
+    #[error(transparent)]
+    InvalidTerminalFailureCode(#[from] TerminalFailureCodeError),
+    #[error("unsafe provider metadata in `{field}`: {violation}")]
+    UnsafeProviderMetadata {
+        field: &'static str,
+        violation: ProviderMetadataViolation,
+    },
     #[error(transparent)]
     Redaction(#[from] RedactionError),
     #[error("redaction leak detected in persistable output")]
@@ -126,27 +174,30 @@ async fn execute_with_contract_internal<A: HarnessAdapter>(
     emit_contract_event(observer, HarnessExecutionEventKind::AdapterInvoked);
 
     let mut adapter_observer = AdapterObserverProxy { inner: observer };
-    let signal = match adapter.execute(request, &mut adapter_observer).await {
+    let signal = match adapter
+        .execute(request, &mut adapter_observer, ContractCallToken::new())
+        .await
+    {
         Ok(signal) => signal,
         Err(provider_failure) => {
-            let class = classify_provider_failure(&provider_failure.context);
             let sanitized = sanitize_provider_failure(provider_failure, redactor, &hints)
                 .map_err(HarnessContractError::Redaction)?;
+            ensure_terminal_failure_code(sanitized.context.typed_code)?;
+            let class = classify_provider_failure(&sanitized.context);
             return Err(HarnessContractError::AdapterFailure(
                 HarnessFailure::from_provider_failure_with_class(sanitized, class),
             ));
         }
     };
-    let output = redactor.redact(signal.output, &hints)?;
-    if redactor.has_known_secret_leak(&output, &hints)
-        || redactor.has_policy_residual_leak(&output, &hints)
-    {
+    let redaction = redactor.redact_with_audit(signal.output, &hints)?;
+    if redaction.audit.has_any_leak() {
         return Err(HarnessContractError::RedactionLeakDetected);
     }
+    let provider_run_id = sanitize_provider_run_id(signal.provider_run_id, redactor, &hints)?;
     emit_contract_event(observer, HarnessExecutionEventKind::PersistableOutputReady);
     Ok(HarnessExecutionResult {
-        output,
-        provider_run_id: signal.provider_run_id,
+        output: redaction.output,
+        provider_run_id,
         session_resumed: signal.session_resumed,
     })
 }
@@ -169,18 +220,84 @@ impl HarnessObserver for AdapterObserverProxy<'_> {
 fn sanitize_provider_failure(
     mut failure: ProviderFailure,
     redactor: &dyn OutputRedactor,
-    hints: &crate::redaction::RedactionHints,
+    hints: &RedactionHints,
 ) -> Result<ProviderFailure, RedactionError> {
+    let context = failure.context.clone();
+    let sanitized = sanitize_failure_payload(
+        redactor,
+        hints,
+        &failure.message,
+        context.exit_code,
+        context.stdout_tail.as_deref(),
+        context.stderr_tail.as_deref(),
+    )?;
+    if sanitized.audit.has_any_leak() {
+        return Err(RedactionError::PolicyViolation);
+    }
+    failure.message = sanitized
+        .output
+        .gate_output
+        .unwrap_or_else(|| "[REDACTED]".to_owned());
+    failure.context.stdout_tail = sanitized.output.tail_output;
+    failure.context.stderr_tail = sanitized.output.stderr_tail;
+    Ok(failure)
+}
+
+fn sanitize_provider_run_id(
+    provider_run_id: Option<String>,
+    redactor: &dyn OutputRedactor,
+    hints: &RedactionHints,
+) -> Result<Option<String>, HarnessContractError> {
+    let Some(raw_value) = provider_run_id else {
+        return Ok(None);
+    };
+    let sanitized = sanitize_failure_payload(redactor, hints, &raw_value, None, None, None)
+        .map_err(HarnessContractError::Redaction)?;
+    if sanitized.audit.has_any_leak() {
+        return Err(HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::LeakDetected,
+        });
+    }
+    let Some(candidate) = sanitized.output.gate_output else {
+        return Err(HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::RedactedOrMutated,
+        });
+    };
+    if candidate != raw_value {
+        return Err(HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::RedactedOrMutated,
+        });
+    }
+    if !is_valid_provider_run_id(&candidate) {
+        return Err(HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::InvalidFormat,
+        });
+    }
+    Ok(Some(candidate))
+}
+
+fn sanitize_failure_payload(
+    redactor: &dyn OutputRedactor,
+    hints: &RedactionHints,
+    gate_output: &str,
+    exit_code: Option<i32>,
+    tail_output: Option<&str>,
+    stderr_tail: Option<&str>,
+) -> Result<crate::redaction::RedactionOutcome, RedactionError> {
     let zero_duration =
         tanren_domain::FiniteF64::try_new(0.0).map_err(|_| RedactionError::PolicyViolation)?;
     let output = RawExecutionOutput {
         outcome: tanren_domain::Outcome::Error,
         signal: None,
-        exit_code: failure.context.exit_code,
+        exit_code,
         duration_secs: zero_duration,
-        gate_output: Some(failure.message),
-        tail_output: failure.context.stdout_tail.take(),
-        stderr_tail: failure.context.stderr_tail.take(),
+        gate_output: Some(gate_output.to_owned()),
+        tail_output: tail_output.map(str::to_owned),
+        stderr_tail: stderr_tail.map(str::to_owned),
         pushed: false,
         plan_hash: None,
         unchecked_tasks: 0,
@@ -188,13 +305,16 @@ fn sanitize_provider_failure(
         findings: Vec::new(),
         token_usage: None,
     };
-    let sanitized = redactor.redact(output, hints)?;
-    failure.message = sanitized
-        .gate_output
-        .unwrap_or_else(|| "[REDACTED]".to_owned());
-    failure.context.stdout_tail = sanitized.tail_output;
-    failure.context.stderr_tail = sanitized.stderr_tail;
-    Ok(failure)
+    redactor.redact_with_audit(output, hints)
+}
+
+fn is_valid_provider_run_id(value: &str) -> bool {
+    const MAX_PROVIDER_RUN_ID_LEN: usize = 128;
+    !value.is_empty()
+        && value.len() <= MAX_PROVIDER_RUN_ID_LEN
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
 use crate::failure::HarnessFailure;
-use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
+use crate::redaction::{OutputRedactor, RedactionError};
 
 /// Events emitted by the contract wrapper and adapters during execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,7 +70,6 @@ pub async fn execute_with_contract(
     adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
-    hints: &RedactionHints,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
     adapter
@@ -84,8 +83,9 @@ pub async fn execute_with_contract(
     observer.on_event(HarnessExecutionEvent::AdapterInvoked);
 
     let signal = adapter.execute(request, observer).await?;
-    let output = redactor.redact(signal.output, hints)?;
-    if redactor.has_known_secret_leak(&output, hints) {
+    let hints = request.redaction_hints();
+    let output = redactor.redact(signal.output, &hints)?;
+    if redactor.has_known_secret_leak(&output, &hints) {
         return Err(HarnessContractError::RedactionLeakDetected);
     }
     observer.on_event(HarnessExecutionEvent::PersistableOutputReady);

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use std::sync::OnceLock;
+use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
@@ -87,9 +88,8 @@ pub struct ExecutionSignal {
 /// Adapter trait for provider-specific harness integrations.
 #[async_trait]
 pub trait HarnessAdapter: Send + Sync {
-    const CAPABILITIES: HarnessCapabilities;
-
     fn adapter_name(&self) -> &'static str;
+    fn capabilities(&self) -> HarnessCapabilities;
 
     /// Execute one request and return raw output prior to redaction.
     ///
@@ -101,6 +101,60 @@ pub trait HarnessAdapter: Send + Sync {
         observer: &mut dyn HarnessObserver,
         token: ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure>;
+}
+
+/// Runtime registry for trait-object harness adapter instances.
+#[derive(Default, Clone)]
+pub struct HarnessAdapterRegistry {
+    adapters: BTreeMap<&'static str, Arc<dyn HarnessAdapter>>,
+}
+
+impl std::fmt::Debug for HarnessAdapterRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HarnessAdapterRegistry")
+            .field("adapters", &self.names())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum HarnessAdapterRegistryError {
+    #[error("adapter `{name}` is already registered")]
+    DuplicateAdapterName { name: &'static str },
+}
+
+impl HarnessAdapterRegistry {
+    pub fn register(
+        &mut self,
+        adapter: Arc<dyn HarnessAdapter>,
+    ) -> Result<(), HarnessAdapterRegistryError> {
+        let name = adapter.adapter_name();
+        if self.adapters.contains_key(name) {
+            return Err(HarnessAdapterRegistryError::DuplicateAdapterName { name });
+        }
+        self.adapters.insert(name, adapter);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&dyn HarnessAdapter> {
+        self.adapters.get(name).map(Arc::as_ref)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.adapters.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.adapters.is_empty()
+    }
+
+    #[must_use]
+    pub fn names(&self) -> Vec<&'static str> {
+        self.adapters.keys().copied().collect()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -139,8 +193,8 @@ pub enum HarnessContractError {
 ///
 /// # Errors
 /// Returns [`HarnessContractError`] for any failed stage.
-pub async fn execute_with_contract<A: HarnessAdapter>(
-    adapter: &A,
+pub async fn execute_with_contract(
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
@@ -149,14 +203,15 @@ pub async fn execute_with_contract<A: HarnessAdapter>(
     execute_with_contract_internal(adapter, request, redactor, observer).await
 }
 
-async fn execute_with_contract_internal<A: HarnessAdapter>(
-    adapter: &A,
+async fn execute_with_contract_internal(
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
     let hints = request.redaction_hints();
-    A::CAPABILITIES
+    adapter
+        .capabilities()
         .ensure_admissible(&request.requirements)
         .map_err(|err| {
             emit_contract_event(
@@ -375,8 +430,8 @@ fn sanitize_failure_payload(
 }
 
 #[cfg(test)]
-pub(crate) async fn execute_with_contract_for_tests<A: HarnessAdapter>(
-    adapter: &A,
+pub(crate) async fn execute_with_contract_for_tests(
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
-use crate::failure::{HarnessFailure, ProviderFailure};
+use crate::failure::{HarnessFailure, ProviderFailure, classify_provider_failure};
 use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError};
 
 /// Events emitted by the contract wrapper and adapters during execution.
@@ -60,9 +60,9 @@ pub struct ExecutionSignal {
 /// Adapter trait for provider-specific harness integrations.
 #[async_trait]
 pub trait HarnessAdapter: Send + Sync {
-    fn adapter_name(&self) -> &'static str;
+    const CAPABILITIES: HarnessCapabilities;
 
-    fn capabilities(&self) -> HarnessCapabilities;
+    fn adapter_name(&self) -> &'static str;
 
     /// Execute one request and return raw output prior to redaction.
     ///
@@ -96,8 +96,8 @@ pub enum HarnessContractError {
 ///
 /// # Errors
 /// Returns [`HarnessContractError`] for any failed stage.
-pub async fn execute_with_contract(
-    adapter: &dyn HarnessAdapter,
+pub async fn execute_with_contract<A: HarnessAdapter>(
+    adapter: &A,
     request: &HarnessExecutionRequest,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
@@ -106,14 +106,14 @@ pub async fn execute_with_contract(
     execute_with_contract_internal(adapter, request, redactor, observer).await
 }
 
-async fn execute_with_contract_internal(
-    adapter: &dyn HarnessAdapter,
+async fn execute_with_contract_internal<A: HarnessAdapter>(
+    adapter: &A,
     request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
-    adapter
-        .capabilities()
+    let hints = request.redaction_hints();
+    A::CAPABILITIES
         .ensure_admissible(&request.requirements)
         .map_err(|err| {
             emit_contract_event(
@@ -126,12 +126,17 @@ async fn execute_with_contract_internal(
     emit_contract_event(observer, HarnessExecutionEventKind::AdapterInvoked);
 
     let mut adapter_observer = AdapterObserverProxy { inner: observer };
-    let signal = adapter
-        .execute(request, &mut adapter_observer)
-        .await
-        .map_err(HarnessFailure::from_provider_failure)
-        .map_err(HarnessContractError::AdapterFailure)?;
-    let hints = request.redaction_hints();
+    let signal = match adapter.execute(request, &mut adapter_observer).await {
+        Ok(signal) => signal,
+        Err(provider_failure) => {
+            let class = classify_provider_failure(&provider_failure.context);
+            let sanitized = sanitize_provider_failure(provider_failure, redactor, &hints)
+                .map_err(HarnessContractError::Redaction)?;
+            return Err(HarnessContractError::AdapterFailure(
+                HarnessFailure::from_provider_failure_with_class(sanitized, class),
+            ));
+        }
+    };
     let output = redactor.redact(signal.output, &hints)?;
     if redactor.has_known_secret_leak(&output, &hints)
         || redactor.has_policy_residual_leak(&output, &hints)
@@ -161,9 +166,40 @@ impl HarnessObserver for AdapterObserverProxy<'_> {
     }
 }
 
+fn sanitize_provider_failure(
+    mut failure: ProviderFailure,
+    redactor: &dyn OutputRedactor,
+    hints: &crate::redaction::RedactionHints,
+) -> Result<ProviderFailure, RedactionError> {
+    let zero_duration =
+        tanren_domain::FiniteF64::try_new(0.0).map_err(|_| RedactionError::PolicyViolation)?;
+    let output = RawExecutionOutput {
+        outcome: tanren_domain::Outcome::Error,
+        signal: None,
+        exit_code: failure.context.exit_code,
+        duration_secs: zero_duration,
+        gate_output: Some(failure.message),
+        tail_output: failure.context.stdout_tail.take(),
+        stderr_tail: failure.context.stderr_tail.take(),
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: Vec::new(),
+        token_usage: None,
+    };
+    let sanitized = redactor.redact(output, hints)?;
+    failure.message = sanitized
+        .gate_output
+        .unwrap_or_else(|| "[REDACTED]".to_owned());
+    failure.context.stdout_tail = sanitized.tail_output;
+    failure.context.stderr_tail = sanitized.stderr_tail;
+    Ok(failure)
+}
+
 #[cfg(test)]
-pub(crate) async fn execute_with_contract_for_tests(
-    adapter: &dyn HarnessAdapter,
+pub(crate) async fn execute_with_contract_for_tests<A: HarnessAdapter>(
+    adapter: &A,
     request: &HarnessExecutionRequest,
     redactor: &dyn OutputRedactor,
     observer: &mut dyn HarnessObserver,

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -1,17 +1,47 @@
 use async_trait::async_trait;
+use std::sync::OnceLock;
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
-use crate::failure::HarnessFailure;
+use crate::failure::{HarnessFailure, ProviderFailure};
 use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError};
 
 /// Events emitted by the contract wrapper and adapters during execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HarnessExecutionEvent {
+pub enum HarnessExecutionEventKind {
     PreflightAccepted,
     PreflightDenied(CompatibilityDenialKind),
     AdapterInvoked,
     PersistableOutputReady,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessEventSource {
+    Contract,
+    Adapter,
+}
+
+/// Events emitted by the contract wrapper and adapters during execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessExecutionEvent {
+    pub source: HarnessEventSource,
+    pub kind: HarnessExecutionEventKind,
+}
+
+impl HarnessExecutionEvent {
+    #[must_use]
+    pub const fn contract(kind: HarnessExecutionEventKind) -> Self {
+        Self {
+            source: HarnessEventSource::Contract,
+            kind,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_source(mut self, source: HarnessEventSource) -> Self {
+        self.source = source;
+        self
+    }
 }
 
 /// Observer for execution events.
@@ -37,12 +67,12 @@ pub trait HarnessAdapter: Send + Sync {
     /// Execute one request and return raw output prior to redaction.
     ///
     /// # Errors
-    /// Returns [`HarnessFailure`] if the provider returns a terminal failure.
+    /// Returns [`ProviderFailure`] if the provider returns a terminal failure.
     async fn execute(
         &self,
         request: &HarnessExecutionRequest,
         observer: &mut dyn HarnessObserver,
-    ) -> Result<ExecutionSignal, HarnessFailure>;
+    ) -> Result<ExecutionSignal, ProviderFailure>;
 }
 
 /// Contract-level failures surfaced to orchestrator/worker layers.
@@ -71,8 +101,9 @@ pub async fn execute_with_contract(
     request: &HarnessExecutionRequest,
     observer: &mut dyn HarnessObserver,
 ) -> Result<HarnessExecutionResult, HarnessContractError> {
-    let redactor = DefaultOutputRedactor::default();
-    execute_with_contract_internal(adapter, request, &redactor, observer).await
+    static DEFAULT_OUTPUT_REDACTOR: OnceLock<DefaultOutputRedactor> = OnceLock::new();
+    let redactor = DEFAULT_OUTPUT_REDACTOR.get_or_init(DefaultOutputRedactor::default);
+    execute_with_contract_internal(adapter, request, redactor, observer).await
 }
 
 async fn execute_with_contract_internal(
@@ -85,24 +116,49 @@ async fn execute_with_contract_internal(
         .capabilities()
         .ensure_admissible(&request.requirements)
         .map_err(|err| {
-            observer.on_event(HarnessExecutionEvent::PreflightDenied(err.kind));
+            emit_contract_event(
+                observer,
+                HarnessExecutionEventKind::PreflightDenied(err.kind),
+            );
             HarnessContractError::CompatibilityDenied(err)
         })?;
-    observer.on_event(HarnessExecutionEvent::PreflightAccepted);
-    observer.on_event(HarnessExecutionEvent::AdapterInvoked);
+    emit_contract_event(observer, HarnessExecutionEventKind::PreflightAccepted);
+    emit_contract_event(observer, HarnessExecutionEventKind::AdapterInvoked);
 
-    let signal = adapter.execute(request, observer).await?;
+    let mut adapter_observer = AdapterObserverProxy { inner: observer };
+    let signal = adapter
+        .execute(request, &mut adapter_observer)
+        .await
+        .map_err(HarnessFailure::from_provider_failure)
+        .map_err(HarnessContractError::AdapterFailure)?;
     let hints = request.redaction_hints();
     let output = redactor.redact(signal.output, &hints)?;
-    if redactor.has_known_secret_leak(&output, &hints) {
+    if redactor.has_known_secret_leak(&output, &hints)
+        || redactor.has_policy_residual_leak(&output, &hints)
+    {
         return Err(HarnessContractError::RedactionLeakDetected);
     }
-    observer.on_event(HarnessExecutionEvent::PersistableOutputReady);
+    emit_contract_event(observer, HarnessExecutionEventKind::PersistableOutputReady);
     Ok(HarnessExecutionResult {
         output,
         provider_run_id: signal.provider_run_id,
         session_resumed: signal.session_resumed,
     })
+}
+
+fn emit_contract_event(observer: &mut dyn HarnessObserver, kind: HarnessExecutionEventKind) {
+    observer.on_event(HarnessExecutionEvent::contract(kind));
+}
+
+struct AdapterObserverProxy<'a> {
+    inner: &'a mut dyn HarnessObserver,
+}
+
+impl HarnessObserver for AdapterObserverProxy<'_> {
+    fn on_event(&mut self, event: HarnessExecutionEvent) {
+        self.inner
+            .on_event(event.with_source(HarnessEventSource::Adapter));
+    }
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/adapter.rs
+++ b/crates/tanren-runtime/src/adapter.rs
@@ -3,10 +3,7 @@ use std::sync::OnceLock;
 
 use crate::capability::{CompatibilityDenial, CompatibilityDenialKind, HarnessCapabilities};
 use crate::execution::{HarnessExecutionRequest, HarnessExecutionResult, RawExecutionOutput};
-use crate::failure::{
-    HarnessFailure, ProviderFailure, TerminalFailureCodeError, classify_provider_failure,
-    ensure_terminal_failure_code,
-};
+use crate::failure::{HarnessFailure, ProviderFailure, ProviderIdentifier};
 use crate::redaction::{DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints};
 
 /// Events emitted by the contract wrapper and adapters during execution.
@@ -123,8 +120,6 @@ pub enum HarnessContractError {
     CompatibilityDenied(#[from] CompatibilityDenial),
     #[error(transparent)]
     AdapterFailure(#[from] HarnessFailure),
-    #[error(transparent)]
-    InvalidTerminalFailureCode(#[from] TerminalFailureCodeError),
     #[error("unsafe provider metadata in `{field}`: {violation}")]
     UnsafeProviderMetadata {
         field: &'static str,
@@ -180,12 +175,9 @@ async fn execute_with_contract_internal<A: HarnessAdapter>(
     {
         Ok(signal) => signal,
         Err(provider_failure) => {
-            let sanitized = sanitize_provider_failure(provider_failure, redactor, &hints)
-                .map_err(HarnessContractError::Redaction)?;
-            ensure_terminal_failure_code(sanitized.context.typed_code)?;
-            let class = classify_provider_failure(&sanitized.context);
+            let sanitized = sanitize_provider_failure(provider_failure, redactor, &hints)?;
             return Err(HarnessContractError::AdapterFailure(
-                HarnessFailure::from_provider_failure_with_class(sanitized, class),
+                HarnessFailure::from_provider_failure(sanitized),
             ));
         }
     };
@@ -221,7 +213,7 @@ fn sanitize_provider_failure(
     mut failure: ProviderFailure,
     redactor: &dyn OutputRedactor,
     hints: &RedactionHints,
-) -> Result<ProviderFailure, RedactionError> {
+) -> Result<ProviderFailure, HarnessContractError> {
     let context = failure.context.clone();
     let sanitized = sanitize_failure_payload(
         redactor,
@@ -230,9 +222,12 @@ fn sanitize_provider_failure(
         context.exit_code,
         context.stdout_tail.as_deref(),
         context.stderr_tail.as_deref(),
-    )?;
+    )
+    .map_err(HarnessContractError::Redaction)?;
     if sanitized.audit.has_any_leak() {
-        return Err(RedactionError::PolicyViolation);
+        return Err(HarnessContractError::Redaction(
+            RedactionError::PolicyViolation,
+        ));
     }
     failure.message = sanitized
         .output
@@ -240,7 +235,45 @@ fn sanitize_provider_failure(
         .unwrap_or_else(|| "[REDACTED]".to_owned());
     failure.context.stdout_tail = sanitized.output.tail_output;
     failure.context.stderr_tail = sanitized.output.stderr_tail;
+    failure.context.provider_code = sanitize_provider_identifier(
+        "provider_code",
+        failure.context.provider_code,
+        redactor,
+        hints,
+    )?;
+    failure.context.provider_kind = sanitize_provider_identifier(
+        "provider_kind",
+        failure.context.provider_kind,
+        redactor,
+        hints,
+    )?;
     Ok(failure)
+}
+
+fn sanitize_provider_identifier(
+    field: &'static str,
+    provider_identifier: Option<ProviderIdentifier>,
+    redactor: &dyn OutputRedactor,
+    hints: &RedactionHints,
+) -> Result<Option<ProviderIdentifier>, HarnessContractError> {
+    let Some(raw_identifier) = provider_identifier else {
+        return Ok(None);
+    };
+
+    let candidate = sanitize_metadata_value(
+        field,
+        raw_identifier.as_str(),
+        ProviderIdentifier::MAX_LEN,
+        redactor,
+        hints,
+    )?;
+    let parsed = ProviderIdentifier::try_new(candidate).map_err(|_| {
+        HarnessContractError::UnsafeProviderMetadata {
+            field,
+            violation: ProviderMetadataViolation::InvalidFormat,
+        }
+    })?;
+    Ok(Some(parsed))
 }
 
 fn sanitize_provider_run_id(
@@ -248,36 +281,69 @@ fn sanitize_provider_run_id(
     redactor: &dyn OutputRedactor,
     hints: &RedactionHints,
 ) -> Result<Option<String>, HarnessContractError> {
+    const MAX_PROVIDER_RUN_ID_LEN: usize = 128;
+
     let Some(raw_value) = provider_run_id else {
         return Ok(None);
     };
-    let sanitized = sanitize_failure_payload(redactor, hints, &raw_value, None, None, None)
+
+    let candidate = sanitize_metadata_value(
+        "provider_run_id",
+        &raw_value,
+        MAX_PROVIDER_RUN_ID_LEN,
+        redactor,
+        hints,
+    )?;
+    Ok(Some(candidate))
+}
+
+fn sanitize_metadata_value(
+    field: &'static str,
+    raw_value: &str,
+    max_len: usize,
+    redactor: &dyn OutputRedactor,
+    hints: &RedactionHints,
+) -> Result<String, HarnessContractError> {
+    let sanitized = sanitize_failure_payload(redactor, hints, raw_value, None, None, None)
         .map_err(HarnessContractError::Redaction)?;
+
     if sanitized.audit.has_any_leak() {
         return Err(HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
+            field,
             violation: ProviderMetadataViolation::LeakDetected,
         });
     }
+
     let Some(candidate) = sanitized.output.gate_output else {
         return Err(HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
+            field,
             violation: ProviderMetadataViolation::RedactedOrMutated,
         });
     };
+
     if candidate != raw_value {
         return Err(HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
+            field,
             violation: ProviderMetadataViolation::RedactedOrMutated,
         });
     }
-    if !is_valid_provider_run_id(&candidate) {
+
+    if !is_valid_provider_metadata_value(&candidate, max_len) {
         return Err(HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
+            field,
             violation: ProviderMetadataViolation::InvalidFormat,
         });
     }
-    Ok(Some(candidate))
+
+    Ok(candidate)
+}
+
+fn is_valid_provider_metadata_value(value: &str, max_len: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
 }
 
 fn sanitize_failure_payload(
@@ -306,15 +372,6 @@ fn sanitize_failure_payload(
         token_usage: None,
     };
     redactor.redact_with_audit(output, hints)
-}
-
-fn is_valid_provider_run_id(value: &str) -> bool {
-    const MAX_PROVIDER_RUN_ID_LEN: usize = 128;
-    !value.is_empty()
-        && value.len() <= MAX_PROVIDER_RUN_ID_LEN
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -32,8 +32,7 @@ struct MockAdapter {
     provider_run_id: Option<String>,
 }
 
-#[async_trait]
-impl HarnessAdapter for MockAdapter {
+impl MockAdapter {
     const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
         output_streaming: OutputStreaming::TextAndToolEvents,
         can_use_tools: true,
@@ -42,9 +41,16 @@ impl HarnessAdapter for MockAdapter {
         sandbox_mode: SandboxMode::WorkspaceWrite,
         approval_mode: ApprovalMode::OnDemand,
     };
+}
 
+#[async_trait]
+impl HarnessAdapter for MockAdapter {
     fn adapter_name(&self) -> &'static str {
         "mock"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        Self::CAPABILITIES
     }
 
     async fn execute(
@@ -489,3 +495,5 @@ async fn fails_closed_when_provider_run_id_is_redaction_mutated() {
         }
     ));
 }
+
+mod registry_tests;

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -9,7 +9,9 @@ use crate::capability::{
     SandboxMode, SessionResumeSupport,
 };
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
-use crate::failure::{ProviderFailure, ProviderFailureCode, ProviderFailureContext};
+use crate::failure::{
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, TerminalFailureCodeError,
+};
 use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
 
 #[derive(Default)]
@@ -27,6 +29,7 @@ impl HarnessObserver for Recorder {
 struct MockAdapter {
     output: RawExecutionOutput,
     provider_failure: Option<ProviderFailure>,
+    provider_run_id: Option<String>,
 }
 
 #[async_trait]
@@ -48,13 +51,14 @@ impl HarnessAdapter for MockAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
+        _token: ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure> {
         if let Some(failure) = &self.provider_failure {
             return Err(failure.clone());
         }
         Ok(ExecutionSignal {
             output: self.output.clone(),
-            provider_run_id: None,
+            provider_run_id: self.provider_run_id.clone(),
             session_resumed: false,
         })
     }
@@ -204,7 +208,11 @@ fn capabilities_are_immutable_type_metadata() {
 async fn emits_expected_event_sequence_for_adapter_failure() {
     let adapter = MockAdapter {
         output: raw_output(),
-        provider_failure: Some(ProviderFailure::new("adapter failed")),
+        provider_failure: Some(ProviderFailure::new(
+            ProviderFailureCode::Fatal,
+            "adapter failed",
+        )),
+        provider_run_id: None,
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract(&adapter, &request(), &mut recorder)
@@ -224,13 +232,16 @@ async fn emits_expected_event_sequence_for_adapter_failure() {
 async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
     let adapter = MockAdapter {
         output: raw_output(),
-        provider_failure: Some(ProviderFailure::new("provider timeout").with_context(
-            ProviderFailureContext {
-                typed_code: Some(ProviderFailureCode::Timeout),
-                stderr_tail: Some("401 invalid api key".into()),
-                ..ProviderFailureContext::default()
-            },
-        )),
+        provider_failure: Some(
+            ProviderFailure::new(ProviderFailureCode::Timeout, "provider timeout").with_context(
+                ProviderFailureContext {
+                    typed_code: ProviderFailureCode::Timeout,
+                    stderr_tail: Some("401 invalid api key".into()),
+                    ..ProviderFailureContext::default()
+                },
+            ),
+        ),
+        provider_run_id: None,
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract(&adapter, &request(), &mut recorder)
@@ -244,7 +255,7 @@ async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
         failure.class(),
         crate::failure::HarnessFailureClass::Timeout
     );
-    assert_eq!(failure.typed_code(), Some(ProviderFailureCode::Timeout));
+    assert_eq!(failure.typed_code(), ProviderFailureCode::Timeout);
 }
 
 #[tokio::test]
@@ -252,14 +263,18 @@ async fn sanitizes_failure_message_and_context_before_surface() {
     let adapter = MockAdapter {
         output: raw_output(),
         provider_failure: Some(
-            ProviderFailure::new("request failed with API_TOKEN=super-secret and sk-live-secret")
-                .with_context(ProviderFailureContext {
-                    typed_code: Some(ProviderFailureCode::Authentication),
-                    stdout_tail: Some("stdout secret sk-live-secret".into()),
-                    stderr_tail: Some("stderr secret API_TOKEN=super-secret".into()),
-                    ..ProviderFailureContext::default()
-                }),
+            ProviderFailure::new(
+                ProviderFailureCode::Authentication,
+                "request failed with API_TOKEN=super-secret and sk-live-secret",
+            )
+            .with_context(ProviderFailureContext {
+                typed_code: ProviderFailureCode::Authentication,
+                stdout_tail: Some("stdout secret sk-live-secret".into()),
+                stderr_tail: Some("stderr secret API_TOKEN=super-secret".into()),
+                ..ProviderFailureContext::default()
+            }),
         ),
+        provider_run_id: None,
     };
     let mut req = request();
     req.secret_values_for_redaction = vec![RedactionSecret::from("super-secret")];
@@ -285,6 +300,7 @@ async fn emits_expected_event_sequence_for_redaction_error() {
     let adapter = MockAdapter {
         output: raw_output(),
         provider_failure: None,
+        provider_run_id: None,
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract_for_tests(&adapter, &request(), &ErrorRedactor, &mut recorder)
@@ -305,6 +321,7 @@ async fn emits_expected_event_sequence_for_leak_detection() {
     let adapter = MockAdapter {
         output: raw_output(),
         provider_failure: None,
+        provider_run_id: None,
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract_for_tests(&adapter, &request(), &LeakRedactor, &mut recorder)
@@ -325,6 +342,7 @@ async fn emits_expected_event_sequence_for_policy_residual_leak_detection() {
     let adapter = MockAdapter {
         output: raw_output(),
         provider_failure: None,
+        provider_run_id: None,
     };
     let mut recorder = Recorder::default();
     let err =
@@ -339,4 +357,77 @@ async fn emits_expected_event_sequence_for_policy_residual_leak_detection() {
             HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
         ]
     );
+}
+
+#[tokio::test]
+async fn preserves_provider_run_id_when_it_is_safe() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: Some("run_12345:abc.DEF".into()),
+    };
+    let mut recorder = Recorder::default();
+    let result = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect("must succeed");
+    assert_eq!(result.provider_run_id.as_deref(), Some("run_12345:abc.DEF"));
+}
+
+#[tokio::test]
+async fn fails_closed_when_provider_run_id_format_is_invalid() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: Some("run with spaces".into()),
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail closed");
+    assert!(matches!(
+        err,
+        HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::InvalidFormat
+        }
+    ));
+}
+
+#[tokio::test]
+async fn fails_closed_when_provider_run_id_is_redaction_mutated() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: Some("run-sk-live-secret".into()),
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail closed");
+    assert!(matches!(
+        err,
+        HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::RedactedOrMutated
+        }
+    ));
+}
+
+#[tokio::test]
+async fn rejects_unknown_typed_code_for_terminal_adapter_failures() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: Some(ProviderFailure::new(ProviderFailureCode::Unknown, "opaque")),
+        provider_run_id: None,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(
+        err,
+        HarnessContractError::InvalidTerminalFailureCode(
+            TerminalFailureCodeError::UnknownForbidden
+        )
+    ));
 }

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -10,7 +10,7 @@ use crate::capability::{
 };
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 use crate::failure::{
-    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier, ProviderRunId,
 };
 use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
 
@@ -29,7 +29,7 @@ impl HarnessObserver for Recorder {
 struct MockAdapter {
     output: RawExecutionOutput,
     provider_failure: Option<ProviderFailure>,
-    provider_run_id: Option<String>,
+    provider_run_id: Option<ProviderRunId>,
 }
 
 impl MockAdapter {
@@ -225,6 +225,33 @@ async fn emits_expected_event_sequence_for_adapter_failure() {
         .await
         .expect_err("must fail");
     assert!(matches!(err, HarnessContractError::AdapterFailure(_)));
+    assert_eq!(
+        recorder.events,
+        vec![
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
+        ]
+    );
+}
+
+#[tokio::test]
+async fn emits_dedicated_error_for_failure_path_leak_detection() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: Some(ProviderFailure::new(
+            ProviderFailureCode::Fatal,
+            "adapter failed with secret",
+        )),
+        provider_run_id: None,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract_for_tests(&adapter, &request(), &LeakRedactor, &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(
+        err,
+        HarnessContractError::FailurePathRedactionLeakDetected
+    ));
     assert_eq!(
         recorder.events,
         vec![
@@ -442,58 +469,5 @@ async fn emits_expected_event_sequence_for_policy_residual_leak_detection() {
     );
 }
 
-#[tokio::test]
-async fn preserves_provider_run_id_when_it_is_safe() {
-    let adapter = MockAdapter {
-        output: raw_output(),
-        provider_failure: None,
-        provider_run_id: Some("run_12345:abc.DEF".into()),
-    };
-    let mut recorder = Recorder::default();
-    let result = execute_with_contract(&adapter, &request(), &mut recorder)
-        .await
-        .expect("must succeed");
-    assert_eq!(result.provider_run_id.as_deref(), Some("run_12345:abc.DEF"));
-}
-
-#[tokio::test]
-async fn fails_closed_when_provider_run_id_format_is_invalid() {
-    let adapter = MockAdapter {
-        output: raw_output(),
-        provider_failure: None,
-        provider_run_id: Some("run with spaces".into()),
-    };
-    let mut recorder = Recorder::default();
-    let err = execute_with_contract(&adapter, &request(), &mut recorder)
-        .await
-        .expect_err("must fail closed");
-    assert!(matches!(
-        err,
-        HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
-            violation: ProviderMetadataViolation::InvalidFormat
-        }
-    ));
-}
-
-#[tokio::test]
-async fn fails_closed_when_provider_run_id_is_redaction_mutated() {
-    let adapter = MockAdapter {
-        output: raw_output(),
-        provider_failure: None,
-        provider_run_id: Some("run-sk-live-secret".into()),
-    };
-    let mut recorder = Recorder::default();
-    let err = execute_with_contract(&adapter, &request(), &mut recorder)
-        .await
-        .expect_err("must fail closed");
-    assert!(matches!(
-        err,
-        HarnessContractError::UnsafeProviderMetadata {
-            field: "provider_run_id",
-            violation: ProviderMetadataViolation::RedactedOrMutated
-        }
-    ));
-}
-
+mod provider_run_id_tests;
 mod registry_tests;

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -31,19 +31,17 @@ struct MockAdapter {
 
 #[async_trait]
 impl HarnessAdapter for MockAdapter {
+    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+        output_streaming: OutputStreaming::TextAndToolEvents,
+        can_use_tools: true,
+        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+        session_resume: SessionResumeSupport::CrossProcess,
+        sandbox_mode: SandboxMode::WorkspaceWrite,
+        approval_mode: ApprovalMode::OnDemand,
+    };
+
     fn adapter_name(&self) -> &'static str {
         "mock"
-    }
-
-    fn capabilities(&self) -> HarnessCapabilities {
-        HarnessCapabilities {
-            output_streaming: OutputStreaming::TextAndToolEvents,
-            can_use_tools: true,
-            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
-            session_resume: SessionResumeSupport::CrossProcess,
-            sandbox_mode: SandboxMode::WorkspaceWrite,
-            approval_mode: ApprovalMode::OnDemand,
-        }
     }
 
     async fn execute(
@@ -195,6 +193,13 @@ fn raw_output() -> RawExecutionOutput {
     }
 }
 
+#[test]
+fn capabilities_are_immutable_type_metadata() {
+    let capabilities = MockAdapter::CAPABILITIES;
+    assert!(capabilities.can_use_tools);
+    assert_eq!(capabilities.sandbox_mode, SandboxMode::WorkspaceWrite);
+}
+
 #[tokio::test]
 async fn emits_expected_event_sequence_for_adapter_failure() {
     let adapter = MockAdapter {
@@ -240,6 +245,39 @@ async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
         crate::failure::HarnessFailureClass::Timeout
     );
     assert_eq!(failure.typed_code(), Some(ProviderFailureCode::Timeout));
+}
+
+#[tokio::test]
+async fn sanitizes_failure_message_and_context_before_surface() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: Some(
+            ProviderFailure::new("request failed with API_TOKEN=super-secret and sk-live-secret")
+                .with_context(ProviderFailureContext {
+                    typed_code: Some(ProviderFailureCode::Authentication),
+                    stdout_tail: Some("stdout secret sk-live-secret".into()),
+                    stderr_tail: Some("stderr secret API_TOKEN=super-secret".into()),
+                    ..ProviderFailureContext::default()
+                }),
+        ),
+    };
+    let mut req = request();
+    req.secret_values_for_redaction = vec![RedactionSecret::from("super-secret")];
+    req.required_secret_names = vec![SecretName::try_new("API_TOKEN").expect("secret key")];
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &req, &mut recorder)
+        .await
+        .expect_err("must fail");
+    let HarnessContractError::AdapterFailure(failure) = err else {
+        unreachable!("checked by expect_err");
+    };
+    assert!(!failure.message().contains("super-secret"));
+    assert!(!failure.message().contains("sk-live-secret"));
+    assert!(failure.message().contains("[REDACTED]"));
+    assert_eq!(
+        failure.class(),
+        crate::failure::HarnessFailureClass::Authentication
+    );
 }
 
 #[tokio::test]

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -10,7 +10,7 @@ use crate::capability::{
 };
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 use crate::failure::{
-    ProviderFailure, ProviderFailureCode, ProviderFailureContext, TerminalFailureCodeError,
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
 };
 use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
 
@@ -236,8 +236,12 @@ async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
             ProviderFailure::new(ProviderFailureCode::Timeout, "provider timeout").with_context(
                 ProviderFailureContext {
                     typed_code: ProviderFailureCode::Timeout,
+                    provider_code: None,
+                    provider_kind: None,
+                    signal: None,
+                    exit_code: None,
+                    stdout_tail: None,
                     stderr_tail: Some("401 invalid api key".into()),
-                    ..ProviderFailureContext::default()
                 },
             ),
         ),
@@ -259,6 +263,76 @@ async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
 }
 
 #[tokio::test]
+async fn preserves_safe_provider_failure_identifiers() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: Some(
+            ProviderFailure::new(ProviderFailureCode::Authentication, "auth failed").with_context(
+                ProviderFailureContext {
+                    typed_code: ProviderFailureCode::Authentication,
+                    provider_code: Some(ProviderIdentifier::try_new("auth_401").expect("code")),
+                    provider_kind: Some(ProviderIdentifier::try_new("http").expect("kind")),
+                    signal: None,
+                    exit_code: None,
+                    stdout_tail: None,
+                    stderr_tail: None,
+                },
+            ),
+        ),
+        provider_run_id: None,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail");
+    let HarnessContractError::AdapterFailure(failure) = err else {
+        unreachable!("checked by expect_err");
+    };
+    assert_eq!(
+        failure.provider_code().map(ProviderIdentifier::as_str),
+        Some("auth_401")
+    );
+    assert_eq!(
+        failure.provider_kind().map(ProviderIdentifier::as_str),
+        Some("http")
+    );
+}
+
+#[tokio::test]
+async fn fails_closed_when_provider_failure_identifier_is_redaction_mutated() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: Some(
+            ProviderFailure::new(ProviderFailureCode::Authentication, "auth failed").with_context(
+                ProviderFailureContext {
+                    typed_code: ProviderFailureCode::Authentication,
+                    provider_code: Some(
+                        ProviderIdentifier::try_new("sk-live-secret").expect("identifier"),
+                    ),
+                    provider_kind: None,
+                    signal: None,
+                    exit_code: None,
+                    stdout_tail: None,
+                    stderr_tail: None,
+                },
+            ),
+        ),
+        provider_run_id: None,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail closed");
+    assert!(matches!(
+        err,
+        HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_code",
+            violation: ProviderMetadataViolation::RedactedOrMutated
+        }
+    ));
+}
+
+#[tokio::test]
 async fn sanitizes_failure_message_and_context_before_surface() {
     let adapter = MockAdapter {
         output: raw_output(),
@@ -269,9 +343,12 @@ async fn sanitizes_failure_message_and_context_before_surface() {
             )
             .with_context(ProviderFailureContext {
                 typed_code: ProviderFailureCode::Authentication,
+                provider_code: None,
+                provider_kind: None,
+                signal: None,
+                exit_code: None,
                 stdout_tail: Some("stdout secret sk-live-secret".into()),
                 stderr_tail: Some("stderr secret API_TOKEN=super-secret".into()),
-                ..ProviderFailureContext::default()
             }),
         ),
         provider_run_id: None,
@@ -410,24 +487,5 @@ async fn fails_closed_when_provider_run_id_is_redaction_mutated() {
             field: "provider_run_id",
             violation: ProviderMetadataViolation::RedactedOrMutated
         }
-    ));
-}
-
-#[tokio::test]
-async fn rejects_unknown_typed_code_for_terminal_adapter_failures() {
-    let adapter = MockAdapter {
-        output: raw_output(),
-        provider_failure: Some(ProviderFailure::new(ProviderFailureCode::Unknown, "opaque")),
-        provider_run_id: None,
-    };
-    let mut recorder = Recorder::default();
-    let err = execute_with_contract(&adapter, &request(), &mut recorder)
-        .await
-        .expect_err("must fail");
-    assert!(matches!(
-        err,
-        HarnessContractError::InvalidTerminalFailureCode(
-            TerminalFailureCodeError::UnknownForbidden
-        )
     ));
 }

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -9,7 +9,7 @@ use crate::capability::{
     SandboxMode, SessionResumeSupport,
 };
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
-use crate::failure::{HarnessFailure, HarnessFailureClass};
+use crate::failure::{ProviderFailure, ProviderFailureCode, ProviderFailureContext};
 use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
 
 #[derive(Default)]
@@ -26,7 +26,7 @@ impl HarnessObserver for Recorder {
 #[derive(Clone)]
 struct MockAdapter {
     output: RawExecutionOutput,
-    should_fail: bool,
+    provider_failure: Option<ProviderFailure>,
 }
 
 #[async_trait]
@@ -50,15 +50,9 @@ impl HarnessAdapter for MockAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
-    ) -> Result<ExecutionSignal, HarnessFailure> {
-        if self.should_fail {
-            return Err(HarnessFailure {
-                class: HarnessFailureClass::Fatal,
-                message: "adapter failed".into(),
-                provider_code: None,
-                provider_kind: None,
-                typed_code: None,
-            });
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        if let Some(failure) = &self.provider_failure {
+            return Err(failure.clone());
         }
         Ok(ExecutionSignal {
             output: self.output.clone(),
@@ -80,8 +74,7 @@ impl OutputRedactor for LeakRedactor {
             outcome: output.outcome,
             signal: output.signal,
             exit_code: output.exit_code,
-            duration_secs: FiniteF64::try_new(output.duration_secs)
-                .map_err(|_| RedactionError::InvalidDuration)?,
+            duration_secs: output.duration_secs,
             gate_output: output.gate_output,
             tail_output: output.tail_output,
             stderr_tail: output.stderr_tail,
@@ -95,6 +88,76 @@ impl OutputRedactor for LeakRedactor {
     }
 
     fn has_known_secret_leak(&self, _output: &PersistableOutput, _hints: &RedactionHints) -> bool {
+        true
+    }
+
+    fn has_policy_residual_leak(
+        &self,
+        _output: &PersistableOutput,
+        _hints: &RedactionHints,
+    ) -> bool {
+        false
+    }
+}
+
+struct ErrorRedactor;
+
+impl OutputRedactor for ErrorRedactor {
+    fn redact(
+        &self,
+        _output: RawExecutionOutput,
+        _hints: &RedactionHints,
+    ) -> Result<PersistableOutput, RedactionError> {
+        Err(RedactionError::PolicyViolation)
+    }
+
+    fn has_known_secret_leak(&self, _output: &PersistableOutput, _hints: &RedactionHints) -> bool {
+        false
+    }
+
+    fn has_policy_residual_leak(
+        &self,
+        _output: &PersistableOutput,
+        _hints: &RedactionHints,
+    ) -> bool {
+        false
+    }
+}
+
+struct PolicyLeakRedactor;
+
+impl OutputRedactor for PolicyLeakRedactor {
+    fn redact(
+        &self,
+        output: RawExecutionOutput,
+        _hints: &RedactionHints,
+    ) -> Result<PersistableOutput, RedactionError> {
+        Ok(PersistableOutput {
+            outcome: output.outcome,
+            signal: output.signal,
+            exit_code: output.exit_code,
+            duration_secs: output.duration_secs,
+            gate_output: output.gate_output,
+            tail_output: output.tail_output,
+            stderr_tail: output.stderr_tail,
+            pushed: output.pushed,
+            plan_hash: output.plan_hash,
+            unchecked_tasks: output.unchecked_tasks,
+            spec_modified: output.spec_modified,
+            findings: output.findings,
+            token_usage: output.token_usage,
+        })
+    }
+
+    fn has_known_secret_leak(&self, _output: &PersistableOutput, _hints: &RedactionHints) -> bool {
+        false
+    }
+
+    fn has_policy_residual_leak(
+        &self,
+        _output: &PersistableOutput,
+        _hints: &RedactionHints,
+    ) -> bool {
         true
     }
 }
@@ -119,7 +182,7 @@ fn raw_output() -> RawExecutionOutput {
         outcome: Outcome::Success,
         signal: None,
         exit_code: Some(0),
-        duration_secs: 1.0,
+        duration_secs: FiniteF64::try_new(1.0).expect("finite"),
         gate_output: Some("safe".into()),
         tail_output: Some("safe".into()),
         stderr_tail: Some("safe".into()),
@@ -136,7 +199,7 @@ fn raw_output() -> RawExecutionOutput {
 async fn emits_expected_event_sequence_for_adapter_failure() {
     let adapter = MockAdapter {
         output: raw_output(),
-        should_fail: true,
+        provider_failure: Some(ProviderFailure::new("adapter failed")),
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract(&adapter, &request(), &mut recorder)
@@ -146,31 +209,55 @@ async fn emits_expected_event_sequence_for_adapter_failure() {
     assert_eq!(
         recorder.events,
         vec![
-            HarnessExecutionEvent::PreflightAccepted,
-            HarnessExecutionEvent::AdapterInvoked
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
         ]
     );
 }
 
 #[tokio::test]
-async fn emits_expected_event_sequence_for_redaction_error() {
+async fn normalizes_adapter_provider_failure_in_contract_wrapper() {
     let adapter = MockAdapter {
-        output: RawExecutionOutput {
-            duration_secs: f64::NAN,
-            ..raw_output()
-        },
-        should_fail: false,
+        output: raw_output(),
+        provider_failure: Some(ProviderFailure::new("provider timeout").with_context(
+            ProviderFailureContext {
+                typed_code: Some(ProviderFailureCode::Timeout),
+                stderr_tail: Some("401 invalid api key".into()),
+                ..ProviderFailureContext::default()
+            },
+        )),
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(err, HarnessContractError::AdapterFailure(_)));
+    let HarnessContractError::AdapterFailure(failure) = err else {
+        unreachable!("checked by matches assertion");
+    };
+    assert_eq!(
+        failure.class(),
+        crate::failure::HarnessFailureClass::Timeout
+    );
+    assert_eq!(failure.typed_code(), Some(ProviderFailureCode::Timeout));
+}
+
+#[tokio::test]
+async fn emits_expected_event_sequence_for_redaction_error() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract_for_tests(&adapter, &request(), &ErrorRedactor, &mut recorder)
         .await
         .expect_err("must fail");
     assert!(matches!(err, HarnessContractError::Redaction(_)));
     assert_eq!(
         recorder.events,
         vec![
-            HarnessExecutionEvent::PreflightAccepted,
-            HarnessExecutionEvent::AdapterInvoked
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
         ]
     );
 }
@@ -179,7 +266,7 @@ async fn emits_expected_event_sequence_for_redaction_error() {
 async fn emits_expected_event_sequence_for_leak_detection() {
     let adapter = MockAdapter {
         output: raw_output(),
-        should_fail: false,
+        provider_failure: None,
     };
     let mut recorder = Recorder::default();
     let err = execute_with_contract_for_tests(&adapter, &request(), &LeakRedactor, &mut recorder)
@@ -189,8 +276,29 @@ async fn emits_expected_event_sequence_for_leak_detection() {
     assert_eq!(
         recorder.events,
         vec![
-            HarnessExecutionEvent::PreflightAccepted,
-            HarnessExecutionEvent::AdapterInvoked
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
+        ]
+    );
+}
+
+#[tokio::test]
+async fn emits_expected_event_sequence_for_policy_residual_leak_detection() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+    };
+    let mut recorder = Recorder::default();
+    let err =
+        execute_with_contract_for_tests(&adapter, &request(), &PolicyLeakRedactor, &mut recorder)
+            .await
+            .expect_err("must fail");
+    assert!(matches!(err, HarnessContractError::RedactionLeakDetected));
+    assert_eq!(
+        recorder.events,
+        vec![
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+            HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked)
         ]
     );
 }

--- a/crates/tanren-runtime/src/adapter/tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests.rs
@@ -1,0 +1,196 @@
+use async_trait::async_trait;
+use tanren_domain::{
+    Cli, DispatchId, FiniteF64, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs,
+};
+
+use super::*;
+use crate::capability::{
+    ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplySupport,
+    SandboxMode, SessionResumeSupport,
+};
+use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
+use crate::failure::{HarnessFailure, HarnessFailureClass};
+use crate::redaction::{OutputRedactor, RedactionError, RedactionHints};
+
+#[derive(Default)]
+struct Recorder {
+    events: Vec<HarnessExecutionEvent>,
+}
+
+impl HarnessObserver for Recorder {
+    fn on_event(&mut self, event: HarnessExecutionEvent) {
+        self.events.push(event);
+    }
+}
+
+#[derive(Clone)]
+struct MockAdapter {
+    output: RawExecutionOutput,
+    should_fail: bool,
+}
+
+#[async_trait]
+impl HarnessAdapter for MockAdapter {
+    fn adapter_name(&self) -> &'static str {
+        "mock"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        HarnessCapabilities {
+            output_streaming: OutputStreaming::TextAndToolEvents,
+            can_use_tools: true,
+            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+            session_resume: SessionResumeSupport::CrossProcess,
+            sandbox_mode: SandboxMode::WorkspaceWrite,
+            approval_mode: ApprovalMode::OnDemand,
+        }
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, HarnessFailure> {
+        if self.should_fail {
+            return Err(HarnessFailure {
+                class: HarnessFailureClass::Fatal,
+                message: "adapter failed".into(),
+                provider_code: None,
+                provider_kind: None,
+                typed_code: None,
+            });
+        }
+        Ok(ExecutionSignal {
+            output: self.output.clone(),
+            provider_run_id: None,
+            session_resumed: false,
+        })
+    }
+}
+
+struct LeakRedactor;
+
+impl OutputRedactor for LeakRedactor {
+    fn redact(
+        &self,
+        output: RawExecutionOutput,
+        _hints: &RedactionHints,
+    ) -> Result<PersistableOutput, RedactionError> {
+        Ok(PersistableOutput {
+            outcome: output.outcome,
+            signal: output.signal,
+            exit_code: output.exit_code,
+            duration_secs: FiniteF64::try_new(output.duration_secs)
+                .map_err(|_| RedactionError::InvalidDuration)?,
+            gate_output: output.gate_output,
+            tail_output: output.tail_output,
+            stderr_tail: output.stderr_tail,
+            pushed: output.pushed,
+            plan_hash: output.plan_hash,
+            unchecked_tasks: output.unchecked_tasks,
+            spec_modified: output.spec_modified,
+            findings: output.findings,
+            token_usage: output.token_usage,
+        })
+    }
+
+    fn has_known_secret_leak(&self, _output: &PersistableOutput, _hints: &RedactionHints) -> bool {
+        true
+    }
+}
+
+fn request() -> HarnessExecutionRequest {
+    HarnessExecutionRequest {
+        dispatch_id: DispatchId::new(),
+        step_id: StepId::new(),
+        cli: Cli::Codex,
+        phase: Phase::DoTask,
+        timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+        working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+        prompt: "perform work".into(),
+        requirements: HarnessRequirements::default(),
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+        secret_values_for_redaction: vec![RedactionSecret::from("sk-live-secret")],
+    }
+}
+
+fn raw_output() -> RawExecutionOutput {
+    RawExecutionOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: 1.0,
+        gate_output: Some("safe".into()),
+        tail_output: Some("safe".into()),
+        stderr_tail: Some("safe".into()),
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    }
+}
+
+#[tokio::test]
+async fn emits_expected_event_sequence_for_adapter_failure() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        should_fail: true,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(err, HarnessContractError::AdapterFailure(_)));
+    assert_eq!(
+        recorder.events,
+        vec![
+            HarnessExecutionEvent::PreflightAccepted,
+            HarnessExecutionEvent::AdapterInvoked
+        ]
+    );
+}
+
+#[tokio::test]
+async fn emits_expected_event_sequence_for_redaction_error() {
+    let adapter = MockAdapter {
+        output: RawExecutionOutput {
+            duration_secs: f64::NAN,
+            ..raw_output()
+        },
+        should_fail: false,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(err, HarnessContractError::Redaction(_)));
+    assert_eq!(
+        recorder.events,
+        vec![
+            HarnessExecutionEvent::PreflightAccepted,
+            HarnessExecutionEvent::AdapterInvoked
+        ]
+    );
+}
+
+#[tokio::test]
+async fn emits_expected_event_sequence_for_leak_detection() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        should_fail: false,
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract_for_tests(&adapter, &request(), &LeakRedactor, &mut recorder)
+        .await
+        .expect_err("must fail");
+    assert!(matches!(err, HarnessContractError::RedactionLeakDetected));
+    assert_eq!(
+        recorder.events,
+        vec![
+            HarnessExecutionEvent::PreflightAccepted,
+            HarnessExecutionEvent::AdapterInvoked
+        ]
+    );
+}

--- a/crates/tanren-runtime/src/adapter/tests/provider_run_id_tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests/provider_run_id_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+#[tokio::test]
+async fn preserves_provider_run_id_when_it_is_safe() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: Some(ProviderRunId::try_new("run_12345:abc.DEF").expect("run id")),
+    };
+    let mut recorder = Recorder::default();
+    let result = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect("must succeed");
+    assert_eq!(
+        result.provider_run_id.as_ref().map(ProviderRunId::as_str),
+        Some("run_12345:abc.DEF")
+    );
+}
+
+#[tokio::test]
+async fn fails_closed_when_provider_run_id_is_redaction_mutated() {
+    let adapter = MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: Some(ProviderRunId::try_new("run-sk-live-secret").expect("run id")),
+    };
+    let mut recorder = Recorder::default();
+    let err = execute_with_contract(&adapter, &request(), &mut recorder)
+        .await
+        .expect_err("must fail closed");
+    assert!(matches!(
+        err,
+        HarnessContractError::UnsafeProviderMetadata {
+            field: "provider_run_id",
+            violation: ProviderMetadataViolation::RedactedOrMutated
+        }
+    ));
+}

--- a/crates/tanren-runtime/src/adapter/tests/registry_tests.rs
+++ b/crates/tanren-runtime/src/adapter/tests/registry_tests.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use super::*;
+
+#[test]
+fn registry_supports_trait_object_lookup() {
+    let adapter = Arc::new(MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: None,
+    });
+    let mut registry = HarnessAdapterRegistry::default();
+    assert!(registry.register(adapter).is_ok());
+    assert_eq!(registry.len(), 1);
+    assert!(!registry.is_empty());
+    let Some(registered) = registry.get("mock") else {
+        unreachable!("registry lookup must resolve registered adapter");
+    };
+    assert_eq!(registered.adapter_name(), "mock");
+    assert!(registered.capabilities().can_use_tools);
+}
+
+#[test]
+fn registry_rejects_duplicate_adapter_names() {
+    let first = Arc::new(MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: None,
+    });
+    let second = Arc::new(MockAdapter {
+        output: raw_output(),
+        provider_failure: None,
+        provider_run_id: None,
+    });
+    let mut registry = HarnessAdapterRegistry::default();
+    assert!(registry.register(first).is_ok());
+    let duplicate = registry
+        .register(second)
+        .expect_err("must reject duplicate adapter name");
+    assert_eq!(
+        duplicate,
+        HarnessAdapterRegistryError::DuplicateAdapterName { name: "mock" }
+    );
+}

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+mod requirements;
+
+pub use requirements::{
+    ApprovalModeBounds, HarnessRequirements, HarnessRequirementsBuilder,
+    OutputStreamingRequirement, PatchApplyRequirement, RequirementBoundsError, RequirementLevel,
+    SandboxModeBounds, SessionResumeRequirement,
+};
+
 /// Output streaming support advertised by a harness adapter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -72,81 +80,6 @@ pub struct HarnessCapabilities {
     pub approval_mode: ApprovalMode,
 }
 
-/// Requirement strictness for one capability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum RequirementLevel {
-    #[default]
-    Optional,
-    Required,
-}
-
-impl RequirementLevel {
-    #[must_use]
-    pub const fn is_required(self) -> bool {
-        matches!(self, Self::Required)
-    }
-}
-
-/// Required output-streaming class.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum OutputStreamingRequirement {
-    #[default]
-    None,
-    Text,
-    TextAndToolEvents,
-}
-
-/// Minimum patch-apply support required for admissibility.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum PatchApplyRequirement {
-    #[default]
-    None,
-    ApplyPatchOnly,
-    ApplyPatchAndUnifiedDiff,
-}
-
-/// Minimum session-resume support required for admissibility.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum SessionResumeRequirement {
-    #[default]
-    None,
-    SameProcessOnly,
-    CrossProcess,
-}
-
-/// Pre-execution requirements a dispatch needs from the selected harness.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct HarnessRequirements {
-    #[serde(default)]
-    pub output_streaming: OutputStreamingRequirement,
-    #[serde(default)]
-    pub tool_use: RequirementLevel,
-    #[serde(default)]
-    pub patch_apply: PatchApplyRequirement,
-    #[serde(default)]
-    pub session_resume: SessionResumeRequirement,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "required_sandbox_mode"
-    )]
-    pub minimum_sandbox_mode: Option<SandboxMode>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum_sandbox_mode: Option<SandboxMode>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "required_approval_mode"
-    )]
-    pub minimum_approval_mode: Option<ApprovalMode>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum_approval_mode: Option<ApprovalMode>,
-}
-
 /// Typed mismatch classes used for deterministic denial handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -158,7 +91,6 @@ pub enum CompatibilityDenialKind {
     SessionResumeLevelInsufficient,
     SandboxModeBelowMinimum,
     SandboxModeExceedsMaximum,
-    SandboxModeInvalidRange,
     ApprovalModeBelowMinimum,
     ApprovalModeExceedsMaximum,
 }
@@ -181,7 +113,7 @@ impl HarnessCapabilities {
     /// Evaluate whether this adapter can satisfy the provided requirements.
     #[must_use]
     pub fn evaluate(&self, requirements: &HarnessRequirements) -> CapabilityAdmissibility {
-        match requirements.output_streaming {
+        match requirements.output_streaming() {
             OutputStreamingRequirement::None => {}
             OutputStreamingRequirement::Text => {
                 if !self.output_streaming.supports_text() {
@@ -199,39 +131,31 @@ impl HarnessCapabilities {
             }
         }
 
-        if requirements.tool_use.is_required() && !self.can_use_tools {
+        if requirements.tool_use().is_required() && !self.can_use_tools {
             return CapabilityAdmissibility::Denied(CompatibilityDenialKind::ToolUseUnsupported);
         }
 
-        if !patch_apply_satisfies(self.patch_apply, requirements.patch_apply) {
+        if !patch_apply_satisfies(self.patch_apply, requirements.patch_apply()) {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::PatchApplyLevelInsufficient,
             );
         }
 
-        if !session_resume_satisfies(self.session_resume, requirements.session_resume) {
+        if !session_resume_satisfies(self.session_resume, requirements.session_resume()) {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::SessionResumeLevelInsufficient,
             );
         }
 
-        if let (Some(minimum), Some(maximum)) = (
-            requirements.minimum_sandbox_mode,
-            requirements.maximum_sandbox_mode,
-        ) && sandbox_mode_rank(minimum) > sandbox_mode_rank(maximum)
-        {
-            return CapabilityAdmissibility::Denied(
-                CompatibilityDenialKind::SandboxModeInvalidRange,
-            );
-        }
-        if let Some(minimum) = requirements.minimum_sandbox_mode
+        let sandbox_bounds = requirements.sandbox_mode_bounds();
+        if let Some(minimum) = sandbox_bounds.minimum()
             && !sandbox_mode_satisfies(self.sandbox_mode, minimum)
         {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::SandboxModeBelowMinimum,
             );
         }
-        if let Some(maximum) = requirements.maximum_sandbox_mode
+        if let Some(maximum) = sandbox_bounds.maximum()
             && sandbox_mode_rank(self.sandbox_mode) > sandbox_mode_rank(maximum)
         {
             return CapabilityAdmissibility::Denied(
@@ -239,14 +163,15 @@ impl HarnessCapabilities {
             );
         }
 
-        if let Some(minimum) = requirements.minimum_approval_mode
+        let approval_bounds = requirements.approval_mode_bounds();
+        if let Some(minimum) = approval_bounds.minimum()
             && !approval_mode_satisfies_minimum(self.approval_mode, minimum)
         {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::ApprovalModeBelowMinimum,
             );
         }
-        if let Some(maximum) = requirements.maximum_approval_mode
+        if let Some(maximum) = approval_bounds.maximum()
             && !approval_mode_within_maximum(self.approval_mode, maximum)
         {
             return CapabilityAdmissibility::Denied(

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -49,6 +49,10 @@ pub enum SandboxMode {
 }
 
 /// Human approval behavior for restricted actions.
+///
+/// Ordering semantics are explicit and dual-axis:
+/// - minimum bounds use strictness (`never` < `on_escalation` < `on_demand`)
+/// - maximum bounds use privilege risk (`on_demand` < `on_escalation` < `never`)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalMode {
@@ -239,21 +243,21 @@ impl HarnessCapabilities {
         if let (Some(minimum), Some(maximum)) = (
             requirements.minimum_approval_mode,
             requirements.maximum_approval_mode,
-        ) && approval_mode_rank(minimum) > approval_mode_rank(maximum)
+        ) && !approval_mode_range_has_solution(minimum, maximum)
         {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::ApprovalModeInvalidRange,
             );
         }
         if let Some(minimum) = requirements.minimum_approval_mode
-            && !approval_mode_satisfies(self.approval_mode, minimum)
+            && !approval_mode_satisfies_minimum(self.approval_mode, minimum)
         {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::ApprovalModeBelowMinimum,
             );
         }
         if let Some(maximum) = requirements.maximum_approval_mode
-            && approval_mode_rank(self.approval_mode) > approval_mode_rank(maximum)
+            && !approval_mode_within_maximum(self.approval_mode, maximum)
         {
             return CapabilityAdmissibility::Denied(
                 CompatibilityDenialKind::ApprovalModeExceedsMaximum,
@@ -334,7 +338,7 @@ const fn sandbox_mode_satisfies(actual: SandboxMode, required: SandboxMode) -> b
     sandbox_mode_rank(actual) >= sandbox_mode_rank(required)
 }
 
-const fn approval_mode_rank(mode: ApprovalMode) -> u8 {
+const fn approval_strictness_rank(mode: ApprovalMode) -> u8 {
     match mode {
         ApprovalMode::Never => 0,
         ApprovalMode::OnEscalation => 1,
@@ -342,8 +346,29 @@ const fn approval_mode_rank(mode: ApprovalMode) -> u8 {
     }
 }
 
-const fn approval_mode_satisfies(actual: ApprovalMode, required: ApprovalMode) -> bool {
-    approval_mode_rank(actual) >= approval_mode_rank(required)
+const fn approval_privilege_rank(mode: ApprovalMode) -> u8 {
+    match mode {
+        ApprovalMode::OnDemand => 0,
+        ApprovalMode::OnEscalation => 1,
+        ApprovalMode::Never => 2,
+    }
+}
+
+const fn approval_mode_satisfies_minimum(actual: ApprovalMode, minimum: ApprovalMode) -> bool {
+    approval_strictness_rank(actual) >= approval_strictness_rank(minimum)
+}
+
+const fn approval_mode_within_maximum(actual: ApprovalMode, maximum: ApprovalMode) -> bool {
+    approval_privilege_rank(actual) <= approval_privilege_rank(maximum)
+}
+
+const fn approval_mode_range_has_solution(minimum: ApprovalMode, maximum: ApprovalMode) -> bool {
+    approval_mode_satisfies_minimum(ApprovalMode::Never, minimum)
+        && approval_mode_within_maximum(ApprovalMode::Never, maximum)
+        || approval_mode_satisfies_minimum(ApprovalMode::OnEscalation, minimum)
+            && approval_mode_within_maximum(ApprovalMode::OnEscalation, maximum)
+        || approval_mode_satisfies_minimum(ApprovalMode::OnDemand, minimum)
+            && approval_mode_within_maximum(ApprovalMode::OnDemand, maximum)
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -125,10 +125,22 @@ pub struct HarnessRequirements {
     pub patch_apply: PatchApplyRequirement,
     #[serde(default)]
     pub session_resume: SessionResumeRequirement,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "required_sandbox_mode"
+    )]
+    pub minimum_sandbox_mode: Option<SandboxMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub required_sandbox_mode: Option<SandboxMode>,
+    pub maximum_sandbox_mode: Option<SandboxMode>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "required_approval_mode"
+    )]
+    pub minimum_approval_mode: Option<ApprovalMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub required_approval_mode: Option<ApprovalMode>,
+    pub maximum_approval_mode: Option<ApprovalMode>,
 }
 
 /// Typed mismatch classes used for deterministic denial handling.
@@ -140,8 +152,12 @@ pub enum CompatibilityDenialKind {
     ToolUseUnsupported,
     PatchApplyLevelInsufficient,
     SessionResumeLevelInsufficient,
-    SandboxModeInsufficient,
-    ApprovalModeInsufficient,
+    SandboxModeBelowMinimum,
+    SandboxModeExceedsMaximum,
+    SandboxModeInvalidRange,
+    ApprovalModeBelowMinimum,
+    ApprovalModeExceedsMaximum,
+    ApprovalModeInvalidRange,
 }
 
 /// Typed denial returned when requirements do not match adapter capabilities.
@@ -196,20 +212,52 @@ impl HarnessCapabilities {
             );
         }
 
-        if let Some(required) = requirements.required_sandbox_mode {
-            if !sandbox_mode_satisfies(self.sandbox_mode, required) {
-                return CapabilityAdmissibility::Denied(
-                    CompatibilityDenialKind::SandboxModeInsufficient,
-                );
-            }
+        if let (Some(minimum), Some(maximum)) = (
+            requirements.minimum_sandbox_mode,
+            requirements.maximum_sandbox_mode,
+        ) && sandbox_mode_rank(minimum) > sandbox_mode_rank(maximum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::SandboxModeInvalidRange,
+            );
+        }
+        if let Some(minimum) = requirements.minimum_sandbox_mode
+            && !sandbox_mode_satisfies(self.sandbox_mode, minimum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::SandboxModeBelowMinimum,
+            );
+        }
+        if let Some(maximum) = requirements.maximum_sandbox_mode
+            && sandbox_mode_rank(self.sandbox_mode) > sandbox_mode_rank(maximum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::SandboxModeExceedsMaximum,
+            );
         }
 
-        if let Some(required) = requirements.required_approval_mode {
-            if !approval_mode_satisfies(self.approval_mode, required) {
-                return CapabilityAdmissibility::Denied(
-                    CompatibilityDenialKind::ApprovalModeInsufficient,
-                );
-            }
+        if let (Some(minimum), Some(maximum)) = (
+            requirements.minimum_approval_mode,
+            requirements.maximum_approval_mode,
+        ) && approval_mode_rank(minimum) > approval_mode_rank(maximum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::ApprovalModeInvalidRange,
+            );
+        }
+        if let Some(minimum) = requirements.minimum_approval_mode
+            && !approval_mode_satisfies(self.approval_mode, minimum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::ApprovalModeBelowMinimum,
+            );
+        }
+        if let Some(maximum) = requirements.maximum_approval_mode
+            && approval_mode_rank(self.approval_mode) > approval_mode_rank(maximum)
+        {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::ApprovalModeExceedsMaximum,
+            );
         }
 
         CapabilityAdmissibility::Admissible
@@ -299,202 +347,4 @@ const fn approval_mode_satisfies(actual: ApprovalMode, required: ApprovalMode) -
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn baseline() -> HarnessCapabilities {
-        HarnessCapabilities {
-            output_streaming: OutputStreaming::TextAndToolEvents,
-            can_use_tools: true,
-            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
-            session_resume: SessionResumeSupport::CrossProcess,
-            sandbox_mode: SandboxMode::WorkspaceWrite,
-            approval_mode: ApprovalMode::OnDemand,
-        }
-    }
-
-    #[test]
-    fn baseline_is_admissible_for_default_requirements() {
-        let requirements = HarnessRequirements::default();
-        assert_eq!(
-            baseline().evaluate(&requirements),
-            CapabilityAdmissibility::Admissible
-        );
-    }
-
-    #[test]
-    fn denies_text_streaming_requirement_when_output_streaming_is_none() {
-        let caps = HarnessCapabilities {
-            output_streaming: OutputStreaming::None,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            output_streaming: OutputStreamingRequirement::Text,
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny text requirement");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::TextStreamingUnsupported
-        );
-    }
-
-    #[test]
-    fn denies_tool_event_streaming_requirement_without_tool_events() {
-        let caps = HarnessCapabilities {
-            output_streaming: OutputStreaming::TextDeltas,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            output_streaming: OutputStreamingRequirement::TextAndToolEvents,
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny tool-events requirement");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::ToolEventStreamingUnsupported
-        );
-    }
-
-    #[test]
-    fn allows_text_requirement_with_text_deltas() {
-        let caps = HarnessCapabilities {
-            output_streaming: OutputStreaming::TextDeltas,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            output_streaming: OutputStreamingRequirement::Text,
-            ..HarnessRequirements::default()
-        };
-        assert!(caps.ensure_admissible(&requirements).is_ok());
-    }
-
-    #[test]
-    fn denies_when_tool_use_is_required_but_missing() {
-        let mut caps = baseline();
-        caps.can_use_tools = false;
-        let requirements = HarnessRequirements {
-            tool_use: RequirementLevel::Required,
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny");
-        assert_eq!(denial.kind, CompatibilityDenialKind::ToolUseUnsupported);
-    }
-
-    #[test]
-    fn denies_when_patch_apply_level_is_insufficient() {
-        let caps = HarnessCapabilities {
-            patch_apply: PatchApplySupport::ApplyPatchOnly,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::PatchApplyLevelInsufficient
-        );
-    }
-
-    #[test]
-    fn denies_when_session_resume_level_is_insufficient() {
-        let caps = HarnessCapabilities {
-            session_resume: SessionResumeSupport::SameProcessOnly,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            session_resume: SessionResumeRequirement::CrossProcess,
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::SessionResumeLevelInsufficient
-        );
-    }
-
-    #[test]
-    fn allows_cross_process_for_same_process_requirement() {
-        let requirements = HarnessRequirements {
-            session_resume: SessionResumeRequirement::SameProcessOnly,
-            ..HarnessRequirements::default()
-        };
-        assert!(baseline().ensure_admissible(&requirements).is_ok());
-    }
-
-    #[test]
-    fn denies_when_sandbox_rank_is_insufficient() {
-        let caps = HarnessCapabilities {
-            sandbox_mode: SandboxMode::ReadOnly,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            required_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::SandboxModeInsufficient
-        );
-    }
-
-    #[test]
-    fn allows_stronger_sandbox_mode() {
-        let caps = HarnessCapabilities {
-            sandbox_mode: SandboxMode::Unrestricted,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            required_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-            ..HarnessRequirements::default()
-        };
-        assert!(caps.ensure_admissible(&requirements).is_ok());
-    }
-
-    #[test]
-    fn denies_when_approval_mode_is_insufficient() {
-        let caps = HarnessCapabilities {
-            approval_mode: ApprovalMode::OnEscalation,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            required_approval_mode: Some(ApprovalMode::OnDemand),
-            ..HarnessRequirements::default()
-        };
-        let denial = caps
-            .ensure_admissible(&requirements)
-            .expect_err("must deny");
-        assert_eq!(
-            denial.kind,
-            CompatibilityDenialKind::ApprovalModeInsufficient
-        );
-    }
-
-    #[test]
-    fn allows_stronger_approval_mode() {
-        let caps = HarnessCapabilities {
-            approval_mode: ApprovalMode::OnDemand,
-            ..baseline()
-        };
-        let requirements = HarnessRequirements {
-            required_approval_mode: Some(ApprovalMode::OnEscalation),
-            ..HarnessRequirements::default()
-        };
-        assert!(caps.ensure_admissible(&requirements).is_ok());
-    }
-}
+mod tests;

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -161,7 +161,6 @@ pub enum CompatibilityDenialKind {
     SandboxModeInvalidRange,
     ApprovalModeBelowMinimum,
     ApprovalModeExceedsMaximum,
-    ApprovalModeInvalidRange,
 }
 
 /// Typed denial returned when requirements do not match adapter capabilities.
@@ -240,15 +239,6 @@ impl HarnessCapabilities {
             );
         }
 
-        if let (Some(minimum), Some(maximum)) = (
-            requirements.minimum_approval_mode,
-            requirements.maximum_approval_mode,
-        ) && !approval_mode_range_has_solution(minimum, maximum)
-        {
-            return CapabilityAdmissibility::Denied(
-                CompatibilityDenialKind::ApprovalModeInvalidRange,
-            );
-        }
         if let Some(minimum) = requirements.minimum_approval_mode
             && !approval_mode_satisfies_minimum(self.approval_mode, minimum)
         {
@@ -360,15 +350,6 @@ const fn approval_mode_satisfies_minimum(actual: ApprovalMode, minimum: Approval
 
 const fn approval_mode_within_maximum(actual: ApprovalMode, maximum: ApprovalMode) -> bool {
     approval_privilege_rank(actual) <= approval_privilege_rank(maximum)
-}
-
-const fn approval_mode_range_has_solution(minimum: ApprovalMode, maximum: ApprovalMode) -> bool {
-    approval_mode_satisfies_minimum(ApprovalMode::Never, minimum)
-        && approval_mode_within_maximum(ApprovalMode::Never, maximum)
-        || approval_mode_satisfies_minimum(ApprovalMode::OnEscalation, minimum)
-            && approval_mode_within_maximum(ApprovalMode::OnEscalation, maximum)
-        || approval_mode_satisfies_minimum(ApprovalMode::OnDemand, minimum)
-            && approval_mode_within_maximum(ApprovalMode::OnDemand, maximum)
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -30,13 +30,6 @@ pub enum PatchApplySupport {
     ApplyPatchAndUnifiedDiff,
 }
 
-impl PatchApplySupport {
-    #[must_use]
-    pub const fn supports_apply_patch(self) -> bool {
-        !matches!(self, Self::Unsupported)
-    }
-}
-
 /// Session behavior supported by the harness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -44,13 +37,6 @@ pub enum SessionResumeSupport {
     Never,
     SameProcessOnly,
     CrossProcess,
-}
-
-impl SessionResumeSupport {
-    #[must_use]
-    pub const fn allows_resume(self) -> bool {
-        !matches!(self, Self::Never)
-    }
 }
 
 /// Sandbox behavior normalized across providers.
@@ -108,6 +94,26 @@ pub enum OutputStreamingRequirement {
     TextAndToolEvents,
 }
 
+/// Minimum patch-apply support required for admissibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchApplyRequirement {
+    #[default]
+    None,
+    ApplyPatchOnly,
+    ApplyPatchAndUnifiedDiff,
+}
+
+/// Minimum session-resume support required for admissibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionResumeRequirement {
+    #[default]
+    None,
+    SameProcessOnly,
+    CrossProcess,
+}
+
 /// Pre-execution requirements a dispatch needs from the selected harness.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct HarnessRequirements {
@@ -116,9 +122,9 @@ pub struct HarnessRequirements {
     #[serde(default)]
     pub tool_use: RequirementLevel,
     #[serde(default)]
-    pub patch_apply: RequirementLevel,
+    pub patch_apply: PatchApplyRequirement,
     #[serde(default)]
-    pub session_resume: RequirementLevel,
+    pub session_resume: SessionResumeRequirement,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_sandbox_mode: Option<SandboxMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -132,8 +138,8 @@ pub enum CompatibilityDenialKind {
     TextStreamingUnsupported,
     ToolEventStreamingUnsupported,
     ToolUseUnsupported,
-    PatchApplyUnsupported,
-    SessionResumeUnsupported,
+    PatchApplyLevelInsufficient,
+    SessionResumeLevelInsufficient,
     SandboxModeInsufficient,
     ApprovalModeInsufficient,
 }
@@ -173,17 +179,23 @@ impl HarnessCapabilities {
                 }
             }
         }
+
         if requirements.tool_use.is_required() && !self.can_use_tools {
             return CapabilityAdmissibility::Denied(CompatibilityDenialKind::ToolUseUnsupported);
         }
-        if requirements.patch_apply.is_required() && !self.patch_apply.supports_apply_patch() {
-            return CapabilityAdmissibility::Denied(CompatibilityDenialKind::PatchApplyUnsupported);
-        }
-        if requirements.session_resume.is_required() && !self.session_resume.allows_resume() {
+
+        if !patch_apply_satisfies(self.patch_apply, requirements.patch_apply) {
             return CapabilityAdmissibility::Denied(
-                CompatibilityDenialKind::SessionResumeUnsupported,
+                CompatibilityDenialKind::PatchApplyLevelInsufficient,
             );
         }
+
+        if !session_resume_satisfies(self.session_resume, requirements.session_resume) {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::SessionResumeLevelInsufficient,
+            );
+        }
+
         if let Some(required) = requirements.required_sandbox_mode {
             if !sandbox_mode_satisfies(self.sandbox_mode, required) {
                 return CapabilityAdmissibility::Denied(
@@ -191,6 +203,7 @@ impl HarnessCapabilities {
                 );
             }
         }
+
         if let Some(required) = requirements.required_approval_mode {
             if !approval_mode_satisfies(self.approval_mode, required) {
                 return CapabilityAdmissibility::Denied(
@@ -198,6 +211,7 @@ impl HarnessCapabilities {
                 );
             }
         }
+
         CapabilityAdmissibility::Admissible
     }
 
@@ -215,6 +229,49 @@ impl HarnessCapabilities {
             CapabilityAdmissibility::Denied(kind) => Err(CompatibilityDenial { kind }),
         }
     }
+}
+
+const fn patch_apply_support_rank(support: PatchApplySupport) -> u8 {
+    match support {
+        PatchApplySupport::Unsupported => 0,
+        PatchApplySupport::ApplyPatchOnly => 1,
+        PatchApplySupport::ApplyPatchAndUnifiedDiff => 2,
+    }
+}
+
+const fn patch_apply_requirement_rank(requirement: PatchApplyRequirement) -> u8 {
+    match requirement {
+        PatchApplyRequirement::None => 0,
+        PatchApplyRequirement::ApplyPatchOnly => 1,
+        PatchApplyRequirement::ApplyPatchAndUnifiedDiff => 2,
+    }
+}
+
+const fn patch_apply_satisfies(actual: PatchApplySupport, required: PatchApplyRequirement) -> bool {
+    patch_apply_support_rank(actual) >= patch_apply_requirement_rank(required)
+}
+
+const fn session_resume_support_rank(support: SessionResumeSupport) -> u8 {
+    match support {
+        SessionResumeSupport::Never => 0,
+        SessionResumeSupport::SameProcessOnly => 1,
+        SessionResumeSupport::CrossProcess => 2,
+    }
+}
+
+const fn session_resume_requirement_rank(requirement: SessionResumeRequirement) -> u8 {
+    match requirement {
+        SessionResumeRequirement::None => 0,
+        SessionResumeRequirement::SameProcessOnly => 1,
+        SessionResumeRequirement::CrossProcess => 2,
+    }
+}
+
+const fn session_resume_satisfies(
+    actual: SessionResumeSupport,
+    required: SessionResumeRequirement,
+) -> bool {
+    session_resume_support_rank(actual) >= session_resume_requirement_rank(required)
 }
 
 const fn sandbox_mode_rank(mode: SandboxMode) -> u8 {
@@ -266,6 +323,57 @@ mod tests {
     }
 
     #[test]
+    fn denies_text_streaming_requirement_when_output_streaming_is_none() {
+        let caps = HarnessCapabilities {
+            output_streaming: OutputStreaming::None,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            output_streaming: OutputStreamingRequirement::Text,
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny text requirement");
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::TextStreamingUnsupported
+        );
+    }
+
+    #[test]
+    fn denies_tool_event_streaming_requirement_without_tool_events() {
+        let caps = HarnessCapabilities {
+            output_streaming: OutputStreaming::TextDeltas,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            output_streaming: OutputStreamingRequirement::TextAndToolEvents,
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny tool-events requirement");
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::ToolEventStreamingUnsupported
+        );
+    }
+
+    #[test]
+    fn allows_text_requirement_with_text_deltas() {
+        let caps = HarnessCapabilities {
+            output_streaming: OutputStreaming::TextDeltas,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            output_streaming: OutputStreamingRequirement::Text,
+            ..HarnessRequirements::default()
+        };
+        assert!(caps.ensure_admissible(&requirements).is_ok());
+    }
+
+    #[test]
     fn denies_when_tool_use_is_required_but_missing() {
         let mut caps = baseline();
         caps.can_use_tools = false;
@@ -280,17 +388,50 @@ mod tests {
     }
 
     #[test]
-    fn denies_when_patch_apply_is_required_but_missing() {
-        let mut caps = baseline();
-        caps.patch_apply = PatchApplySupport::Unsupported;
+    fn denies_when_patch_apply_level_is_insufficient() {
+        let caps = HarnessCapabilities {
+            patch_apply: PatchApplySupport::ApplyPatchOnly,
+            ..baseline()
+        };
         let requirements = HarnessRequirements {
-            patch_apply: RequirementLevel::Required,
+            patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
             ..HarnessRequirements::default()
         };
         let denial = caps
             .ensure_admissible(&requirements)
             .expect_err("must deny");
-        assert_eq!(denial.kind, CompatibilityDenialKind::PatchApplyUnsupported);
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::PatchApplyLevelInsufficient
+        );
+    }
+
+    #[test]
+    fn denies_when_session_resume_level_is_insufficient() {
+        let caps = HarnessCapabilities {
+            session_resume: SessionResumeSupport::SameProcessOnly,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            session_resume: SessionResumeRequirement::CrossProcess,
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny");
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::SessionResumeLevelInsufficient
+        );
+    }
+
+    #[test]
+    fn allows_cross_process_for_same_process_requirement() {
+        let requirements = HarnessRequirements {
+            session_resume: SessionResumeRequirement::SameProcessOnly,
+            ..HarnessRequirements::default()
+        };
+        assert!(baseline().ensure_admissible(&requirements).is_ok());
     }
 
     #[test]
@@ -320,6 +461,38 @@ mod tests {
         };
         let requirements = HarnessRequirements {
             required_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+            ..HarnessRequirements::default()
+        };
+        assert!(caps.ensure_admissible(&requirements).is_ok());
+    }
+
+    #[test]
+    fn denies_when_approval_mode_is_insufficient() {
+        let caps = HarnessCapabilities {
+            approval_mode: ApprovalMode::OnEscalation,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            required_approval_mode: Some(ApprovalMode::OnDemand),
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny");
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::ApprovalModeInsufficient
+        );
+    }
+
+    #[test]
+    fn allows_stronger_approval_mode() {
+        let caps = HarnessCapabilities {
+            approval_mode: ApprovalMode::OnDemand,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            required_approval_mode: Some(ApprovalMode::OnEscalation),
             ..HarnessRequirements::default()
         };
         assert!(caps.ensure_admissible(&requirements).is_ok());

--- a/crates/tanren-runtime/src/capability.rs
+++ b/crates/tanren-runtime/src/capability.rs
@@ -1,0 +1,327 @@
+use serde::{Deserialize, Serialize};
+
+/// Output streaming support advertised by a harness adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStreaming {
+    None,
+    TextDeltas,
+    TextAndToolEvents,
+}
+
+impl OutputStreaming {
+    #[must_use]
+    pub const fn supports_text(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    #[must_use]
+    pub const fn supports_tool_events(self) -> bool {
+        matches!(self, Self::TextAndToolEvents)
+    }
+}
+
+/// Whether the harness supports applying patches natively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchApplySupport {
+    Unsupported,
+    ApplyPatchOnly,
+    ApplyPatchAndUnifiedDiff,
+}
+
+impl PatchApplySupport {
+    #[must_use]
+    pub const fn supports_apply_patch(self) -> bool {
+        !matches!(self, Self::Unsupported)
+    }
+}
+
+/// Session behavior supported by the harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionResumeSupport {
+    Never,
+    SameProcessOnly,
+    CrossProcess,
+}
+
+impl SessionResumeSupport {
+    #[must_use]
+    pub const fn allows_resume(self) -> bool {
+        !matches!(self, Self::Never)
+    }
+}
+
+/// Sandbox behavior normalized across providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    Unrestricted,
+}
+
+/// Human approval behavior for restricted actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalMode {
+    Never,
+    OnEscalation,
+    OnDemand,
+}
+
+/// Capabilities a harness adapter advertises.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessCapabilities {
+    pub output_streaming: OutputStreaming,
+    pub can_use_tools: bool,
+    pub patch_apply: PatchApplySupport,
+    pub session_resume: SessionResumeSupport,
+    pub sandbox_mode: SandboxMode,
+    pub approval_mode: ApprovalMode,
+}
+
+/// Requirement strictness for one capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementLevel {
+    #[default]
+    Optional,
+    Required,
+}
+
+impl RequirementLevel {
+    #[must_use]
+    pub const fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
+
+/// Required output-streaming class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStreamingRequirement {
+    #[default]
+    None,
+    Text,
+    TextAndToolEvents,
+}
+
+/// Pre-execution requirements a dispatch needs from the selected harness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HarnessRequirements {
+    #[serde(default)]
+    pub output_streaming: OutputStreamingRequirement,
+    #[serde(default)]
+    pub tool_use: RequirementLevel,
+    #[serde(default)]
+    pub patch_apply: RequirementLevel,
+    #[serde(default)]
+    pub session_resume: RequirementLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_sandbox_mode: Option<SandboxMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_approval_mode: Option<ApprovalMode>,
+}
+
+/// Typed mismatch classes used for deterministic denial handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityDenialKind {
+    TextStreamingUnsupported,
+    ToolEventStreamingUnsupported,
+    ToolUseUnsupported,
+    PatchApplyUnsupported,
+    SessionResumeUnsupported,
+    SandboxModeInsufficient,
+    ApprovalModeInsufficient,
+}
+
+/// Typed denial returned when requirements do not match adapter capabilities.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("capability mismatch: {kind:?}")]
+pub struct CompatibilityDenial {
+    pub kind: CompatibilityDenialKind,
+}
+
+/// Compatibility verdict returned by preflight checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityAdmissibility {
+    Admissible,
+    Denied(CompatibilityDenialKind),
+}
+
+impl HarnessCapabilities {
+    /// Evaluate whether this adapter can satisfy the provided requirements.
+    #[must_use]
+    pub fn evaluate(&self, requirements: &HarnessRequirements) -> CapabilityAdmissibility {
+        match requirements.output_streaming {
+            OutputStreamingRequirement::None => {}
+            OutputStreamingRequirement::Text => {
+                if !self.output_streaming.supports_text() {
+                    return CapabilityAdmissibility::Denied(
+                        CompatibilityDenialKind::TextStreamingUnsupported,
+                    );
+                }
+            }
+            OutputStreamingRequirement::TextAndToolEvents => {
+                if !self.output_streaming.supports_tool_events() {
+                    return CapabilityAdmissibility::Denied(
+                        CompatibilityDenialKind::ToolEventStreamingUnsupported,
+                    );
+                }
+            }
+        }
+        if requirements.tool_use.is_required() && !self.can_use_tools {
+            return CapabilityAdmissibility::Denied(CompatibilityDenialKind::ToolUseUnsupported);
+        }
+        if requirements.patch_apply.is_required() && !self.patch_apply.supports_apply_patch() {
+            return CapabilityAdmissibility::Denied(CompatibilityDenialKind::PatchApplyUnsupported);
+        }
+        if requirements.session_resume.is_required() && !self.session_resume.allows_resume() {
+            return CapabilityAdmissibility::Denied(
+                CompatibilityDenialKind::SessionResumeUnsupported,
+            );
+        }
+        if let Some(required) = requirements.required_sandbox_mode {
+            if !sandbox_mode_satisfies(self.sandbox_mode, required) {
+                return CapabilityAdmissibility::Denied(
+                    CompatibilityDenialKind::SandboxModeInsufficient,
+                );
+            }
+        }
+        if let Some(required) = requirements.required_approval_mode {
+            if !approval_mode_satisfies(self.approval_mode, required) {
+                return CapabilityAdmissibility::Denied(
+                    CompatibilityDenialKind::ApprovalModeInsufficient,
+                );
+            }
+        }
+        CapabilityAdmissibility::Admissible
+    }
+
+    /// Return `Ok(())` when admissible, otherwise a typed denial.
+    ///
+    /// # Errors
+    /// Returns [`CompatibilityDenial`] if this adapter cannot satisfy the
+    /// given requirements.
+    pub fn ensure_admissible(
+        &self,
+        requirements: &HarnessRequirements,
+    ) -> Result<(), CompatibilityDenial> {
+        match self.evaluate(requirements) {
+            CapabilityAdmissibility::Admissible => Ok(()),
+            CapabilityAdmissibility::Denied(kind) => Err(CompatibilityDenial { kind }),
+        }
+    }
+}
+
+const fn sandbox_mode_rank(mode: SandboxMode) -> u8 {
+    match mode {
+        SandboxMode::ReadOnly => 0,
+        SandboxMode::WorkspaceWrite => 1,
+        SandboxMode::Unrestricted => 2,
+    }
+}
+
+const fn sandbox_mode_satisfies(actual: SandboxMode, required: SandboxMode) -> bool {
+    sandbox_mode_rank(actual) >= sandbox_mode_rank(required)
+}
+
+const fn approval_mode_rank(mode: ApprovalMode) -> u8 {
+    match mode {
+        ApprovalMode::Never => 0,
+        ApprovalMode::OnEscalation => 1,
+        ApprovalMode::OnDemand => 2,
+    }
+}
+
+const fn approval_mode_satisfies(actual: ApprovalMode, required: ApprovalMode) -> bool {
+    approval_mode_rank(actual) >= approval_mode_rank(required)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn baseline() -> HarnessCapabilities {
+        HarnessCapabilities {
+            output_streaming: OutputStreaming::TextAndToolEvents,
+            can_use_tools: true,
+            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+            session_resume: SessionResumeSupport::CrossProcess,
+            sandbox_mode: SandboxMode::WorkspaceWrite,
+            approval_mode: ApprovalMode::OnDemand,
+        }
+    }
+
+    #[test]
+    fn baseline_is_admissible_for_default_requirements() {
+        let requirements = HarnessRequirements::default();
+        assert_eq!(
+            baseline().evaluate(&requirements),
+            CapabilityAdmissibility::Admissible
+        );
+    }
+
+    #[test]
+    fn denies_when_tool_use_is_required_but_missing() {
+        let mut caps = baseline();
+        caps.can_use_tools = false;
+        let requirements = HarnessRequirements {
+            tool_use: RequirementLevel::Required,
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny");
+        assert_eq!(denial.kind, CompatibilityDenialKind::ToolUseUnsupported);
+    }
+
+    #[test]
+    fn denies_when_patch_apply_is_required_but_missing() {
+        let mut caps = baseline();
+        caps.patch_apply = PatchApplySupport::Unsupported;
+        let requirements = HarnessRequirements {
+            patch_apply: RequirementLevel::Required,
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny");
+        assert_eq!(denial.kind, CompatibilityDenialKind::PatchApplyUnsupported);
+    }
+
+    #[test]
+    fn denies_when_sandbox_rank_is_insufficient() {
+        let caps = HarnessCapabilities {
+            sandbox_mode: SandboxMode::ReadOnly,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            required_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+            ..HarnessRequirements::default()
+        };
+        let denial = caps
+            .ensure_admissible(&requirements)
+            .expect_err("must deny");
+        assert_eq!(
+            denial.kind,
+            CompatibilityDenialKind::SandboxModeInsufficient
+        );
+    }
+
+    #[test]
+    fn allows_stronger_sandbox_mode() {
+        let caps = HarnessCapabilities {
+            sandbox_mode: SandboxMode::Unrestricted,
+            ..baseline()
+        };
+        let requirements = HarnessRequirements {
+            required_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+            ..HarnessRequirements::default()
+        };
+        assert!(caps.ensure_admissible(&requirements).is_ok());
+    }
+}

--- a/crates/tanren-runtime/src/capability/requirements.rs
+++ b/crates/tanren-runtime/src/capability/requirements.rs
@@ -1,0 +1,310 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ApprovalMode, SandboxMode};
+
+/// Requirement strictness for one capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementLevel {
+    #[default]
+    Optional,
+    Required,
+}
+
+impl RequirementLevel {
+    #[must_use]
+    pub const fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
+
+/// Required output-streaming class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStreamingRequirement {
+    #[default]
+    None,
+    Text,
+    TextAndToolEvents,
+}
+
+/// Minimum patch-apply support required for admissibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchApplyRequirement {
+    #[default]
+    None,
+    ApplyPatchOnly,
+    ApplyPatchAndUnifiedDiff,
+}
+
+/// Minimum session-resume support required for admissibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionResumeRequirement {
+    #[default]
+    None,
+    SameProcessOnly,
+    CrossProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum RequirementBoundsError {
+    #[error("sandbox minimum exceeds maximum")]
+    SandboxModeInvalidRange,
+}
+
+/// Validated sandbox bound requirements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default)]
+pub struct SandboxModeBounds {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "minimum_sandbox_mode",
+        alias = "required_sandbox_mode"
+    )]
+    minimum: Option<SandboxMode>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "maximum_sandbox_mode"
+    )]
+    maximum: Option<SandboxMode>,
+}
+
+impl SandboxModeBounds {
+    /// # Errors
+    /// Returns [`RequirementBoundsError::SandboxModeInvalidRange`] when invalid.
+    pub fn try_new(
+        minimum: Option<SandboxMode>,
+        maximum: Option<SandboxMode>,
+    ) -> Result<Self, RequirementBoundsError> {
+        if let (Some(minimum), Some(maximum)) = (minimum, maximum)
+            && sandbox_mode_rank(minimum) > sandbox_mode_rank(maximum)
+        {
+            return Err(RequirementBoundsError::SandboxModeInvalidRange);
+        }
+        Ok(Self { minimum, maximum })
+    }
+
+    #[must_use]
+    pub const fn minimum(self) -> Option<SandboxMode> {
+        self.minimum
+    }
+
+    #[must_use]
+    pub const fn maximum(self) -> Option<SandboxMode> {
+        self.maximum
+    }
+}
+
+#[derive(Deserialize)]
+struct SandboxModeBoundsWire {
+    #[serde(
+        default,
+        alias = "required_sandbox_mode",
+        rename = "minimum_sandbox_mode"
+    )]
+    minimum: Option<SandboxMode>,
+    #[serde(default, rename = "maximum_sandbox_mode")]
+    maximum: Option<SandboxMode>,
+}
+
+impl<'de> Deserialize<'de> for SandboxModeBounds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = SandboxModeBoundsWire::deserialize(deserializer)?;
+        Self::try_new(wire.minimum, wire.maximum).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validated approval bound requirements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Default)]
+pub struct ApprovalModeBounds {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "minimum_approval_mode",
+        alias = "required_approval_mode"
+    )]
+    minimum: Option<ApprovalMode>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "maximum_approval_mode"
+    )]
+    maximum: Option<ApprovalMode>,
+}
+
+impl ApprovalModeBounds {
+    #[must_use]
+    pub const fn new(minimum: Option<ApprovalMode>, maximum: Option<ApprovalMode>) -> Self {
+        Self { minimum, maximum }
+    }
+
+    #[must_use]
+    pub const fn minimum(self) -> Option<ApprovalMode> {
+        self.minimum
+    }
+
+    #[must_use]
+    pub const fn maximum(self) -> Option<ApprovalMode> {
+        self.maximum
+    }
+}
+
+#[derive(Deserialize)]
+struct ApprovalModeBoundsWire {
+    #[serde(
+        default,
+        alias = "required_approval_mode",
+        rename = "minimum_approval_mode"
+    )]
+    minimum: Option<ApprovalMode>,
+    #[serde(default, rename = "maximum_approval_mode")]
+    maximum: Option<ApprovalMode>,
+}
+
+impl<'de> Deserialize<'de> for ApprovalModeBounds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = ApprovalModeBoundsWire::deserialize(deserializer)?;
+        Ok(Self::new(wire.minimum, wire.maximum))
+    }
+}
+
+/// Pre-execution requirements a dispatch needs from the selected harness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessRequirements {
+    #[serde(default)]
+    output_streaming: OutputStreamingRequirement,
+    #[serde(default)]
+    tool_use: RequirementLevel,
+    #[serde(default)]
+    patch_apply: PatchApplyRequirement,
+    #[serde(default)]
+    session_resume: SessionResumeRequirement,
+    #[serde(default, flatten)]
+    sandbox_mode_bounds: SandboxModeBounds,
+    #[serde(default, flatten)]
+    approval_mode_bounds: ApprovalModeBounds,
+}
+
+impl Default for HarnessRequirements {
+    fn default() -> Self {
+        Self {
+            output_streaming: OutputStreamingRequirement::None,
+            tool_use: RequirementLevel::Optional,
+            patch_apply: PatchApplyRequirement::None,
+            session_resume: SessionResumeRequirement::None,
+            sandbox_mode_bounds: SandboxModeBounds::default(),
+            approval_mode_bounds: ApprovalModeBounds::default(),
+        }
+    }
+}
+
+impl HarnessRequirements {
+    #[must_use]
+    pub fn builder() -> HarnessRequirementsBuilder {
+        HarnessRequirementsBuilder::default()
+    }
+
+    #[must_use]
+    pub const fn output_streaming(&self) -> OutputStreamingRequirement {
+        self.output_streaming
+    }
+
+    #[must_use]
+    pub const fn tool_use(&self) -> RequirementLevel {
+        self.tool_use
+    }
+
+    #[must_use]
+    pub const fn patch_apply(&self) -> PatchApplyRequirement {
+        self.patch_apply
+    }
+
+    #[must_use]
+    pub const fn session_resume(&self) -> SessionResumeRequirement {
+        self.session_resume
+    }
+
+    #[must_use]
+    pub const fn sandbox_mode_bounds(&self) -> SandboxModeBounds {
+        self.sandbox_mode_bounds
+    }
+
+    #[must_use]
+    pub const fn approval_mode_bounds(&self) -> ApprovalModeBounds {
+        self.approval_mode_bounds
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HarnessRequirementsBuilder {
+    requirements: HarnessRequirements,
+}
+
+impl HarnessRequirementsBuilder {
+    #[must_use]
+    pub fn output_streaming(mut self, requirement: OutputStreamingRequirement) -> Self {
+        self.requirements.output_streaming = requirement;
+        self
+    }
+
+    #[must_use]
+    pub fn tool_use(mut self, requirement: RequirementLevel) -> Self {
+        self.requirements.tool_use = requirement;
+        self
+    }
+
+    #[must_use]
+    pub fn patch_apply(mut self, requirement: PatchApplyRequirement) -> Self {
+        self.requirements.patch_apply = requirement;
+        self
+    }
+
+    #[must_use]
+    pub fn session_resume(mut self, requirement: SessionResumeRequirement) -> Self {
+        self.requirements.session_resume = requirement;
+        self
+    }
+
+    /// # Errors
+    /// Returns [`RequirementBoundsError`] when bounds are malformed.
+    pub fn sandbox_mode_bounds(
+        mut self,
+        minimum: Option<SandboxMode>,
+        maximum: Option<SandboxMode>,
+    ) -> Result<Self, RequirementBoundsError> {
+        self.requirements.sandbox_mode_bounds = SandboxModeBounds::try_new(minimum, maximum)?;
+        Ok(self)
+    }
+
+    #[must_use]
+    pub fn approval_mode_bounds(
+        mut self,
+        minimum: Option<ApprovalMode>,
+        maximum: Option<ApprovalMode>,
+    ) -> Self {
+        self.requirements.approval_mode_bounds = ApprovalModeBounds::new(minimum, maximum);
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> HarnessRequirements {
+        self.requirements
+    }
+}
+
+const fn sandbox_mode_rank(mode: SandboxMode) -> u8 {
+    match mode {
+        SandboxMode::ReadOnly => 0,
+        SandboxMode::WorkspaceWrite => 1,
+        SandboxMode::Unrestricted => 2,
+    }
+}

--- a/crates/tanren-runtime/src/capability/tests.rs
+++ b/crates/tanren-runtime/src/capability/tests.rs
@@ -208,7 +208,7 @@ fn denies_when_approval_mode_is_below_minimum() {
 #[test]
 fn denies_when_approval_mode_exceeds_maximum() {
     let caps = HarnessCapabilities {
-        approval_mode: ApprovalMode::OnDemand,
+        approval_mode: ApprovalMode::Never,
         ..baseline()
     };
     let requirements = HarnessRequirements {
@@ -225,19 +225,17 @@ fn denies_when_approval_mode_exceeds_maximum() {
 }
 
 #[test]
-fn denies_when_approval_range_is_invalid() {
+fn approval_minimum_and_maximum_can_coexist_with_dual_ordering() {
     let requirements = HarnessRequirements {
         minimum_approval_mode: Some(ApprovalMode::OnDemand),
         maximum_approval_mode: Some(ApprovalMode::OnEscalation),
         ..HarnessRequirements::default()
     };
-    let denial = baseline()
-        .ensure_admissible(&requirements)
-        .expect_err("must deny invalid range");
-    assert_eq!(
-        denial.kind,
-        CompatibilityDenialKind::ApprovalModeInvalidRange
-    );
+    let caps = HarnessCapabilities {
+        approval_mode: ApprovalMode::OnDemand,
+        ..baseline()
+    };
+    assert!(caps.ensure_admissible(&requirements).is_ok());
 }
 
 #[test]
@@ -246,8 +244,90 @@ fn allows_when_modes_are_within_min_max_bounds() {
         minimum_sandbox_mode: Some(SandboxMode::ReadOnly),
         maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
         minimum_approval_mode: Some(ApprovalMode::OnEscalation),
-        maximum_approval_mode: Some(ApprovalMode::OnDemand),
+        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
         ..HarnessRequirements::default()
     };
     assert!(baseline().ensure_admissible(&requirements).is_ok());
+}
+
+fn strictness_rank(mode: ApprovalMode) -> u8 {
+    match mode {
+        ApprovalMode::Never => 0,
+        ApprovalMode::OnEscalation => 1,
+        ApprovalMode::OnDemand => 2,
+    }
+}
+
+fn privilege_rank(mode: ApprovalMode) -> u8 {
+    match mode {
+        ApprovalMode::OnDemand => 0,
+        ApprovalMode::OnEscalation => 1,
+        ApprovalMode::Never => 2,
+    }
+}
+
+fn expected_approval_denial(
+    actual: ApprovalMode,
+    minimum: Option<ApprovalMode>,
+    maximum: Option<ApprovalMode>,
+) -> Option<CompatibilityDenialKind> {
+    if let Some(minimum_mode) = minimum
+        && strictness_rank(actual) < strictness_rank(minimum_mode)
+    {
+        return Some(CompatibilityDenialKind::ApprovalModeBelowMinimum);
+    }
+    if let Some(maximum_mode) = maximum
+        && privilege_rank(actual) > privilege_rank(maximum_mode)
+    {
+        return Some(CompatibilityDenialKind::ApprovalModeExceedsMaximum);
+    }
+    None
+}
+
+#[test]
+fn approval_mode_dual_ordering_matrix_is_exhaustive() {
+    let modes = [
+        ApprovalMode::Never,
+        ApprovalMode::OnEscalation,
+        ApprovalMode::OnDemand,
+    ];
+    let bounds = [
+        None,
+        Some(ApprovalMode::Never),
+        Some(ApprovalMode::OnEscalation),
+        Some(ApprovalMode::OnDemand),
+    ];
+
+    for actual in modes {
+        for minimum in bounds {
+            for maximum in bounds {
+                let caps = HarnessCapabilities {
+                    approval_mode: actual,
+                    ..baseline()
+                };
+                let requirements = HarnessRequirements {
+                    minimum_approval_mode: minimum,
+                    maximum_approval_mode: maximum,
+                    ..HarnessRequirements::default()
+                };
+                let expected = expected_approval_denial(actual, minimum, maximum);
+                let result = caps.ensure_admissible(&requirements);
+                match expected {
+                    Some(expected_kind) => {
+                        let denial = result.expect_err("expected denial");
+                        assert_eq!(
+                            denial.kind, expected_kind,
+                            "actual={actual:?} minimum={minimum:?} maximum={maximum:?}"
+                        );
+                    }
+                    None => {
+                        assert!(
+                            result.is_ok(),
+                            "actual={actual:?} minimum={minimum:?} maximum={maximum:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/crates/tanren-runtime/src/capability/tests.rs
+++ b/crates/tanren-runtime/src/capability/tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+
+fn baseline() -> HarnessCapabilities {
+    HarnessCapabilities {
+        output_streaming: OutputStreaming::TextAndToolEvents,
+        can_use_tools: true,
+        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+        session_resume: SessionResumeSupport::CrossProcess,
+        sandbox_mode: SandboxMode::WorkspaceWrite,
+        approval_mode: ApprovalMode::OnDemand,
+    }
+}
+
+#[test]
+fn baseline_is_admissible_for_default_requirements() {
+    let requirements = HarnessRequirements::default();
+    assert_eq!(
+        baseline().evaluate(&requirements),
+        CapabilityAdmissibility::Admissible
+    );
+}
+
+#[test]
+fn denies_text_streaming_requirement_when_output_streaming_is_none() {
+    let caps = HarnessCapabilities {
+        output_streaming: OutputStreaming::None,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        output_streaming: OutputStreamingRequirement::Text,
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny text requirement");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::TextStreamingUnsupported
+    );
+}
+
+#[test]
+fn denies_tool_event_streaming_requirement_without_tool_events() {
+    let caps = HarnessCapabilities {
+        output_streaming: OutputStreaming::TextDeltas,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        output_streaming: OutputStreamingRequirement::TextAndToolEvents,
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny tool-events requirement");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::ToolEventStreamingUnsupported
+    );
+}
+
+#[test]
+fn allows_text_requirement_with_text_deltas() {
+    let caps = HarnessCapabilities {
+        output_streaming: OutputStreaming::TextDeltas,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        output_streaming: OutputStreamingRequirement::Text,
+        ..HarnessRequirements::default()
+    };
+    assert!(caps.ensure_admissible(&requirements).is_ok());
+}
+
+#[test]
+fn denies_when_tool_use_is_required_but_missing() {
+    let mut caps = baseline();
+    caps.can_use_tools = false;
+    let requirements = HarnessRequirements {
+        tool_use: RequirementLevel::Required,
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(denial.kind, CompatibilityDenialKind::ToolUseUnsupported);
+}
+
+#[test]
+fn denies_when_patch_apply_level_is_insufficient() {
+    let caps = HarnessCapabilities {
+        patch_apply: PatchApplySupport::ApplyPatchOnly,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::PatchApplyLevelInsufficient
+    );
+}
+
+#[test]
+fn denies_when_session_resume_level_is_insufficient() {
+    let caps = HarnessCapabilities {
+        session_resume: SessionResumeSupport::SameProcessOnly,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        session_resume: SessionResumeRequirement::CrossProcess,
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::SessionResumeLevelInsufficient
+    );
+}
+
+#[test]
+fn allows_cross_process_for_same_process_requirement() {
+    let requirements = HarnessRequirements {
+        session_resume: SessionResumeRequirement::SameProcessOnly,
+        ..HarnessRequirements::default()
+    };
+    assert!(baseline().ensure_admissible(&requirements).is_ok());
+}
+
+#[test]
+fn denies_when_sandbox_mode_is_below_minimum() {
+    let caps = HarnessCapabilities {
+        sandbox_mode: SandboxMode::ReadOnly,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        minimum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::SandboxModeBelowMinimum
+    );
+}
+
+#[test]
+fn denies_when_sandbox_mode_exceeds_maximum() {
+    let caps = HarnessCapabilities {
+        sandbox_mode: SandboxMode::Unrestricted,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::SandboxModeExceedsMaximum
+    );
+}
+
+#[test]
+fn denies_when_sandbox_range_is_invalid() {
+    let requirements = HarnessRequirements {
+        minimum_sandbox_mode: Some(SandboxMode::Unrestricted),
+        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+        ..HarnessRequirements::default()
+    };
+    let denial = baseline()
+        .ensure_admissible(&requirements)
+        .expect_err("must deny invalid range");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::SandboxModeInvalidRange
+    );
+}
+
+#[test]
+fn denies_when_approval_mode_is_below_minimum() {
+    let caps = HarnessCapabilities {
+        approval_mode: ApprovalMode::OnEscalation,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        minimum_approval_mode: Some(ApprovalMode::OnDemand),
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::ApprovalModeBelowMinimum
+    );
+}
+
+#[test]
+fn denies_when_approval_mode_exceeds_maximum() {
+    let caps = HarnessCapabilities {
+        approval_mode: ApprovalMode::OnDemand,
+        ..baseline()
+    };
+    let requirements = HarnessRequirements {
+        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
+        ..HarnessRequirements::default()
+    };
+    let denial = caps
+        .ensure_admissible(&requirements)
+        .expect_err("must deny");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::ApprovalModeExceedsMaximum
+    );
+}
+
+#[test]
+fn denies_when_approval_range_is_invalid() {
+    let requirements = HarnessRequirements {
+        minimum_approval_mode: Some(ApprovalMode::OnDemand),
+        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
+        ..HarnessRequirements::default()
+    };
+    let denial = baseline()
+        .ensure_admissible(&requirements)
+        .expect_err("must deny invalid range");
+    assert_eq!(
+        denial.kind,
+        CompatibilityDenialKind::ApprovalModeInvalidRange
+    );
+}
+
+#[test]
+fn allows_when_modes_are_within_min_max_bounds() {
+    let requirements = HarnessRequirements {
+        minimum_sandbox_mode: Some(SandboxMode::ReadOnly),
+        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
+        minimum_approval_mode: Some(ApprovalMode::OnEscalation),
+        maximum_approval_mode: Some(ApprovalMode::OnDemand),
+        ..HarnessRequirements::default()
+    };
+    assert!(baseline().ensure_admissible(&requirements).is_ok());
+}

--- a/crates/tanren-runtime/src/capability/tests.rs
+++ b/crates/tanren-runtime/src/capability/tests.rs
@@ -26,10 +26,9 @@ fn denies_text_streaming_requirement_when_output_streaming_is_none() {
         output_streaming: OutputStreaming::None,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        output_streaming: OutputStreamingRequirement::Text,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .output_streaming(OutputStreamingRequirement::Text)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny text requirement");
@@ -45,10 +44,9 @@ fn denies_tool_event_streaming_requirement_without_tool_events() {
         output_streaming: OutputStreaming::TextDeltas,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        output_streaming: OutputStreamingRequirement::TextAndToolEvents,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .output_streaming(OutputStreamingRequirement::TextAndToolEvents)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny tool-events requirement");
@@ -64,10 +62,9 @@ fn allows_text_requirement_with_text_deltas() {
         output_streaming: OutputStreaming::TextDeltas,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        output_streaming: OutputStreamingRequirement::Text,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .output_streaming(OutputStreamingRequirement::Text)
+        .build();
     assert!(caps.ensure_admissible(&requirements).is_ok());
 }
 
@@ -75,10 +72,9 @@ fn allows_text_requirement_with_text_deltas() {
 fn denies_when_tool_use_is_required_but_missing() {
     let mut caps = baseline();
     caps.can_use_tools = false;
-    let requirements = HarnessRequirements {
-        tool_use: RequirementLevel::Required,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .tool_use(RequirementLevel::Required)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -91,10 +87,9 @@ fn denies_when_patch_apply_level_is_insufficient() {
         patch_apply: PatchApplySupport::ApplyPatchOnly,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .patch_apply(PatchApplyRequirement::ApplyPatchAndUnifiedDiff)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -110,10 +105,9 @@ fn denies_when_session_resume_level_is_insufficient() {
         session_resume: SessionResumeSupport::SameProcessOnly,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        session_resume: SessionResumeRequirement::CrossProcess,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .session_resume(SessionResumeRequirement::CrossProcess)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -125,10 +119,9 @@ fn denies_when_session_resume_level_is_insufficient() {
 
 #[test]
 fn allows_cross_process_for_same_process_requirement() {
-    let requirements = HarnessRequirements {
-        session_resume: SessionResumeRequirement::SameProcessOnly,
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .session_resume(SessionResumeRequirement::SameProcessOnly)
+        .build();
     assert!(baseline().ensure_admissible(&requirements).is_ok());
 }
 
@@ -138,10 +131,10 @@ fn denies_when_sandbox_mode_is_below_minimum() {
         sandbox_mode: SandboxMode::ReadOnly,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        minimum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .sandbox_mode_bounds(Some(SandboxMode::WorkspaceWrite), None)
+        .expect("valid bounds")
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -157,10 +150,10 @@ fn denies_when_sandbox_mode_exceeds_maximum() {
         sandbox_mode: SandboxMode::Unrestricted,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .sandbox_mode_bounds(None, Some(SandboxMode::WorkspaceWrite))
+        .expect("valid bounds")
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -171,19 +164,14 @@ fn denies_when_sandbox_mode_exceeds_maximum() {
 }
 
 #[test]
-fn denies_when_sandbox_range_is_invalid() {
-    let requirements = HarnessRequirements {
-        minimum_sandbox_mode: Some(SandboxMode::Unrestricted),
-        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-        ..HarnessRequirements::default()
-    };
-    let denial = baseline()
-        .ensure_admissible(&requirements)
-        .expect_err("must deny invalid range");
-    assert_eq!(
-        denial.kind,
-        CompatibilityDenialKind::SandboxModeInvalidRange
-    );
+fn rejects_invalid_sandbox_bounds_at_construction() {
+    let err = HarnessRequirements::builder()
+        .sandbox_mode_bounds(
+            Some(SandboxMode::Unrestricted),
+            Some(SandboxMode::WorkspaceWrite),
+        )
+        .expect_err("must reject invalid range");
+    assert_eq!(err, RequirementBoundsError::SandboxModeInvalidRange);
 }
 
 #[test]
@@ -192,10 +180,9 @@ fn denies_when_approval_mode_is_below_minimum() {
         approval_mode: ApprovalMode::OnEscalation,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        minimum_approval_mode: Some(ApprovalMode::OnDemand),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .approval_mode_bounds(Some(ApprovalMode::OnDemand), None)
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -211,10 +198,9 @@ fn denies_when_approval_mode_exceeds_maximum() {
         approval_mode: ApprovalMode::Never,
         ..baseline()
     };
-    let requirements = HarnessRequirements {
-        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .approval_mode_bounds(None, Some(ApprovalMode::OnEscalation))
+        .build();
     let denial = caps
         .ensure_admissible(&requirements)
         .expect_err("must deny");
@@ -226,11 +212,12 @@ fn denies_when_approval_mode_exceeds_maximum() {
 
 #[test]
 fn approval_minimum_and_maximum_can_coexist_with_dual_ordering() {
-    let requirements = HarnessRequirements {
-        minimum_approval_mode: Some(ApprovalMode::OnDemand),
-        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .approval_mode_bounds(
+            Some(ApprovalMode::OnDemand),
+            Some(ApprovalMode::OnEscalation),
+        )
+        .build();
     let caps = HarnessCapabilities {
         approval_mode: ApprovalMode::OnDemand,
         ..baseline()
@@ -240,13 +227,17 @@ fn approval_minimum_and_maximum_can_coexist_with_dual_ordering() {
 
 #[test]
 fn allows_when_modes_are_within_min_max_bounds() {
-    let requirements = HarnessRequirements {
-        minimum_sandbox_mode: Some(SandboxMode::ReadOnly),
-        maximum_sandbox_mode: Some(SandboxMode::WorkspaceWrite),
-        minimum_approval_mode: Some(ApprovalMode::OnEscalation),
-        maximum_approval_mode: Some(ApprovalMode::OnEscalation),
-        ..HarnessRequirements::default()
-    };
+    let requirements = HarnessRequirements::builder()
+        .sandbox_mode_bounds(
+            Some(SandboxMode::ReadOnly),
+            Some(SandboxMode::WorkspaceWrite),
+        )
+        .expect("valid bounds")
+        .approval_mode_bounds(
+            Some(ApprovalMode::OnEscalation),
+            Some(ApprovalMode::OnEscalation),
+        )
+        .build();
     assert!(baseline().ensure_admissible(&requirements).is_ok());
 }
 
@@ -305,11 +296,9 @@ fn approval_mode_dual_ordering_matrix_is_exhaustive() {
                     approval_mode: actual,
                     ..baseline()
                 };
-                let requirements = HarnessRequirements {
-                    minimum_approval_mode: minimum,
-                    maximum_approval_mode: maximum,
-                    ..HarnessRequirements::default()
-                };
+                let requirements = HarnessRequirements::builder()
+                    .approval_mode_bounds(minimum, maximum)
+                    .build();
                 let expected = expected_approval_denial(actual, minimum, maximum);
                 let result = caps.ensure_admissible(&requirements);
                 match expected {
@@ -330,4 +319,14 @@ fn approval_mode_dual_ordering_matrix_is_exhaustive() {
             }
         }
     }
+}
+
+#[test]
+fn deserialization_rejects_invalid_sandbox_bounds() {
+    let json = serde_json::json!({
+        "minimum_sandbox_mode": "unrestricted",
+        "maximum_sandbox_mode": "workspace_write"
+    });
+    let err = serde_json::from_value::<HarnessRequirements>(json).expect_err("must reject");
+    assert!(err.to_string().contains("sandbox minimum exceeds maximum"));
 }

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -121,7 +121,7 @@ pub async fn assert_redaction_before_persistence(
 
     assert_event_ordering(recorder.events())?;
 
-    let hints = request.redaction_hints();
+    let hints = request.redaction_hints().map_err(|err| err.to_string())?;
     let channels = [
         result.output.gate_output.as_deref(),
         result.output.tail_output.as_deref(),
@@ -226,6 +226,20 @@ pub fn assert_terminal_typed_code_mapping(
 ) -> Result<(), String> {
     let ctx = ProviderFailureContext::new(typed_code);
     assert_failure_classification(&ctx, expected)
+}
+
+/// Assert that adapter failure payload sanitization reports dedicated leak errors.
+///
+/// # Errors
+/// Returns a message when the error is not the expected failure-path leak variant.
+pub fn assert_failure_path_leak_detected(err: &HarnessContractError) -> Result<(), String> {
+    if matches!(err, HarnessContractError::FailurePathRedactionLeakDetected) {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected FailurePathRedactionLeakDetected, got {err}"
+        ))
+    }
 }
 
 /// Assert that unsafe provider metadata is rejected fail-closed.

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -1,6 +1,6 @@
 use crate::adapter::{
-    HarnessAdapter, HarnessContractError, HarnessExecutionEvent, HarnessObserver,
-    execute_with_contract,
+    HarnessAdapter, HarnessContractError, HarnessEventSource, HarnessExecutionEvent,
+    HarnessExecutionEventKind, HarnessObserver, execute_with_contract,
 };
 use crate::execution::HarnessExecutionRequest;
 use crate::failure::{HarnessFailureClass, ProviderFailureContext, classify_provider_failure};
@@ -54,11 +54,10 @@ pub async fn assert_capability_denial_is_preflight(
         HarnessContractError::CompatibilityDenied(_) => {}
         other => return Err(format!("expected compatibility denial, got {other}")),
     }
-    if recorder
-        .events()
-        .iter()
-        .any(|event| matches!(event, HarnessExecutionEvent::AdapterInvoked))
-    {
+    if recorder.events().iter().any(|event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
+    }) {
         return Err("adapter was invoked despite capability denial".into());
     }
     Ok(ConformanceResult {
@@ -133,7 +132,6 @@ pub async fn assert_redaction_before_persistence(
             ));
         }
     }
-
     for fragment in &expectations.required_absent_fragments {
         if channels
             .iter()
@@ -181,17 +179,23 @@ pub fn assert_failure_classification(
 
 fn assert_event_ordering(events: &[HarnessExecutionEvent]) -> Result<(), String> {
     let accepted = event_index(events, |event| {
-        matches!(event, HarnessExecutionEvent::PreflightAccepted)
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
     })
     .ok_or_else(|| "missing PreflightAccepted event".to_string())?;
 
     let invoked = event_index(events, |event| {
-        matches!(event, HarnessExecutionEvent::AdapterInvoked)
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
     })
     .ok_or_else(|| "missing AdapterInvoked event".to_string())?;
 
     let persistable = event_index(events, |event| {
-        matches!(event, HarnessExecutionEvent::PersistableOutputReady)
+        event.source == HarnessEventSource::Contract
+            && matches!(
+                event.kind,
+                HarnessExecutionEventKind::PersistableOutputReady
+            )
     })
     .ok_or_else(|| "missing PersistableOutputReady event".to_string())?;
 

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -4,7 +4,7 @@ use crate::adapter::{
 };
 use crate::execution::HarnessExecutionRequest;
 use crate::failure::{HarnessFailureClass, ProviderFailureContext, classify_provider_failure};
-use crate::redaction::{DefaultOutputRedactor, default_redaction_policy};
+use crate::redaction::{default_redaction_policy, scanner};
 
 /// Minimal result wrapper for reusable conformance checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,8 +47,7 @@ pub async fn assert_capability_denial_is_preflight(
     request: &HarnessExecutionRequest,
 ) -> Result<ConformanceResult, String> {
     let mut recorder = ConformanceEventRecorder::default();
-    let redactor = DefaultOutputRedactor::default();
-    let err = execute_with_contract(adapter, request, &redactor, &mut recorder)
+    let err = execute_with_contract(adapter, request, &mut recorder)
         .await
         .expect_err("request should be denied");
     match err {
@@ -77,9 +76,8 @@ pub async fn assert_redaction_before_persistence(
     expectations: &RedactionConformanceExpectations,
 ) -> Result<ConformanceResult, String> {
     let policy = default_redaction_policy();
-    let redactor = DefaultOutputRedactor::new(policy.clone());
     let mut recorder = ConformanceEventRecorder::default();
-    let result = execute_with_contract(adapter, request, &redactor, &mut recorder)
+    let result = execute_with_contract(adapter, request, &mut recorder)
         .await
         .map_err(|err| err.to_string())?;
 
@@ -93,14 +91,11 @@ pub async fn assert_redaction_before_persistence(
     ];
 
     for secret in &hints.secret_values {
+        let secret = secret.expose();
         if secret.trim().is_empty() {
             continue;
         }
-        if channels
-            .iter()
-            .flatten()
-            .any(|text| text.contains(secret.as_str()))
-        {
+        if channels.iter().flatten().any(|text| text.contains(secret)) {
             return Err("persistable output leaked explicit secret value".into());
         }
     }
@@ -109,28 +104,30 @@ pub async fn assert_redaction_before_persistence(
         if channels
             .iter()
             .flatten()
-            .any(|text| contains_unredacted_assignment(text, key))
+            .any(|text| scanner::contains_unredacted_assignment(text, key.as_str(), "[REDACTED]"))
         {
             return Err(format!(
-                "persistable output leaked unredacted key assignment for `{key}`"
+                "persistable output leaked unredacted key assignment for `{}`",
+                key.as_str()
             ));
         }
     }
 
-    if channels
-        .iter()
-        .flatten()
-        .any(|text| contains_unredacted_bearer_token(text, policy.min_token_len))
-    {
+    if channels.iter().flatten().any(|text| {
+        scanner::contains_unredacted_bearer_token(text, policy.min_token_len, "[REDACTED]")
+    }) {
         return Err("persistable output leaked bearer-style token".into());
     }
 
     for prefix in &policy.token_prefixes {
-        if channels
-            .iter()
-            .flatten()
-            .any(|text| contains_unredacted_prefixed_token(text, prefix, policy.min_token_len))
-        {
+        if channels.iter().flatten().any(|text| {
+            scanner::contains_unredacted_prefixed_token(
+                text,
+                prefix,
+                policy.min_token_len,
+                "[REDACTED]",
+            )
+        }) {
             return Err(format!(
                 "persistable output leaked token with sensitive prefix `{prefix}`"
             ));
@@ -210,146 +207,6 @@ fn event_index(
     predicate: impl Fn(&HarnessExecutionEvent) -> bool,
 ) -> Option<usize> {
     events.iter().position(predicate)
-}
-
-fn contains_unredacted_assignment(text: &str, key: &str) -> bool {
-    let key_lower = key.to_ascii_lowercase();
-    for line in text.lines() {
-        let line_lower = line.to_ascii_lowercase();
-        let mut search_from = 0;
-
-        while let Some(offset) = line_lower[search_from..].find(&key_lower) {
-            let key_start = search_from + offset;
-            let key_end = key_start + key_lower.len();
-
-            let mut cursor = key_end;
-            while cursor < line.len() && line.as_bytes()[cursor].is_ascii_whitespace() {
-                cursor += 1;
-            }
-            if cursor >= line.len() || !matches!(line.as_bytes()[cursor], b'=' | b':') {
-                search_from = key_end;
-                continue;
-            }
-            cursor += 1;
-            while cursor < line.len() && line.as_bytes()[cursor].is_ascii_whitespace() {
-                cursor += 1;
-            }
-            if cursor >= line.len() {
-                return false;
-            }
-
-            let (value_start, value_end) = if matches!(line.as_bytes()[cursor], b'"' | b'\'') {
-                let quoted_end = find_quoted_end(line, cursor).unwrap_or(line.len());
-                (cursor.saturating_add(1), quoted_end)
-            } else {
-                (cursor, find_unquoted_end(line, cursor))
-            };
-
-            let value = &line[value_start..value_end];
-            if !value.starts_with("[REDACTED]") {
-                return true;
-            }
-
-            search_from = value_end.saturating_add(1);
-        }
-    }
-    false
-}
-
-fn contains_unredacted_bearer_token(text: &str, min_token_len: usize) -> bool {
-    let mut search_from = 0;
-    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
-        let token_start = index + "bearer ".len();
-        let token_end = find_unquoted_end(text, token_start);
-        if token_end.saturating_sub(token_start) >= min_token_len {
-            let token = &text[token_start..token_end];
-            if token != "[REDACTED]" {
-                return true;
-            }
-        }
-        search_from = token_end.saturating_add(1);
-    }
-    false
-}
-
-fn contains_unredacted_prefixed_token(text: &str, prefix: &str, min_token_len: usize) -> bool {
-    let mut search_from = 0;
-    while let Some(offset) = text[search_from..].find(prefix) {
-        let start = search_from + offset;
-        let mut end = start + prefix.len();
-        while end < text.len() {
-            let ch = text.as_bytes()[end];
-            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
-                break;
-            }
-            end += 1;
-        }
-
-        if end.saturating_sub(start) >= min_token_len && &text[start..end] != "[REDACTED]" {
-            return true;
-        }
-
-        search_from = end.saturating_add(1);
-    }
-    false
-}
-
-fn find_ascii_case_insensitive(haystack: &str, needle: &str, start: usize) -> Option<usize> {
-    if needle.is_empty() || start >= haystack.len() {
-        return None;
-    }
-
-    let haystack_bytes = haystack.as_bytes();
-    let needle_bytes = needle.as_bytes();
-    if haystack_bytes.len() < needle_bytes.len() {
-        return None;
-    }
-
-    let mut idx = start;
-    while idx + needle_bytes.len() <= haystack_bytes.len() {
-        let mut match_all = true;
-        for offset in 0..needle_bytes.len() {
-            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
-                match_all = false;
-                break;
-            }
-        }
-        if match_all {
-            return Some(idx);
-        }
-        idx += 1;
-    }
-
-    None
-}
-
-fn find_quoted_end(value: &str, start: usize) -> Option<usize> {
-    let bytes = value.as_bytes();
-    if start >= bytes.len() {
-        return None;
-    }
-    let quote = bytes[start];
-    let mut cursor = start + 1;
-    while cursor < bytes.len() {
-        if bytes[cursor] == quote && bytes[cursor.saturating_sub(1)] != b'\\' {
-            return Some(cursor);
-        }
-        cursor += 1;
-    }
-    Some(value.len())
-}
-
-fn find_unquoted_end(value: &str, start: usize) -> usize {
-    let bytes = value.as_bytes();
-    let mut cursor = start;
-    while cursor < bytes.len() {
-        let ch = bytes[cursor];
-        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
-            break;
-        }
-        cursor += 1;
-    }
-    cursor
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -4,12 +4,19 @@ use crate::adapter::{
 };
 use crate::execution::HarnessExecutionRequest;
 use crate::failure::{HarnessFailureClass, ProviderFailureContext, classify_provider_failure};
-use crate::redaction::{DefaultOutputRedactor, RedactionHints};
+use crate::redaction::{DefaultOutputRedactor, default_redaction_policy};
 
 /// Minimal result wrapper for reusable conformance checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConformanceResult {
     pub events: Vec<HarnessExecutionEvent>,
+}
+
+/// Additional conformance assertions for redaction outcomes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RedactionConformanceExpectations {
+    pub required_absent_fragments: Vec<String>,
+    pub required_present_fragments: Vec<String>,
 }
 
 /// Simple observer used by reusable conformance assertions.
@@ -41,8 +48,7 @@ pub async fn assert_capability_denial_is_preflight(
 ) -> Result<ConformanceResult, String> {
     let mut recorder = ConformanceEventRecorder::default();
     let redactor = DefaultOutputRedactor::default();
-    let hints = RedactionHints::default();
-    let err = execute_with_contract(adapter, request, &redactor, &hints, &mut recorder)
+    let err = execute_with_contract(adapter, request, &redactor, &mut recorder)
         .await
         .expect_err("request should be denied");
     match err {
@@ -68,43 +74,93 @@ pub async fn assert_capability_denial_is_preflight(
 pub async fn assert_redaction_before_persistence(
     adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
-    hints: &RedactionHints,
+    expectations: &RedactionConformanceExpectations,
 ) -> Result<ConformanceResult, String> {
-    let redactor = DefaultOutputRedactor::default();
+    let policy = default_redaction_policy();
+    let redactor = DefaultOutputRedactor::new(policy.clone());
     let mut recorder = ConformanceEventRecorder::default();
-    let result = execute_with_contract(adapter, request, &redactor, hints, &mut recorder)
+    let result = execute_with_contract(adapter, request, &redactor, &mut recorder)
         .await
         .map_err(|err| err.to_string())?;
+
+    assert_event_ordering(recorder.events())?;
+
+    let hints = request.redaction_hints();
+    let channels = [
+        result.output.gate_output.as_deref(),
+        result.output.tail_output.as_deref(),
+        result.output.stderr_tail.as_deref(),
+    ];
+
     for secret in &hints.secret_values {
         if secret.trim().is_empty() {
             continue;
         }
-        if result
-            .output
-            .gate_output
-            .as_deref()
-            .is_some_and(|value| value.contains(secret))
-            || result
-                .output
-                .tail_output
-                .as_deref()
-                .is_some_and(|value| value.contains(secret))
-            || result
-                .output
-                .stderr_tail
-                .as_deref()
-                .is_some_and(|value| value.contains(secret))
+        if channels
+            .iter()
+            .flatten()
+            .any(|text| text.contains(secret.as_str()))
         {
-            return Err("persistable output leaked secret value".into());
+            return Err("persistable output leaked explicit secret value".into());
         }
     }
-    if !recorder
-        .events()
-        .iter()
-        .any(|event| matches!(event, HarnessExecutionEvent::PersistableOutputReady))
-    {
-        return Err("persistable output event missing".into());
+
+    for key in &hints.required_secret_names {
+        if channels
+            .iter()
+            .flatten()
+            .any(|text| contains_unredacted_assignment(text, key))
+        {
+            return Err(format!(
+                "persistable output leaked unredacted key assignment for `{key}`"
+            ));
+        }
     }
+
+    if channels
+        .iter()
+        .flatten()
+        .any(|text| contains_unredacted_bearer_token(text, policy.min_token_len))
+    {
+        return Err("persistable output leaked bearer-style token".into());
+    }
+
+    for prefix in &policy.token_prefixes {
+        if channels
+            .iter()
+            .flatten()
+            .any(|text| contains_unredacted_prefixed_token(text, prefix, policy.min_token_len))
+        {
+            return Err(format!(
+                "persistable output leaked token with sensitive prefix `{prefix}`"
+            ));
+        }
+    }
+
+    for fragment in &expectations.required_absent_fragments {
+        if channels
+            .iter()
+            .flatten()
+            .any(|text| text.contains(fragment.as_str()))
+        {
+            return Err(format!(
+                "persistable output retained forbidden fragment `{fragment}`"
+            ));
+        }
+    }
+
+    for fragment in &expectations.required_present_fragments {
+        if !channels
+            .iter()
+            .flatten()
+            .any(|text| text.contains(fragment.as_str()))
+        {
+            return Err(format!(
+                "persistable output removed required benign fragment `{fragment}`"
+            ));
+        }
+    }
+
     Ok(ConformanceResult {
         events: recorder.events,
     })
@@ -126,158 +182,175 @@ pub fn assert_failure_classification(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+fn assert_event_ordering(events: &[HarnessExecutionEvent]) -> Result<(), String> {
+    let accepted = event_index(events, |event| {
+        matches!(event, HarnessExecutionEvent::PreflightAccepted)
+    })
+    .ok_or_else(|| "missing PreflightAccepted event".to_string())?;
 
-    use async_trait::async_trait;
-    use tanren_domain::{Cli, DispatchId, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs};
+    let invoked = event_index(events, |event| {
+        matches!(event, HarnessExecutionEvent::AdapterInvoked)
+    })
+    .ok_or_else(|| "missing AdapterInvoked event".to_string())?;
 
-    use super::*;
-    use crate::adapter::ExecutionSignal;
-    use crate::capability::{
-        ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplySupport,
-        SandboxMode, SessionResumeSupport,
-    };
-    use crate::execution::RawExecutionOutput;
+    let persistable = event_index(events, |event| {
+        matches!(event, HarnessExecutionEvent::PersistableOutputReady)
+    })
+    .ok_or_else(|| "missing PersistableOutputReady event".to_string())?;
 
-    #[derive(Debug, Clone)]
-    struct MockHarnessAdapter {
-        capabilities: HarnessCapabilities,
-        raw_output: RawExecutionOutput,
-        call_count: Arc<AtomicUsize>,
+    if !(accepted < invoked && invoked < persistable) {
+        return Err("execution events are out of required order".into());
     }
 
-    impl MockHarnessAdapter {
-        fn new(capabilities: HarnessCapabilities, raw_output: RawExecutionOutput) -> Self {
-            Self {
-                capabilities,
-                raw_output,
-                call_count: Arc::new(AtomicUsize::new(0)),
+    Ok(())
+}
+
+fn event_index(
+    events: &[HarnessExecutionEvent],
+    predicate: impl Fn(&HarnessExecutionEvent) -> bool,
+) -> Option<usize> {
+    events.iter().position(predicate)
+}
+
+fn contains_unredacted_assignment(text: &str, key: &str) -> bool {
+    let key_lower = key.to_ascii_lowercase();
+    for line in text.lines() {
+        let line_lower = line.to_ascii_lowercase();
+        let mut search_from = 0;
+
+        while let Some(offset) = line_lower[search_from..].find(&key_lower) {
+            let key_start = search_from + offset;
+            let key_end = key_start + key_lower.len();
+
+            let mut cursor = key_end;
+            while cursor < line.len() && line.as_bytes()[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            if cursor >= line.len() || !matches!(line.as_bytes()[cursor], b'=' | b':') {
+                search_from = key_end;
+                continue;
+            }
+            cursor += 1;
+            while cursor < line.len() && line.as_bytes()[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            if cursor >= line.len() {
+                return false;
+            }
+
+            let (value_start, value_end) = if matches!(line.as_bytes()[cursor], b'"' | b'\'') {
+                let quoted_end = find_quoted_end(line, cursor).unwrap_or(line.len());
+                (cursor.saturating_add(1), quoted_end)
+            } else {
+                (cursor, find_unquoted_end(line, cursor))
+            };
+
+            let value = &line[value_start..value_end];
+            if !value.starts_with("[REDACTED]") {
+                return true;
+            }
+
+            search_from = value_end.saturating_add(1);
+        }
+    }
+    false
+}
+
+fn contains_unredacted_bearer_token(text: &str, min_token_len: usize) -> bool {
+    let mut search_from = 0;
+    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
+        let token_start = index + "bearer ".len();
+        let token_end = find_unquoted_end(text, token_start);
+        if token_end.saturating_sub(token_start) >= min_token_len {
+            let token = &text[token_start..token_end];
+            if token != "[REDACTED]" {
+                return true;
             }
         }
-
-        fn calls(&self) -> usize {
-            self.call_count.load(Ordering::SeqCst)
-        }
+        search_from = token_end.saturating_add(1);
     }
-
-    #[async_trait]
-    impl HarnessAdapter for MockHarnessAdapter {
-        fn adapter_name(&self) -> &'static str {
-            "mock"
-        }
-
-        fn capabilities(&self) -> HarnessCapabilities {
-            self.capabilities.clone()
-        }
-
-        async fn execute(
-            &self,
-            _request: &HarnessExecutionRequest,
-            _observer: &mut dyn HarnessObserver,
-        ) -> Result<ExecutionSignal, crate::failure::HarnessFailure> {
-            self.call_count.fetch_add(1, Ordering::SeqCst);
-            Ok(ExecutionSignal {
-                output: self.raw_output.clone(),
-                provider_run_id: Some("mock-run".into()),
-                session_resumed: false,
-            })
-        }
-    }
-
-    fn default_capabilities() -> HarnessCapabilities {
-        HarnessCapabilities {
-            output_streaming: OutputStreaming::TextAndToolEvents,
-            can_use_tools: true,
-            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
-            session_resume: SessionResumeSupport::CrossProcess,
-            sandbox_mode: SandboxMode::WorkspaceWrite,
-            approval_mode: ApprovalMode::OnDemand,
-        }
-    }
-
-    fn request(requirements: HarnessRequirements) -> HarnessExecutionRequest {
-        HarnessExecutionRequest {
-            dispatch_id: DispatchId::new(),
-            step_id: StepId::new(),
-            cli: Cli::Codex,
-            phase: Phase::DoTask,
-            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
-            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
-            prompt: "perform work".into(),
-            requirements,
-            required_secret_names: vec!["API_TOKEN".into()],
-            secret_values_for_redaction: vec!["line1-secret\nline2-secret".into()],
-        }
-    }
-
-    fn raw_output_with_secret() -> RawExecutionOutput {
-        RawExecutionOutput {
-            outcome: Outcome::Success,
-            signal: None,
-            exit_code: Some(0),
-            duration_secs: 1.2,
-            gate_output: Some("API_TOKEN=abc line1-secret".into()),
-            tail_output: Some("Bearer sk-live-secret line2-secret".into()),
-            stderr_tail: Some("aws_secret_access_key=def".into()),
-            pushed: false,
-            plan_hash: None,
-            unchecked_tasks: 0,
-            spec_modified: false,
-            findings: vec![],
-            token_usage: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn conformance_denies_before_adapter_side_effects() {
-        let capabilities = HarnessCapabilities {
-            can_use_tools: false,
-            ..default_capabilities()
-        };
-        let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
-        let req = request(HarnessRequirements {
-            tool_use: crate::capability::RequirementLevel::Required,
-            ..HarnessRequirements::default()
-        });
-        let result = assert_capability_denial_is_preflight(&adapter, &req).await;
-        assert!(
-            result.is_ok(),
-            "{}",
-            result
-                .err()
-                .unwrap_or_else(|| "expected conformance success".to_string())
-        );
-        assert_eq!(adapter.calls(), 0);
-    }
-
-    #[tokio::test]
-    async fn conformance_enforces_redaction_before_persistence() {
-        let adapter = MockHarnessAdapter::new(default_capabilities(), raw_output_with_secret());
-        let req = request(HarnessRequirements::default());
-        let hints = RedactionHints {
-            required_secret_names: vec!["API_TOKEN".into()],
-            secret_values: vec!["line1-secret\nline2-secret".into()],
-        };
-        let result = assert_redaction_before_persistence(&adapter, &req, &hints).await;
-        assert!(
-            result.is_ok(),
-            "{}",
-            result
-                .err()
-                .unwrap_or_else(|| "expected conformance success".to_string())
-        );
-        assert_eq!(adapter.calls(), 1);
-    }
-
-    #[test]
-    fn conformance_classifies_failures() {
-        let ctx = ProviderFailureContext {
-            stderr_tail: Some("429 too many requests".into()),
-            ..ProviderFailureContext::default()
-        };
-        assert!(assert_failure_classification(&ctx, HarnessFailureClass::RateLimited).is_ok());
-    }
+    false
 }
+
+fn contains_unredacted_prefixed_token(text: &str, prefix: &str, min_token_len: usize) -> bool {
+    let mut search_from = 0;
+    while let Some(offset) = text[search_from..].find(prefix) {
+        let start = search_from + offset;
+        let mut end = start + prefix.len();
+        while end < text.len() {
+            let ch = text.as_bytes()[end];
+            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
+                break;
+            }
+            end += 1;
+        }
+
+        if end.saturating_sub(start) >= min_token_len && &text[start..end] != "[REDACTED]" {
+            return true;
+        }
+
+        search_from = end.saturating_add(1);
+    }
+    false
+}
+
+fn find_ascii_case_insensitive(haystack: &str, needle: &str, start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+
+    let haystack_bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if haystack_bytes.len() < needle_bytes.len() {
+        return None;
+    }
+
+    let mut idx = start;
+    while idx + needle_bytes.len() <= haystack_bytes.len() {
+        let mut match_all = true;
+        for offset in 0..needle_bytes.len() {
+            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
+                match_all = false;
+                break;
+            }
+        }
+        if match_all {
+            return Some(idx);
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+fn find_quoted_end(value: &str, start: usize) -> Option<usize> {
+    let bytes = value.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+    let quote = bytes[start];
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == quote && bytes[cursor.saturating_sub(1)] != b'\\' {
+            return Some(cursor);
+        }
+        cursor += 1;
+    }
+    Some(value.len())
+}
+
+fn find_unquoted_end(value: &str, start: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        let ch = bytes[cursor];
+        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
+            break;
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -45,7 +45,7 @@ impl HarnessObserver for ConformanceEventRecorder {
 /// # Errors
 /// Returns a message describing the violated conformance rule.
 pub async fn assert_capability_denial_is_preflight(
-    adapter: &impl HarnessAdapter,
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
 ) -> Result<ConformanceResult, String> {
     let mut recorder = ConformanceEventRecorder::default();
@@ -71,19 +71,34 @@ pub async fn assert_capability_denial_is_preflight(
         ));
     }
 
-    if recorder.events().iter().any(|event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
-    }) {
+    if count_contract_events(
+        recorder.events(),
+        |kind| matches!(kind, HarnessExecutionEventKind::PreflightDenied(kind) if *kind == denial_kind),
+    ) != 1
+    {
+        return Err("expected exactly one matching PreflightDenied contract event".into());
+    }
+
+    if count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::PreflightAccepted)
+    }) != 0
+    {
         return Err("preflight accepted event emitted for denied request".into());
     }
 
-    if recorder.events().iter().any(|event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
-    }) {
+    if count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::AdapterInvoked)
+    }) != 0
+    {
         return Err("adapter was invoked despite capability denial".into());
     }
+    if count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::PersistableOutputReady)
+    }) != 0
+    {
+        return Err("persistable output event emitted for denied request".into());
+    }
+
     Ok(ConformanceResult {
         events: recorder.events,
     })
@@ -94,7 +109,7 @@ pub async fn assert_capability_denial_is_preflight(
 /// # Errors
 /// Returns a message describing the violated conformance rule.
 pub async fn assert_redaction_before_persistence(
-    adapter: &impl HarnessAdapter,
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     expectations: &RedactionConformanceExpectations,
 ) -> Result<ConformanceResult, String> {
@@ -137,17 +152,17 @@ pub async fn assert_redaction_before_persistence(
     }
 
     if channels.iter().flatten().any(|text| {
-        scanner::contains_unredacted_bearer_token(text, policy.min_token_len, "[REDACTED]")
+        scanner::contains_unredacted_bearer_token(text, policy.min_token_len(), "[REDACTED]")
     }) {
         return Err("persistable output leaked bearer-style token".into());
     }
 
-    for prefix in &policy.token_prefixes {
+    for prefix in policy.token_prefixes() {
         if channels.iter().flatten().any(|text| {
             scanner::contains_unredacted_prefixed_token(
                 text,
                 prefix,
-                policy.min_token_len,
+                policy.min_token_len(),
                 "[REDACTED]",
             )
         }) {
@@ -218,7 +233,7 @@ pub fn assert_terminal_typed_code_mapping(
 /// # Errors
 /// Returns a message describing the violated conformance rule.
 pub async fn assert_provider_metadata_fail_closed(
-    adapter: &impl HarnessAdapter,
+    adapter: &dyn HarnessAdapter,
     request: &HarnessExecutionRequest,
     field: &'static str,
 ) -> Result<ConformanceResult, String> {
@@ -248,26 +263,17 @@ pub async fn assert_provider_metadata_fail_closed(
         ));
     }
 
-    let accepted = event_index(recorder.events(), |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
-    })
-    .is_some();
-    let invoked = event_index(recorder.events(), |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
-    })
-    .is_some();
-    let persistable = event_index(recorder.events(), |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(
-                event.kind,
-                HarnessExecutionEventKind::PersistableOutputReady
-            )
-    })
-    .is_some();
+    let accepted = count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::PreflightAccepted)
+    });
+    let invoked = count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::AdapterInvoked)
+    });
+    let persistable = count_contract_events(recorder.events(), |kind| {
+        matches!(kind, HarnessExecutionEventKind::PersistableOutputReady)
+    });
 
-    if !(accepted && invoked && !persistable) {
+    if accepted != 1 || invoked != 1 || persistable != 0 {
         return Err("metadata fail-closed event ordering invariant violated".to_string());
     }
 
@@ -277,26 +283,15 @@ pub async fn assert_provider_metadata_fail_closed(
 }
 
 fn assert_event_ordering(events: &[HarnessExecutionEvent]) -> Result<(), String> {
-    let accepted = event_index(events, |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
-    })
-    .ok_or_else(|| "missing PreflightAccepted event".to_string())?;
-
-    let invoked = event_index(events, |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
-    })
-    .ok_or_else(|| "missing AdapterInvoked event".to_string())?;
-
-    let persistable = event_index(events, |event| {
-        event.source == HarnessEventSource::Contract
-            && matches!(
-                event.kind,
-                HarnessExecutionEventKind::PersistableOutputReady
-            )
-    })
-    .ok_or_else(|| "missing PersistableOutputReady event".to_string())?;
+    let accepted = single_contract_event_index(events, |kind| {
+        matches!(kind, HarnessExecutionEventKind::PreflightAccepted)
+    })?;
+    let invoked = single_contract_event_index(events, |kind| {
+        matches!(kind, HarnessExecutionEventKind::AdapterInvoked)
+    })?;
+    let persistable = single_contract_event_index(events, |kind| {
+        matches!(kind, HarnessExecutionEventKind::PersistableOutputReady)
+    })?;
 
     if !(accepted < invoked && invoked < persistable) {
         return Err("execution events are out of required order".into());
@@ -305,11 +300,36 @@ fn assert_event_ordering(events: &[HarnessExecutionEvent]) -> Result<(), String>
     Ok(())
 }
 
-fn event_index(
+fn single_contract_event_index(
     events: &[HarnessExecutionEvent],
-    predicate: impl Fn(&HarnessExecutionEvent) -> bool,
-) -> Option<usize> {
-    events.iter().position(predicate)
+    predicate: impl Fn(&HarnessExecutionEventKind) -> bool,
+) -> Result<usize, String> {
+    let mut indexes = events
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, event)| {
+            (event.source == HarnessEventSource::Contract && predicate(&event.kind)).then_some(idx)
+        })
+        .collect::<Vec<_>>();
+
+    if indexes.len() != 1 {
+        return Err(format!(
+            "expected exactly one matching contract event, found {}",
+            indexes.len()
+        ));
+    }
+
+    Ok(indexes.remove(0))
+}
+
+fn count_contract_events(
+    events: &[HarnessExecutionEvent],
+    predicate: impl Fn(&HarnessExecutionEventKind) -> bool,
+) -> usize {
+    events
+        .iter()
+        .filter(|event| event.source == HarnessEventSource::Contract && predicate(&event.kind))
+        .count()
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -1,9 +1,11 @@
 use crate::adapter::{
     HarnessAdapter, HarnessContractError, HarnessEventSource, HarnessExecutionEvent,
-    HarnessExecutionEventKind, HarnessObserver, execute_with_contract,
+    HarnessExecutionEventKind, HarnessObserver, ProviderMetadataViolation, execute_with_contract,
 };
 use crate::execution::HarnessExecutionRequest;
-use crate::failure::{HarnessFailureClass, ProviderFailureContext, classify_provider_failure};
+use crate::failure::{
+    HarnessFailureClass, ProviderFailureCode, ProviderFailureContext, classify_provider_failure,
+};
 use crate::redaction::{default_redaction_policy, scanner};
 
 /// Minimal result wrapper for reusable conformance checks.
@@ -197,6 +199,81 @@ pub fn assert_failure_classification(
     } else {
         Err(format!("expected {expected:?}, got {actual:?}"))
     }
+}
+
+/// Assert that terminal typed-code semantics are deterministic and stable.
+///
+/// # Errors
+/// Returns a message when the code-to-class mapping does not match.
+pub fn assert_terminal_typed_code_mapping(
+    typed_code: ProviderFailureCode,
+    expected: HarnessFailureClass,
+) -> Result<(), String> {
+    let ctx = ProviderFailureContext::new(typed_code);
+    assert_failure_classification(&ctx, expected)
+}
+
+/// Assert that unsafe provider metadata is rejected fail-closed.
+///
+/// # Errors
+/// Returns a message describing the violated conformance rule.
+pub async fn assert_provider_metadata_fail_closed(
+    adapter: &impl HarnessAdapter,
+    request: &HarnessExecutionRequest,
+    field: &'static str,
+) -> Result<ConformanceResult, String> {
+    let mut recorder = ConformanceEventRecorder::default();
+    let err = execute_with_contract(adapter, request, &mut recorder).await;
+    let violation = match err {
+        Err(HarnessContractError::UnsafeProviderMetadata {
+            field: actual_field,
+            violation,
+        }) if actual_field == field => violation,
+        Err(other) => {
+            return Err(format!(
+                "expected UnsafeProviderMetadata for `{field}`, got {other}"
+            ));
+        }
+        Ok(_) => return Err("expected unsafe provider metadata failure".to_string()),
+    };
+
+    if !matches!(
+        violation,
+        ProviderMetadataViolation::RedactedOrMutated
+            | ProviderMetadataViolation::InvalidFormat
+            | ProviderMetadataViolation::LeakDetected
+    ) {
+        return Err(format!(
+            "unexpected provider metadata violation for `{field}`: {violation:?}"
+        ));
+    }
+
+    let accepted = event_index(recorder.events(), |event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
+    })
+    .is_some();
+    let invoked = event_index(recorder.events(), |event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
+    })
+    .is_some();
+    let persistable = event_index(recorder.events(), |event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(
+                event.kind,
+                HarnessExecutionEventKind::PersistableOutputReady
+            )
+    })
+    .is_some();
+
+    if !(accepted && invoked && !persistable) {
+        return Err("metadata fail-closed event ordering invariant violated".to_string());
+    }
+
+    Ok(ConformanceResult {
+        events: recorder.events,
+    })
 }
 
 fn assert_event_ordering(events: &[HarnessExecutionEvent]) -> Result<(), String> {

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -43,17 +43,39 @@ impl HarnessObserver for ConformanceEventRecorder {
 /// # Errors
 /// Returns a message describing the violated conformance rule.
 pub async fn assert_capability_denial_is_preflight(
-    adapter: &dyn HarnessAdapter,
+    adapter: &impl HarnessAdapter,
     request: &HarnessExecutionRequest,
 ) -> Result<ConformanceResult, String> {
     let mut recorder = ConformanceEventRecorder::default();
-    let err = execute_with_contract(adapter, request, &mut recorder)
-        .await
-        .expect_err("request should be denied");
-    match err {
-        HarnessContractError::CompatibilityDenied(_) => {}
-        other => return Err(format!("expected compatibility denial, got {other}")),
+    let err = execute_with_contract(adapter, request, &mut recorder).await;
+    let denial_kind = match err {
+        Err(HarnessContractError::CompatibilityDenied(denial)) => denial.kind,
+        Err(other) => return Err(format!("expected compatibility denial, got {other}")),
+        Ok(_) => {
+            return Err("expected compatibility denial but execution succeeded".to_string());
+        }
+    };
+
+    let denied = recorder.events().iter().any(|event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(
+                event.kind,
+                HarnessExecutionEventKind::PreflightDenied(kind) if kind == denial_kind
+            )
+    });
+    if !denied {
+        return Err(format!(
+            "missing PreflightDenied({denial_kind:?}) contract event"
+        ));
     }
+
+    if recorder.events().iter().any(|event| {
+        event.source == HarnessEventSource::Contract
+            && matches!(event.kind, HarnessExecutionEventKind::PreflightAccepted)
+    }) {
+        return Err("preflight accepted event emitted for denied request".into());
+    }
+
     if recorder.events().iter().any(|event| {
         event.source == HarnessEventSource::Contract
             && matches!(event.kind, HarnessExecutionEventKind::AdapterInvoked)
@@ -70,7 +92,7 @@ pub async fn assert_capability_denial_is_preflight(
 /// # Errors
 /// Returns a message describing the violated conformance rule.
 pub async fn assert_redaction_before_persistence(
-    adapter: &dyn HarnessAdapter,
+    adapter: &impl HarnessAdapter,
     request: &HarnessExecutionRequest,
     expectations: &RedactionConformanceExpectations,
 ) -> Result<ConformanceResult, String> {

--- a/crates/tanren-runtime/src/conformance.rs
+++ b/crates/tanren-runtime/src/conformance.rs
@@ -1,0 +1,283 @@
+use crate::adapter::{
+    HarnessAdapter, HarnessContractError, HarnessExecutionEvent, HarnessObserver,
+    execute_with_contract,
+};
+use crate::execution::HarnessExecutionRequest;
+use crate::failure::{HarnessFailureClass, ProviderFailureContext, classify_provider_failure};
+use crate::redaction::{DefaultOutputRedactor, RedactionHints};
+
+/// Minimal result wrapper for reusable conformance checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceResult {
+    pub events: Vec<HarnessExecutionEvent>,
+}
+
+/// Simple observer used by reusable conformance assertions.
+#[derive(Debug, Default, Clone)]
+pub struct ConformanceEventRecorder {
+    events: Vec<HarnessExecutionEvent>,
+}
+
+impl ConformanceEventRecorder {
+    #[must_use]
+    pub fn events(&self) -> &[HarnessExecutionEvent] {
+        &self.events
+    }
+}
+
+impl HarnessObserver for ConformanceEventRecorder {
+    fn on_event(&mut self, event: HarnessExecutionEvent) {
+        self.events.push(event);
+    }
+}
+
+/// Assert that an incompatible request is denied before adapter side effects.
+///
+/// # Errors
+/// Returns a message describing the violated conformance rule.
+pub async fn assert_capability_denial_is_preflight(
+    adapter: &dyn HarnessAdapter,
+    request: &HarnessExecutionRequest,
+) -> Result<ConformanceResult, String> {
+    let mut recorder = ConformanceEventRecorder::default();
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints::default();
+    let err = execute_with_contract(adapter, request, &redactor, &hints, &mut recorder)
+        .await
+        .expect_err("request should be denied");
+    match err {
+        HarnessContractError::CompatibilityDenied(_) => {}
+        other => return Err(format!("expected compatibility denial, got {other}")),
+    }
+    if recorder
+        .events()
+        .iter()
+        .any(|event| matches!(event, HarnessExecutionEvent::AdapterInvoked))
+    {
+        return Err("adapter was invoked despite capability denial".into());
+    }
+    Ok(ConformanceResult {
+        events: recorder.events,
+    })
+}
+
+/// Assert that redaction runs before persistence and removes known secrets.
+///
+/// # Errors
+/// Returns a message describing the violated conformance rule.
+pub async fn assert_redaction_before_persistence(
+    adapter: &dyn HarnessAdapter,
+    request: &HarnessExecutionRequest,
+    hints: &RedactionHints,
+) -> Result<ConformanceResult, String> {
+    let redactor = DefaultOutputRedactor::default();
+    let mut recorder = ConformanceEventRecorder::default();
+    let result = execute_with_contract(adapter, request, &redactor, hints, &mut recorder)
+        .await
+        .map_err(|err| err.to_string())?;
+    for secret in &hints.secret_values {
+        if secret.trim().is_empty() {
+            continue;
+        }
+        if result
+            .output
+            .gate_output
+            .as_deref()
+            .is_some_and(|value| value.contains(secret))
+            || result
+                .output
+                .tail_output
+                .as_deref()
+                .is_some_and(|value| value.contains(secret))
+            || result
+                .output
+                .stderr_tail
+                .as_deref()
+                .is_some_and(|value| value.contains(secret))
+        {
+            return Err("persistable output leaked secret value".into());
+        }
+    }
+    if !recorder
+        .events()
+        .iter()
+        .any(|event| matches!(event, HarnessExecutionEvent::PersistableOutputReady))
+    {
+        return Err("persistable output event missing".into());
+    }
+    Ok(ConformanceResult {
+        events: recorder.events,
+    })
+}
+
+/// Assert that provider-failure classification maps to a stable typed class.
+///
+/// # Errors
+/// Returns a message when the classification does not match.
+pub fn assert_failure_classification(
+    ctx: &ProviderFailureContext,
+    expected: HarnessFailureClass,
+) -> Result<(), String> {
+    let actual = classify_provider_failure(ctx);
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(format!("expected {expected:?}, got {actual:?}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use tanren_domain::{Cli, DispatchId, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs};
+
+    use super::*;
+    use crate::adapter::ExecutionSignal;
+    use crate::capability::{
+        ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplySupport,
+        SandboxMode, SessionResumeSupport,
+    };
+    use crate::execution::RawExecutionOutput;
+
+    #[derive(Debug, Clone)]
+    struct MockHarnessAdapter {
+        capabilities: HarnessCapabilities,
+        raw_output: RawExecutionOutput,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl MockHarnessAdapter {
+        fn new(capabilities: HarnessCapabilities, raw_output: RawExecutionOutput) -> Self {
+            Self {
+                capabilities,
+                raw_output,
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl HarnessAdapter for MockHarnessAdapter {
+        fn adapter_name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn capabilities(&self) -> HarnessCapabilities {
+            self.capabilities.clone()
+        }
+
+        async fn execute(
+            &self,
+            _request: &HarnessExecutionRequest,
+            _observer: &mut dyn HarnessObserver,
+        ) -> Result<ExecutionSignal, crate::failure::HarnessFailure> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(ExecutionSignal {
+                output: self.raw_output.clone(),
+                provider_run_id: Some("mock-run".into()),
+                session_resumed: false,
+            })
+        }
+    }
+
+    fn default_capabilities() -> HarnessCapabilities {
+        HarnessCapabilities {
+            output_streaming: OutputStreaming::TextAndToolEvents,
+            can_use_tools: true,
+            patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+            session_resume: SessionResumeSupport::CrossProcess,
+            sandbox_mode: SandboxMode::WorkspaceWrite,
+            approval_mode: ApprovalMode::OnDemand,
+        }
+    }
+
+    fn request(requirements: HarnessRequirements) -> HarnessExecutionRequest {
+        HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "perform work".into(),
+            requirements,
+            required_secret_names: vec!["API_TOKEN".into()],
+            secret_values_for_redaction: vec!["line1-secret\nline2-secret".into()],
+        }
+    }
+
+    fn raw_output_with_secret() -> RawExecutionOutput {
+        RawExecutionOutput {
+            outcome: Outcome::Success,
+            signal: None,
+            exit_code: Some(0),
+            duration_secs: 1.2,
+            gate_output: Some("API_TOKEN=abc line1-secret".into()),
+            tail_output: Some("Bearer sk-live-secret line2-secret".into()),
+            stderr_tail: Some("aws_secret_access_key=def".into()),
+            pushed: false,
+            plan_hash: None,
+            unchecked_tasks: 0,
+            spec_modified: false,
+            findings: vec![],
+            token_usage: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn conformance_denies_before_adapter_side_effects() {
+        let capabilities = HarnessCapabilities {
+            can_use_tools: false,
+            ..default_capabilities()
+        };
+        let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
+        let req = request(HarnessRequirements {
+            tool_use: crate::capability::RequirementLevel::Required,
+            ..HarnessRequirements::default()
+        });
+        let result = assert_capability_denial_is_preflight(&adapter, &req).await;
+        assert!(
+            result.is_ok(),
+            "{}",
+            result
+                .err()
+                .unwrap_or_else(|| "expected conformance success".to_string())
+        );
+        assert_eq!(adapter.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn conformance_enforces_redaction_before_persistence() {
+        let adapter = MockHarnessAdapter::new(default_capabilities(), raw_output_with_secret());
+        let req = request(HarnessRequirements::default());
+        let hints = RedactionHints {
+            required_secret_names: vec!["API_TOKEN".into()],
+            secret_values: vec!["line1-secret\nline2-secret".into()],
+        };
+        let result = assert_redaction_before_persistence(&adapter, &req, &hints).await;
+        assert!(
+            result.is_ok(),
+            "{}",
+            result
+                .err()
+                .unwrap_or_else(|| "expected conformance success".to_string())
+        );
+        assert_eq!(adapter.calls(), 1);
+    }
+
+    #[test]
+    fn conformance_classifies_failures() {
+        let ctx = ProviderFailureContext {
+            stderr_tail: Some("429 too many requests".into()),
+            ..ProviderFailureContext::default()
+        };
+        assert!(assert_failure_classification(&ctx, HarnessFailureClass::RateLimited).is_ok());
+    }
+}

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -18,6 +18,33 @@ use crate::failure::{
     ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
 };
 
+const FULL_CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+    output_streaming: OutputStreaming::TextAndToolEvents,
+    can_use_tools: true,
+    patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+    session_resume: SessionResumeSupport::CrossProcess,
+    sandbox_mode: SandboxMode::WorkspaceWrite,
+    approval_mode: ApprovalMode::OnDemand,
+};
+
+const TOOL_DENIED_CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+    output_streaming: OutputStreaming::TextAndToolEvents,
+    can_use_tools: false,
+    patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+    session_resume: SessionResumeSupport::CrossProcess,
+    sandbox_mode: SandboxMode::WorkspaceWrite,
+    approval_mode: ApprovalMode::OnDemand,
+};
+
+const LIMITED_LEVEL_CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+    output_streaming: OutputStreaming::TextAndToolEvents,
+    can_use_tools: true,
+    patch_apply: PatchApplySupport::ApplyPatchOnly,
+    session_resume: SessionResumeSupport::SameProcessOnly,
+    sandbox_mode: SandboxMode::WorkspaceWrite,
+    approval_mode: ApprovalMode::OnDemand,
+};
+
 #[derive(Debug, Clone)]
 struct FullHarnessAdapter {
     raw_output: RawExecutionOutput,
@@ -39,17 +66,12 @@ impl FullHarnessAdapter {
 
 #[async_trait]
 impl HarnessAdapter for FullHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
-        output_streaming: OutputStreaming::TextAndToolEvents,
-        can_use_tools: true,
-        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
-        session_resume: SessionResumeSupport::CrossProcess,
-        sandbox_mode: SandboxMode::WorkspaceWrite,
-        approval_mode: ApprovalMode::OnDemand,
-    };
-
     fn adapter_name(&self) -> &'static str {
         "full"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        FULL_CAPABILITIES
     }
 
     async fn execute(
@@ -74,10 +96,12 @@ struct PollutingHarnessAdapter {
 
 #[async_trait]
 impl HarnessAdapter for PollutingHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
-
     fn adapter_name(&self) -> &'static str {
         "polluting-mock"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        FULL_CAPABILITIES
     }
 
     async fn execute(
@@ -118,17 +142,12 @@ impl ToolDeniedHarnessAdapter {
 
 #[async_trait]
 impl HarnessAdapter for ToolDeniedHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
-        output_streaming: OutputStreaming::TextAndToolEvents,
-        can_use_tools: false,
-        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
-        session_resume: SessionResumeSupport::CrossProcess,
-        sandbox_mode: SandboxMode::WorkspaceWrite,
-        approval_mode: ApprovalMode::OnDemand,
-    };
-
     fn adapter_name(&self) -> &'static str {
         "tool-denied"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        TOOL_DENIED_CAPABILITIES
     }
 
     async fn execute(
@@ -167,17 +186,12 @@ impl LimitedLevelsHarnessAdapter {
 
 #[async_trait]
 impl HarnessAdapter for LimitedLevelsHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
-        output_streaming: OutputStreaming::TextAndToolEvents,
-        can_use_tools: true,
-        patch_apply: PatchApplySupport::ApplyPatchOnly,
-        session_resume: SessionResumeSupport::SameProcessOnly,
-        sandbox_mode: SandboxMode::WorkspaceWrite,
-        approval_mode: ApprovalMode::OnDemand,
-    };
-
     fn adapter_name(&self) -> &'static str {
         "levels-limited"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        LIMITED_LEVEL_CAPABILITIES
     }
 
     async fn execute(
@@ -202,10 +216,12 @@ struct UnsafeMetadataHarnessAdapter {
 
 #[async_trait]
 impl HarnessAdapter for UnsafeMetadataHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
-
     fn adapter_name(&self) -> &'static str {
         "unsafe-metadata"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        FULL_CAPABILITIES
     }
 
     async fn execute(
@@ -227,10 +243,12 @@ struct UnsafeFailureMetadataHarnessAdapter;
 
 #[async_trait]
 impl HarnessAdapter for UnsafeFailureMetadataHarnessAdapter {
-    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
-
     fn adapter_name(&self) -> &'static str {
         "unsafe-failure-metadata"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        FULL_CAPABILITIES
     }
 
     async fn execute(
@@ -416,5 +434,37 @@ fn conformance_enforces_terminal_typed_code_mapping() {
             HarnessFailureClass::TransportUnavailable,
         )
         .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn conformance_helpers_accept_dyn_adapter_objects() {
+    let adapter: Box<dyn HarnessAdapter> =
+        Box::new(FullHarnessAdapter::new(raw_output_with_secret()));
+    let req = request(HarnessRequirements::default());
+    let expectations = RedactionConformanceExpectations {
+        required_absent_fragments: vec!["abc".into(), "def".into(), "ghi".into()],
+        required_present_fragments: vec!["SAFE_MARKER".into()],
+    };
+    let result = assert_redaction_before_persistence(adapter.as_ref(), &req, &expectations).await;
+    assert!(
+        result.is_ok(),
+        "dyn adapter should satisfy conformance checks"
+    );
+}
+
+#[test]
+fn conformance_event_ordering_requires_exact_contract_event_cardinality() {
+    let events = vec![
+        HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+        HarnessExecutionEvent::contract(HarnessExecutionEventKind::PreflightAccepted),
+        HarnessExecutionEvent::contract(HarnessExecutionEventKind::AdapterInvoked),
+        HarnessExecutionEvent::contract(HarnessExecutionEventKind::PersistableOutputReady),
+    ];
+
+    let err = assert_event_ordering(&events).expect_err("duplicate contract events must fail");
+    assert!(
+        err.contains("expected exactly one matching contract event"),
+        "unexpected error: {err}"
     );
 }

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -54,6 +54,7 @@ impl HarnessAdapter for FullHarnessAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
@@ -81,6 +82,7 @@ impl HarnessAdapter for PollutingHarnessAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure> {
         observer.on_event(HarnessExecutionEvent::contract(
             HarnessExecutionEventKind::PersistableOutputReady,
@@ -131,6 +133,7 @@ impl HarnessAdapter for ToolDeniedHarnessAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
@@ -179,6 +182,7 @@ impl HarnessAdapter for LimitedLevelsHarnessAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
     ) -> Result<ExecutionSignal, ProviderFailure> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
@@ -303,6 +307,7 @@ async fn conformance_enforces_capability_levels() {
 #[test]
 fn conformance_classifies_failures() {
     let ctx = ProviderFailureContext {
+        typed_code: crate::failure::ProviderFailureCode::RateLimited,
         provider_code: Some(ProviderIdentifier::try_new("429").expect("provider code")),
         ..ProviderFailureContext::default()
     };

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -17,16 +17,14 @@ use crate::execution::{RawExecutionOutput, RedactionSecret, SecretName};
 use crate::failure::{ProviderFailure, ProviderIdentifier};
 
 #[derive(Debug, Clone)]
-struct MockHarnessAdapter {
-    capabilities: HarnessCapabilities,
+struct FullHarnessAdapter {
     raw_output: RawExecutionOutput,
     call_count: Arc<AtomicUsize>,
 }
 
-impl MockHarnessAdapter {
-    fn new(capabilities: HarnessCapabilities, raw_output: RawExecutionOutput) -> Self {
+impl FullHarnessAdapter {
+    fn new(raw_output: RawExecutionOutput) -> Self {
         Self {
-            capabilities,
             raw_output,
             call_count: Arc::new(AtomicUsize::new(0)),
         }
@@ -38,13 +36,18 @@ impl MockHarnessAdapter {
 }
 
 #[async_trait]
-impl HarnessAdapter for MockHarnessAdapter {
-    fn adapter_name(&self) -> &'static str {
-        "mock"
-    }
+impl HarnessAdapter for FullHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+        output_streaming: OutputStreaming::TextAndToolEvents,
+        can_use_tools: true,
+        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+        session_resume: SessionResumeSupport::CrossProcess,
+        sandbox_mode: SandboxMode::WorkspaceWrite,
+        approval_mode: ApprovalMode::OnDemand,
+    };
 
-    fn capabilities(&self) -> HarnessCapabilities {
-        self.capabilities.clone()
+    fn adapter_name(&self) -> &'static str {
+        "full"
     }
 
     async fn execute(
@@ -63,18 +66,15 @@ impl HarnessAdapter for MockHarnessAdapter {
 
 #[derive(Debug, Clone)]
 struct PollutingHarnessAdapter {
-    capabilities: HarnessCapabilities,
     raw_output: RawExecutionOutput,
 }
 
 #[async_trait]
 impl HarnessAdapter for PollutingHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
+
     fn adapter_name(&self) -> &'static str {
         "polluting-mock"
-    }
-
-    fn capabilities(&self) -> HarnessCapabilities {
-        self.capabilities.clone()
     }
 
     async fn execute(
@@ -93,14 +93,99 @@ impl HarnessAdapter for PollutingHarnessAdapter {
     }
 }
 
-fn default_capabilities() -> HarnessCapabilities {
-    HarnessCapabilities {
+#[derive(Debug, Clone)]
+struct ToolDeniedHarnessAdapter {
+    raw_output: RawExecutionOutput,
+    call_count: Arc<AtomicUsize>,
+}
+
+impl ToolDeniedHarnessAdapter {
+    fn new(raw_output: RawExecutionOutput) -> Self {
+        Self {
+            raw_output,
+            call_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for ToolDeniedHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
         output_streaming: OutputStreaming::TextAndToolEvents,
-        can_use_tools: true,
+        can_use_tools: false,
         patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
         session_resume: SessionResumeSupport::CrossProcess,
         sandbox_mode: SandboxMode::WorkspaceWrite,
         approval_mode: ApprovalMode::OnDemand,
+    };
+
+    fn adapter_name(&self) -> &'static str {
+        "tool-denied"
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ExecutionSignal {
+            output: self.raw_output.clone(),
+            provider_run_id: Some("tool-denied-run".into()),
+            session_resumed: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LimitedLevelsHarnessAdapter {
+    raw_output: RawExecutionOutput,
+    call_count: Arc<AtomicUsize>,
+}
+
+impl LimitedLevelsHarnessAdapter {
+    fn new(raw_output: RawExecutionOutput) -> Self {
+        Self {
+            raw_output,
+            call_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for LimitedLevelsHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
+        output_streaming: OutputStreaming::TextAndToolEvents,
+        can_use_tools: true,
+        patch_apply: PatchApplySupport::ApplyPatchOnly,
+        session_resume: SessionResumeSupport::SameProcessOnly,
+        sandbox_mode: SandboxMode::WorkspaceWrite,
+        approval_mode: ApprovalMode::OnDemand,
+    };
+
+    fn adapter_name(&self) -> &'static str {
+        "levels-limited"
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ExecutionSignal {
+            output: self.raw_output.clone(),
+            provider_run_id: Some("levels-limited-run".into()),
+            session_resumed: false,
+        })
     }
 }
 
@@ -140,7 +225,6 @@ fn raw_output_with_secret() -> RawExecutionOutput {
 #[tokio::test]
 async fn conformance_event_order_ignores_adapter_event_pollution() {
     let adapter = PollutingHarnessAdapter {
-        capabilities: default_capabilities(),
         raw_output: raw_output_with_secret(),
     };
     let req = request(HarnessRequirements::default());
@@ -161,11 +245,7 @@ async fn conformance_event_order_ignores_adapter_event_pollution() {
 
 #[tokio::test]
 async fn conformance_denies_before_adapter_side_effects() {
-    let capabilities = HarnessCapabilities {
-        can_use_tools: false,
-        ..default_capabilities()
-    };
-    let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
+    let adapter = ToolDeniedHarnessAdapter::new(raw_output_with_secret());
     let req = request(HarnessRequirements {
         tool_use: RequirementLevel::Required,
         ..HarnessRequirements::default()
@@ -183,7 +263,7 @@ async fn conformance_denies_before_adapter_side_effects() {
 
 #[tokio::test]
 async fn conformance_enforces_redaction_before_persistence() {
-    let adapter = MockHarnessAdapter::new(default_capabilities(), raw_output_with_secret());
+    let adapter = FullHarnessAdapter::new(raw_output_with_secret());
     let req = request(HarnessRequirements::default());
     let expectations = RedactionConformanceExpectations {
         required_absent_fragments: vec![
@@ -208,12 +288,7 @@ async fn conformance_enforces_redaction_before_persistence() {
 
 #[tokio::test]
 async fn conformance_enforces_capability_levels() {
-    let capabilities = HarnessCapabilities {
-        patch_apply: PatchApplySupport::ApplyPatchOnly,
-        session_resume: SessionResumeSupport::SameProcessOnly,
-        ..default_capabilities()
-    };
-    let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
+    let adapter = LimitedLevelsHarnessAdapter::new(raw_output_with_secret());
     let req = request(HarnessRequirements {
         patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
         session_resume: SessionResumeRequirement::CrossProcess,

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -7,7 +7,9 @@ use tanren_domain::{
 };
 
 use super::*;
-use crate::adapter::{ExecutionSignal, HarnessExecutionEvent, HarnessExecutionEventKind};
+use crate::adapter::{
+    ExecutionSignal, HarnessContractError, HarnessExecutionEvent, HarnessExecutionEventKind,
+};
 use crate::capability::{
     ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplyRequirement,
     PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeRequirement,
@@ -15,7 +17,7 @@ use crate::capability::{
 };
 use crate::execution::{RawExecutionOutput, RedactionSecret, SecretName};
 use crate::failure::{
-    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier, ProviderRunId,
 };
 
 const FULL_CAPABILITIES: HarnessCapabilities = HarnessCapabilities {
@@ -83,7 +85,7 @@ impl HarnessAdapter for FullHarnessAdapter {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
-            provider_run_id: Some("mock-run".into()),
+            provider_run_id: Some(ProviderRunId::try_new("mock-run").expect("run id")),
             session_resumed: false,
         })
     }
@@ -115,7 +117,7 @@ impl HarnessAdapter for PollutingHarnessAdapter {
         ));
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
-            provider_run_id: Some("polluting-run".into()),
+            provider_run_id: Some(ProviderRunId::try_new("polluting-run").expect("run id")),
             session_resumed: false,
         })
     }
@@ -159,7 +161,7 @@ impl HarnessAdapter for ToolDeniedHarnessAdapter {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
-            provider_run_id: Some("tool-denied-run".into()),
+            provider_run_id: Some(ProviderRunId::try_new("tool-denied-run").expect("run id")),
             session_resumed: false,
         })
     }
@@ -203,7 +205,7 @@ impl HarnessAdapter for LimitedLevelsHarnessAdapter {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
-            provider_run_id: Some("levels-limited-run".into()),
+            provider_run_id: Some(ProviderRunId::try_new("levels-limited-run").expect("run id")),
             session_resumed: false,
         })
     }
@@ -232,7 +234,7 @@ impl HarnessAdapter for UnsafeMetadataHarnessAdapter {
     ) -> Result<ExecutionSignal, ProviderFailure> {
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
-            provider_run_id: Some("run-sk-live-secret".into()),
+            provider_run_id: Some(ProviderRunId::try_new("run-sk-live-secret").expect("run id")),
             session_resumed: false,
         })
     }
@@ -434,6 +436,14 @@ fn conformance_enforces_terminal_typed_code_mapping() {
             HarnessFailureClass::TransportUnavailable,
         )
         .is_ok()
+    );
+}
+
+#[test]
+fn conformance_asserts_dedicated_failure_path_leak_error() {
+    assert!(
+        assert_failure_path_leak_detected(&HarnessContractError::FailurePathRedactionLeakDetected)
+            .is_ok()
     );
 }
 

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -14,7 +14,9 @@ use crate::capability::{
     SessionResumeSupport,
 };
 use crate::execution::{RawExecutionOutput, RedactionSecret, SecretName};
-use crate::failure::{ProviderFailure, ProviderIdentifier};
+use crate::failure::{
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
+};
 
 #[derive(Debug, Clone)]
 struct FullHarnessAdapter {
@@ -193,6 +195,68 @@ impl HarnessAdapter for LimitedLevelsHarnessAdapter {
     }
 }
 
+#[derive(Debug, Clone)]
+struct UnsafeMetadataHarnessAdapter {
+    raw_output: RawExecutionOutput,
+}
+
+#[async_trait]
+impl HarnessAdapter for UnsafeMetadataHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
+
+    fn adapter_name(&self) -> &'static str {
+        "unsafe-metadata"
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        Ok(ExecutionSignal {
+            output: self.raw_output.clone(),
+            provider_run_id: Some("run-sk-live-secret".into()),
+            session_resumed: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UnsafeFailureMetadataHarnessAdapter;
+
+#[async_trait]
+impl HarnessAdapter for UnsafeFailureMetadataHarnessAdapter {
+    const CAPABILITIES: HarnessCapabilities = FullHarnessAdapter::CAPABILITIES;
+
+    fn adapter_name(&self) -> &'static str {
+        "unsafe-failure-metadata"
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+        _token: crate::adapter::ContractCallToken,
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        Err(
+            ProviderFailure::new(ProviderFailureCode::Authentication, "auth").with_context(
+                ProviderFailureContext {
+                    typed_code: ProviderFailureCode::Authentication,
+                    provider_code: Some(
+                        ProviderIdentifier::try_new("sk-live-secret").expect("identifier"),
+                    ),
+                    provider_kind: None,
+                    signal: None,
+                    exit_code: None,
+                    stdout_tail: None,
+                    stderr_tail: None,
+                },
+            ),
+        )
+    }
+}
+
 fn request(requirements: HarnessRequirements) -> HarnessExecutionRequest {
     HarnessExecutionRequest {
         dispatch_id: DispatchId::new(),
@@ -250,10 +314,11 @@ async fn conformance_event_order_ignores_adapter_event_pollution() {
 #[tokio::test]
 async fn conformance_denies_before_adapter_side_effects() {
     let adapter = ToolDeniedHarnessAdapter::new(raw_output_with_secret());
-    let req = request(HarnessRequirements {
-        tool_use: RequirementLevel::Required,
-        ..HarnessRequirements::default()
-    });
+    let req = request(
+        HarnessRequirements::builder()
+            .tool_use(RequirementLevel::Required)
+            .build(),
+    );
     let result = assert_capability_denial_is_preflight(&adapter, &req).await;
     assert!(
         result.is_ok(),
@@ -293,23 +358,63 @@ async fn conformance_enforces_redaction_before_persistence() {
 #[tokio::test]
 async fn conformance_enforces_capability_levels() {
     let adapter = LimitedLevelsHarnessAdapter::new(raw_output_with_secret());
-    let req = request(HarnessRequirements {
-        patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
-        session_resume: SessionResumeRequirement::CrossProcess,
-        ..HarnessRequirements::default()
-    });
+    let requirements = HarnessRequirements::builder()
+        .patch_apply(PatchApplyRequirement::ApplyPatchAndUnifiedDiff)
+        .session_resume(SessionResumeRequirement::CrossProcess)
+        .build();
+    let req = request(requirements);
 
     let result = assert_capability_denial_is_preflight(&adapter, &req).await;
     assert!(result.is_ok(), "must deny insufficient capability levels");
     assert_eq!(adapter.calls(), 0);
 }
 
+#[tokio::test]
+async fn conformance_enforces_metadata_fail_closed_for_run_id() {
+    let adapter = UnsafeMetadataHarnessAdapter {
+        raw_output: raw_output_with_secret(),
+    };
+    let mut req = request(HarnessRequirements::default());
+    req.secret_values_for_redaction = vec![RedactionSecret::from("sk-live-secret")];
+    let result = assert_provider_metadata_fail_closed(&adapter, &req, "provider_run_id").await;
+    assert!(
+        result.is_ok(),
+        "must fail closed for unsafe provider metadata"
+    );
+}
+
+#[tokio::test]
+async fn conformance_enforces_metadata_fail_closed_for_provider_code() {
+    let adapter = UnsafeFailureMetadataHarnessAdapter;
+    let req = request(HarnessRequirements::default());
+    let result = assert_provider_metadata_fail_closed(&adapter, &req, "provider_code").await;
+    assert!(
+        result.is_ok(),
+        "must fail closed for unsafe provider metadata"
+    );
+}
+
 #[test]
 fn conformance_classifies_failures() {
     let ctx = ProviderFailureContext {
-        typed_code: crate::failure::ProviderFailureCode::RateLimited,
+        typed_code: ProviderFailureCode::RateLimited,
         provider_code: Some(ProviderIdentifier::try_new("429").expect("provider code")),
-        ..ProviderFailureContext::default()
+        provider_kind: None,
+        signal: None,
+        exit_code: None,
+        stdout_tail: None,
+        stderr_tail: None,
     };
     assert!(assert_failure_classification(&ctx, HarnessFailureClass::RateLimited).is_ok());
+}
+
+#[test]
+fn conformance_enforces_terminal_typed_code_mapping() {
+    assert!(
+        assert_terminal_typed_code_mapping(
+            ProviderFailureCode::TransportUnavailable,
+            HarnessFailureClass::TransportUnavailable,
+        )
+        .is_ok()
+    );
 }

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -11,7 +11,8 @@ use crate::capability::{
     PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeRequirement,
     SessionResumeSupport,
 };
-use crate::execution::{RawExecutionOutput, RedactionSecret};
+use crate::execution::{RawExecutionOutput, RedactionSecret, SecretName};
+use crate::failure::ProviderIdentifier;
 
 #[derive(Debug, Clone)]
 struct MockHarnessAdapter {
@@ -79,7 +80,7 @@ fn request(requirements: HarnessRequirements) -> HarnessExecutionRequest {
         working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
         prompt: "perform work".into(),
         requirements,
-        required_secret_names: vec!["API_TOKEN".into()],
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
         secret_values_for_redaction: vec![RedactionSecret::from("line1-secret\nline2-secret")],
     }
 }
@@ -171,7 +172,7 @@ async fn conformance_enforces_capability_levels() {
 #[test]
 fn conformance_classifies_failures() {
     let ctx = ProviderFailureContext {
-        provider_code: Some("429".into()),
+        provider_code: Some(ProviderIdentifier::try_new("429").expect("provider code")),
         ..ProviderFailureContext::default()
     };
     assert!(assert_failure_classification(&ctx, HarnessFailureClass::RateLimited).is_ok());

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use tanren_domain::{Cli, DispatchId, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs};
+
+use super::*;
+use crate::adapter::ExecutionSignal;
+use crate::capability::{
+    ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplyRequirement,
+    PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeRequirement,
+    SessionResumeSupport,
+};
+use crate::execution::{RawExecutionOutput, RedactionSecret};
+
+#[derive(Debug, Clone)]
+struct MockHarnessAdapter {
+    capabilities: HarnessCapabilities,
+    raw_output: RawExecutionOutput,
+    call_count: Arc<AtomicUsize>,
+}
+
+impl MockHarnessAdapter {
+    fn new(capabilities: HarnessCapabilities, raw_output: RawExecutionOutput) -> Self {
+        Self {
+            capabilities,
+            raw_output,
+            call_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for MockHarnessAdapter {
+    fn adapter_name(&self) -> &'static str {
+        "mock"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        self.capabilities.clone()
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        _observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, crate::failure::HarnessFailure> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ExecutionSignal {
+            output: self.raw_output.clone(),
+            provider_run_id: Some("mock-run".into()),
+            session_resumed: false,
+        })
+    }
+}
+
+fn default_capabilities() -> HarnessCapabilities {
+    HarnessCapabilities {
+        output_streaming: OutputStreaming::TextAndToolEvents,
+        can_use_tools: true,
+        patch_apply: PatchApplySupport::ApplyPatchAndUnifiedDiff,
+        session_resume: SessionResumeSupport::CrossProcess,
+        sandbox_mode: SandboxMode::WorkspaceWrite,
+        approval_mode: ApprovalMode::OnDemand,
+    }
+}
+
+fn request(requirements: HarnessRequirements) -> HarnessExecutionRequest {
+    HarnessExecutionRequest {
+        dispatch_id: DispatchId::new(),
+        step_id: StepId::new(),
+        cli: Cli::Codex,
+        phase: Phase::DoTask,
+        timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+        working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+        prompt: "perform work".into(),
+        requirements,
+        required_secret_names: vec!["API_TOKEN".into()],
+        secret_values_for_redaction: vec![RedactionSecret::from("line1-secret\nline2-secret")],
+    }
+}
+
+fn raw_output_with_secret() -> RawExecutionOutput {
+    RawExecutionOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: 1.2,
+        gate_output: Some("API_TOKEN=abc API_TOKEN='def' SAFE_MARKER".into()),
+        tail_output: Some("Bearer sk-live-secret line1-secret AKIA123456789012345".into()),
+        stderr_tail: Some("aws_secret_access_key=ghi line2-secret".into()),
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    }
+}
+
+#[tokio::test]
+async fn conformance_denies_before_adapter_side_effects() {
+    let capabilities = HarnessCapabilities {
+        can_use_tools: false,
+        ..default_capabilities()
+    };
+    let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
+    let req = request(HarnessRequirements {
+        tool_use: RequirementLevel::Required,
+        ..HarnessRequirements::default()
+    });
+    let result = assert_capability_denial_is_preflight(&adapter, &req).await;
+    assert!(
+        result.is_ok(),
+        "{}",
+        result
+            .err()
+            .unwrap_or_else(|| "expected conformance success".to_string())
+    );
+    assert_eq!(adapter.calls(), 0);
+}
+
+#[tokio::test]
+async fn conformance_enforces_redaction_before_persistence() {
+    let adapter = MockHarnessAdapter::new(default_capabilities(), raw_output_with_secret());
+    let req = request(HarnessRequirements::default());
+    let expectations = RedactionConformanceExpectations {
+        required_absent_fragments: vec![
+            "abc".into(),
+            "def".into(),
+            "ghi".into(),
+            "line1-secret".into(),
+            "line2-secret".into(),
+        ],
+        required_present_fragments: vec!["SAFE_MARKER".into()],
+    };
+    let result = assert_redaction_before_persistence(&adapter, &req, &expectations).await;
+    assert!(
+        result.is_ok(),
+        "{}",
+        result
+            .err()
+            .unwrap_or_else(|| "expected conformance success".to_string())
+    );
+    assert_eq!(adapter.calls(), 1);
+}
+
+#[tokio::test]
+async fn conformance_enforces_capability_levels() {
+    let capabilities = HarnessCapabilities {
+        patch_apply: PatchApplySupport::ApplyPatchOnly,
+        session_resume: SessionResumeSupport::SameProcessOnly,
+        ..default_capabilities()
+    };
+    let adapter = MockHarnessAdapter::new(capabilities, raw_output_with_secret());
+    let req = request(HarnessRequirements {
+        patch_apply: PatchApplyRequirement::ApplyPatchAndUnifiedDiff,
+        session_resume: SessionResumeRequirement::CrossProcess,
+        ..HarnessRequirements::default()
+    });
+
+    let result = assert_capability_denial_is_preflight(&adapter, &req).await;
+    assert!(result.is_ok(), "must deny insufficient capability levels");
+    assert_eq!(adapter.calls(), 0);
+}
+
+#[test]
+fn conformance_classifies_failures() {
+    let ctx = ProviderFailureContext {
+        provider_code: Some("429".into()),
+        ..ProviderFailureContext::default()
+    };
+    assert!(assert_failure_classification(&ctx, HarnessFailureClass::RateLimited).is_ok());
+}

--- a/crates/tanren-runtime/src/conformance/tests.rs
+++ b/crates/tanren-runtime/src/conformance/tests.rs
@@ -2,17 +2,19 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use tanren_domain::{Cli, DispatchId, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs};
+use tanren_domain::{
+    Cli, DispatchId, FiniteF64, NonEmptyString, Outcome, Phase, StepId, TimeoutSecs,
+};
 
 use super::*;
-use crate::adapter::ExecutionSignal;
+use crate::adapter::{ExecutionSignal, HarnessExecutionEvent, HarnessExecutionEventKind};
 use crate::capability::{
     ApprovalMode, HarnessCapabilities, HarnessRequirements, OutputStreaming, PatchApplyRequirement,
     PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeRequirement,
     SessionResumeSupport,
 };
 use crate::execution::{RawExecutionOutput, RedactionSecret, SecretName};
-use crate::failure::ProviderIdentifier;
+use crate::failure::{ProviderFailure, ProviderIdentifier};
 
 #[derive(Debug, Clone)]
 struct MockHarnessAdapter {
@@ -49,11 +51,43 @@ impl HarnessAdapter for MockHarnessAdapter {
         &self,
         _request: &HarnessExecutionRequest,
         _observer: &mut dyn HarnessObserver,
-    ) -> Result<ExecutionSignal, crate::failure::HarnessFailure> {
+    ) -> Result<ExecutionSignal, ProviderFailure> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         Ok(ExecutionSignal {
             output: self.raw_output.clone(),
             provider_run_id: Some("mock-run".into()),
+            session_resumed: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PollutingHarnessAdapter {
+    capabilities: HarnessCapabilities,
+    raw_output: RawExecutionOutput,
+}
+
+#[async_trait]
+impl HarnessAdapter for PollutingHarnessAdapter {
+    fn adapter_name(&self) -> &'static str {
+        "polluting-mock"
+    }
+
+    fn capabilities(&self) -> HarnessCapabilities {
+        self.capabilities.clone()
+    }
+
+    async fn execute(
+        &self,
+        _request: &HarnessExecutionRequest,
+        observer: &mut dyn HarnessObserver,
+    ) -> Result<ExecutionSignal, ProviderFailure> {
+        observer.on_event(HarnessExecutionEvent::contract(
+            HarnessExecutionEventKind::PersistableOutputReady,
+        ));
+        Ok(ExecutionSignal {
+            output: self.raw_output.clone(),
+            provider_run_id: Some("polluting-run".into()),
             session_resumed: false,
         })
     }
@@ -90,7 +124,7 @@ fn raw_output_with_secret() -> RawExecutionOutput {
         outcome: Outcome::Success,
         signal: None,
         exit_code: Some(0),
-        duration_secs: 1.2,
+        duration_secs: FiniteF64::try_new(1.2).expect("finite"),
         gate_output: Some("API_TOKEN=abc API_TOKEN='def' SAFE_MARKER".into()),
         tail_output: Some("Bearer sk-live-secret line1-secret AKIA123456789012345".into()),
         stderr_tail: Some("aws_secret_access_key=ghi line2-secret".into()),
@@ -101,6 +135,28 @@ fn raw_output_with_secret() -> RawExecutionOutput {
         findings: vec![],
         token_usage: None,
     }
+}
+
+#[tokio::test]
+async fn conformance_event_order_ignores_adapter_event_pollution() {
+    let adapter = PollutingHarnessAdapter {
+        capabilities: default_capabilities(),
+        raw_output: raw_output_with_secret(),
+    };
+    let req = request(HarnessRequirements::default());
+    let expectations = RedactionConformanceExpectations {
+        required_absent_fragments: vec!["abc".into(), "def".into(), "ghi".into()],
+        required_present_fragments: vec!["SAFE_MARKER".into()],
+    };
+
+    let result = assert_redaction_before_persistence(&adapter, &req, &expectations).await;
+    assert!(
+        result.is_ok(),
+        "{}",
+        result
+            .err()
+            .unwrap_or_else(|| "expected conformance success".to_string())
+    );
 }
 
 #[tokio::test]

--- a/crates/tanren-runtime/src/execution.rs
+++ b/crates/tanren-runtime/src/execution.rs
@@ -1,0 +1,185 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use tanren_domain::{
+    Cli, DispatchId, ExecuteResult, Finding, FiniteF64, NonEmptyString, Outcome, Phase, StepId,
+    TimeoutSecs, TokenUsage,
+};
+
+use crate::capability::HarnessRequirements;
+
+/// Normalized harness execution request.
+///
+/// Secret values are carried only for in-process redaction and are never
+/// persisted as part of runtime/domain events.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessExecutionRequest {
+    pub dispatch_id: DispatchId,
+    pub step_id: StepId,
+    pub cli: Cli,
+    pub phase: Phase,
+    pub timeout_secs: TimeoutSecs,
+    pub working_directory: NonEmptyString,
+    pub prompt: String,
+    #[serde(default)]
+    pub requirements: HarnessRequirements,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_secret_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_values_for_redaction: Vec<String>,
+}
+
+impl fmt::Debug for HarnessExecutionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HarnessExecutionRequest")
+            .field("dispatch_id", &self.dispatch_id)
+            .field("step_id", &self.step_id)
+            .field("cli", &self.cli)
+            .field("phase", &self.phase)
+            .field("timeout_secs", &self.timeout_secs)
+            .field("working_directory", &self.working_directory)
+            .field("prompt_len", &self.prompt.len())
+            .field("requirements", &self.requirements)
+            .field("required_secret_names", &self.required_secret_names)
+            .field(
+                "secret_values_for_redaction_count",
+                &self.secret_values_for_redaction.len(),
+            )
+            .finish()
+    }
+}
+
+/// Raw output emitted by a harness adapter before redaction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RawExecutionOutput {
+    pub outcome: Outcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub duration_secs: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tail_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_tail: Option<String>,
+    #[serde(default)]
+    pub pushed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_hash: Option<String>,
+    #[serde(default)]
+    pub unchecked_tasks: u32,
+    #[serde(default)]
+    pub spec_modified: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<Finding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
+}
+
+/// Output that is safe to persist in domain events.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PersistableOutput {
+    pub outcome: Outcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub duration_secs: FiniteF64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tail_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_tail: Option<String>,
+    #[serde(default)]
+    pub pushed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_hash: Option<String>,
+    #[serde(default)]
+    pub unchecked_tasks: u32,
+    #[serde(default)]
+    pub spec_modified: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<Finding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
+}
+
+impl PersistableOutput {
+    #[must_use]
+    pub fn into_execute_result(self) -> ExecuteResult {
+        ExecuteResult {
+            outcome: self.outcome,
+            signal: self.signal,
+            exit_code: self.exit_code,
+            duration_secs: self.duration_secs,
+            gate_output: self.gate_output,
+            tail_output: self.tail_output,
+            stderr_tail: self.stderr_tail,
+            pushed: self.pushed,
+            plan_hash: self.plan_hash,
+            unchecked_tasks: self.unchecked_tasks,
+            spec_modified: self.spec_modified,
+            findings: self.findings,
+            token_usage: self.token_usage,
+        }
+    }
+}
+
+/// Normalized terminal result returned by the harness contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarnessExecutionResult {
+    pub output: PersistableOutput,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_run_id: Option<String>,
+    #[serde(default)]
+    pub session_resumed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_debug_redacts_secret_values() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec!["API_TOKEN".into()],
+            secret_values_for_redaction: vec!["sk-super-secret".into()],
+        };
+        let debug = format!("{request:?}");
+        assert!(debug.contains("secret_values_for_redaction_count"));
+        assert!(!debug.contains("sk-super-secret"));
+    }
+
+    #[test]
+    fn persistable_output_converts_to_domain_execute_result() {
+        let output = PersistableOutput {
+            outcome: Outcome::Success,
+            signal: None,
+            exit_code: Some(0),
+            duration_secs: FiniteF64::try_new(1.25).expect("finite"),
+            gate_output: Some("ok".into()),
+            tail_output: Some("done".into()),
+            stderr_tail: None,
+            pushed: true,
+            plan_hash: Some("abc123".into()),
+            unchecked_tasks: 0,
+            spec_modified: true,
+            findings: vec![],
+            token_usage: Some(TokenUsage::default()),
+        };
+        let execute = output.into_execute_result();
+        assert_eq!(execute.outcome, Outcome::Success);
+        assert_eq!(execute.tail_output.as_deref(), Some("done"));
+    }
+}

--- a/crates/tanren-runtime/src/execution.rs
+++ b/crates/tanren-runtime/src/execution.rs
@@ -8,7 +8,8 @@ use tanren_domain::{
 };
 
 use crate::capability::HarnessRequirements;
-use crate::redaction::RedactionHints;
+use crate::failure::ProviderRunId;
+use crate::redaction::{RedactionHintBoundsError, RedactionHints};
 
 /// In-memory secret material used only for redaction.
 #[derive(Clone)]
@@ -111,19 +112,15 @@ pub struct HarnessExecutionRequest {
 }
 
 impl HarnessExecutionRequest {
-    #[must_use]
-    pub fn redaction_hints(&self) -> RedactionHints {
-        RedactionHints {
-            required_secret_names: self.required_secret_names.clone(),
-            secret_values: self
-                .secret_values_for_redaction
-                .iter()
-                .filter_map(|secret| {
-                    let trimmed = secret.expose().trim();
-                    (!trimmed.is_empty()).then(|| RedactionSecret::from(trimmed))
-                })
-                .collect(),
-        }
+    /// Build validated redaction hints for contract-owned redaction.
+    ///
+    /// # Errors
+    /// Returns [`RedactionHintBoundsError`] when explicit secret hints exceed hard bounds.
+    pub fn redaction_hints(&self) -> Result<RedactionHints, RedactionHintBoundsError> {
+        RedactionHints::try_from_request(
+            self.required_secret_names.clone(),
+            &self.secret_values_for_redaction,
+        )
     }
 }
 
@@ -231,7 +228,7 @@ impl PersistableOutput {
 pub struct HarnessExecutionResult {
     pub output: PersistableOutput,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_run_id: Option<String>,
+    pub provider_run_id: Option<ProviderRunId>,
     #[serde(default)]
     pub session_resumed: bool,
 }
@@ -276,7 +273,7 @@ mod tests {
                 RedactionSecret::from("  "),
             ],
         };
-        let hints = request.redaction_hints();
+        let hints = request.redaction_hints().expect("hints");
         assert_eq!(
             hints.required_secret_names,
             vec![SecretName::try_new("api_token").expect("k")]
@@ -285,6 +282,107 @@ mod tests {
             hints.secret_values,
             vec![RedactionSecret::from("sk-super-secret")]
         );
+    }
+
+    #[test]
+    fn redaction_hints_reject_secret_count_over_limit() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec![],
+            secret_values_for_redaction: vec![RedactionSecret::from("x"); 257],
+        };
+
+        let err = request
+            .redaction_hints()
+            .expect_err("must reject over-count");
+        assert!(matches!(
+            err,
+            RedactionHintBoundsError::TooManySecrets {
+                max_count: 256,
+                actual_count: 257
+            }
+        ));
+    }
+
+    #[test]
+    fn redaction_hints_reject_oversized_secret_literal() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec![],
+            secret_values_for_redaction: vec![RedactionSecret::from("x".repeat(4097))],
+        };
+
+        let err = request
+            .redaction_hints()
+            .expect_err("must reject oversize secret");
+        assert!(matches!(
+            err,
+            RedactionHintBoundsError::SecretTooLarge {
+                index: 0,
+                max_bytes: 4096,
+                actual_bytes: 4097
+            }
+        ));
+    }
+
+    #[test]
+    fn redaction_hints_reject_total_secret_bytes_over_limit() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec![],
+            secret_values_for_redaction: vec![RedactionSecret::from("a".repeat(4096)); 17],
+        };
+
+        let err = request
+            .redaction_hints()
+            .expect_err("must reject total bytes overflow");
+        assert!(matches!(
+            err,
+            RedactionHintBoundsError::TotalBytesExceeded {
+                max_total_bytes: 65536,
+                actual_total_bytes
+            } if actual_total_bytes > 65536
+        ));
+    }
+
+    #[test]
+    fn redaction_hints_accept_boundary_sized_secret_payload() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec![],
+            secret_values_for_redaction: vec![RedactionSecret::from("a".repeat(4096)); 16],
+        };
+
+        let hints = request.redaction_hints().expect("must accept boundary");
+        assert_eq!(hints.secret_values.len(), 16);
     }
 
     #[test]

--- a/crates/tanren-runtime/src/execution.rs
+++ b/crates/tanren-runtime/src/execution.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use tanren_domain::{
     Cli, DispatchId, ExecuteResult, Finding, FiniteF64, NonEmptyString, Outcome, Phase, StepId,
@@ -7,6 +8,49 @@ use tanren_domain::{
 };
 
 use crate::capability::HarnessRequirements;
+use crate::redaction::RedactionHints;
+
+/// In-memory secret material used only for redaction.
+#[derive(Clone)]
+pub struct RedactionSecret(SecretString);
+
+impl RedactionSecret {
+    #[must_use]
+    pub fn new(value: String) -> Self {
+        Self(SecretString::from(value))
+    }
+
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        self.0.expose_secret()
+    }
+}
+
+impl fmt::Debug for RedactionSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RedactionSecret([REDACTED])")
+    }
+}
+
+impl PartialEq for RedactionSecret {
+    fn eq(&self, other: &Self) -> bool {
+        self.expose() == other.expose()
+    }
+}
+
+impl Eq for RedactionSecret {}
+
+impl From<String> for RedactionSecret {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for RedactionSecret {
+    fn from(value: &str) -> Self {
+        Self::new(value.to_owned())
+    }
+}
 
 /// Normalized harness execution request.
 ///
@@ -25,8 +69,31 @@ pub struct HarnessExecutionRequest {
     pub requirements: HarnessRequirements,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_secret_names: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub secret_values_for_redaction: Vec<String>,
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub secret_values_for_redaction: Vec<RedactionSecret>,
+}
+
+impl HarnessExecutionRequest {
+    #[must_use]
+    pub fn redaction_hints(&self) -> RedactionHints {
+        RedactionHints {
+            required_secret_names: self
+                .required_secret_names
+                .iter()
+                .map(|key| key.trim())
+                .filter(|key| !key.is_empty())
+                .map(str::to_owned)
+                .collect(),
+            secret_values: self
+                .secret_values_for_redaction
+                .iter()
+                .map(RedactionSecret::expose)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
 }
 
 impl fmt::Debug for HarnessExecutionRequest {
@@ -154,11 +221,33 @@ mod tests {
             prompt: "ship it".into(),
             requirements: HarnessRequirements::default(),
             required_secret_names: vec!["API_TOKEN".into()],
-            secret_values_for_redaction: vec!["sk-super-secret".into()],
+            secret_values_for_redaction: vec![RedactionSecret::from("sk-super-secret")],
         };
         let debug = format!("{request:?}");
         assert!(debug.contains("secret_values_for_redaction_count"));
         assert!(!debug.contains("sk-super-secret"));
+    }
+
+    #[test]
+    fn redaction_hints_are_derived_from_request_secrets() {
+        let request = HarnessExecutionRequest {
+            dispatch_id: DispatchId::new(),
+            step_id: StepId::new(),
+            cli: Cli::Codex,
+            phase: Phase::DoTask,
+            timeout_secs: TimeoutSecs::try_new(60).expect("timeout"),
+            working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
+            prompt: "ship it".into(),
+            requirements: HarnessRequirements::default(),
+            required_secret_names: vec![" API_TOKEN ".into(), String::new()],
+            secret_values_for_redaction: vec![
+                RedactionSecret::from("sk-super-secret"),
+                RedactionSecret::from("  "),
+            ],
+        };
+        let hints = request.redaction_hints();
+        assert_eq!(hints.required_secret_names, vec!["API_TOKEN"]);
+        assert_eq!(hints.secret_values, vec!["sk-super-secret"]);
     }
 
     #[test]

--- a/crates/tanren-runtime/src/execution.rs
+++ b/crates/tanren-runtime/src/execution.rs
@@ -155,7 +155,7 @@ pub struct RawExecutionOutput {
     pub signal: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
-    pub duration_secs: f64,
+    pub duration_secs: FiniteF64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gate_output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/tanren-runtime/src/execution.rs
+++ b/crates/tanren-runtime/src/execution.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use tanren_domain::{
-    Cli, DispatchId, ExecuteResult, Finding, FiniteF64, NonEmptyString, Outcome, Phase, StepId,
-    TimeoutSecs, TokenUsage,
+    Cli, DispatchId, DomainError, ExecuteResult, Finding, FiniteF64, NonEmptyString, Outcome,
+    Phase, StepId, TimeoutSecs, TokenUsage,
 };
 
 use crate::capability::HarnessRequirements;
@@ -52,6 +52,43 @@ impl From<&str> for RedactionSecret {
     }
 }
 
+/// Canonical key identifier for secret assignments.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SecretName(NonEmptyString);
+
+impl SecretName {
+    /// Build a normalized secret key name.
+    ///
+    /// # Errors
+    /// Returns [`DomainError`] when the name is blank after normalization.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, DomainError> {
+        let normalized = value.into().trim().to_ascii_lowercase();
+        Ok(Self(NonEmptyString::try_new(normalized)?))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Debug for SecretName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::try_new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Normalized harness execution request.
 ///
 /// Secret values are carried only for in-process redaction and are never
@@ -68,7 +105,7 @@ pub struct HarnessExecutionRequest {
     #[serde(default)]
     pub requirements: HarnessRequirements,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_secret_names: Vec<String>,
+    pub required_secret_names: Vec<SecretName>,
     #[serde(default, skip_serializing, skip_deserializing)]
     pub secret_values_for_redaction: Vec<RedactionSecret>,
 }
@@ -77,20 +114,14 @@ impl HarnessExecutionRequest {
     #[must_use]
     pub fn redaction_hints(&self) -> RedactionHints {
         RedactionHints {
-            required_secret_names: self
-                .required_secret_names
-                .iter()
-                .map(|key| key.trim())
-                .filter(|key| !key.is_empty())
-                .map(str::to_owned)
-                .collect(),
+            required_secret_names: self.required_secret_names.clone(),
             secret_values: self
                 .secret_values_for_redaction
                 .iter()
-                .map(RedactionSecret::expose)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_owned)
+                .filter_map(|secret| {
+                    let trimmed = secret.expose().trim();
+                    (!trimmed.is_empty()).then(|| RedactionSecret::from(trimmed))
+                })
                 .collect(),
         }
     }
@@ -220,7 +251,7 @@ mod tests {
             working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
             prompt: "ship it".into(),
             requirements: HarnessRequirements::default(),
-            required_secret_names: vec!["API_TOKEN".into()],
+            required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
             secret_values_for_redaction: vec![RedactionSecret::from("sk-super-secret")],
         };
         let debug = format!("{request:?}");
@@ -239,15 +270,21 @@ mod tests {
             working_directory: NonEmptyString::try_new("/tmp/work").expect("dir"),
             prompt: "ship it".into(),
             requirements: HarnessRequirements::default(),
-            required_secret_names: vec![" API_TOKEN ".into(), String::new()],
+            required_secret_names: vec![SecretName::try_new(" API_TOKEN ").expect("secret key")],
             secret_values_for_redaction: vec![
                 RedactionSecret::from("sk-super-secret"),
                 RedactionSecret::from("  "),
             ],
         };
         let hints = request.redaction_hints();
-        assert_eq!(hints.required_secret_names, vec!["API_TOKEN"]);
-        assert_eq!(hints.secret_values, vec!["sk-super-secret"]);
+        assert_eq!(
+            hints.required_secret_names,
+            vec![SecretName::try_new("api_token").expect("k")]
+        );
+        assert_eq!(
+            hints.secret_values,
+            vec![RedactionSecret::from("sk-super-secret")]
+        );
     }
 
     #[test]

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -1,3 +1,5 @@
+mod text_classifier;
+
 use serde::{Deserialize, Serialize};
 use tanren_domain::{ErrorClass, NonEmptyString};
 
@@ -113,20 +115,6 @@ pub enum ProviderIdentifierError {
     EmptyOrWhitespace,
 }
 
-/// Typed failure payload returned by harness adapters.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-#[error("{class:?}: {message}")]
-pub struct HarnessFailure {
-    pub class: HarnessFailureClass,
-    pub message: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_code: Option<ProviderIdentifier>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_kind: Option<ProviderIdentifier>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub typed_code: Option<ProviderFailureCode>,
-}
-
 /// Normalized raw context adapters can pass into classification helpers.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ProviderFailureContext {
@@ -146,13 +134,145 @@ pub struct ProviderFailureContext {
     pub stderr_tail: Option<String>,
 }
 
+/// Provider-native failure payload adapters return to the contract wrapper.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("{message}")]
+pub struct ProviderFailure {
+    pub message: String,
+    #[serde(flatten)]
+    pub context: ProviderFailureContext,
+}
+
+impl ProviderFailure {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            context: ProviderFailureContext::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_context(mut self, context: ProviderFailureContext) -> Self {
+        self.context = context;
+        self
+    }
+
+    #[must_use]
+    pub fn into_harness_failure(self) -> HarnessFailure {
+        HarnessFailure::from_provider_failure(self)
+    }
+}
+
+/// Typed failure payload returned by the harness contract wrapper.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, thiserror::Error)]
+#[error("{class:?}: {message}")]
+pub struct HarnessFailure {
+    class: HarnessFailureClass,
+    message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_code: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_kind: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    typed_code: Option<ProviderFailureCode>,
+}
+
+impl HarnessFailure {
+    #[must_use]
+    pub fn new(class: HarnessFailureClass, message: impl Into<String>) -> Self {
+        Self {
+            class,
+            message: message.into(),
+            provider_code: None,
+            provider_kind: None,
+            typed_code: None,
+        }
+    }
+
+    #[must_use]
+    pub fn from_provider_failure(failure: ProviderFailure) -> Self {
+        let class = classify_provider_failure(&failure.context);
+        Self {
+            class,
+            message: failure.message,
+            provider_code: failure.context.provider_code,
+            provider_kind: failure.context.provider_kind,
+            typed_code: failure.context.typed_code,
+        }
+    }
+
+    #[must_use]
+    pub const fn class(&self) -> HarnessFailureClass {
+        self.class
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub fn provider_code(&self) -> Option<&ProviderIdentifier> {
+        self.provider_code.as_ref()
+    }
+
+    #[must_use]
+    pub fn provider_kind(&self) -> Option<&ProviderIdentifier> {
+        self.provider_kind.as_ref()
+    }
+
+    #[must_use]
+    pub const fn typed_code(&self) -> Option<ProviderFailureCode> {
+        self.typed_code
+    }
+}
+
+#[derive(Deserialize)]
+struct HarnessFailureWire {
+    class: HarnessFailureClass,
+    message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_code: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_kind: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    typed_code: Option<ProviderFailureCode>,
+}
+
+impl<'de> Deserialize<'de> for HarnessFailure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = HarnessFailureWire::deserialize(deserializer)?;
+        if let Some(typed_code) = wire.typed_code {
+            let expected = typed_code.to_harness_failure_class();
+            if wire.class != expected {
+                return Err(serde::de::Error::custom(format!(
+                    "typed_code {typed_code:?} implies class {expected:?}, got {:?}",
+                    wire.class
+                )));
+            }
+        }
+
+        Ok(Self {
+            class: wire.class,
+            message: wire.message,
+            provider_code: wire.provider_code,
+            provider_kind: wire.provider_kind,
+            typed_code: wire.typed_code,
+        })
+    }
+}
+
 /// Classify provider-native failures into stable harness classes.
 ///
 /// Order of precedence:
 /// 1) typed code from adapter
 /// 2) deterministic exact-token mappings from structured fields
 /// 3) deterministic exit/signal mappings
-/// 4) boundary-aware text fallback heuristics
+/// 4) bounded boundary-aware text fallback heuristics
 #[must_use]
 pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailureClass {
     if let Some(code) = ctx.typed_code {
@@ -183,16 +303,7 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
         return class;
     }
 
-    let mut merged = String::new();
-    if let Some(value) = &ctx.stdout_tail {
-        merged.push_str(value);
-        merged.push('\n');
-    }
-    if let Some(value) = &ctx.stderr_tail {
-        merged.push_str(value);
-    }
-
-    classify_text_fallback(&merged)
+    text_classifier::classify_text_fallback(ctx.stdout_tail.as_deref(), ctx.stderr_tail.as_deref())
 }
 
 fn normalize_identifier(raw: &str) -> String {
@@ -245,113 +356,6 @@ const fn classify_exit_code(code: i32) -> Option<HarnessFailureClass> {
     }
 }
 
-fn classify_text_fallback(text: &str) -> HarnessFailureClass {
-    let tokens = tokenize(text);
-
-    if has_token(&tokens, "capability_denied")
-        || has_phrase(&tokens, &["unsupported", "capability"])
-    {
-        return HarnessFailureClass::CapabilityDenied;
-    }
-    if has_phrase(&tokens, &["approval", "denied"])
-        || has_token(&tokens, "approval_required")
-        || has_phrase(&tokens, &["consent", "denied"])
-    {
-        return HarnessFailureClass::ApprovalDenied;
-    }
-    if has_token(&tokens, "authentication")
-        || has_token(&tokens, "invalid_api_key")
-        || has_phrase(&tokens, &["invalid", "api", "key"])
-        || has_phrase(&tokens, &["permission", "denied"])
-        || has_any_token(&tokens, &["401", "403"])
-    {
-        return HarnessFailureClass::Authentication;
-    }
-    if has_phrase(&tokens, &["rate", "limit"])
-        || has_token(&tokens, "rate_limited")
-        || has_token(&tokens, "too_many_requests")
-        || has_phrase(&tokens, &["too", "many", "requests"])
-        || has_token(&tokens, "429")
-    {
-        return HarnessFailureClass::RateLimited;
-    }
-    if has_any_token(&tokens, &["timeout", "deadline_exceeded", "timed_out"])
-        || has_phrase(&tokens, &["deadline", "exceeded"])
-        || has_phrase(&tokens, &["timed", "out"])
-    {
-        return HarnessFailureClass::Timeout;
-    }
-    if has_phrase(&tokens, &["connection", "refused"])
-        || has_phrase(&tokens, &["network", "unreachable"])
-        || has_any_token(&tokens, &["dns", "econnreset"])
-        || has_phrase(&tokens, &["temporarily", "unavailable"])
-        || has_token(&tokens, "503")
-    {
-        return HarnessFailureClass::TransportUnavailable;
-    }
-    if has_phrase(&tokens, &["out", "of", "memory"])
-        || has_phrase(&tokens, &["resource", "exhausted"])
-        || has_phrase(&tokens, &["quota", "exceeded"])
-        || has_phrase(&tokens, &["exit", "code", "137"])
-    {
-        return HarnessFailureClass::ResourceExhausted;
-    }
-    if has_any_token(&tokens, &["temporary", "retryable", "transient", "eagain"])
-        || has_phrase(&tokens, &["try", "again"])
-    {
-        return HarnessFailureClass::Transient;
-    }
-    if has_phrase(&tokens, &["invalid", "argument"])
-        || has_phrase(&tokens, &["bad", "request"])
-        || has_token(&tokens, "malformed")
-    {
-        return HarnessFailureClass::InvalidRequest;
-    }
-    if has_any_token(&tokens, &["panic", "fatal", "internal_error"])
-        || has_phrase(&tokens, &["internal", "error"])
-    {
-        return HarnessFailureClass::Fatal;
-    }
-
-    HarnessFailureClass::Unknown
-}
-
-fn tokenize(text: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    for ch in text.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '_' {
-            current.push(ch.to_ascii_lowercase());
-        } else if !current.is_empty() {
-            tokens.push(std::mem::take(&mut current));
-        }
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-    tokens
-}
-
-fn has_token(tokens: &[String], token: &str) -> bool {
-    tokens.iter().any(|value| value == token)
-}
-
-fn has_any_token(tokens: &[String], expected: &[&str]) -> bool {
-    expected.iter().any(|token| has_token(tokens, token))
-}
-
-fn has_phrase(tokens: &[String], phrase: &[&str]) -> bool {
-    if phrase.is_empty() || tokens.len() < phrase.len() {
-        return false;
-    }
-    tokens.windows(phrase.len()).any(|window| {
-        window
-            .iter()
-            .zip(phrase.iter())
-            .all(|(actual, expected)| actual == expected)
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
@@ -366,6 +370,20 @@ mod tests {
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::Timeout);
+    }
+
+    #[test]
+    fn provider_failure_normalizes_through_context_classification() {
+        let provider_failure =
+            ProviderFailure::new("raw adapter failure").with_context(ProviderFailureContext {
+                typed_code: Some(ProviderFailureCode::RateLimited),
+                stderr_tail: Some("fatal panic".into()),
+                ..ProviderFailureContext::default()
+            });
+
+        let failure = provider_failure.into_harness_failure();
+        assert_eq!(failure.class(), HarnessFailureClass::RateLimited);
+        assert_eq!(failure.typed_code(), Some(ProviderFailureCode::RateLimited));
     }
 
     #[test]
@@ -430,6 +448,15 @@ mod tests {
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::Unknown);
+    }
+
+    #[test]
+    fn fallback_scans_bounded_tail_for_large_output() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some(format!("{} timeout", "x".repeat(24 * 1024))),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::Timeout);
     }
 
     #[test]

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -284,6 +284,15 @@ impl ProviderFailure {
 }
 
 /// Typed failure payload returned by the harness contract wrapper.
+///
+/// External callers cannot construct terminal failures directly; adapter
+/// failures must be normalized by the contract wrapper.
+///
+/// ```compile_fail
+/// use tanren_runtime::{HarnessFailure, ProviderFailureCode};
+///
+/// let _ = HarnessFailure::new(ProviderFailureCode::Fatal, "unsanitized");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, thiserror::Error)]
 #[error("{class:?}: {message}")]
 pub struct HarnessFailure {
@@ -297,17 +306,6 @@ pub struct HarnessFailure {
 }
 
 impl HarnessFailure {
-    #[must_use]
-    pub fn new(typed_code: ProviderFailureCode, message: impl Into<String>) -> Self {
-        Self {
-            class: typed_code.to_harness_failure_class(),
-            message: message.into(),
-            provider_code: None,
-            provider_kind: None,
-            typed_code,
-        }
-    }
-
     #[must_use]
     pub(crate) fn from_provider_failure(failure: ProviderFailure) -> Self {
         let class = classify_provider_failure(&failure.context);

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -187,6 +187,63 @@ pub enum ProviderIdentifierError {
     InvalidCharacter,
 }
 
+/// Normalized provider run identifier surfaced on successful execution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ProviderRunId(String);
+
+impl ProviderRunId {
+    pub const MAX_LEN: usize = 128;
+
+    /// Build a strict provider run identifier.
+    ///
+    /// # Errors
+    /// Returns [`ProviderRunIdError`] when empty or format-invalid.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, ProviderRunIdError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ProviderRunIdError::EmptyOrWhitespace);
+        }
+        if value.len() > Self::MAX_LEN {
+            return Err(ProviderRunIdError::TooLong {
+                max_len: Self::MAX_LEN,
+            });
+        }
+        if !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+        {
+            return Err(ProviderRunIdError::InvalidCharacter);
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderRunId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::try_new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderRunIdError {
+    #[error("provider run id must not be empty")]
+    EmptyOrWhitespace,
+    #[error("provider run id exceeds max length {max_len}")]
+    TooLong { max_len: usize },
+    #[error("provider run id contains unsupported characters")]
+    InvalidCharacter,
+}
+
 /// Normalized context adapters pass for terminal failure classification.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderFailureContext {

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tanren_domain::ErrorClass;
+use tanren_domain::{ErrorClass, NonEmptyString};
 
 /// Canonical failure classes exposed by harness adapters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -74,6 +74,45 @@ impl ProviderFailureCode {
     }
 }
 
+/// Normalized provider identifier used by failure classification.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ProviderIdentifier(NonEmptyString);
+
+impl ProviderIdentifier {
+    /// Build a normalized provider identifier.
+    ///
+    /// # Errors
+    /// Returns [`ProviderIdentifierError`] when the value is blank.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, ProviderIdentifierError> {
+        let normalized = normalize_identifier(&value.into());
+        let value = NonEmptyString::try_new(normalized)
+            .map_err(|_| ProviderIdentifierError::EmptyOrWhitespace)?;
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::try_new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderIdentifierError {
+    #[error("provider identifier must not be empty")]
+    EmptyOrWhitespace,
+}
+
 /// Typed failure payload returned by harness adapters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("{class:?}: {message}")]
@@ -81,9 +120,9 @@ pub struct HarnessFailure {
     pub class: HarnessFailureClass,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_code: Option<String>,
+    pub provider_code: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_kind: Option<String>,
+    pub provider_kind: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub typed_code: Option<ProviderFailureCode>,
 }
@@ -94,9 +133,9 @@ pub struct ProviderFailureContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub typed_code: Option<ProviderFailureCode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_code: Option<String>,
+    pub provider_code: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_kind: Option<String>,
+    pub provider_kind: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signal: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -113,7 +152,7 @@ pub struct ProviderFailureContext {
 /// 1) typed code from adapter
 /// 2) deterministic exact-token mappings from structured fields
 /// 3) deterministic exit/signal mappings
-/// 4) free-text fallback heuristics
+/// 4) boundary-aware text fallback heuristics
 #[must_use]
 pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailureClass {
     if let Some(code) = ctx.typed_code {
@@ -122,16 +161,16 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
 
     if let Some(class) = ctx
         .provider_code
-        .as_deref()
-        .and_then(classify_exact_identifier)
+        .as_ref()
+        .and_then(|value| classify_exact_identifier(value.as_str()))
     {
         return class;
     }
 
     if let Some(class) = ctx
         .provider_kind
-        .as_deref()
-        .and_then(classify_exact_identifier)
+        .as_ref()
+        .and_then(|value| classify_exact_identifier(value.as_str()))
     {
         return class;
     }
@@ -207,80 +246,110 @@ const fn classify_exit_code(code: i32) -> Option<HarnessFailureClass> {
 }
 
 fn classify_text_fallback(text: &str) -> HarnessFailureClass {
-    let haystack = text.to_ascii_lowercase();
+    let tokens = tokenize(text);
 
-    if contains_any(&haystack, &["capability_denied", "unsupported capability"]) {
+    if has_token(&tokens, "capability_denied")
+        || has_phrase(&tokens, &["unsupported", "capability"])
+    {
         return HarnessFailureClass::CapabilityDenied;
     }
-    if contains_any(
-        &haystack,
-        &["approval denied", "approval_required", "consent denied"],
-    ) {
+    if has_phrase(&tokens, &["approval", "denied"])
+        || has_token(&tokens, "approval_required")
+        || has_phrase(&tokens, &["consent", "denied"])
+    {
         return HarnessFailureClass::ApprovalDenied;
     }
-    if contains_any(
-        &haystack,
-        &[
-            "authentication",
-            "invalid api key",
-            "permission denied",
-            "401",
-            "403",
-        ],
-    ) {
+    if has_token(&tokens, "authentication")
+        || has_token(&tokens, "invalid_api_key")
+        || has_phrase(&tokens, &["invalid", "api", "key"])
+        || has_phrase(&tokens, &["permission", "denied"])
+        || has_any_token(&tokens, &["401", "403"])
+    {
         return HarnessFailureClass::Authentication;
     }
-    if contains_any(
-        &haystack,
-        &["rate limit", "rate_limited", "too many requests", "429"],
-    ) {
+    if has_phrase(&tokens, &["rate", "limit"])
+        || has_token(&tokens, "rate_limited")
+        || has_token(&tokens, "too_many_requests")
+        || has_phrase(&tokens, &["too", "many", "requests"])
+        || has_token(&tokens, "429")
+    {
         return HarnessFailureClass::RateLimited;
     }
-    if contains_any(&haystack, &["timeout", "deadline exceeded", "timed out"]) {
+    if has_any_token(&tokens, &["timeout", "deadline_exceeded", "timed_out"])
+        || has_phrase(&tokens, &["deadline", "exceeded"])
+        || has_phrase(&tokens, &["timed", "out"])
+    {
         return HarnessFailureClass::Timeout;
     }
-    if contains_any(
-        &haystack,
-        &[
-            "connection refused",
-            "network unreachable",
-            "dns",
-            "econnreset",
-            "temporarily unavailable",
-            "503",
-        ],
-    ) {
+    if has_phrase(&tokens, &["connection", "refused"])
+        || has_phrase(&tokens, &["network", "unreachable"])
+        || has_any_token(&tokens, &["dns", "econnreset"])
+        || has_phrase(&tokens, &["temporarily", "unavailable"])
+        || has_token(&tokens, "503")
+    {
         return HarnessFailureClass::TransportUnavailable;
     }
-    if contains_any(
-        &haystack,
-        &[
-            "out of memory",
-            "resource exhausted",
-            "quota exceeded",
-            "exit code 137",
-        ],
-    ) {
+    if has_phrase(&tokens, &["out", "of", "memory"])
+        || has_phrase(&tokens, &["resource", "exhausted"])
+        || has_phrase(&tokens, &["quota", "exceeded"])
+        || has_phrase(&tokens, &["exit", "code", "137"])
+    {
         return HarnessFailureClass::ResourceExhausted;
     }
-    if contains_any(
-        &haystack,
-        &["temporary", "retryable", "transient", "try again", "eagain"],
-    ) {
+    if has_any_token(&tokens, &["temporary", "retryable", "transient", "eagain"])
+        || has_phrase(&tokens, &["try", "again"])
+    {
         return HarnessFailureClass::Transient;
     }
-    if contains_any(&haystack, &["invalid argument", "bad request", "malformed"]) {
+    if has_phrase(&tokens, &["invalid", "argument"])
+        || has_phrase(&tokens, &["bad", "request"])
+        || has_token(&tokens, "malformed")
+    {
         return HarnessFailureClass::InvalidRequest;
     }
-    if contains_any(&haystack, &["panic", "fatal", "internal error"]) {
+    if has_any_token(&tokens, &["panic", "fatal", "internal_error"])
+        || has_phrase(&tokens, &["internal", "error"])
+    {
         return HarnessFailureClass::Fatal;
     }
 
     HarnessFailureClass::Unknown
 }
 
-fn contains_any(haystack: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| haystack.contains(needle))
+fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            current.push(ch.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn has_token(tokens: &[String], token: &str) -> bool {
+    tokens.iter().any(|value| value == token)
+}
+
+fn has_any_token(tokens: &[String], expected: &[&str]) -> bool {
+    expected.iter().any(|token| has_token(tokens, token))
+}
+
+fn has_phrase(tokens: &[String], phrase: &[&str]) -> bool {
+    if phrase.is_empty() || tokens.len() < phrase.len() {
+        return false;
+    }
+    tokens.windows(phrase.len()).any(|window| {
+        window
+            .iter()
+            .zip(phrase.iter())
+            .all(|(actual, expected)| actual == expected)
+    })
 }
 
 #[cfg(test)]
@@ -302,7 +371,7 @@ mod tests {
     #[test]
     fn maps_exact_provider_code_without_text_fallback() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_code: Some("rate_limited".into()),
+            provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
@@ -326,7 +395,7 @@ mod tests {
     #[test]
     fn maps_rate_limit_to_transient_domain_error_class() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_code: Some("429".into()),
+            provider_code: Some(ProviderIdentifier::try_new("429").expect("code")),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
@@ -336,7 +405,9 @@ mod tests {
     #[test]
     fn maps_capability_denial_to_fatal_domain_error_class() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_kind: Some("unsupported_capability".into()),
+            provider_kind: Some(
+                ProviderIdentifier::try_new("unsupported_capability").expect("kind"),
+            ),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::CapabilityDenied);
@@ -350,6 +421,15 @@ mod tests {
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
+    }
+
+    #[test]
+    fn fallback_ignores_numeric_substrings_without_token_boundaries() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some("artifact_1401 metrics_2403".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::Unknown);
     }
 
     #[test]

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -38,6 +38,42 @@ impl HarnessFailureClass {
     }
 }
 
+/// Typed provider-level error codes adapters should emit when available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderFailureCode {
+    CapabilityDenied,
+    ApprovalDenied,
+    Authentication,
+    RateLimited,
+    Timeout,
+    TransportUnavailable,
+    ResourceExhausted,
+    InvalidRequest,
+    Fatal,
+    Transient,
+    Unknown,
+}
+
+impl ProviderFailureCode {
+    #[must_use]
+    pub const fn to_harness_failure_class(self) -> HarnessFailureClass {
+        match self {
+            Self::CapabilityDenied => HarnessFailureClass::CapabilityDenied,
+            Self::ApprovalDenied => HarnessFailureClass::ApprovalDenied,
+            Self::Authentication => HarnessFailureClass::Authentication,
+            Self::RateLimited => HarnessFailureClass::RateLimited,
+            Self::Timeout => HarnessFailureClass::Timeout,
+            Self::TransportUnavailable => HarnessFailureClass::TransportUnavailable,
+            Self::ResourceExhausted => HarnessFailureClass::ResourceExhausted,
+            Self::InvalidRequest => HarnessFailureClass::InvalidRequest,
+            Self::Fatal => HarnessFailureClass::Fatal,
+            Self::Transient => HarnessFailureClass::Transient,
+            Self::Unknown => HarnessFailureClass::Unknown,
+        }
+    }
+}
+
 /// Typed failure payload returned by harness adapters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("{class:?}: {message}")]
@@ -48,11 +84,15 @@ pub struct HarnessFailure {
     pub provider_code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub typed_code: Option<ProviderFailureCode>,
 }
 
 /// Normalized raw context adapters can pass into classification helpers.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ProviderFailureContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub typed_code: Option<ProviderFailureCode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -67,22 +107,44 @@ pub struct ProviderFailureContext {
     pub stderr_tail: Option<String>,
 }
 
-/// Best-effort classifier for provider-native failures.
+/// Classify provider-native failures into stable harness classes.
+///
+/// Order of precedence:
+/// 1) typed code from adapter
+/// 2) deterministic exact-token mappings from structured fields
+/// 3) deterministic exit/signal mappings
+/// 4) free-text fallback heuristics
 #[must_use]
 pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailureClass {
+    if let Some(code) = ctx.typed_code {
+        return code.to_harness_failure_class();
+    }
+
+    if let Some(class) = ctx
+        .provider_code
+        .as_deref()
+        .and_then(classify_exact_identifier)
+    {
+        return class;
+    }
+
+    if let Some(class) = ctx
+        .provider_kind
+        .as_deref()
+        .and_then(classify_exact_identifier)
+    {
+        return class;
+    }
+
+    if let Some(class) = ctx.signal.as_deref().and_then(classify_exact_identifier) {
+        return class;
+    }
+
+    if let Some(class) = ctx.exit_code.and_then(classify_exit_code) {
+        return class;
+    }
+
     let mut merged = String::new();
-    if let Some(value) = &ctx.provider_code {
-        merged.push_str(value);
-        merged.push('\n');
-    }
-    if let Some(value) = &ctx.provider_kind {
-        merged.push_str(value);
-        merged.push('\n');
-    }
-    if let Some(value) = &ctx.signal {
-        merged.push_str(value);
-        merged.push('\n');
-    }
     if let Some(value) = &ctx.stdout_tail {
         merged.push_str(value);
         merged.push('\n');
@@ -90,7 +152,62 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
     if let Some(value) = &ctx.stderr_tail {
         merged.push_str(value);
     }
-    let haystack = merged.to_ascii_lowercase();
+
+    classify_text_fallback(&merged)
+}
+
+fn normalize_identifier(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase().replace([' ', '-'], "_")
+}
+
+fn classify_exact_identifier(raw: &str) -> Option<HarnessFailureClass> {
+    let token = normalize_identifier(raw);
+    match token.as_str() {
+        "capability_denied" | "unsupported_capability" => {
+            Some(HarnessFailureClass::CapabilityDenied)
+        }
+        "approval_denied" | "approval_required" | "consent_denied" => {
+            Some(HarnessFailureClass::ApprovalDenied)
+        }
+        "authentication" | "unauthorized" | "forbidden" | "invalid_api_key" | "401" | "403" => {
+            Some(HarnessFailureClass::Authentication)
+        }
+        "rate_limited" | "rate_limit" | "too_many_requests" | "429" => {
+            Some(HarnessFailureClass::RateLimited)
+        }
+        "timeout" | "deadline_exceeded" | "timed_out" | "124" => Some(HarnessFailureClass::Timeout),
+        "transport_unavailable"
+        | "connection_refused"
+        | "network_unreachable"
+        | "dns"
+        | "econnreset"
+        | "503" => Some(HarnessFailureClass::TransportUnavailable),
+        "resource_exhausted" | "out_of_memory" | "quota_exceeded" | "137" => {
+            Some(HarnessFailureClass::ResourceExhausted)
+        }
+        "invalid_request" | "invalid_argument" | "bad_request" | "malformed" | "400" => {
+            Some(HarnessFailureClass::InvalidRequest)
+        }
+        "transient" | "temporary" | "temporarily_unavailable" | "retryable" | "eagain" | "75" => {
+            Some(HarnessFailureClass::Transient)
+        }
+        "fatal" | "panic" | "internal_error" => Some(HarnessFailureClass::Fatal),
+        "unknown" => Some(HarnessFailureClass::Unknown),
+        _ => None,
+    }
+}
+
+const fn classify_exit_code(code: i32) -> Option<HarnessFailureClass> {
+    match code {
+        124 => Some(HarnessFailureClass::Timeout),
+        137 => Some(HarnessFailureClass::ResourceExhausted),
+        75 => Some(HarnessFailureClass::Transient),
+        _ => None,
+    }
+}
+
+fn classify_text_fallback(text: &str) -> HarnessFailureClass {
+    let haystack = text.to_ascii_lowercase();
 
     if contains_any(&haystack, &["capability_denied", "unsupported capability"]) {
         return HarnessFailureClass::CapabilityDenied;
@@ -146,14 +263,14 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
     ) {
         return HarnessFailureClass::ResourceExhausted;
     }
+    if contains_any(
+        &haystack,
+        &["temporary", "retryable", "transient", "try again", "eagain"],
+    ) {
+        return HarnessFailureClass::Transient;
+    }
     if contains_any(&haystack, &["invalid argument", "bad request", "malformed"]) {
         return HarnessFailureClass::InvalidRequest;
-    }
-    if ctx.exit_code == Some(137) {
-        return HarnessFailureClass::ResourceExhausted;
-    }
-    if ctx.exit_code == Some(124) {
-        return HarnessFailureClass::Timeout;
     }
     if contains_any(&haystack, &["panic", "fatal", "internal error"]) {
         return HarnessFailureClass::Fatal;
@@ -168,12 +285,48 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
 
     #[test]
-    fn maps_rate_limit_to_transient() {
+    fn typed_code_has_priority_over_text_heuristics() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("429 too many requests".into()),
+            typed_code: Some(ProviderFailureCode::Timeout),
+            stderr_tail: Some("401 invalid api key".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::Timeout);
+    }
+
+    #[test]
+    fn maps_exact_provider_code_without_text_fallback() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            provider_code: Some("rate_limited".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::RateLimited);
+    }
+
+    #[test]
+    fn maps_transient_from_structured_signal_or_exit_code() {
+        let from_signal = classify_provider_failure(&ProviderFailureContext {
+            signal: Some("temporary".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(from_signal, HarnessFailureClass::Transient);
+
+        let from_exit = classify_provider_failure(&ProviderFailureContext {
+            exit_code: Some(75),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(from_exit, HarnessFailureClass::Transient);
+    }
+
+    #[test]
+    fn maps_rate_limit_to_transient_domain_error_class() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            provider_code: Some("429".into()),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
@@ -181,9 +334,9 @@ mod tests {
     }
 
     #[test]
-    fn maps_capability_denial_to_fatal() {
+    fn maps_capability_denial_to_fatal_domain_error_class() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_kind: Some("unsupported capability: tool_events".into()),
+            provider_kind: Some("unsupported_capability".into()),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::CapabilityDenied);
@@ -191,12 +344,12 @@ mod tests {
     }
 
     #[test]
-    fn maps_exit_code_137_to_resource_exhausted() {
+    fn fallback_heuristics_only_used_when_structured_data_missing() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            exit_code: Some(137),
+            stderr_tail: Some("429 too many requests".into()),
             ..ProviderFailureContext::default()
         });
-        assert_eq!(class, HarnessFailureClass::ResourceExhausted);
+        assert_eq!(class, HarnessFailureClass::RateLimited);
     }
 
     #[test]
@@ -207,5 +360,28 @@ mod tests {
         });
         assert_eq!(class, HarnessFailureClass::Unknown);
         assert_eq!(class.to_domain_error_class(), ErrorClass::Ambiguous);
+    }
+
+    proptest! {
+        #[test]
+        fn typed_codes_are_never_overridden_by_fallback_text(noise in ".{0,120}") {
+            let class = classify_provider_failure(&ProviderFailureContext {
+                typed_code: Some(ProviderFailureCode::Authentication),
+                stdout_tail: Some(noise),
+                stderr_tail: Some("429 too many requests temporary".into()),
+                ..ProviderFailureContext::default()
+            });
+            prop_assert_eq!(class, HarnessFailureClass::Authentication);
+        }
+
+        #[test]
+        fn exit_code_75_remains_transient_even_with_unrelated_text(noise in ".{0,120}") {
+            let class = classify_provider_failure(&ProviderFailureContext {
+                exit_code: Some(75),
+                stderr_tail: Some(noise),
+                ..ProviderFailureContext::default()
+            });
+            prop_assert_eq!(class, HarnessFailureClass::Transient);
+        }
     }
 }

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -2,8 +2,8 @@ mod taxonomy;
 mod text_classifier;
 
 use serde::{Deserialize, Serialize};
-use tanren_domain::{ErrorClass, NonEmptyString};
-use taxonomy::{classify_exact_identifier, classify_exit_code, normalize_identifier};
+use tanren_domain::ErrorClass;
+use taxonomy::{classify_exact_identifier, classify_exit_code};
 
 /// Canonical failure classes exposed by harness adapters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -42,10 +42,44 @@ impl HarnessFailureClass {
     }
 }
 
-/// Typed provider-level error codes adapters should emit when available.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+/// Typed provider-level error codes adapters emit for terminal failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderFailureCode {
+    CapabilityDenied,
+    ApprovalDenied,
+    Authentication,
+    RateLimited,
+    Timeout,
+    TransportUnavailable,
+    ResourceExhausted,
+    InvalidRequest,
+    Fatal,
+    Transient,
+}
+
+impl ProviderFailureCode {
+    #[must_use]
+    pub const fn to_harness_failure_class(self) -> HarnessFailureClass {
+        match self {
+            Self::CapabilityDenied => HarnessFailureClass::CapabilityDenied,
+            Self::ApprovalDenied => HarnessFailureClass::ApprovalDenied,
+            Self::Authentication => HarnessFailureClass::Authentication,
+            Self::RateLimited => HarnessFailureClass::RateLimited,
+            Self::Timeout => HarnessFailureClass::Timeout,
+            Self::TransportUnavailable => HarnessFailureClass::TransportUnavailable,
+            Self::ResourceExhausted => HarnessFailureClass::ResourceExhausted,
+            Self::InvalidRequest => HarnessFailureClass::InvalidRequest,
+            Self::Fatal => HarnessFailureClass::Fatal,
+            Self::Transient => HarnessFailureClass::Transient,
+        }
+    }
+}
+
+/// Typed provider-level error codes used in audit/telemetry paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditProviderFailureCode {
     CapabilityDenied,
     ApprovalDenied,
     Authentication,
@@ -60,38 +94,38 @@ pub enum ProviderFailureCode {
     Unknown,
 }
 
-impl ProviderFailureCode {
+impl AuditProviderFailureCode {
     #[must_use]
-    pub const fn from_harness_failure_class(class: HarnessFailureClass) -> Self {
-        match class {
-            HarnessFailureClass::CapabilityDenied => Self::CapabilityDenied,
-            HarnessFailureClass::ApprovalDenied => Self::ApprovalDenied,
-            HarnessFailureClass::Authentication => Self::Authentication,
-            HarnessFailureClass::RateLimited => Self::RateLimited,
-            HarnessFailureClass::Timeout => Self::Timeout,
-            HarnessFailureClass::TransportUnavailable => Self::TransportUnavailable,
-            HarnessFailureClass::ResourceExhausted => Self::ResourceExhausted,
-            HarnessFailureClass::InvalidRequest => Self::InvalidRequest,
-            HarnessFailureClass::Fatal => Self::Fatal,
-            HarnessFailureClass::Transient => Self::Transient,
-            HarnessFailureClass::Unknown => Self::Unknown,
+    pub const fn to_terminal_code(self) -> Option<ProviderFailureCode> {
+        match self {
+            Self::CapabilityDenied => Some(ProviderFailureCode::CapabilityDenied),
+            Self::ApprovalDenied => Some(ProviderFailureCode::ApprovalDenied),
+            Self::Authentication => Some(ProviderFailureCode::Authentication),
+            Self::RateLimited => Some(ProviderFailureCode::RateLimited),
+            Self::Timeout => Some(ProviderFailureCode::Timeout),
+            Self::TransportUnavailable => Some(ProviderFailureCode::TransportUnavailable),
+            Self::ResourceExhausted => Some(ProviderFailureCode::ResourceExhausted),
+            Self::InvalidRequest => Some(ProviderFailureCode::InvalidRequest),
+            Self::Fatal => Some(ProviderFailureCode::Fatal),
+            Self::Transient => Some(ProviderFailureCode::Transient),
+            Self::Unknown => None,
         }
     }
+}
 
-    #[must_use]
-    pub const fn to_harness_failure_class(self) -> HarnessFailureClass {
-        match self {
-            Self::CapabilityDenied => HarnessFailureClass::CapabilityDenied,
-            Self::ApprovalDenied => HarnessFailureClass::ApprovalDenied,
-            Self::Authentication => HarnessFailureClass::Authentication,
-            Self::RateLimited => HarnessFailureClass::RateLimited,
-            Self::Timeout => HarnessFailureClass::Timeout,
-            Self::TransportUnavailable => HarnessFailureClass::TransportUnavailable,
-            Self::ResourceExhausted => HarnessFailureClass::ResourceExhausted,
-            Self::InvalidRequest => HarnessFailureClass::InvalidRequest,
-            Self::Fatal => HarnessFailureClass::Fatal,
-            Self::Transient => HarnessFailureClass::Transient,
-            Self::Unknown => HarnessFailureClass::Unknown,
+impl From<ProviderFailureCode> for AuditProviderFailureCode {
+    fn from(value: ProviderFailureCode) -> Self {
+        match value {
+            ProviderFailureCode::CapabilityDenied => Self::CapabilityDenied,
+            ProviderFailureCode::ApprovalDenied => Self::ApprovalDenied,
+            ProviderFailureCode::Authentication => Self::Authentication,
+            ProviderFailureCode::RateLimited => Self::RateLimited,
+            ProviderFailureCode::Timeout => Self::Timeout,
+            ProviderFailureCode::TransportUnavailable => Self::TransportUnavailable,
+            ProviderFailureCode::ResourceExhausted => Self::ResourceExhausted,
+            ProviderFailureCode::InvalidRequest => Self::InvalidRequest,
+            ProviderFailureCode::Fatal => Self::Fatal,
+            ProviderFailureCode::Transient => Self::Transient,
         }
     }
 }
@@ -99,17 +133,31 @@ impl ProviderFailureCode {
 /// Normalized provider identifier used by failure classification.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
-pub struct ProviderIdentifier(NonEmptyString);
+pub struct ProviderIdentifier(String);
 
 impl ProviderIdentifier {
-    /// Build a normalized provider identifier.
+    pub const MAX_LEN: usize = 64;
+
+    /// Build a strict provider identifier.
     ///
     /// # Errors
-    /// Returns [`ProviderIdentifierError`] when the value is blank.
+    /// Returns [`ProviderIdentifierError`] when empty or format-invalid.
     pub fn try_new(value: impl Into<String>) -> Result<Self, ProviderIdentifierError> {
-        let normalized = normalize_identifier(&value.into());
-        let value = NonEmptyString::try_new(normalized)
-            .map_err(|_| ProviderIdentifierError::EmptyOrWhitespace)?;
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ProviderIdentifierError::EmptyOrWhitespace);
+        }
+        if value.len() > Self::MAX_LEN {
+            return Err(ProviderIdentifierError::TooLong {
+                max_len: Self::MAX_LEN,
+            });
+        }
+        if !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+        {
+            return Err(ProviderIdentifierError::InvalidCharacter);
+        }
         Ok(Self(value))
     }
 
@@ -133,10 +181,14 @@ impl<'de> Deserialize<'de> for ProviderIdentifier {
 pub enum ProviderIdentifierError {
     #[error("provider identifier must not be empty")]
     EmptyOrWhitespace,
+    #[error("provider identifier exceeds max length {max_len}")]
+    TooLong { max_len: usize },
+    #[error("provider identifier contains unsupported characters")]
+    InvalidCharacter,
 }
 
-/// Normalized raw context adapters can pass into classification helpers.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+/// Normalized context adapters pass for terminal failure classification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderFailureContext {
     pub typed_code: ProviderFailureCode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -153,6 +205,53 @@ pub struct ProviderFailureContext {
     pub stderr_tail: Option<String>,
 }
 
+impl ProviderFailureContext {
+    #[must_use]
+    pub fn new(typed_code: ProviderFailureCode) -> Self {
+        Self {
+            typed_code,
+            provider_code: None,
+            provider_kind: None,
+            signal: None,
+            exit_code: None,
+            stdout_tail: None,
+            stderr_tail: None,
+        }
+    }
+}
+
+/// Context for audit-only fallback classification paths.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AuditProviderFailureContext {
+    pub typed_code: AuditProviderFailureCode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_code: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<ProviderIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout_tail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_tail: Option<String>,
+}
+
+impl From<&ProviderFailureContext> for AuditProviderFailureContext {
+    fn from(value: &ProviderFailureContext) -> Self {
+        Self {
+            typed_code: value.typed_code.into(),
+            provider_code: value.provider_code.clone(),
+            provider_kind: value.provider_kind.clone(),
+            signal: value.signal.clone(),
+            exit_code: value.exit_code,
+            stdout_tail: value.stdout_tail.clone(),
+            stderr_tail: value.stderr_tail.clone(),
+        }
+    }
+}
+
 /// Provider-native failure payload adapters return to the contract wrapper.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("{message}")]
@@ -167,10 +266,7 @@ impl ProviderFailure {
     pub fn new(typed_code: ProviderFailureCode, message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            context: ProviderFailureContext {
-                typed_code,
-                ..ProviderFailureContext::default()
-            },
+            context: ProviderFailureContext::new(typed_code),
         }
     }
 
@@ -183,8 +279,7 @@ impl ProviderFailure {
     #[cfg(test)]
     #[must_use]
     pub(crate) fn into_harness_failure(self) -> HarnessFailure {
-        let class = classify_provider_failure(&self.context);
-        HarnessFailure::from_provider_failure_with_class(self, class)
+        HarnessFailure::from_provider_failure(self)
     }
 }
 
@@ -203,21 +298,19 @@ pub struct HarnessFailure {
 
 impl HarnessFailure {
     #[must_use]
-    pub fn new(class: HarnessFailureClass, message: impl Into<String>) -> Self {
+    pub fn new(typed_code: ProviderFailureCode, message: impl Into<String>) -> Self {
         Self {
-            class,
+            class: typed_code.to_harness_failure_class(),
             message: message.into(),
             provider_code: None,
             provider_kind: None,
-            typed_code: ProviderFailureCode::from_harness_failure_class(class),
+            typed_code,
         }
     }
 
     #[must_use]
-    pub(crate) fn from_provider_failure_with_class(
-        failure: ProviderFailure,
-        class: HarnessFailureClass,
-    ) -> Self {
+    pub(crate) fn from_provider_failure(failure: ProviderFailure) -> Self {
+        let class = classify_provider_failure(&failure.context);
         Self {
             class,
             message: failure.message,
@@ -261,7 +354,6 @@ struct HarnessFailureWire {
     provider_code: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     provider_kind: Option<ProviderIdentifier>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     typed_code: ProviderFailureCode,
 }
 
@@ -271,11 +363,6 @@ impl<'de> Deserialize<'de> for HarnessFailure {
         D: serde::Deserializer<'de>,
     {
         let wire = HarnessFailureWire::deserialize(deserializer)?;
-        if wire.typed_code == ProviderFailureCode::Unknown {
-            return Err(serde::de::Error::custom(
-                "typed_code unknown is forbidden for terminal harness failures",
-            ));
-        }
         let expected = wire.typed_code.to_harness_failure_class();
         if wire.class != expected {
             return Err(serde::de::Error::custom(format!(
@@ -306,9 +393,11 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
 ///
 /// This API is explicitly non-authoritative for terminal failure semantics.
 #[must_use]
-pub fn classify_provider_failure_for_audit(ctx: &ProviderFailureContext) -> HarnessFailureClass {
-    if ctx.typed_code != ProviderFailureCode::Unknown {
-        return ctx.typed_code.to_harness_failure_class();
+pub fn classify_provider_failure_for_audit(
+    ctx: &AuditProviderFailureContext,
+) -> HarnessFailureClass {
+    if let Some(typed_code) = ctx.typed_code.to_terminal_code() {
+        return typed_code.to_harness_failure_class();
     }
 
     if let Some(class) = ctx
@@ -338,134 +427,5 @@ pub fn classify_provider_failure_for_audit(ctx: &ProviderFailureContext) -> Harn
     text_classifier::classify_text_fallback(ctx.stdout_tail.as_deref(), ctx.stderr_tail.as_deref())
 }
 
-/// Validate terminal adapter failure context invariants.
-///
-/// # Errors
-/// Returns [`TerminalFailureCodeError`] when `typed_code` is not admissible.
-pub(crate) fn ensure_terminal_failure_code(
-    code: ProviderFailureCode,
-) -> Result<(), TerminalFailureCodeError> {
-    if code == ProviderFailureCode::Unknown {
-        return Err(TerminalFailureCodeError::UnknownForbidden);
-    }
-    Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum TerminalFailureCodeError {
-    #[error("typed_code unknown is forbidden for terminal adapter failures")]
-    UnknownForbidden,
-}
-
 #[cfg(test)]
-mod tests {
-    use proptest::prelude::*;
-
-    use super::*;
-
-    #[test]
-    fn typed_code_is_the_only_terminal_classification_input() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            typed_code: ProviderFailureCode::Timeout,
-            provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
-            stderr_tail: Some("401 invalid api key".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::Timeout);
-    }
-
-    #[test]
-    fn provider_failure_normalizes_through_context_classification() {
-        let provider_failure =
-            ProviderFailure::new(ProviderFailureCode::RateLimited, "raw adapter failure")
-                .with_context(ProviderFailureContext {
-                    typed_code: ProviderFailureCode::RateLimited,
-                    stderr_tail: Some("fatal panic".into()),
-                    ..ProviderFailureContext::default()
-                });
-
-        let failure = provider_failure.into_harness_failure();
-        assert_eq!(failure.class(), HarnessFailureClass::RateLimited);
-        assert_eq!(failure.typed_code(), ProviderFailureCode::RateLimited);
-    }
-
-    #[test]
-    fn audit_classifier_uses_structured_and_text_fallback_only_for_unknown_typed_code() {
-        let class = classify_provider_failure_for_audit(&ProviderFailureContext {
-            typed_code: ProviderFailureCode::Unknown,
-            provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::RateLimited);
-
-        let from_text = classify_provider_failure_for_audit(&ProviderFailureContext {
-            typed_code: ProviderFailureCode::Unknown,
-            stderr_tail: Some("429 too many requests".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(from_text, HarnessFailureClass::RateLimited);
-    }
-
-    #[test]
-    fn maps_rate_limit_to_transient_domain_error_class() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            typed_code: ProviderFailureCode::RateLimited,
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::RateLimited);
-        assert_eq!(class.to_domain_error_class(), ErrorClass::Transient);
-    }
-
-    #[test]
-    fn maps_capability_denial_to_fatal_domain_error_class() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            typed_code: ProviderFailureCode::CapabilityDenied,
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::CapabilityDenied);
-        assert_eq!(class.to_domain_error_class(), ErrorClass::Fatal);
-    }
-
-    #[test]
-    fn terminal_unknown_typed_code_is_rejected() {
-        let err =
-            ensure_terminal_failure_code(ProviderFailureCode::Unknown).expect_err("must deny");
-        assert_eq!(err, TerminalFailureCodeError::UnknownForbidden);
-    }
-
-    #[test]
-    fn deserialization_rejects_unknown_typed_code() {
-        let payload = serde_json::json!({
-            "class": "unknown",
-            "message": "bad",
-            "typed_code": "unknown"
-        });
-        let err = serde_json::from_value::<HarnessFailure>(payload).expect_err("must reject");
-        let msg = err.to_string();
-        assert!(msg.contains("unknown is forbidden"), "{msg}");
-    }
-
-    proptest! {
-        #[test]
-        fn typed_codes_are_never_overridden_by_audit_fallback(noise in ".{0,120}") {
-            let class = classify_provider_failure(&ProviderFailureContext {
-                typed_code: ProviderFailureCode::Authentication,
-                stdout_tail: Some(noise),
-                stderr_tail: Some("429 too many requests temporary".into()),
-                ..ProviderFailureContext::default()
-            });
-            prop_assert_eq!(class, HarnessFailureClass::Authentication);
-        }
-
-        #[test]
-        fn audit_fallback_still_classifies_unknown_typed_code_from_exit_code(noise in ".{0,120}") {
-            let class = classify_provider_failure_for_audit(&ProviderFailureContext {
-                typed_code: ProviderFailureCode::Unknown,
-                exit_code: Some(75),
-                stderr_tail: Some(noise),
-                ..ProviderFailureContext::default()
-            });
-            prop_assert_eq!(class, HarnessFailureClass::Transient);
-        }
-    }
-}
+mod tests;

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -1,7 +1,9 @@
+mod taxonomy;
 mod text_classifier;
 
 use serde::{Deserialize, Serialize};
 use tanren_domain::{ErrorClass, NonEmptyString};
+use taxonomy::{classify_exact_identifier, classify_exit_code, normalize_identifier};
 
 /// Canonical failure classes exposed by harness adapters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -193,6 +195,14 @@ impl HarnessFailure {
     #[must_use]
     pub fn from_provider_failure(failure: ProviderFailure) -> Self {
         let class = classify_provider_failure(&failure.context);
+        Self::from_provider_failure_with_class(failure, class)
+    }
+
+    #[must_use]
+    pub fn from_provider_failure_with_class(
+        failure: ProviderFailure,
+        class: HarnessFailureClass,
+    ) -> Self {
         Self {
             class,
             message: failure.message,
@@ -306,56 +316,6 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
     text_classifier::classify_text_fallback(ctx.stdout_tail.as_deref(), ctx.stderr_tail.as_deref())
 }
 
-fn normalize_identifier(raw: &str) -> String {
-    raw.trim().to_ascii_lowercase().replace([' ', '-'], "_")
-}
-
-fn classify_exact_identifier(raw: &str) -> Option<HarnessFailureClass> {
-    let token = normalize_identifier(raw);
-    match token.as_str() {
-        "capability_denied" | "unsupported_capability" => {
-            Some(HarnessFailureClass::CapabilityDenied)
-        }
-        "approval_denied" | "approval_required" | "consent_denied" => {
-            Some(HarnessFailureClass::ApprovalDenied)
-        }
-        "authentication" | "unauthorized" | "forbidden" | "invalid_api_key" | "401" | "403" => {
-            Some(HarnessFailureClass::Authentication)
-        }
-        "rate_limited" | "rate_limit" | "too_many_requests" | "429" => {
-            Some(HarnessFailureClass::RateLimited)
-        }
-        "timeout" | "deadline_exceeded" | "timed_out" | "124" => Some(HarnessFailureClass::Timeout),
-        "transport_unavailable"
-        | "connection_refused"
-        | "network_unreachable"
-        | "dns"
-        | "econnreset"
-        | "503" => Some(HarnessFailureClass::TransportUnavailable),
-        "resource_exhausted" | "out_of_memory" | "quota_exceeded" | "137" => {
-            Some(HarnessFailureClass::ResourceExhausted)
-        }
-        "invalid_request" | "invalid_argument" | "bad_request" | "malformed" | "400" => {
-            Some(HarnessFailureClass::InvalidRequest)
-        }
-        "transient" | "temporary" | "temporarily_unavailable" | "retryable" | "eagain" | "75" => {
-            Some(HarnessFailureClass::Transient)
-        }
-        "fatal" | "panic" | "internal_error" => Some(HarnessFailureClass::Fatal),
-        "unknown" => Some(HarnessFailureClass::Unknown),
-        _ => None,
-    }
-}
-
-const fn classify_exit_code(code: i32) -> Option<HarnessFailureClass> {
-    match code {
-        124 => Some(HarnessFailureClass::Timeout),
-        137 => Some(HarnessFailureClass::ResourceExhausted),
-        75 => Some(HarnessFailureClass::Transient),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
@@ -408,6 +368,12 @@ mod tests {
             ..ProviderFailureContext::default()
         });
         assert_eq!(from_exit, HarnessFailureClass::Transient);
+
+        let from_sigterm_exit = classify_provider_failure(&ProviderFailureContext {
+            exit_code: Some(143),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(from_sigterm_exit, HarnessFailureClass::Transient);
     }
 
     #[test]
@@ -442,6 +408,30 @@ mod tests {
     }
 
     #[test]
+    fn classification_covers_common_provider_variants() {
+        let cases = [
+            ("auth_failed", HarnessFailureClass::Authentication),
+            ("throttling", HarnessFailureClass::RateLimited),
+            ("gateway_timeout", HarnessFailureClass::Timeout),
+            ("econnrefused", HarnessFailureClass::TransportUnavailable),
+            (
+                "context_length_exceeded",
+                HarnessFailureClass::ResourceExhausted,
+            ),
+            ("unprocessable_entity", HarnessFailureClass::InvalidRequest),
+            ("backoff_required", HarnessFailureClass::Transient),
+            ("assertion_failed", HarnessFailureClass::Fatal),
+        ];
+        for (provider_code, expected) in cases {
+            let class = classify_provider_failure(&ProviderFailureContext {
+                provider_code: Some(ProviderIdentifier::try_new(provider_code).expect("code")),
+                ..ProviderFailureContext::default()
+            });
+            assert_eq!(class, expected, "provider_code={provider_code}");
+        }
+    }
+
+    #[test]
     fn fallback_ignores_numeric_substrings_without_token_boundaries() {
         let class = classify_provider_failure(&ProviderFailureContext {
             stderr_tail: Some("artifact_1401 metrics_2403".into()),
@@ -457,6 +447,21 @@ mod tests {
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::Timeout);
+    }
+
+    #[test]
+    fn fallback_phrase_detection_uses_shared_taxonomy() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some("provider returned permission denied for token".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::Authentication);
+
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some("service unavailable while dialing upstream".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::TransportUnavailable);
     }
 
     #[test]

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -1,0 +1,211 @@
+use serde::{Deserialize, Serialize};
+use tanren_domain::ErrorClass;
+
+/// Canonical failure classes exposed by harness adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessFailureClass {
+    CapabilityDenied,
+    ApprovalDenied,
+    Authentication,
+    RateLimited,
+    Timeout,
+    TransportUnavailable,
+    ResourceExhausted,
+    InvalidRequest,
+    Fatal,
+    Transient,
+    Unknown,
+}
+
+impl HarnessFailureClass {
+    /// Map harness failure class into the domain retry class.
+    #[must_use]
+    pub const fn to_domain_error_class(self) -> ErrorClass {
+        match self {
+            Self::RateLimited
+            | Self::Timeout
+            | Self::TransportUnavailable
+            | Self::ResourceExhausted
+            | Self::Transient => ErrorClass::Transient,
+            Self::CapabilityDenied
+            | Self::ApprovalDenied
+            | Self::Authentication
+            | Self::InvalidRequest
+            | Self::Fatal => ErrorClass::Fatal,
+            Self::Unknown => ErrorClass::Ambiguous,
+        }
+    }
+}
+
+/// Typed failure payload returned by harness adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("{class:?}: {message}")]
+pub struct HarnessFailure {
+    pub class: HarnessFailureClass,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+}
+
+/// Normalized raw context adapters can pass into classification helpers.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ProviderFailureContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout_tail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_tail: Option<String>,
+}
+
+/// Best-effort classifier for provider-native failures.
+#[must_use]
+pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailureClass {
+    let mut merged = String::new();
+    if let Some(value) = &ctx.provider_code {
+        merged.push_str(value);
+        merged.push('\n');
+    }
+    if let Some(value) = &ctx.provider_kind {
+        merged.push_str(value);
+        merged.push('\n');
+    }
+    if let Some(value) = &ctx.signal {
+        merged.push_str(value);
+        merged.push('\n');
+    }
+    if let Some(value) = &ctx.stdout_tail {
+        merged.push_str(value);
+        merged.push('\n');
+    }
+    if let Some(value) = &ctx.stderr_tail {
+        merged.push_str(value);
+    }
+    let haystack = merged.to_ascii_lowercase();
+
+    if contains_any(&haystack, &["capability_denied", "unsupported capability"]) {
+        return HarnessFailureClass::CapabilityDenied;
+    }
+    if contains_any(
+        &haystack,
+        &["approval denied", "approval_required", "consent denied"],
+    ) {
+        return HarnessFailureClass::ApprovalDenied;
+    }
+    if contains_any(
+        &haystack,
+        &[
+            "authentication",
+            "invalid api key",
+            "permission denied",
+            "401",
+            "403",
+        ],
+    ) {
+        return HarnessFailureClass::Authentication;
+    }
+    if contains_any(
+        &haystack,
+        &["rate limit", "rate_limited", "too many requests", "429"],
+    ) {
+        return HarnessFailureClass::RateLimited;
+    }
+    if contains_any(&haystack, &["timeout", "deadline exceeded", "timed out"]) {
+        return HarnessFailureClass::Timeout;
+    }
+    if contains_any(
+        &haystack,
+        &[
+            "connection refused",
+            "network unreachable",
+            "dns",
+            "econnreset",
+            "temporarily unavailable",
+            "503",
+        ],
+    ) {
+        return HarnessFailureClass::TransportUnavailable;
+    }
+    if contains_any(
+        &haystack,
+        &[
+            "out of memory",
+            "resource exhausted",
+            "quota exceeded",
+            "exit code 137",
+        ],
+    ) {
+        return HarnessFailureClass::ResourceExhausted;
+    }
+    if contains_any(&haystack, &["invalid argument", "bad request", "malformed"]) {
+        return HarnessFailureClass::InvalidRequest;
+    }
+    if ctx.exit_code == Some(137) {
+        return HarnessFailureClass::ResourceExhausted;
+    }
+    if ctx.exit_code == Some(124) {
+        return HarnessFailureClass::Timeout;
+    }
+    if contains_any(&haystack, &["panic", "fatal", "internal error"]) {
+        return HarnessFailureClass::Fatal;
+    }
+
+    HarnessFailureClass::Unknown
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_rate_limit_to_transient() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some("429 too many requests".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::RateLimited);
+        assert_eq!(class.to_domain_error_class(), ErrorClass::Transient);
+    }
+
+    #[test]
+    fn maps_capability_denial_to_fatal() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            provider_kind: Some("unsupported capability: tool_events".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::CapabilityDenied);
+        assert_eq!(class.to_domain_error_class(), ErrorClass::Fatal);
+    }
+
+    #[test]
+    fn maps_exit_code_137_to_resource_exhausted() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            exit_code: Some(137),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::ResourceExhausted);
+    }
+
+    #[test]
+    fn maps_unknown_to_ambiguous() {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            stderr_tail: Some("something odd happened".into()),
+            ..ProviderFailureContext::default()
+        });
+        assert_eq!(class, HarnessFailureClass::Unknown);
+        assert_eq!(class.to_domain_error_class(), ErrorClass::Ambiguous);
+    }
+}

--- a/crates/tanren-runtime/src/failure.rs
+++ b/crates/tanren-runtime/src/failure.rs
@@ -43,7 +43,7 @@ impl HarnessFailureClass {
 }
 
 /// Typed provider-level error codes adapters should emit when available.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderFailureCode {
     CapabilityDenied,
@@ -56,10 +56,28 @@ pub enum ProviderFailureCode {
     InvalidRequest,
     Fatal,
     Transient,
+    #[default]
     Unknown,
 }
 
 impl ProviderFailureCode {
+    #[must_use]
+    pub const fn from_harness_failure_class(class: HarnessFailureClass) -> Self {
+        match class {
+            HarnessFailureClass::CapabilityDenied => Self::CapabilityDenied,
+            HarnessFailureClass::ApprovalDenied => Self::ApprovalDenied,
+            HarnessFailureClass::Authentication => Self::Authentication,
+            HarnessFailureClass::RateLimited => Self::RateLimited,
+            HarnessFailureClass::Timeout => Self::Timeout,
+            HarnessFailureClass::TransportUnavailable => Self::TransportUnavailable,
+            HarnessFailureClass::ResourceExhausted => Self::ResourceExhausted,
+            HarnessFailureClass::InvalidRequest => Self::InvalidRequest,
+            HarnessFailureClass::Fatal => Self::Fatal,
+            HarnessFailureClass::Transient => Self::Transient,
+            HarnessFailureClass::Unknown => Self::Unknown,
+        }
+    }
+
     #[must_use]
     pub const fn to_harness_failure_class(self) -> HarnessFailureClass {
         match self {
@@ -120,8 +138,7 @@ pub enum ProviderIdentifierError {
 /// Normalized raw context adapters can pass into classification helpers.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ProviderFailureContext {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub typed_code: Option<ProviderFailureCode>,
+    pub typed_code: ProviderFailureCode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_code: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -147,10 +164,13 @@ pub struct ProviderFailure {
 
 impl ProviderFailure {
     #[must_use]
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(typed_code: ProviderFailureCode, message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            context: ProviderFailureContext::default(),
+            context: ProviderFailureContext {
+                typed_code,
+                ..ProviderFailureContext::default()
+            },
         }
     }
 
@@ -160,9 +180,11 @@ impl ProviderFailure {
         self
     }
 
+    #[cfg(test)]
     #[must_use]
-    pub fn into_harness_failure(self) -> HarnessFailure {
-        HarnessFailure::from_provider_failure(self)
+    pub(crate) fn into_harness_failure(self) -> HarnessFailure {
+        let class = classify_provider_failure(&self.context);
+        HarnessFailure::from_provider_failure_with_class(self, class)
     }
 }
 
@@ -176,8 +198,7 @@ pub struct HarnessFailure {
     provider_code: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     provider_kind: Option<ProviderIdentifier>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    typed_code: Option<ProviderFailureCode>,
+    typed_code: ProviderFailureCode,
 }
 
 impl HarnessFailure {
@@ -188,18 +209,12 @@ impl HarnessFailure {
             message: message.into(),
             provider_code: None,
             provider_kind: None,
-            typed_code: None,
+            typed_code: ProviderFailureCode::from_harness_failure_class(class),
         }
     }
 
     #[must_use]
-    pub fn from_provider_failure(failure: ProviderFailure) -> Self {
-        let class = classify_provider_failure(&failure.context);
-        Self::from_provider_failure_with_class(failure, class)
-    }
-
-    #[must_use]
-    pub fn from_provider_failure_with_class(
+    pub(crate) fn from_provider_failure_with_class(
         failure: ProviderFailure,
         class: HarnessFailureClass,
     ) -> Self {
@@ -233,7 +248,7 @@ impl HarnessFailure {
     }
 
     #[must_use]
-    pub const fn typed_code(&self) -> Option<ProviderFailureCode> {
+    pub const fn typed_code(&self) -> ProviderFailureCode {
         self.typed_code
     }
 }
@@ -247,7 +262,7 @@ struct HarnessFailureWire {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     provider_kind: Option<ProviderIdentifier>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    typed_code: Option<ProviderFailureCode>,
+    typed_code: ProviderFailureCode,
 }
 
 impl<'de> Deserialize<'de> for HarnessFailure {
@@ -256,14 +271,17 @@ impl<'de> Deserialize<'de> for HarnessFailure {
         D: serde::Deserializer<'de>,
     {
         let wire = HarnessFailureWire::deserialize(deserializer)?;
-        if let Some(typed_code) = wire.typed_code {
-            let expected = typed_code.to_harness_failure_class();
-            if wire.class != expected {
-                return Err(serde::de::Error::custom(format!(
-                    "typed_code {typed_code:?} implies class {expected:?}, got {:?}",
-                    wire.class
-                )));
-            }
+        if wire.typed_code == ProviderFailureCode::Unknown {
+            return Err(serde::de::Error::custom(
+                "typed_code unknown is forbidden for terminal harness failures",
+            ));
+        }
+        let expected = wire.typed_code.to_harness_failure_class();
+        if wire.class != expected {
+            return Err(serde::de::Error::custom(format!(
+                "typed_code {:?} implies class {expected:?}, got {:?}",
+                wire.typed_code, wire.class
+            )));
         }
 
         Ok(Self {
@@ -278,15 +296,19 @@ impl<'de> Deserialize<'de> for HarnessFailure {
 
 /// Classify provider-native failures into stable harness classes.
 ///
-/// Order of precedence:
-/// 1) typed code from adapter
-/// 2) deterministic exact-token mappings from structured fields
-/// 3) deterministic exit/signal mappings
-/// 4) bounded boundary-aware text fallback heuristics
+/// Terminal semantic normalization is strictly typed and deterministic.
 #[must_use]
 pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailureClass {
-    if let Some(code) = ctx.typed_code {
-        return code.to_harness_failure_class();
+    ctx.typed_code.to_harness_failure_class()
+}
+
+/// Last-resort telemetry/audit classifier that allows bounded heuristics.
+///
+/// This API is explicitly non-authoritative for terminal failure semantics.
+#[must_use]
+pub fn classify_provider_failure_for_audit(ctx: &ProviderFailureContext) -> HarnessFailureClass {
+    if ctx.typed_code != ProviderFailureCode::Unknown {
+        return ctx.typed_code.to_harness_failure_class();
     }
 
     if let Some(class) = ctx
@@ -316,6 +338,25 @@ pub fn classify_provider_failure(ctx: &ProviderFailureContext) -> HarnessFailure
     text_classifier::classify_text_fallback(ctx.stdout_tail.as_deref(), ctx.stderr_tail.as_deref())
 }
 
+/// Validate terminal adapter failure context invariants.
+///
+/// # Errors
+/// Returns [`TerminalFailureCodeError`] when `typed_code` is not admissible.
+pub(crate) fn ensure_terminal_failure_code(
+    code: ProviderFailureCode,
+) -> Result<(), TerminalFailureCodeError> {
+    if code == ProviderFailureCode::Unknown {
+        return Err(TerminalFailureCodeError::UnknownForbidden);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TerminalFailureCodeError {
+    #[error("typed_code unknown is forbidden for terminal adapter failures")]
+    UnknownForbidden,
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
@@ -323,9 +364,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn typed_code_has_priority_over_text_heuristics() {
+    fn typed_code_is_the_only_terminal_classification_input() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            typed_code: Some(ProviderFailureCode::Timeout),
+            typed_code: ProviderFailureCode::Timeout,
+            provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
             stderr_tail: Some("401 invalid api key".into()),
             ..ProviderFailureContext::default()
         });
@@ -335,51 +377,39 @@ mod tests {
     #[test]
     fn provider_failure_normalizes_through_context_classification() {
         let provider_failure =
-            ProviderFailure::new("raw adapter failure").with_context(ProviderFailureContext {
-                typed_code: Some(ProviderFailureCode::RateLimited),
-                stderr_tail: Some("fatal panic".into()),
-                ..ProviderFailureContext::default()
-            });
+            ProviderFailure::new(ProviderFailureCode::RateLimited, "raw adapter failure")
+                .with_context(ProviderFailureContext {
+                    typed_code: ProviderFailureCode::RateLimited,
+                    stderr_tail: Some("fatal panic".into()),
+                    ..ProviderFailureContext::default()
+                });
 
         let failure = provider_failure.into_harness_failure();
         assert_eq!(failure.class(), HarnessFailureClass::RateLimited);
-        assert_eq!(failure.typed_code(), Some(ProviderFailureCode::RateLimited));
+        assert_eq!(failure.typed_code(), ProviderFailureCode::RateLimited);
     }
 
     #[test]
-    fn maps_exact_provider_code_without_text_fallback() {
-        let class = classify_provider_failure(&ProviderFailureContext {
+    fn audit_classifier_uses_structured_and_text_fallback_only_for_unknown_typed_code() {
+        let class = classify_provider_failure_for_audit(&ProviderFailureContext {
+            typed_code: ProviderFailureCode::Unknown,
             provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
-    }
 
-    #[test]
-    fn maps_transient_from_structured_signal_or_exit_code() {
-        let from_signal = classify_provider_failure(&ProviderFailureContext {
-            signal: Some("temporary".into()),
+        let from_text = classify_provider_failure_for_audit(&ProviderFailureContext {
+            typed_code: ProviderFailureCode::Unknown,
+            stderr_tail: Some("429 too many requests".into()),
             ..ProviderFailureContext::default()
         });
-        assert_eq!(from_signal, HarnessFailureClass::Transient);
-
-        let from_exit = classify_provider_failure(&ProviderFailureContext {
-            exit_code: Some(75),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(from_exit, HarnessFailureClass::Transient);
-
-        let from_sigterm_exit = classify_provider_failure(&ProviderFailureContext {
-            exit_code: Some(143),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(from_sigterm_exit, HarnessFailureClass::Transient);
+        assert_eq!(from_text, HarnessFailureClass::RateLimited);
     }
 
     #[test]
     fn maps_rate_limit_to_transient_domain_error_class() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_code: Some(ProviderIdentifier::try_new("429").expect("code")),
+            typed_code: ProviderFailureCode::RateLimited,
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::RateLimited);
@@ -389,9 +419,7 @@ mod tests {
     #[test]
     fn maps_capability_denial_to_fatal_domain_error_class() {
         let class = classify_provider_failure(&ProviderFailureContext {
-            provider_kind: Some(
-                ProviderIdentifier::try_new("unsupported_capability").expect("kind"),
-            ),
+            typed_code: ProviderFailureCode::CapabilityDenied,
             ..ProviderFailureContext::default()
         });
         assert_eq!(class, HarnessFailureClass::CapabilityDenied);
@@ -399,86 +427,29 @@ mod tests {
     }
 
     #[test]
-    fn fallback_heuristics_only_used_when_structured_data_missing() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("429 too many requests".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::RateLimited);
+    fn terminal_unknown_typed_code_is_rejected() {
+        let err =
+            ensure_terminal_failure_code(ProviderFailureCode::Unknown).expect_err("must deny");
+        assert_eq!(err, TerminalFailureCodeError::UnknownForbidden);
     }
 
     #[test]
-    fn classification_covers_common_provider_variants() {
-        let cases = [
-            ("auth_failed", HarnessFailureClass::Authentication),
-            ("throttling", HarnessFailureClass::RateLimited),
-            ("gateway_timeout", HarnessFailureClass::Timeout),
-            ("econnrefused", HarnessFailureClass::TransportUnavailable),
-            (
-                "context_length_exceeded",
-                HarnessFailureClass::ResourceExhausted,
-            ),
-            ("unprocessable_entity", HarnessFailureClass::InvalidRequest),
-            ("backoff_required", HarnessFailureClass::Transient),
-            ("assertion_failed", HarnessFailureClass::Fatal),
-        ];
-        for (provider_code, expected) in cases {
-            let class = classify_provider_failure(&ProviderFailureContext {
-                provider_code: Some(ProviderIdentifier::try_new(provider_code).expect("code")),
-                ..ProviderFailureContext::default()
-            });
-            assert_eq!(class, expected, "provider_code={provider_code}");
-        }
-    }
-
-    #[test]
-    fn fallback_ignores_numeric_substrings_without_token_boundaries() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("artifact_1401 metrics_2403".into()),
-            ..ProviderFailureContext::default()
+    fn deserialization_rejects_unknown_typed_code() {
+        let payload = serde_json::json!({
+            "class": "unknown",
+            "message": "bad",
+            "typed_code": "unknown"
         });
-        assert_eq!(class, HarnessFailureClass::Unknown);
-    }
-
-    #[test]
-    fn fallback_scans_bounded_tail_for_large_output() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some(format!("{} timeout", "x".repeat(24 * 1024))),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::Timeout);
-    }
-
-    #[test]
-    fn fallback_phrase_detection_uses_shared_taxonomy() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("provider returned permission denied for token".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::Authentication);
-
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("service unavailable while dialing upstream".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::TransportUnavailable);
-    }
-
-    #[test]
-    fn maps_unknown_to_ambiguous() {
-        let class = classify_provider_failure(&ProviderFailureContext {
-            stderr_tail: Some("something odd happened".into()),
-            ..ProviderFailureContext::default()
-        });
-        assert_eq!(class, HarnessFailureClass::Unknown);
-        assert_eq!(class.to_domain_error_class(), ErrorClass::Ambiguous);
+        let err = serde_json::from_value::<HarnessFailure>(payload).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("unknown is forbidden"), "{msg}");
     }
 
     proptest! {
         #[test]
-        fn typed_codes_are_never_overridden_by_fallback_text(noise in ".{0,120}") {
+        fn typed_codes_are_never_overridden_by_audit_fallback(noise in ".{0,120}") {
             let class = classify_provider_failure(&ProviderFailureContext {
-                typed_code: Some(ProviderFailureCode::Authentication),
+                typed_code: ProviderFailureCode::Authentication,
                 stdout_tail: Some(noise),
                 stderr_tail: Some("429 too many requests temporary".into()),
                 ..ProviderFailureContext::default()
@@ -487,8 +458,9 @@ mod tests {
         }
 
         #[test]
-        fn exit_code_75_remains_transient_even_with_unrelated_text(noise in ".{0,120}") {
-            let class = classify_provider_failure(&ProviderFailureContext {
+        fn audit_fallback_still_classifies_unknown_typed_code_from_exit_code(noise in ".{0,120}") {
+            let class = classify_provider_failure_for_audit(&ProviderFailureContext {
+                typed_code: ProviderFailureCode::Unknown,
                 exit_code: Some(75),
                 stderr_tail: Some(noise),
                 ..ProviderFailureContext::default()

--- a/crates/tanren-runtime/src/failure/taxonomy.rs
+++ b/crates/tanren-runtime/src/failure/taxonomy.rs
@@ -1,0 +1,314 @@
+use super::HarnessFailureClass;
+
+pub(super) struct FailureTaxonomyRule {
+    pub(super) class: HarnessFailureClass,
+    pub(super) exact_identifiers: &'static [&'static str],
+    pub(super) text_tokens: &'static [&'static str],
+    pub(super) text_phrases: &'static [&'static [&'static str]],
+}
+
+const CAPABILITY_PHRASES: &[&[&str]] = &[&["unsupported", "capability"], &["not", "supported"]];
+const APPROVAL_PHRASES: &[&[&str]] = &[
+    &["approval", "denied"],
+    &["consent", "denied"],
+    &["user", "rejected"],
+];
+const AUTH_PHRASES: &[&[&str]] = &[
+    &["invalid", "api", "key"],
+    &["permission", "denied"],
+    &["access", "denied"],
+];
+const RATE_LIMIT_PHRASES: &[&[&str]] = &[
+    &["rate", "limit"],
+    &["rate", "limited"],
+    &["too", "many", "requests"],
+];
+const TIMEOUT_PHRASES: &[&[&str]] = &[
+    &["deadline", "exceeded"],
+    &["timed", "out"],
+    &["request", "timed", "out"],
+    &["gateway", "timeout"],
+];
+const TRANSPORT_PHRASES: &[&[&str]] = &[
+    &["connection", "refused"],
+    &["network", "unreachable"],
+    &["service", "unavailable"],
+    &["connection", "timed", "out"],
+];
+const RESOURCE_PHRASES: &[&[&str]] = &[
+    &["out", "of", "memory"],
+    &["resource", "exhausted"],
+    &["quota", "exceeded"],
+    &["context", "length", "exceeded"],
+    &["max", "tokens", "exceeded"],
+    &["exit", "code", "137"],
+];
+const INVALID_REQUEST_PHRASES: &[&[&str]] = &[
+    &["invalid", "argument"],
+    &["bad", "request"],
+    &["unprocessable", "entity"],
+];
+const TRANSIENT_PHRASES: &[&[&str]] = &[
+    &["try", "again"],
+    &["please", "retry"],
+    &["temporarily", "unavailable"],
+];
+const FATAL_PHRASES: &[&[&str]] = &[&["internal", "error"], &["fatal", "error"]];
+
+pub(super) const FAILURE_TAXONOMY: &[FailureTaxonomyRule] = &[
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::CapabilityDenied,
+        exact_identifiers: &[
+            "capability_denied",
+            "unsupported_capability",
+            "unsupported_feature",
+            "not_supported",
+        ],
+        text_tokens: &["capability_denied", "unsupported_capability"],
+        text_phrases: CAPABILITY_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::ApprovalDenied,
+        exact_identifiers: &[
+            "approval_denied",
+            "approval_required",
+            "consent_denied",
+            "user_rejected",
+            "requires_approval",
+        ],
+        text_tokens: &["approval_denied", "approval_required", "consent_denied"],
+        text_phrases: APPROVAL_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::Authentication,
+        exact_identifiers: &[
+            "authentication",
+            "auth_error",
+            "auth_failed",
+            "unauthorized",
+            "unauthenticated",
+            "forbidden",
+            "invalid_api_key",
+            "invalid_token",
+            "expired_token",
+            "permission_denied",
+            "access_denied",
+            "401",
+            "403",
+        ],
+        text_tokens: &[
+            "authentication",
+            "auth_error",
+            "auth_failed",
+            "unauthorized",
+            "unauthenticated",
+            "forbidden",
+            "invalid_api_key",
+            "invalid_token",
+            "expired_token",
+            "permission_denied",
+            "access_denied",
+            "401",
+            "403",
+        ],
+        text_phrases: AUTH_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::RateLimited,
+        exact_identifiers: &[
+            "rate_limited",
+            "rate_limit",
+            "too_many_requests",
+            "throttled",
+            "throttling",
+            "quota_rate_limited",
+            "429",
+        ],
+        text_tokens: &[
+            "rate_limited",
+            "rate_limit",
+            "too_many_requests",
+            "throttled",
+            "throttling",
+            "429",
+        ],
+        text_phrases: RATE_LIMIT_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::Timeout,
+        exact_identifiers: &[
+            "timeout",
+            "deadline_exceeded",
+            "timed_out",
+            "request_timeout",
+            "gateway_timeout",
+            "operation_timed_out",
+            "124",
+            "408",
+            "504",
+        ],
+        text_tokens: &[
+            "timeout",
+            "deadline_exceeded",
+            "timed_out",
+            "request_timeout",
+            "gateway_timeout",
+            "operation_timed_out",
+            "124",
+            "408",
+            "504",
+        ],
+        text_phrases: TIMEOUT_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::TransportUnavailable,
+        exact_identifiers: &[
+            "transport_unavailable",
+            "connection_refused",
+            "network_unreachable",
+            "dns",
+            "econnreset",
+            "econnrefused",
+            "enotfound",
+            "service_unavailable",
+            "connection_timeout",
+            "502",
+            "503",
+        ],
+        text_tokens: &[
+            "transport_unavailable",
+            "connection_refused",
+            "network_unreachable",
+            "dns",
+            "econnreset",
+            "econnrefused",
+            "enotfound",
+            "service_unavailable",
+            "connection_timeout",
+            "502",
+            "503",
+        ],
+        text_phrases: TRANSPORT_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::ResourceExhausted,
+        exact_identifiers: &[
+            "resource_exhausted",
+            "out_of_memory",
+            "oom",
+            "quota_exceeded",
+            "context_length_exceeded",
+            "max_tokens_exceeded",
+            "137",
+        ],
+        text_tokens: &[
+            "resource_exhausted",
+            "out_of_memory",
+            "oom",
+            "quota_exceeded",
+            "context_length_exceeded",
+            "max_tokens_exceeded",
+            "137",
+        ],
+        text_phrases: RESOURCE_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::Transient,
+        exact_identifiers: &[
+            "transient",
+            "temporary",
+            "temporarily_unavailable",
+            "retryable",
+            "eagain",
+            "try_again",
+            "backoff_required",
+            "sigterm",
+            "interrupted",
+            "75",
+        ],
+        text_tokens: &[
+            "transient",
+            "temporary",
+            "temporarily_unavailable",
+            "retryable",
+            "eagain",
+            "try_again",
+            "backoff_required",
+            "sigterm",
+            "interrupted",
+            "75",
+        ],
+        text_phrases: TRANSIENT_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::InvalidRequest,
+        exact_identifiers: &[
+            "invalid_request",
+            "invalid_argument",
+            "bad_request",
+            "malformed",
+            "unprocessable_entity",
+            "invalid_payload",
+            "400",
+            "422",
+        ],
+        text_tokens: &[
+            "invalid_request",
+            "invalid_argument",
+            "bad_request",
+            "malformed",
+            "unprocessable_entity",
+            "invalid_payload",
+            "400",
+            "422",
+        ],
+        text_phrases: INVALID_REQUEST_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::Fatal,
+        exact_identifiers: &[
+            "fatal",
+            "panic",
+            "internal_error",
+            "assertion_failed",
+            "unrecoverable",
+        ],
+        text_tokens: &[
+            "fatal",
+            "panic",
+            "internal_error",
+            "assertion_failed",
+            "unrecoverable",
+        ],
+        text_phrases: FATAL_PHRASES,
+    },
+    FailureTaxonomyRule {
+        class: HarnessFailureClass::Unknown,
+        exact_identifiers: &["unknown"],
+        text_tokens: &[],
+        text_phrases: &[],
+    },
+];
+
+pub(super) fn normalize_identifier(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase().replace([' ', '-'], "_")
+}
+
+pub(super) fn classify_exact_identifier(raw: &str) -> Option<HarnessFailureClass> {
+    let token = normalize_identifier(raw);
+    FAILURE_TAXONOMY.iter().find_map(|rule| {
+        rule.exact_identifiers
+            .iter()
+            .any(|candidate| *candidate == token)
+            .then_some(rule.class)
+    })
+}
+
+pub(super) const fn classify_exit_code(code: i32) -> Option<HarnessFailureClass> {
+    match code {
+        124 => Some(HarnessFailureClass::Timeout),
+        137 => Some(HarnessFailureClass::ResourceExhausted),
+        143 | 75 => Some(HarnessFailureClass::Transient),
+        _ => None,
+    }
+}

--- a/crates/tanren-runtime/src/failure/tests.rs
+++ b/crates/tanren-runtime/src/failure/tests.rs
@@ -1,0 +1,131 @@
+use proptest::prelude::*;
+
+use super::*;
+
+#[test]
+fn typed_code_is_the_only_terminal_classification_input() {
+    let class = classify_provider_failure(&ProviderFailureContext {
+        typed_code: ProviderFailureCode::Timeout,
+        provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
+        provider_kind: None,
+        signal: None,
+        exit_code: None,
+        stdout_tail: None,
+        stderr_tail: Some("401 invalid api key".into()),
+    });
+    assert_eq!(class, HarnessFailureClass::Timeout);
+}
+
+#[test]
+fn provider_failure_normalizes_through_context_classification() {
+    let provider_failure =
+        ProviderFailure::new(ProviderFailureCode::RateLimited, "raw adapter failure").with_context(
+            ProviderFailureContext {
+                typed_code: ProviderFailureCode::RateLimited,
+                provider_code: None,
+                provider_kind: None,
+                signal: None,
+                exit_code: None,
+                stdout_tail: None,
+                stderr_tail: Some("fatal panic".into()),
+            },
+        );
+
+    let failure = provider_failure.into_harness_failure();
+    assert_eq!(failure.class(), HarnessFailureClass::RateLimited);
+    assert_eq!(failure.typed_code(), ProviderFailureCode::RateLimited);
+}
+
+#[test]
+fn audit_classifier_uses_structured_and_text_fallback_only_for_unknown_typed_code() {
+    let class = classify_provider_failure_for_audit(&AuditProviderFailureContext {
+        typed_code: AuditProviderFailureCode::Unknown,
+        provider_code: Some(ProviderIdentifier::try_new("rate_limited").expect("code")),
+        provider_kind: None,
+        signal: None,
+        exit_code: None,
+        stdout_tail: None,
+        stderr_tail: None,
+    });
+    assert_eq!(class, HarnessFailureClass::RateLimited);
+
+    let from_text = classify_provider_failure_for_audit(&AuditProviderFailureContext {
+        typed_code: AuditProviderFailureCode::Unknown,
+        provider_code: None,
+        provider_kind: None,
+        signal: None,
+        exit_code: None,
+        stdout_tail: None,
+        stderr_tail: Some("429 too many requests".into()),
+    });
+    assert_eq!(from_text, HarnessFailureClass::RateLimited);
+}
+
+#[test]
+fn maps_rate_limit_to_transient_domain_error_class() {
+    let class = classify_provider_failure(&ProviderFailureContext::new(
+        ProviderFailureCode::RateLimited,
+    ));
+    assert_eq!(class, HarnessFailureClass::RateLimited);
+    assert_eq!(class.to_domain_error_class(), ErrorClass::Transient);
+}
+
+#[test]
+fn maps_capability_denial_to_fatal_domain_error_class() {
+    let class = classify_provider_failure(&ProviderFailureContext::new(
+        ProviderFailureCode::CapabilityDenied,
+    ));
+    assert_eq!(class, HarnessFailureClass::CapabilityDenied);
+    assert_eq!(class.to_domain_error_class(), ErrorClass::Fatal);
+}
+
+#[test]
+fn provider_identifier_rejects_whitespace_and_invalid_chars() {
+    let empty = ProviderIdentifier::try_new(" ").expect_err("must reject empty");
+    assert_eq!(empty, ProviderIdentifierError::EmptyOrWhitespace);
+    let invalid = ProviderIdentifier::try_new("bad value")
+        .expect_err("space is not an allowed identifier character");
+    assert_eq!(invalid, ProviderIdentifierError::InvalidCharacter);
+}
+
+#[test]
+fn deserialization_rejects_unknown_typed_code() {
+    let payload = serde_json::json!({
+        "class": "unknown",
+        "message": "bad",
+        "typed_code": "unknown"
+    });
+    let err = serde_json::from_value::<HarnessFailure>(payload).expect_err("must reject");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown variant"), "{msg}");
+}
+
+proptest! {
+    #[test]
+    fn typed_codes_are_never_overridden_by_audit_fallback(noise in ".{0,120}") {
+        let class = classify_provider_failure(&ProviderFailureContext {
+            typed_code: ProviderFailureCode::Authentication,
+            provider_code: None,
+            provider_kind: None,
+            signal: None,
+            exit_code: None,
+            stdout_tail: Some(noise),
+            stderr_tail: Some("429 too many requests temporary".into()),
+        });
+        prop_assert_eq!(class, HarnessFailureClass::Authentication);
+    }
+
+    #[test]
+    fn audit_fallback_still_classifies_unknown_typed_code_from_exit_code(noise in ".{0,120}") {
+        let class = classify_provider_failure_for_audit(&AuditProviderFailureContext {
+            typed_code: AuditProviderFailureCode::Unknown,
+            provider_code: None,
+            provider_kind: None,
+            signal: None,
+            exit_code: Some(75),
+            stdout_tail: None,
+            stderr_tail: Some(noise),
+        });
+        prop_assert_eq!(class, HarnessFailureClass::Transient);
+    }
+}

--- a/crates/tanren-runtime/src/failure/tests.rs
+++ b/crates/tanren-runtime/src/failure/tests.rs
@@ -89,6 +89,15 @@ fn provider_identifier_rejects_whitespace_and_invalid_chars() {
 }
 
 #[test]
+fn provider_run_id_rejects_whitespace_and_invalid_chars() {
+    let empty = ProviderRunId::try_new(" ").expect_err("must reject empty");
+    assert_eq!(empty, ProviderRunIdError::EmptyOrWhitespace);
+    let invalid =
+        ProviderRunId::try_new("bad value").expect_err("space is not an allowed run id character");
+    assert_eq!(invalid, ProviderRunIdError::InvalidCharacter);
+}
+
+#[test]
 fn deserialization_rejects_unknown_typed_code() {
     let payload = serde_json::json!({
         "class": "unknown",

--- a/crates/tanren-runtime/src/failure/text_classifier.rs
+++ b/crates/tanren-runtime/src/failure/text_classifier.rs
@@ -1,360 +1,54 @@
 use super::HarnessFailureClass;
+use super::taxonomy::FAILURE_TAXONOMY;
 
 const MAX_ANALYZED_CHANNEL_BYTES: usize = 16 * 1024;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum PhraseToken {
-    #[default]
-    Other,
-    Unsupported,
-    Capability,
-    Approval,
-    Denied,
-    Consent,
-    Invalid,
-    Api,
-    Key,
-    Permission,
-    Rate,
-    Limit,
-    Too,
-    Many,
-    Requests,
-    Deadline,
-    Exceeded,
-    Timed,
-    Out,
-    Connection,
-    Refused,
-    Network,
-    Unreachable,
-    Temporarily,
-    Unavailable,
-    Resource,
-    Exhausted,
-    Quota,
-    Exit,
-    Code,
-    Try,
-    Again,
-    Bad,
-    Request,
-    Internal,
-    Error,
-    Argument,
-    Of,
-    Memory,
-    Num137,
-}
-
-#[derive(Debug, Clone, Copy)]
-#[repr(u8)]
-enum Feature {
-    CapabilityDeniedToken,
-    UnsupportedCapabilityPhrase,
-    ApprovalDeniedPhrase,
-    ApprovalRequiredToken,
-    ConsentDeniedPhrase,
-    AuthenticationToken,
-    InvalidApiKeyToken,
-    InvalidApiKeyPhrase,
-    PermissionDeniedPhrase,
-    Has401,
-    Has403,
-    RateLimitPhrase,
-    RateLimitedToken,
-    TooManyRequestsToken,
-    TooManyRequestsPhrase,
-    Has429,
-    TimeoutToken,
-    DeadlineExceededToken,
-    TimedOutToken,
-    DeadlineExceededPhrase,
-    TimedOutPhrase,
-    ConnectionRefusedPhrase,
-    NetworkUnreachablePhrase,
-    DnsToken,
-    EconnresetToken,
-    TemporarilyUnavailablePhrase,
-    Has503,
-    OutOfMemoryPhrase,
-    ResourceExhaustedPhrase,
-    QuotaExceededPhrase,
-    ExitCode137Phrase,
-    TemporaryToken,
-    RetryableToken,
-    TransientToken,
-    EagainToken,
-    TryAgainPhrase,
-    InvalidArgumentPhrase,
-    BadRequestPhrase,
-    MalformedToken,
-    PanicToken,
-    FatalToken,
-    InternalErrorToken,
-    InternalErrorPhrase,
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-struct TokenFeatures(u128);
-
-impl TokenFeatures {
-    fn set(&mut self, feature: Feature) {
-        self.0 |= 1_u128 << (feature as u8);
-    }
-
-    fn has(self, feature: Feature) -> bool {
-        self.0 & (1_u128 << (feature as u8)) != 0
-    }
-}
-
-const FEATURE_TOKEN_MAP: [(&[u8], Feature); 17] = [
-    (b"capability_denied", Feature::CapabilityDeniedToken),
-    (b"approval_required", Feature::ApprovalRequiredToken),
-    (b"authentication", Feature::AuthenticationToken),
-    (b"invalid_api_key", Feature::InvalidApiKeyToken),
-    (b"401", Feature::Has401),
-    (b"403", Feature::Has403),
-    (b"rate_limited", Feature::RateLimitedToken),
-    (b"too_many_requests", Feature::TooManyRequestsToken),
-    (b"429", Feature::Has429),
-    (b"timeout", Feature::TimeoutToken),
-    (b"deadline_exceeded", Feature::DeadlineExceededToken),
-    (b"timed_out", Feature::TimedOutToken),
-    (b"dns", Feature::DnsToken),
-    (b"econnreset", Feature::EconnresetToken),
-    (b"503", Feature::Has503),
-    (b"malformed", Feature::MalformedToken),
-    (b"internal_error", Feature::InternalErrorToken),
-];
-
-const FEATURE_TOKEN_MAP_2: [(&[u8], Feature); 4] = [
-    (b"temporary", Feature::TemporaryToken),
-    (b"retryable", Feature::RetryableToken),
-    (b"transient", Feature::TransientToken),
-    (b"eagain", Feature::EagainToken),
-];
-
-const FEATURE_TOKEN_MAP_3: [(&[u8], Feature); 2] = [
-    (b"panic", Feature::PanicToken),
-    (b"fatal", Feature::FatalToken),
-];
-
-const PHRASE_TOKEN_MAP: [(&[u8], PhraseToken); 39] = [
-    (b"unsupported", PhraseToken::Unsupported),
-    (b"capability", PhraseToken::Capability),
-    (b"approval", PhraseToken::Approval),
-    (b"denied", PhraseToken::Denied),
-    (b"consent", PhraseToken::Consent),
-    (b"invalid", PhraseToken::Invalid),
-    (b"api", PhraseToken::Api),
-    (b"key", PhraseToken::Key),
-    (b"permission", PhraseToken::Permission),
-    (b"rate", PhraseToken::Rate),
-    (b"limit", PhraseToken::Limit),
-    (b"too", PhraseToken::Too),
-    (b"many", PhraseToken::Many),
-    (b"requests", PhraseToken::Requests),
-    (b"deadline", PhraseToken::Deadline),
-    (b"exceeded", PhraseToken::Exceeded),
-    (b"timed", PhraseToken::Timed),
-    (b"out", PhraseToken::Out),
-    (b"connection", PhraseToken::Connection),
-    (b"refused", PhraseToken::Refused),
-    (b"network", PhraseToken::Network),
-    (b"unreachable", PhraseToken::Unreachable),
-    (b"temporarily", PhraseToken::Temporarily),
-    (b"unavailable", PhraseToken::Unavailable),
-    (b"resource", PhraseToken::Resource),
-    (b"exhausted", PhraseToken::Exhausted),
-    (b"quota", PhraseToken::Quota),
-    (b"exit", PhraseToken::Exit),
-    (b"code", PhraseToken::Code),
-    (b"try", PhraseToken::Try),
-    (b"again", PhraseToken::Again),
-    (b"bad", PhraseToken::Bad),
-    (b"request", PhraseToken::Request),
-    (b"internal", PhraseToken::Internal),
-    (b"error", PhraseToken::Error),
-    (b"argument", PhraseToken::Argument),
-    (b"of", PhraseToken::Of),
-    (b"memory", PhraseToken::Memory),
-    (b"137", PhraseToken::Num137),
-];
-
-const PHRASE_MAP_2: [((PhraseToken, PhraseToken), Feature); 16] = [
-    (
-        (PhraseToken::Unsupported, PhraseToken::Capability),
-        Feature::UnsupportedCapabilityPhrase,
-    ),
-    (
-        (PhraseToken::Approval, PhraseToken::Denied),
-        Feature::ApprovalDeniedPhrase,
-    ),
-    (
-        (PhraseToken::Consent, PhraseToken::Denied),
-        Feature::ConsentDeniedPhrase,
-    ),
-    (
-        (PhraseToken::Permission, PhraseToken::Denied),
-        Feature::PermissionDeniedPhrase,
-    ),
-    (
-        (PhraseToken::Rate, PhraseToken::Limit),
-        Feature::RateLimitPhrase,
-    ),
-    (
-        (PhraseToken::Deadline, PhraseToken::Exceeded),
-        Feature::DeadlineExceededPhrase,
-    ),
-    (
-        (PhraseToken::Timed, PhraseToken::Out),
-        Feature::TimedOutPhrase,
-    ),
-    (
-        (PhraseToken::Connection, PhraseToken::Refused),
-        Feature::ConnectionRefusedPhrase,
-    ),
-    (
-        (PhraseToken::Network, PhraseToken::Unreachable),
-        Feature::NetworkUnreachablePhrase,
-    ),
-    (
-        (PhraseToken::Temporarily, PhraseToken::Unavailable),
-        Feature::TemporarilyUnavailablePhrase,
-    ),
-    (
-        (PhraseToken::Resource, PhraseToken::Exhausted),
-        Feature::ResourceExhaustedPhrase,
-    ),
-    (
-        (PhraseToken::Quota, PhraseToken::Exceeded),
-        Feature::QuotaExceededPhrase,
-    ),
-    (
-        (PhraseToken::Try, PhraseToken::Again),
-        Feature::TryAgainPhrase,
-    ),
-    (
-        (PhraseToken::Bad, PhraseToken::Request),
-        Feature::BadRequestPhrase,
-    ),
-    (
-        (PhraseToken::Invalid, PhraseToken::Argument),
-        Feature::InvalidArgumentPhrase,
-    ),
-    (
-        (PhraseToken::Internal, PhraseToken::Error),
-        Feature::InternalErrorPhrase,
-    ),
-];
-
-const PHRASE_MAP_3: [((PhraseToken, PhraseToken, PhraseToken), Feature); 4] = [
-    (
-        (PhraseToken::Invalid, PhraseToken::Api, PhraseToken::Key),
-        Feature::InvalidApiKeyPhrase,
-    ),
-    (
-        (PhraseToken::Too, PhraseToken::Many, PhraseToken::Requests),
-        Feature::TooManyRequestsPhrase,
-    ),
-    (
-        (PhraseToken::Out, PhraseToken::Of, PhraseToken::Memory),
-        Feature::OutOfMemoryPhrase,
-    ),
-    (
-        (PhraseToken::Exit, PhraseToken::Code, PhraseToken::Num137),
-        Feature::ExitCode137Phrase,
-    ),
-];
 
 pub(super) fn classify_text_fallback(
     stdout_tail: Option<&str>,
     stderr_tail: Option<&str>,
 ) -> HarnessFailureClass {
-    let mut features = TokenFeatures::default();
+    let mut tokens = Vec::new();
     if let Some(stdout) = stdout_tail {
-        scan_tokens(tail_slice(stdout), &mut features);
+        collect_tokens(tail_slice(stdout), &mut tokens);
     }
     if let Some(stderr) = stderr_tail {
-        scan_tokens(tail_slice(stderr), &mut features);
+        collect_tokens(tail_slice(stderr), &mut tokens);
     }
 
-    if features.has(Feature::CapabilityDeniedToken)
-        || features.has(Feature::UnsupportedCapabilityPhrase)
-    {
-        return HarnessFailureClass::CapabilityDenied;
-    }
-    if features.has(Feature::ApprovalDeniedPhrase)
-        || features.has(Feature::ApprovalRequiredToken)
-        || features.has(Feature::ConsentDeniedPhrase)
-    {
-        return HarnessFailureClass::ApprovalDenied;
-    }
-    if features.has(Feature::AuthenticationToken)
-        || features.has(Feature::InvalidApiKeyToken)
-        || features.has(Feature::InvalidApiKeyPhrase)
-        || features.has(Feature::PermissionDeniedPhrase)
-        || features.has(Feature::Has401)
-        || features.has(Feature::Has403)
-    {
-        return HarnessFailureClass::Authentication;
-    }
-    if features.has(Feature::RateLimitPhrase)
-        || features.has(Feature::RateLimitedToken)
-        || features.has(Feature::TooManyRequestsToken)
-        || features.has(Feature::TooManyRequestsPhrase)
-        || features.has(Feature::Has429)
-    {
-        return HarnessFailureClass::RateLimited;
-    }
-    if features.has(Feature::TimeoutToken)
-        || features.has(Feature::DeadlineExceededToken)
-        || features.has(Feature::TimedOutToken)
-        || features.has(Feature::DeadlineExceededPhrase)
-        || features.has(Feature::TimedOutPhrase)
-    {
-        return HarnessFailureClass::Timeout;
-    }
-    if features.has(Feature::ConnectionRefusedPhrase)
-        || features.has(Feature::NetworkUnreachablePhrase)
-        || features.has(Feature::DnsToken)
-        || features.has(Feature::EconnresetToken)
-        || features.has(Feature::TemporarilyUnavailablePhrase)
-        || features.has(Feature::Has503)
-    {
-        return HarnessFailureClass::TransportUnavailable;
-    }
-    if features.has(Feature::OutOfMemoryPhrase)
-        || features.has(Feature::ResourceExhaustedPhrase)
-        || features.has(Feature::QuotaExceededPhrase)
-        || features.has(Feature::ExitCode137Phrase)
-    {
-        return HarnessFailureClass::ResourceExhausted;
-    }
-    if features.has(Feature::TemporaryToken)
-        || features.has(Feature::RetryableToken)
-        || features.has(Feature::TransientToken)
-        || features.has(Feature::EagainToken)
-        || features.has(Feature::TryAgainPhrase)
-    {
-        return HarnessFailureClass::Transient;
-    }
-    if features.has(Feature::InvalidArgumentPhrase)
-        || features.has(Feature::BadRequestPhrase)
-        || features.has(Feature::MalformedToken)
-    {
-        return HarnessFailureClass::InvalidRequest;
-    }
-    if features.has(Feature::PanicToken)
-        || features.has(Feature::FatalToken)
-        || features.has(Feature::InternalErrorToken)
-        || features.has(Feature::InternalErrorPhrase)
-    {
-        return HarnessFailureClass::Fatal;
+    for rule in FAILURE_TAXONOMY {
+        if matches_rule(rule, &tokens) {
+            return rule.class;
+        }
     }
 
     HarnessFailureClass::Unknown
+}
+
+fn matches_rule(rule: &super::taxonomy::FailureTaxonomyRule, tokens: &[String]) -> bool {
+    if rule
+        .text_tokens
+        .iter()
+        .any(|candidate| tokens.iter().any(|token| token == candidate))
+    {
+        return true;
+    }
+
+    rule.text_phrases
+        .iter()
+        .any(|phrase| contains_phrase(tokens, phrase))
+}
+
+fn contains_phrase(tokens: &[String], phrase: &[&str]) -> bool {
+    if phrase.is_empty() || tokens.len() < phrase.len() {
+        return false;
+    }
+
+    tokens.windows(phrase.len()).any(|window| {
+        window
+            .iter()
+            .zip(phrase.iter())
+            .all(|(actual, expected)| actual == expected)
+    })
 }
 
 fn tail_slice(value: &str) -> &str {
@@ -369,11 +63,9 @@ fn tail_slice(value: &str) -> &str {
     &value[start..]
 }
 
-fn scan_tokens(text: &str, features: &mut TokenFeatures) {
+fn collect_tokens(text: &str, sink: &mut Vec<String>) {
     let bytes = text.as_bytes();
     let mut cursor = 0;
-    let mut prev2 = PhraseToken::Other;
-    let mut prev1 = PhraseToken::Other;
 
     while cursor < bytes.len() {
         while cursor < bytes.len() && !is_token_char(bytes[cursor]) {
@@ -387,70 +79,10 @@ fn scan_tokens(text: &str, features: &mut TokenFeatures) {
             continue;
         }
 
-        let token = &bytes[start..cursor];
-        set_single_token_features(token, features);
-
-        let current = phrase_token(token);
-        set_phrase_features(prev2, prev1, current, features);
-        prev2 = prev1;
-        prev1 = current;
+        sink.push(text[start..cursor].to_ascii_lowercase());
     }
 }
 
 const fn is_token_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
-}
-
-fn set_single_token_features(token: &[u8], features: &mut TokenFeatures) {
-    for (candidate, feature) in FEATURE_TOKEN_MAP {
-        if token_eq(token, candidate) {
-            features.set(feature);
-        }
-    }
-    for (candidate, feature) in FEATURE_TOKEN_MAP_2 {
-        if token_eq(token, candidate) {
-            features.set(feature);
-        }
-    }
-    for (candidate, feature) in FEATURE_TOKEN_MAP_3 {
-        if token_eq(token, candidate) {
-            features.set(feature);
-        }
-    }
-}
-
-fn set_phrase_features(
-    prev2: PhraseToken,
-    prev1: PhraseToken,
-    current: PhraseToken,
-    features: &mut TokenFeatures,
-) {
-    for ((left, right), feature) in PHRASE_MAP_2 {
-        if prev1 == left && current == right {
-            features.set(feature);
-        }
-    }
-
-    for ((left, mid, right), feature) in PHRASE_MAP_3 {
-        if prev2 == left && current == right && (mid == PhraseToken::Other || prev1 == mid) {
-            features.set(feature);
-        }
-    }
-}
-
-fn token_eq(token: &[u8], expected: &[u8]) -> bool {
-    token.len() == expected.len()
-        && token
-            .iter()
-            .zip(expected.iter())
-            .all(|(actual, wanted)| actual.eq_ignore_ascii_case(wanted))
-}
-
-fn phrase_token(token: &[u8]) -> PhraseToken {
-    for (candidate, phrase) in PHRASE_TOKEN_MAP {
-        if token_eq(token, candidate) {
-            return phrase;
-        }
-    }
-    PhraseToken::Other
 }

--- a/crates/tanren-runtime/src/failure/text_classifier.rs
+++ b/crates/tanren-runtime/src/failure/text_classifier.rs
@@ -1,0 +1,456 @@
+use super::HarnessFailureClass;
+
+const MAX_ANALYZED_CHANNEL_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum PhraseToken {
+    #[default]
+    Other,
+    Unsupported,
+    Capability,
+    Approval,
+    Denied,
+    Consent,
+    Invalid,
+    Api,
+    Key,
+    Permission,
+    Rate,
+    Limit,
+    Too,
+    Many,
+    Requests,
+    Deadline,
+    Exceeded,
+    Timed,
+    Out,
+    Connection,
+    Refused,
+    Network,
+    Unreachable,
+    Temporarily,
+    Unavailable,
+    Resource,
+    Exhausted,
+    Quota,
+    Exit,
+    Code,
+    Try,
+    Again,
+    Bad,
+    Request,
+    Internal,
+    Error,
+    Argument,
+    Of,
+    Memory,
+    Num137,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+enum Feature {
+    CapabilityDeniedToken,
+    UnsupportedCapabilityPhrase,
+    ApprovalDeniedPhrase,
+    ApprovalRequiredToken,
+    ConsentDeniedPhrase,
+    AuthenticationToken,
+    InvalidApiKeyToken,
+    InvalidApiKeyPhrase,
+    PermissionDeniedPhrase,
+    Has401,
+    Has403,
+    RateLimitPhrase,
+    RateLimitedToken,
+    TooManyRequestsToken,
+    TooManyRequestsPhrase,
+    Has429,
+    TimeoutToken,
+    DeadlineExceededToken,
+    TimedOutToken,
+    DeadlineExceededPhrase,
+    TimedOutPhrase,
+    ConnectionRefusedPhrase,
+    NetworkUnreachablePhrase,
+    DnsToken,
+    EconnresetToken,
+    TemporarilyUnavailablePhrase,
+    Has503,
+    OutOfMemoryPhrase,
+    ResourceExhaustedPhrase,
+    QuotaExceededPhrase,
+    ExitCode137Phrase,
+    TemporaryToken,
+    RetryableToken,
+    TransientToken,
+    EagainToken,
+    TryAgainPhrase,
+    InvalidArgumentPhrase,
+    BadRequestPhrase,
+    MalformedToken,
+    PanicToken,
+    FatalToken,
+    InternalErrorToken,
+    InternalErrorPhrase,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct TokenFeatures(u128);
+
+impl TokenFeatures {
+    fn set(&mut self, feature: Feature) {
+        self.0 |= 1_u128 << (feature as u8);
+    }
+
+    fn has(self, feature: Feature) -> bool {
+        self.0 & (1_u128 << (feature as u8)) != 0
+    }
+}
+
+const FEATURE_TOKEN_MAP: [(&[u8], Feature); 17] = [
+    (b"capability_denied", Feature::CapabilityDeniedToken),
+    (b"approval_required", Feature::ApprovalRequiredToken),
+    (b"authentication", Feature::AuthenticationToken),
+    (b"invalid_api_key", Feature::InvalidApiKeyToken),
+    (b"401", Feature::Has401),
+    (b"403", Feature::Has403),
+    (b"rate_limited", Feature::RateLimitedToken),
+    (b"too_many_requests", Feature::TooManyRequestsToken),
+    (b"429", Feature::Has429),
+    (b"timeout", Feature::TimeoutToken),
+    (b"deadline_exceeded", Feature::DeadlineExceededToken),
+    (b"timed_out", Feature::TimedOutToken),
+    (b"dns", Feature::DnsToken),
+    (b"econnreset", Feature::EconnresetToken),
+    (b"503", Feature::Has503),
+    (b"malformed", Feature::MalformedToken),
+    (b"internal_error", Feature::InternalErrorToken),
+];
+
+const FEATURE_TOKEN_MAP_2: [(&[u8], Feature); 4] = [
+    (b"temporary", Feature::TemporaryToken),
+    (b"retryable", Feature::RetryableToken),
+    (b"transient", Feature::TransientToken),
+    (b"eagain", Feature::EagainToken),
+];
+
+const FEATURE_TOKEN_MAP_3: [(&[u8], Feature); 2] = [
+    (b"panic", Feature::PanicToken),
+    (b"fatal", Feature::FatalToken),
+];
+
+const PHRASE_TOKEN_MAP: [(&[u8], PhraseToken); 39] = [
+    (b"unsupported", PhraseToken::Unsupported),
+    (b"capability", PhraseToken::Capability),
+    (b"approval", PhraseToken::Approval),
+    (b"denied", PhraseToken::Denied),
+    (b"consent", PhraseToken::Consent),
+    (b"invalid", PhraseToken::Invalid),
+    (b"api", PhraseToken::Api),
+    (b"key", PhraseToken::Key),
+    (b"permission", PhraseToken::Permission),
+    (b"rate", PhraseToken::Rate),
+    (b"limit", PhraseToken::Limit),
+    (b"too", PhraseToken::Too),
+    (b"many", PhraseToken::Many),
+    (b"requests", PhraseToken::Requests),
+    (b"deadline", PhraseToken::Deadline),
+    (b"exceeded", PhraseToken::Exceeded),
+    (b"timed", PhraseToken::Timed),
+    (b"out", PhraseToken::Out),
+    (b"connection", PhraseToken::Connection),
+    (b"refused", PhraseToken::Refused),
+    (b"network", PhraseToken::Network),
+    (b"unreachable", PhraseToken::Unreachable),
+    (b"temporarily", PhraseToken::Temporarily),
+    (b"unavailable", PhraseToken::Unavailable),
+    (b"resource", PhraseToken::Resource),
+    (b"exhausted", PhraseToken::Exhausted),
+    (b"quota", PhraseToken::Quota),
+    (b"exit", PhraseToken::Exit),
+    (b"code", PhraseToken::Code),
+    (b"try", PhraseToken::Try),
+    (b"again", PhraseToken::Again),
+    (b"bad", PhraseToken::Bad),
+    (b"request", PhraseToken::Request),
+    (b"internal", PhraseToken::Internal),
+    (b"error", PhraseToken::Error),
+    (b"argument", PhraseToken::Argument),
+    (b"of", PhraseToken::Of),
+    (b"memory", PhraseToken::Memory),
+    (b"137", PhraseToken::Num137),
+];
+
+const PHRASE_MAP_2: [((PhraseToken, PhraseToken), Feature); 16] = [
+    (
+        (PhraseToken::Unsupported, PhraseToken::Capability),
+        Feature::UnsupportedCapabilityPhrase,
+    ),
+    (
+        (PhraseToken::Approval, PhraseToken::Denied),
+        Feature::ApprovalDeniedPhrase,
+    ),
+    (
+        (PhraseToken::Consent, PhraseToken::Denied),
+        Feature::ConsentDeniedPhrase,
+    ),
+    (
+        (PhraseToken::Permission, PhraseToken::Denied),
+        Feature::PermissionDeniedPhrase,
+    ),
+    (
+        (PhraseToken::Rate, PhraseToken::Limit),
+        Feature::RateLimitPhrase,
+    ),
+    (
+        (PhraseToken::Deadline, PhraseToken::Exceeded),
+        Feature::DeadlineExceededPhrase,
+    ),
+    (
+        (PhraseToken::Timed, PhraseToken::Out),
+        Feature::TimedOutPhrase,
+    ),
+    (
+        (PhraseToken::Connection, PhraseToken::Refused),
+        Feature::ConnectionRefusedPhrase,
+    ),
+    (
+        (PhraseToken::Network, PhraseToken::Unreachable),
+        Feature::NetworkUnreachablePhrase,
+    ),
+    (
+        (PhraseToken::Temporarily, PhraseToken::Unavailable),
+        Feature::TemporarilyUnavailablePhrase,
+    ),
+    (
+        (PhraseToken::Resource, PhraseToken::Exhausted),
+        Feature::ResourceExhaustedPhrase,
+    ),
+    (
+        (PhraseToken::Quota, PhraseToken::Exceeded),
+        Feature::QuotaExceededPhrase,
+    ),
+    (
+        (PhraseToken::Try, PhraseToken::Again),
+        Feature::TryAgainPhrase,
+    ),
+    (
+        (PhraseToken::Bad, PhraseToken::Request),
+        Feature::BadRequestPhrase,
+    ),
+    (
+        (PhraseToken::Invalid, PhraseToken::Argument),
+        Feature::InvalidArgumentPhrase,
+    ),
+    (
+        (PhraseToken::Internal, PhraseToken::Error),
+        Feature::InternalErrorPhrase,
+    ),
+];
+
+const PHRASE_MAP_3: [((PhraseToken, PhraseToken, PhraseToken), Feature); 4] = [
+    (
+        (PhraseToken::Invalid, PhraseToken::Api, PhraseToken::Key),
+        Feature::InvalidApiKeyPhrase,
+    ),
+    (
+        (PhraseToken::Too, PhraseToken::Many, PhraseToken::Requests),
+        Feature::TooManyRequestsPhrase,
+    ),
+    (
+        (PhraseToken::Out, PhraseToken::Of, PhraseToken::Memory),
+        Feature::OutOfMemoryPhrase,
+    ),
+    (
+        (PhraseToken::Exit, PhraseToken::Code, PhraseToken::Num137),
+        Feature::ExitCode137Phrase,
+    ),
+];
+
+pub(super) fn classify_text_fallback(
+    stdout_tail: Option<&str>,
+    stderr_tail: Option<&str>,
+) -> HarnessFailureClass {
+    let mut features = TokenFeatures::default();
+    if let Some(stdout) = stdout_tail {
+        scan_tokens(tail_slice(stdout), &mut features);
+    }
+    if let Some(stderr) = stderr_tail {
+        scan_tokens(tail_slice(stderr), &mut features);
+    }
+
+    if features.has(Feature::CapabilityDeniedToken)
+        || features.has(Feature::UnsupportedCapabilityPhrase)
+    {
+        return HarnessFailureClass::CapabilityDenied;
+    }
+    if features.has(Feature::ApprovalDeniedPhrase)
+        || features.has(Feature::ApprovalRequiredToken)
+        || features.has(Feature::ConsentDeniedPhrase)
+    {
+        return HarnessFailureClass::ApprovalDenied;
+    }
+    if features.has(Feature::AuthenticationToken)
+        || features.has(Feature::InvalidApiKeyToken)
+        || features.has(Feature::InvalidApiKeyPhrase)
+        || features.has(Feature::PermissionDeniedPhrase)
+        || features.has(Feature::Has401)
+        || features.has(Feature::Has403)
+    {
+        return HarnessFailureClass::Authentication;
+    }
+    if features.has(Feature::RateLimitPhrase)
+        || features.has(Feature::RateLimitedToken)
+        || features.has(Feature::TooManyRequestsToken)
+        || features.has(Feature::TooManyRequestsPhrase)
+        || features.has(Feature::Has429)
+    {
+        return HarnessFailureClass::RateLimited;
+    }
+    if features.has(Feature::TimeoutToken)
+        || features.has(Feature::DeadlineExceededToken)
+        || features.has(Feature::TimedOutToken)
+        || features.has(Feature::DeadlineExceededPhrase)
+        || features.has(Feature::TimedOutPhrase)
+    {
+        return HarnessFailureClass::Timeout;
+    }
+    if features.has(Feature::ConnectionRefusedPhrase)
+        || features.has(Feature::NetworkUnreachablePhrase)
+        || features.has(Feature::DnsToken)
+        || features.has(Feature::EconnresetToken)
+        || features.has(Feature::TemporarilyUnavailablePhrase)
+        || features.has(Feature::Has503)
+    {
+        return HarnessFailureClass::TransportUnavailable;
+    }
+    if features.has(Feature::OutOfMemoryPhrase)
+        || features.has(Feature::ResourceExhaustedPhrase)
+        || features.has(Feature::QuotaExceededPhrase)
+        || features.has(Feature::ExitCode137Phrase)
+    {
+        return HarnessFailureClass::ResourceExhausted;
+    }
+    if features.has(Feature::TemporaryToken)
+        || features.has(Feature::RetryableToken)
+        || features.has(Feature::TransientToken)
+        || features.has(Feature::EagainToken)
+        || features.has(Feature::TryAgainPhrase)
+    {
+        return HarnessFailureClass::Transient;
+    }
+    if features.has(Feature::InvalidArgumentPhrase)
+        || features.has(Feature::BadRequestPhrase)
+        || features.has(Feature::MalformedToken)
+    {
+        return HarnessFailureClass::InvalidRequest;
+    }
+    if features.has(Feature::PanicToken)
+        || features.has(Feature::FatalToken)
+        || features.has(Feature::InternalErrorToken)
+        || features.has(Feature::InternalErrorPhrase)
+    {
+        return HarnessFailureClass::Fatal;
+    }
+
+    HarnessFailureClass::Unknown
+}
+
+fn tail_slice(value: &str) -> &str {
+    if value.len() <= MAX_ANALYZED_CHANNEL_BYTES {
+        return value;
+    }
+
+    let mut start = value.len() - MAX_ANALYZED_CHANNEL_BYTES;
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
+    }
+    &value[start..]
+}
+
+fn scan_tokens(text: &str, features: &mut TokenFeatures) {
+    let bytes = text.as_bytes();
+    let mut cursor = 0;
+    let mut prev2 = PhraseToken::Other;
+    let mut prev1 = PhraseToken::Other;
+
+    while cursor < bytes.len() {
+        while cursor < bytes.len() && !is_token_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        let start = cursor;
+        while cursor < bytes.len() && is_token_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        if start == cursor {
+            continue;
+        }
+
+        let token = &bytes[start..cursor];
+        set_single_token_features(token, features);
+
+        let current = phrase_token(token);
+        set_phrase_features(prev2, prev1, current, features);
+        prev2 = prev1;
+        prev1 = current;
+    }
+}
+
+const fn is_token_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn set_single_token_features(token: &[u8], features: &mut TokenFeatures) {
+    for (candidate, feature) in FEATURE_TOKEN_MAP {
+        if token_eq(token, candidate) {
+            features.set(feature);
+        }
+    }
+    for (candidate, feature) in FEATURE_TOKEN_MAP_2 {
+        if token_eq(token, candidate) {
+            features.set(feature);
+        }
+    }
+    for (candidate, feature) in FEATURE_TOKEN_MAP_3 {
+        if token_eq(token, candidate) {
+            features.set(feature);
+        }
+    }
+}
+
+fn set_phrase_features(
+    prev2: PhraseToken,
+    prev1: PhraseToken,
+    current: PhraseToken,
+    features: &mut TokenFeatures,
+) {
+    for ((left, right), feature) in PHRASE_MAP_2 {
+        if prev1 == left && current == right {
+            features.set(feature);
+        }
+    }
+
+    for ((left, mid, right), feature) in PHRASE_MAP_3 {
+        if prev2 == left && current == right && (mid == PhraseToken::Other || prev1 == mid) {
+            features.set(feature);
+        }
+    }
+}
+
+fn token_eq(token: &[u8], expected: &[u8]) -> bool {
+    token.len() == expected.len()
+        && token
+            .iter()
+            .zip(expected.iter())
+            .all(|(actual, wanted)| actual.eq_ignore_ascii_case(wanted))
+}
+
+fn phrase_token(token: &[u8]) -> PhraseToken {
+    for (candidate, phrase) in PHRASE_TOKEN_MAP {
+        if token_eq(token, candidate) {
+            return phrase;
+        }
+    }
+    PhraseToken::Other
+}

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -21,24 +21,26 @@ pub use adapter::{
     execute_with_contract,
 };
 pub use capability::{
-    ApprovalMode, CapabilityAdmissibility, CompatibilityDenial, CompatibilityDenialKind,
-    HarnessCapabilities, HarnessRequirements, OutputStreaming, OutputStreamingRequirement,
-    PatchApplyRequirement, PatchApplySupport, RequirementLevel, SandboxMode,
+    ApprovalMode, ApprovalModeBounds, CapabilityAdmissibility, CompatibilityDenial,
+    CompatibilityDenialKind, HarnessCapabilities, HarnessRequirements, HarnessRequirementsBuilder,
+    OutputStreaming, OutputStreamingRequirement, PatchApplyRequirement, PatchApplySupport,
+    RequirementBoundsError, RequirementLevel, SandboxMode, SandboxModeBounds,
     SessionResumeRequirement, SessionResumeSupport,
 };
 pub use conformance::{
     ConformanceEventRecorder, ConformanceResult, RedactionConformanceExpectations,
     assert_capability_denial_is_preflight, assert_failure_classification,
-    assert_redaction_before_persistence,
+    assert_provider_metadata_fail_closed, assert_redaction_before_persistence,
+    assert_terminal_typed_code_mapping,
 };
 pub use execution::{
     HarnessExecutionRequest, HarnessExecutionResult, PersistableOutput, RawExecutionOutput,
     RedactionSecret, SecretName,
 };
 pub use failure::{
-    HarnessFailure, HarnessFailureClass, ProviderFailure, ProviderFailureCode,
-    ProviderFailureContext, ProviderIdentifier, ProviderIdentifierError, TerminalFailureCodeError,
-    classify_provider_failure, classify_provider_failure_for_audit,
+    AuditProviderFailureCode, AuditProviderFailureContext, HarnessFailure, HarnessFailureClass,
+    ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
+    ProviderIdentifierError, classify_provider_failure, classify_provider_failure_for_audit,
 };
 pub use redaction::{
     DefaultOutputRedactor, OutputRedactor, RedactionAudit, RedactionError, RedactionHints,

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -16,8 +16,9 @@ mod failure;
 mod redaction;
 
 pub use adapter::{
-    ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessEventSource,
-    HarnessExecutionEvent, HarnessExecutionEventKind, HarnessObserver, execute_with_contract,
+    ContractCallToken, ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessEventSource,
+    HarnessExecutionEvent, HarnessExecutionEventKind, HarnessObserver, ProviderMetadataViolation,
+    execute_with_contract,
 };
 pub use capability::{
     ApprovalMode, CapabilityAdmissibility, CompatibilityDenial, CompatibilityDenialKind,
@@ -36,9 +37,11 @@ pub use execution::{
 };
 pub use failure::{
     HarnessFailure, HarnessFailureClass, ProviderFailure, ProviderFailureCode,
-    ProviderFailureContext, ProviderIdentifier, ProviderIdentifierError, classify_provider_failure,
+    ProviderFailureContext, ProviderIdentifier, ProviderIdentifierError, TerminalFailureCodeError,
+    classify_provider_failure, classify_provider_failure_for_audit,
 };
 pub use redaction::{
-    DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints, RedactionPolicy,
-    default_redaction_policy, default_redaction_policy_dataset_version,
+    DefaultOutputRedactor, OutputRedactor, RedactionAudit, RedactionError, RedactionHints,
+    RedactionOutcome, RedactionPolicy, default_redaction_policy,
+    default_redaction_policy_dataset_version,
 };

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -16,9 +16,9 @@ mod failure;
 mod redaction;
 
 pub use adapter::{
-    ContractCallToken, ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessEventSource,
-    HarnessExecutionEvent, HarnessExecutionEventKind, HarnessObserver, ProviderMetadataViolation,
-    execute_with_contract,
+    ContractCallToken, ExecutionSignal, HarnessAdapter, HarnessAdapterRegistry,
+    HarnessAdapterRegistryError, HarnessContractError, HarnessEventSource, HarnessExecutionEvent,
+    HarnessExecutionEventKind, HarnessObserver, ProviderMetadataViolation, execute_with_contract,
 };
 pub use capability::{
     ApprovalMode, ApprovalModeBounds, CapabilityAdmissibility, CompatibilityDenial,
@@ -44,6 +44,6 @@ pub use failure::{
 };
 pub use redaction::{
     DefaultOutputRedactor, OutputRedactor, RedactionAudit, RedactionError, RedactionHints,
-    RedactionOutcome, RedactionPolicy, default_redaction_policy,
-    default_redaction_policy_dataset_version,
+    RedactionOutcome, RedactionPolicy, RedactionPolicyBuilder, RedactionPolicyError,
+    default_redaction_policy, default_redaction_policy_dataset_version,
 };

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -1,15 +1,40 @@
 //! Runtime trait contracts for harness and environment abstractions.
 //!
-//! Depends on: `tanren-domain`
+//! Lane 1.1 scope in this crate focuses on the harness side:
+//! - capability negotiation and preflight admissibility checks
+//! - normalized execution and failure surfaces
+//! - redaction-before-persistence contract
+//! - reusable adapter conformance test helpers
 //!
-//! # Responsibilities
-//!
-//! - Harness trait (execute agent CLI, stream results, normalize telemetry)
-//! - Environment lease trait (provision, run, drain, release, health)
-//! - Normalized run result and event models
-//!
-//! # Design Rules
-//!
-//! - Traits only — no concrete implementations (those live in `runtime-*` and `harness-*`)
-//! - Runtime crates never own policy decisions
-//! - All execution results use normalized domain event types
+//! Provider-specific implementations live in `tanren-harness-*`.
+
+mod adapter;
+mod capability;
+mod conformance;
+mod execution;
+mod failure;
+mod redaction;
+
+pub use adapter::{
+    ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessExecutionEvent, HarnessObserver,
+    execute_with_contract,
+};
+pub use capability::{
+    ApprovalMode, CapabilityAdmissibility, CompatibilityDenial, CompatibilityDenialKind,
+    HarnessCapabilities, HarnessRequirements, OutputStreaming, OutputStreamingRequirement,
+    PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeSupport,
+};
+pub use conformance::{
+    ConformanceEventRecorder, ConformanceResult, assert_capability_denial_is_preflight,
+    assert_failure_classification, assert_redaction_before_persistence,
+};
+pub use execution::{
+    HarnessExecutionRequest, HarnessExecutionResult, PersistableOutput, RawExecutionOutput,
+};
+pub use failure::{
+    HarnessFailure, HarnessFailureClass, ProviderFailureContext, classify_provider_failure,
+};
+pub use redaction::{
+    DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints, RedactionPolicy,
+    default_redaction_policy,
+};

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -32,11 +32,11 @@ pub use conformance::{
 };
 pub use execution::{
     HarnessExecutionRequest, HarnessExecutionResult, PersistableOutput, RawExecutionOutput,
-    RedactionSecret,
+    RedactionSecret, SecretName,
 };
 pub use failure::{
     HarnessFailure, HarnessFailureClass, ProviderFailureCode, ProviderFailureContext,
-    classify_provider_failure,
+    ProviderIdentifier, ProviderIdentifierError, classify_provider_failure,
 };
 pub use redaction::{
     DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints, RedactionPolicy,

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -30,8 +30,8 @@ pub use capability::{
 pub use conformance::{
     ConformanceEventRecorder, ConformanceResult, RedactionConformanceExpectations,
     assert_capability_denial_is_preflight, assert_failure_classification,
-    assert_provider_metadata_fail_closed, assert_redaction_before_persistence,
-    assert_terminal_typed_code_mapping,
+    assert_failure_path_leak_detected, assert_provider_metadata_fail_closed,
+    assert_redaction_before_persistence, assert_terminal_typed_code_mapping,
 };
 pub use execution::{
     HarnessExecutionRequest, HarnessExecutionResult, PersistableOutput, RawExecutionOutput,
@@ -40,10 +40,13 @@ pub use execution::{
 pub use failure::{
     AuditProviderFailureCode, AuditProviderFailureContext, HarnessFailure, HarnessFailureClass,
     ProviderFailure, ProviderFailureCode, ProviderFailureContext, ProviderIdentifier,
-    ProviderIdentifierError, classify_provider_failure, classify_provider_failure_for_audit,
+    ProviderIdentifierError, ProviderRunId, ProviderRunIdError, classify_provider_failure,
+    classify_provider_failure_for_audit,
 };
 pub use redaction::{
-    DefaultOutputRedactor, OutputRedactor, RedactionAudit, RedactionError, RedactionHints,
-    RedactionOutcome, RedactionPolicy, RedactionPolicyBuilder, RedactionPolicyError,
-    default_redaction_policy, default_redaction_policy_dataset_version,
+    DefaultOutputRedactor, MAX_REDACTION_HINT_SECRET_BYTES, MAX_REDACTION_HINT_SECRET_COUNT,
+    MAX_REDACTION_HINT_TOTAL_SECRET_BYTES, OutputRedactor, RedactionAudit, RedactionError,
+    RedactionHintBoundsError, RedactionHints, RedactionOutcome, RedactionPolicy,
+    RedactionPolicyBuilder, RedactionPolicyError, default_redaction_policy,
+    default_redaction_policy_dataset_version,
 };

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -22,17 +22,21 @@ pub use adapter::{
 pub use capability::{
     ApprovalMode, CapabilityAdmissibility, CompatibilityDenial, CompatibilityDenialKind,
     HarnessCapabilities, HarnessRequirements, OutputStreaming, OutputStreamingRequirement,
-    PatchApplySupport, RequirementLevel, SandboxMode, SessionResumeSupport,
+    PatchApplyRequirement, PatchApplySupport, RequirementLevel, SandboxMode,
+    SessionResumeRequirement, SessionResumeSupport,
 };
 pub use conformance::{
-    ConformanceEventRecorder, ConformanceResult, assert_capability_denial_is_preflight,
-    assert_failure_classification, assert_redaction_before_persistence,
+    ConformanceEventRecorder, ConformanceResult, RedactionConformanceExpectations,
+    assert_capability_denial_is_preflight, assert_failure_classification,
+    assert_redaction_before_persistence,
 };
 pub use execution::{
     HarnessExecutionRequest, HarnessExecutionResult, PersistableOutput, RawExecutionOutput,
+    RedactionSecret,
 };
 pub use failure::{
-    HarnessFailure, HarnessFailureClass, ProviderFailureContext, classify_provider_failure,
+    HarnessFailure, HarnessFailureClass, ProviderFailureCode, ProviderFailureContext,
+    classify_provider_failure,
 };
 pub use redaction::{
     DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints, RedactionPolicy,

--- a/crates/tanren-runtime/src/lib.rs
+++ b/crates/tanren-runtime/src/lib.rs
@@ -16,8 +16,8 @@ mod failure;
 mod redaction;
 
 pub use adapter::{
-    ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessExecutionEvent, HarnessObserver,
-    execute_with_contract,
+    ExecutionSignal, HarnessAdapter, HarnessContractError, HarnessEventSource,
+    HarnessExecutionEvent, HarnessExecutionEventKind, HarnessObserver, execute_with_contract,
 };
 pub use capability::{
     ApprovalMode, CapabilityAdmissibility, CompatibilityDenial, CompatibilityDenialKind,
@@ -35,10 +35,10 @@ pub use execution::{
     RedactionSecret, SecretName,
 };
 pub use failure::{
-    HarnessFailure, HarnessFailureClass, ProviderFailureCode, ProviderFailureContext,
-    ProviderIdentifier, ProviderIdentifierError, classify_provider_failure,
+    HarnessFailure, HarnessFailureClass, ProviderFailure, ProviderFailureCode,
+    ProviderFailureContext, ProviderIdentifier, ProviderIdentifierError, classify_provider_failure,
 };
 pub use redaction::{
     DefaultOutputRedactor, OutputRedactor, RedactionError, RedactionHints, RedactionPolicy,
-    default_redaction_policy,
+    default_redaction_policy, default_redaction_policy_dataset_version,
 };

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -121,40 +121,20 @@ impl DefaultOutputRedactor {
         }
     }
 
-    fn redact_text(&self, input: Option<String>, hints: &RedactionHints) -> Option<String> {
+    fn redact_text(
+        &self,
+        input: Option<String>,
+        channel_matcher: &CompiledChannelMatcher<'_>,
+        explicit_secret_matcher: &CompiledSecretMatcher,
+    ) -> Option<String> {
         input.map(|value| {
-            let out = truncate_for_persistence(value, self.policy.max_persistable_channel_bytes);
-            let hint_key_names = hints
-                .required_secret_names
-                .iter()
-                .map(SecretName::as_str)
-                .map(str::to_owned)
-                .collect::<HashSet<_>>();
-
-            let mut ranges = scanner::collect_assignment_value_ranges(
-                &out,
-                &self.normalized_sensitive_key_names,
-                &hint_key_names,
-                REDACTION_TOKEN,
-            );
-            ranges.extend(scanner::collect_bearer_token_ranges(
-                &out,
-                self.policy.min_token_len,
-                REDACTION_TOKEN,
-            ));
-            ranges.extend(scanner::collect_prefixed_token_ranges(
-                &out,
-                &self.policy.token_prefixes,
-                self.policy.min_token_len,
-                REDACTION_TOKEN,
-            ));
-            ranges.extend(collect_explicit_secret_ranges(
-                &out,
-                hints,
-                self.policy.min_secret_fragment_len,
-            ));
-
-            apply_redaction_ranges(out, ranges)
+            let artifacts = channel_matcher.scan(&value);
+            let mut ranges = artifacts.assignment_value_ranges;
+            ranges.extend(artifacts.bearer_token_ranges);
+            ranges.extend(artifacts.prefixed_token_ranges);
+            ranges.extend(explicit_secret_matcher.collect_ranges(&value));
+            let redacted = apply_redaction_ranges(value, ranges);
+            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes)
         })
     }
 
@@ -188,14 +168,41 @@ impl OutputRedactor for DefaultOutputRedactor {
         output: RawExecutionOutput,
         hints: &RedactionHints,
     ) -> Result<PersistableOutput, RedactionError> {
+        let hint_keys = hints
+            .required_secret_names
+            .iter()
+            .map(SecretName::as_str)
+            .map(str::to_owned)
+            .collect::<HashSet<_>>();
+        let channel_matcher = CompiledChannelMatcher::new(
+            &self.normalized_sensitive_key_names,
+            &hint_keys,
+            &self.policy.token_prefixes,
+            self.policy.min_token_len,
+            REDACTION_TOKEN,
+        );
+        let explicit_secret_matcher =
+            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
         Ok(PersistableOutput {
             outcome: output.outcome,
             signal: output.signal,
             exit_code: output.exit_code,
             duration_secs: output.duration_secs,
-            gate_output: self.redact_text(output.gate_output, hints),
-            tail_output: self.redact_text(output.tail_output, hints),
-            stderr_tail: self.redact_text(output.stderr_tail, hints),
+            gate_output: self.redact_text(
+                output.gate_output,
+                &channel_matcher,
+                &explicit_secret_matcher,
+            ),
+            tail_output: self.redact_text(
+                output.tail_output,
+                &channel_matcher,
+                &explicit_secret_matcher,
+            ),
+            stderr_tail: self.redact_text(
+                output.stderr_tail,
+                &channel_matcher,
+                &explicit_secret_matcher,
+            ),
             pushed: output.pushed,
             plan_hash: output.plan_hash,
             unchecked_tasks: output.unchecked_tasks,
@@ -233,78 +240,131 @@ impl OutputRedactor for DefaultOutputRedactor {
             .iter()
             .map(SecretName::as_str)
             .map(str::to_owned)
-            .collect::<Vec<_>>();
+            .collect::<HashSet<_>>();
+        let matcher = CompiledChannelMatcher::new(
+            &self.normalized_sensitive_key_names,
+            &hint_keys,
+            &self.policy.token_prefixes,
+            self.policy.min_token_len,
+            REDACTION_TOKEN,
+        );
 
         for channel in Self::channels(output).iter().flatten() {
-            for key in &self.policy.sensitive_key_names {
-                if scanner::contains_unredacted_assignment(channel, key, REDACTION_TOKEN) {
-                    return true;
-                }
-            }
-            for key in &hint_keys {
-                if scanner::contains_unredacted_assignment(channel, key, REDACTION_TOKEN) {
-                    return true;
-                }
-            }
-            if scanner::contains_unredacted_bearer_token(
-                channel,
-                self.policy.min_token_len,
-                REDACTION_TOKEN,
-            ) {
+            if matcher.scan(channel).has_policy_residual_leak() {
                 return true;
-            }
-            for prefix in &self.policy.token_prefixes {
-                if scanner::contains_unredacted_prefixed_token(
-                    channel,
-                    prefix,
-                    self.policy.min_token_len,
-                    REDACTION_TOKEN,
-                ) {
-                    return true;
-                }
             }
         }
         false
     }
 }
 
-fn collect_explicit_secret_ranges(
-    text: &str,
-    hints: &RedactionHints,
-    min_secret_fragment_len: usize,
-) -> Vec<(usize, usize)> {
-    let mut ranges = Vec::new();
-    for secret in &hints.secret_values {
-        let value = secret.expose();
-        if value.trim().is_empty() {
-            continue;
+struct CompiledChannelMatcher<'a> {
+    policy_keys: &'a HashSet<String>,
+    hint_keys: &'a HashSet<String>,
+    token_prefixes: &'a [String],
+    min_token_len: usize,
+    redaction_token: &'a str,
+}
+
+impl<'a> CompiledChannelMatcher<'a> {
+    fn new(
+        policy_keys: &'a HashSet<String>,
+        hint_keys: &'a HashSet<String>,
+        token_prefixes: &'a [String],
+        min_token_len: usize,
+        redaction_token: &'a str,
+    ) -> Self {
+        Self {
+            policy_keys,
+            hint_keys,
+            token_prefixes,
+            min_token_len,
+            redaction_token,
         }
-        ranges.extend(collect_literal_ranges(text, value));
-        if value.contains('\n') {
-            for fragment in value.lines() {
-                let trimmed = fragment.trim();
-                if trimmed.len() >= min_secret_fragment_len {
-                    ranges.extend(collect_literal_ranges(text, trimmed));
+    }
+
+    fn scan(&self, text: &str) -> scanner::ChannelScanArtifacts {
+        scanner::scan_channel(
+            text,
+            &scanner::ChannelScanConfig {
+                policy_keys: self.policy_keys,
+                hint_keys: self.hint_keys,
+                token_prefixes: self.token_prefixes,
+                min_token_len: self.min_token_len,
+                redaction_token: self.redaction_token,
+            },
+        )
+    }
+}
+
+#[derive(Default)]
+struct CompiledSecretMatcher {
+    by_first_byte: HashMap<u8, Vec<Vec<u8>>>,
+}
+
+impl CompiledSecretMatcher {
+    fn from_hints(hints: &RedactionHints, min_secret_fragment_len: usize) -> Self {
+        let mut literals = HashSet::new();
+        for secret in &hints.secret_values {
+            let value = secret.expose().trim();
+            if value.is_empty() {
+                continue;
+            }
+            literals.insert(value.to_owned());
+            if value.contains('\n') {
+                for fragment in value.lines() {
+                    let trimmed = fragment.trim();
+                    if trimmed.len() >= min_secret_fragment_len {
+                        literals.insert(trimmed.to_owned());
+                    }
                 }
             }
         }
-    }
-    ranges
-}
 
-fn collect_literal_ranges(haystack: &str, needle: &str) -> Vec<(usize, usize)> {
-    if needle.is_empty() {
-        return Vec::new();
+        let mut by_first_byte: HashMap<u8, Vec<Vec<u8>>> = HashMap::new();
+        for literal in literals {
+            let bytes = literal.into_bytes();
+            if let Some(first) = bytes.first().copied() {
+                by_first_byte.entry(first).or_default().push(bytes);
+            }
+        }
+        for candidates in by_first_byte.values_mut() {
+            candidates.sort_by_key(|value| std::cmp::Reverse(value.len()));
+        }
+        Self { by_first_byte }
     }
-    let mut ranges = Vec::new();
-    let mut search_from = 0;
-    while let Some(found) = haystack[search_from..].find(needle) {
-        let start = search_from + found;
-        let end = start + needle.len();
-        ranges.push((start, end));
-        search_from = end;
+
+    fn collect_ranges(&self, text: &str) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let bytes = text.as_bytes();
+        let mut cursor = 0;
+
+        while cursor < bytes.len() {
+            let Some(candidates) = self.by_first_byte.get(&bytes[cursor]) else {
+                cursor += 1;
+                continue;
+            };
+
+            let mut matched = false;
+            for candidate in candidates {
+                let end = cursor.saturating_add(candidate.len());
+                if end <= bytes.len()
+                    && &bytes[cursor..end] == candidate.as_slice()
+                    && text.is_char_boundary(cursor)
+                    && text.is_char_boundary(end)
+                {
+                    ranges.push((cursor, end));
+                    cursor = end;
+                    matched = true;
+                    break;
+                }
+            }
+            if !matched {
+                cursor += 1;
+            }
+        }
+        ranges
     }
-    ranges
 }
 
 fn apply_redaction_ranges(mut text: String, mut ranges: Vec<(usize, usize)>) -> String {

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use tanren_domain::FiniteF64;
 
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 
+pub(crate) mod policy_dataset;
 pub(crate) mod scanner;
 
 const REDACTION_TOKEN: &str = "[REDACTED]";
@@ -41,46 +41,36 @@ pub struct RedactionPolicy {
 
 /// Build the default redaction policy for Phase 1 harness adapters.
 #[must_use]
+pub const fn default_redaction_policy_dataset_version() -> &'static str {
+    policy_dataset::DEFAULT_REDACTION_POLICY_DATASET_VERSION
+}
+
+/// Build the default redaction policy for Phase 1 harness adapters.
+#[must_use]
 pub fn default_redaction_policy() -> RedactionPolicy {
+    let dataset = policy_dataset::default_policy_dataset_v1();
     RedactionPolicy {
-        min_token_len: 10,
-        min_secret_fragment_len: 4,
-        sensitive_key_names: vec![
-            "api_key".into(),
-            "api-token".into(),
-            "api_token".into(),
-            "auth_token".into(),
-            "access_token".into(),
-            "refresh_token".into(),
-            "session_token".into(),
-            "authorization".into(),
-            "bearer".into(),
-            "cookie".into(),
-            "set-cookie".into(),
-            "password".into(),
-            "secret".into(),
-            "private_key".into(),
-            "aws_access_key_id".into(),
-            "aws_secret_access_key".into(),
-            "x-api-key".into(),
-        ],
-        token_prefixes: vec![
-            "sk-".into(),
-            "ghp_".into(),
-            "gho_".into(),
-            "xoxb-".into(),
-            "xoxp-".into(),
-            "AKIA".into(),
-        ],
-        max_persistable_channel_bytes: 512 * 1024,
+        min_token_len: dataset.min_token_len,
+        min_secret_fragment_len: dataset.min_secret_fragment_len,
+        sensitive_key_names: dataset
+            .sensitive_key_names
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        token_prefixes: dataset
+            .token_prefixes
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        max_persistable_channel_bytes: dataset.max_persistable_channel_bytes,
     }
 }
 
 /// Redaction failure classes.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RedactionError {
-    #[error("execution duration is non-finite")]
-    InvalidDuration,
+    #[error("redaction policy violation")]
+    PolicyViolation,
 }
 
 /// Redacts raw harness output into persistable output.
@@ -98,6 +88,10 @@ pub trait OutputRedactor: Send + Sync {
     /// Detect whether the normalized output still leaks known secret values.
     #[must_use]
     fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool;
+
+    /// Detect whether normalized output still contains policy-defined secret patterns.
+    #[must_use]
+    fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool;
 }
 
 /// Default policy-driven output redactor.
@@ -129,66 +123,39 @@ impl DefaultOutputRedactor {
 
     fn redact_text(&self, input: Option<String>, hints: &RedactionHints) -> Option<String> {
         input.map(|value| {
-            let mut out =
-                truncate_for_persistence(value, self.policy.max_persistable_channel_bytes);
-            out = self.redact_structured_key_values(out, hints);
-            out = self.redact_bearer_tokens(out);
-            out = self.redact_prefixed_tokens(out);
-            out = self.redact_explicit_secret_values(out, hints);
-            out
-        })
-    }
+            let out = truncate_for_persistence(value, self.policy.max_persistable_channel_bytes);
+            let hint_key_names = hints
+                .required_secret_names
+                .iter()
+                .map(SecretName::as_str)
+                .map(str::to_owned)
+                .collect::<HashSet<_>>();
 
-    fn redact_structured_key_values(&self, input: String, hints: &RedactionHints) -> String {
-        let hint_key_names = hints
-            .required_secret_names
-            .iter()
-            .map(SecretName::as_str)
-            .map(str::to_owned)
-            .collect::<HashSet<_>>();
-
-        let mut out = String::with_capacity(input.len());
-        for line in input.split_inclusive('\n') {
-            let redacted_line = redact_assignments_for_keys(
-                line,
+            let mut ranges = scanner::collect_assignment_value_ranges(
+                &out,
                 &self.normalized_sensitive_key_names,
                 &hint_key_names,
+                REDACTION_TOKEN,
             );
-            out.push_str(&redacted_line);
-        }
+            ranges.extend(scanner::collect_bearer_token_ranges(
+                &out,
+                self.policy.min_token_len,
+                REDACTION_TOKEN,
+            ));
+            ranges.extend(scanner::collect_prefixed_token_ranges(
+                &out,
+                &self.policy.token_prefixes,
+                self.policy.min_token_len,
+                REDACTION_TOKEN,
+            ));
+            ranges.extend(collect_explicit_secret_ranges(
+                &out,
+                hints,
+                self.policy.min_secret_fragment_len,
+            ));
 
-        if out.is_empty() { input } else { out }
-    }
-
-    fn redact_bearer_tokens(&self, input: String) -> String {
-        redact_keyword_token(input, "bearer ", self.policy.min_token_len)
-    }
-
-    fn redact_prefixed_tokens(&self, input: String) -> String {
-        let mut out = input;
-        for prefix in &self.policy.token_prefixes {
-            out = redact_prefixed_token(out, prefix, self.policy.min_token_len);
-        }
-        out
-    }
-
-    fn redact_explicit_secret_values(&self, input: String, hints: &RedactionHints) -> String {
-        let mut out = input;
-        for secret in &hints.secret_values {
-            let value = secret.expose();
-            if value.trim().is_empty() {
-                continue;
-            }
-            out = out.replace(value, REDACTION_TOKEN);
-            if value.contains('\n') {
-                for fragment in value.lines() {
-                    if fragment.trim().len() >= self.policy.min_secret_fragment_len {
-                        out = out.replace(fragment.trim(), REDACTION_TOKEN);
-                    }
-                }
-            }
-        }
-        out
+            apply_redaction_ranges(out, ranges)
+        })
     }
 
     fn any_field_contains_secret(output: &PersistableOutput, secret: &str) -> bool {
@@ -205,6 +172,14 @@ impl DefaultOutputRedactor {
                 .as_deref()
                 .is_some_and(|v| v.contains(secret))
     }
+
+    fn channels(output: &PersistableOutput) -> [Option<&str>; 3] {
+        [
+            output.gate_output.as_deref(),
+            output.tail_output.as_deref(),
+            output.stderr_tail.as_deref(),
+        ]
+    }
 }
 
 impl OutputRedactor for DefaultOutputRedactor {
@@ -213,13 +188,11 @@ impl OutputRedactor for DefaultOutputRedactor {
         output: RawExecutionOutput,
         hints: &RedactionHints,
     ) -> Result<PersistableOutput, RedactionError> {
-        let duration_secs = FiniteF64::try_new(output.duration_secs)
-            .map_err(|_| RedactionError::InvalidDuration)?;
         Ok(PersistableOutput {
             outcome: output.outcome,
             signal: output.signal,
             exit_code: output.exit_code,
-            duration_secs,
+            duration_secs: output.duration_secs,
             gate_output: self.redact_text(output.gate_output, hints),
             tail_output: self.redact_text(output.tail_output, hints),
             stderr_tail: self.redact_text(output.stderr_tail, hints),
@@ -253,133 +226,110 @@ impl OutputRedactor for DefaultOutputRedactor {
         }
         false
     }
-}
 
-fn redact_assignments_for_keys(
-    line: &str,
-    policy_keys: &HashSet<String>,
-    hint_keys: &HashSet<String>,
-) -> String {
-    let bytes = line.as_bytes();
-    let mut ranges: Vec<(usize, usize)> = Vec::new();
-    let mut cursor = 0;
+    fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
+        let hint_keys = hints
+            .required_secret_names
+            .iter()
+            .map(SecretName::as_str)
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
 
-    while cursor < bytes.len() {
-        if !is_key_start(bytes[cursor]) {
-            cursor += 1;
-            continue;
-        }
-
-        let key_start = cursor;
-        cursor += 1;
-        while cursor < bytes.len() && is_key_char(bytes[cursor]) {
-            cursor += 1;
-        }
-        let key_end = cursor;
-
-        let mut value_cursor = cursor;
-        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
-            value_cursor += 1;
-        }
-        if value_cursor >= bytes.len() || !matches!(bytes[value_cursor], b'=' | b':') {
-            continue;
-        }
-
-        let key = line[key_start..key_end].to_ascii_lowercase();
-        let is_sensitive = policy_keys.contains(&key) || hint_keys.contains(&key);
-
-        value_cursor += 1;
-        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
-            value_cursor += 1;
-        }
-        if value_cursor >= bytes.len() {
-            break;
-        }
-
-        let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
-            let quoted_end =
-                scanner::find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
-            (value_cursor.saturating_add(1), quoted_end)
-        } else {
-            (
-                value_cursor,
-                scanner::find_unquoted_value_end(line, value_cursor),
-            )
-        };
-
-        if is_sensitive
-            && value_start < value_end
-            && &line[value_start..value_end] != REDACTION_TOKEN
-        {
-            ranges.push((value_start, value_end));
-        }
-
-        cursor = value_end.saturating_add(1);
-    }
-
-    if ranges.is_empty() {
-        return line.to_owned();
-    }
-
-    let mut out = line.to_owned();
-    for (start, end) in ranges.into_iter().rev() {
-        out.replace_range(start..end, REDACTION_TOKEN);
-    }
-    out
-}
-
-const fn is_key_start(byte: u8) -> bool {
-    byte.is_ascii_alphabetic() || byte == b'_'
-}
-
-const fn is_key_char(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
-}
-
-fn redact_keyword_token(mut value: String, keyword: &str, min_token_len: usize) -> String {
-    let mut search_from = 0;
-    loop {
-        let Some(index) = scanner::find_ascii_case_insensitive(&value, keyword, search_from) else {
-            return value;
-        };
-
-        let token_start = index + keyword.len();
-        let token_end = scanner::find_unquoted_value_end(&value, token_start);
-        if token_end.saturating_sub(token_start) < min_token_len {
-            search_from = token_end.saturating_add(1);
-            continue;
-        }
-        if &value[token_start..token_end] != REDACTION_TOKEN {
-            value.replace_range(token_start..token_end, REDACTION_TOKEN);
-        }
-        search_from = token_start.saturating_add(REDACTION_TOKEN.len());
-    }
-}
-
-fn redact_prefixed_token(mut value: String, prefix: &str, min_token_len: usize) -> String {
-    let mut search_from = 0;
-    loop {
-        let Some(start) = scanner::find_ascii_case_insensitive(&value, prefix, search_from) else {
-            return value;
-        };
-        let mut end = start + prefix.len();
-        let bytes = value.as_bytes();
-        while end < bytes.len() {
-            let ch = bytes[end];
-            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
-                break;
+        for channel in Self::channels(output).iter().flatten() {
+            for key in &self.policy.sensitive_key_names {
+                if scanner::contains_unredacted_assignment(channel, key, REDACTION_TOKEN) {
+                    return true;
+                }
             }
-            end += 1;
+            for key in &hint_keys {
+                if scanner::contains_unredacted_assignment(channel, key, REDACTION_TOKEN) {
+                    return true;
+                }
+            }
+            if scanner::contains_unredacted_bearer_token(
+                channel,
+                self.policy.min_token_len,
+                REDACTION_TOKEN,
+            ) {
+                return true;
+            }
+            for prefix in &self.policy.token_prefixes {
+                if scanner::contains_unredacted_prefixed_token(
+                    channel,
+                    prefix,
+                    self.policy.min_token_len,
+                    REDACTION_TOKEN,
+                ) {
+                    return true;
+                }
+            }
         }
-        if end.saturating_sub(start) < min_token_len {
-            search_from = end.saturating_add(1);
+        false
+    }
+}
+
+fn collect_explicit_secret_ranges(
+    text: &str,
+    hints: &RedactionHints,
+    min_secret_fragment_len: usize,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    for secret in &hints.secret_values {
+        let value = secret.expose();
+        if value.trim().is_empty() {
             continue;
         }
-        if &value[start..end] != REDACTION_TOKEN {
-            value.replace_range(start..end, REDACTION_TOKEN);
+        ranges.extend(collect_literal_ranges(text, value));
+        if value.contains('\n') {
+            for fragment in value.lines() {
+                let trimmed = fragment.trim();
+                if trimmed.len() >= min_secret_fragment_len {
+                    ranges.extend(collect_literal_ranges(text, trimmed));
+                }
+            }
         }
-        search_from = start.saturating_add(REDACTION_TOKEN.len());
     }
+    ranges
+}
+
+fn collect_literal_ranges(haystack: &str, needle: &str) -> Vec<(usize, usize)> {
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    let mut ranges = Vec::new();
+    let mut search_from = 0;
+    while let Some(found) = haystack[search_from..].find(needle) {
+        let start = search_from + found;
+        let end = start + needle.len();
+        ranges.push((start, end));
+        search_from = end;
+    }
+    ranges
+}
+
+fn apply_redaction_ranges(mut text: String, mut ranges: Vec<(usize, usize)>) -> String {
+    if ranges.is_empty() {
+        return text;
+    }
+
+    ranges.sort_unstable_by_key(|(start, _)| *start);
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        if let Some((_, prev_end)) = merged.last_mut()
+            && start <= *prev_end
+        {
+            *prev_end = (*prev_end).max(end);
+            continue;
+        }
+        merged.push((start, end));
+    }
+
+    for (start, end) in merged.into_iter().rev() {
+        if start < end && end <= text.len() {
+            text.replace_range(start..end, REDACTION_TOKEN);
+        }
+    }
+    text
 }
 
 fn truncate_for_persistence(mut input: String, max_bytes: usize) -> String {

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -180,12 +180,14 @@ impl DefaultOutputRedactor {
         let redacted = apply_redaction_ranges(value, ranges);
         let redacted =
             truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes);
+        let post_scan = channel_matcher.scan(&redacted);
         let known_secret_leak = !explicit_secret_matcher.collect_ranges(&redacted).is_empty();
+        let policy_residual_leak = post_scan.has_policy_residual_leak();
 
         ChannelRedactionResult {
             value: Some(redacted),
             known_secret_leak,
-            policy_residual_leak: false,
+            policy_residual_leak,
         }
     }
 
@@ -352,7 +354,7 @@ impl<'a> CompiledChannelMatcher<'a> {
     }
 }
 
-fn apply_redaction_ranges(mut text: String, mut ranges: Vec<(usize, usize)>) -> String {
+fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> String {
     if ranges.is_empty() {
         return text;
     }
@@ -369,12 +371,27 @@ fn apply_redaction_ranges(mut text: String, mut ranges: Vec<(usize, usize)>) -> 
         merged.push((start, end));
     }
 
-    for (start, end) in merged.into_iter().rev() {
-        if start < end && end <= text.len() {
-            text.replace_range(start..end, REDACTION_TOKEN);
+    let mut redacted = String::with_capacity(text.len());
+    let mut cursor = 0;
+    for (start, end) in merged {
+        if !(start < end
+            && end <= text.len()
+            && text.is_char_boundary(start)
+            && text.is_char_boundary(end))
+        {
+            continue;
         }
+
+        if cursor < start {
+            redacted.push_str(&text[cursor..start]);
+        }
+        redacted.push_str(REDACTION_TOKEN);
+        cursor = end;
     }
-    text
+    if cursor < text.len() {
+        redacted.push_str(&text[cursor..]);
+    }
+    redacted
 }
 
 fn truncate_for_persistence(mut input: String, max_bytes: usize) -> String {

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,14 +1,17 @@
 use std::collections::HashSet;
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
-
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 
+pub(crate) mod policy;
 pub(crate) mod policy_dataset;
 pub(crate) mod scanner;
 pub(crate) mod secret_matcher;
 
+pub use self::policy::{
+    RedactionPolicy, RedactionPolicyBuilder, RedactionPolicyError, default_redaction_policy,
+    default_redaction_policy_dataset_version,
+};
 use self::secret_matcher::CompiledSecretMatcher;
 
 const REDACTION_TOKEN: &str = "[REDACTED]";
@@ -27,45 +30,6 @@ impl fmt::Debug for RedactionHints {
             .field("required_secret_names", &self.required_secret_names)
             .field("secret_value_count", &self.secret_values.len())
             .finish()
-    }
-}
-
-/// Deterministic redaction policy used by all adapters unless overridden.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RedactionPolicy {
-    pub min_token_len: usize,
-    pub min_secret_fragment_len: usize,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub sensitive_key_names: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub token_prefixes: Vec<String>,
-    pub max_persistable_channel_bytes: usize,
-}
-
-/// Build the default redaction policy for Phase 1 harness adapters.
-#[must_use]
-pub const fn default_redaction_policy_dataset_version() -> &'static str {
-    policy_dataset::DEFAULT_REDACTION_POLICY_DATASET_VERSION
-}
-
-/// Build the default redaction policy for Phase 1 harness adapters.
-#[must_use]
-pub fn default_redaction_policy() -> RedactionPolicy {
-    let dataset = policy_dataset::default_policy_dataset_v1();
-    RedactionPolicy {
-        min_token_len: dataset.min_token_len,
-        min_secret_fragment_len: dataset.min_secret_fragment_len,
-        sensitive_key_names: dataset
-            .sensitive_key_names
-            .iter()
-            .map(|value| (*value).to_owned())
-            .collect(),
-        token_prefixes: dataset
-            .token_prefixes
-            .iter()
-            .map(|value| (*value).to_owned())
-            .collect(),
-        max_persistable_channel_bytes: dataset.max_persistable_channel_bytes,
     }
 }
 
@@ -153,7 +117,7 @@ impl DefaultOutputRedactor {
     #[must_use]
     pub fn new(policy: RedactionPolicy) -> Self {
         let normalized_sensitive_key_names = policy
-            .sensitive_key_names
+            .sensitive_key_names()
             .iter()
             .map(|value| value.to_ascii_lowercase())
             .collect();
@@ -179,7 +143,7 @@ impl DefaultOutputRedactor {
         ranges.extend(explicit_secret_matcher.collect_ranges(&value));
         let redacted = apply_redaction_ranges(value, ranges);
         let redacted =
-            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes);
+            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes());
         let post_scan = channel_matcher.scan(&redacted);
         let known_secret_leak = !explicit_secret_matcher.collect_ranges(&redacted).is_empty();
         let policy_residual_leak = post_scan.has_policy_residual_leak();
@@ -218,7 +182,8 @@ impl OutputRedactor for DefaultOutputRedactor {
     }
 
     fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
-        let matcher = CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
+        let matcher =
+            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len());
         Self::channels(output)
             .iter()
             .flatten()
@@ -235,8 +200,8 @@ impl OutputRedactor for DefaultOutputRedactor {
         let matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
             &hint_keys,
-            &self.policy.token_prefixes,
-            self.policy.min_token_len,
+            self.policy.token_prefixes(),
+            self.policy.min_token_len(),
             REDACTION_TOKEN,
         );
 
@@ -262,12 +227,12 @@ impl OutputRedactor for DefaultOutputRedactor {
         let channel_matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
             &hint_keys,
-            &self.policy.token_prefixes,
-            self.policy.min_token_len,
+            self.policy.token_prefixes(),
+            self.policy.min_token_len(),
             REDACTION_TOKEN,
         );
         let explicit_secret_matcher =
-            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
+            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len());
 
         let gate = self.redact_channel(
             output.gate_output,
@@ -318,7 +283,7 @@ impl OutputRedactor for DefaultOutputRedactor {
 struct CompiledChannelMatcher<'a> {
     policy_keys: &'a HashSet<String>,
     hint_keys: &'a HashSet<String>,
-    token_prefixes: &'a [String],
+    token_prefix_matcher: scanner::CompiledTokenPrefixMatcher,
     min_token_len: usize,
     redaction_token: &'a str,
 }
@@ -327,14 +292,14 @@ impl<'a> CompiledChannelMatcher<'a> {
     fn new(
         policy_keys: &'a HashSet<String>,
         hint_keys: &'a HashSet<String>,
-        token_prefixes: &'a [String],
+        token_prefixes: &[String],
         min_token_len: usize,
         redaction_token: &'a str,
     ) -> Self {
         Self {
             policy_keys,
             hint_keys,
-            token_prefixes,
+            token_prefix_matcher: scanner::CompiledTokenPrefixMatcher::new(token_prefixes),
             min_token_len,
             redaction_token,
         }
@@ -346,7 +311,7 @@ impl<'a> CompiledChannelMatcher<'a> {
             &scanner::ChannelScanConfig {
                 policy_keys: self.policy_keys,
                 hint_keys: self.hint_keys,
-                token_prefixes: self.token_prefixes,
+                token_prefix_matcher: &self.token_prefix_matcher,
                 min_token_len: self.min_token_len,
                 redaction_token: self.redaction_token,
             },

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,0 +1,433 @@
+use serde::{Deserialize, Serialize};
+use tanren_domain::FiniteF64;
+
+use crate::execution::{PersistableOutput, RawExecutionOutput};
+
+const REDACTION_TOKEN: &str = "[REDACTED]";
+
+/// Inputs used by redaction policy at capture-time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedactionHints {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_secret_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_values: Vec<String>,
+}
+
+/// Deterministic redaction policy used by all adapters unless overridden.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedactionPolicy {
+    pub min_token_len: usize,
+    pub min_secret_fragment_len: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sensitive_key_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub token_prefixes: Vec<String>,
+}
+
+/// Build the default redaction policy for Phase 1 harness adapters.
+#[must_use]
+pub fn default_redaction_policy() -> RedactionPolicy {
+    RedactionPolicy {
+        min_token_len: 10,
+        min_secret_fragment_len: 4,
+        sensitive_key_names: vec![
+            "api_key".into(),
+            "api-token".into(),
+            "api_token".into(),
+            "auth_token".into(),
+            "access_token".into(),
+            "refresh_token".into(),
+            "session_token".into(),
+            "authorization".into(),
+            "bearer".into(),
+            "cookie".into(),
+            "set-cookie".into(),
+            "password".into(),
+            "secret".into(),
+            "private_key".into(),
+            "aws_access_key_id".into(),
+            "aws_secret_access_key".into(),
+            "x-api-key".into(),
+        ],
+        token_prefixes: vec![
+            "sk-".into(),
+            "ghp_".into(),
+            "gho_".into(),
+            "xoxb-".into(),
+            "xoxp-".into(),
+            "AKIA".into(),
+        ],
+    }
+}
+
+/// Redaction failure classes.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RedactionError {
+    #[error("execution duration is non-finite")]
+    InvalidDuration,
+}
+
+/// Redacts raw harness output into persistable output.
+pub trait OutputRedactor: Send + Sync {
+    /// Apply redaction and normalize the output for durable persistence.
+    ///
+    /// # Errors
+    /// Returns [`RedactionError`] if output cannot be normalized safely.
+    fn redact(
+        &self,
+        output: RawExecutionOutput,
+        hints: &RedactionHints,
+    ) -> Result<PersistableOutput, RedactionError>;
+
+    /// Detect whether the normalized output still leaks known secret values.
+    #[must_use]
+    fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool;
+}
+
+/// Default policy-driven output redactor.
+#[derive(Debug, Clone)]
+pub struct DefaultOutputRedactor {
+    policy: RedactionPolicy,
+}
+
+impl Default for DefaultOutputRedactor {
+    fn default() -> Self {
+        Self {
+            policy: default_redaction_policy(),
+        }
+    }
+}
+
+impl DefaultOutputRedactor {
+    #[must_use]
+    pub fn new(policy: RedactionPolicy) -> Self {
+        Self { policy }
+    }
+
+    fn redact_text(&self, input: Option<String>, hints: &RedactionHints) -> Option<String> {
+        input.map(|value| {
+            let mut out = value;
+            out = self.redact_structured_key_values(out, hints);
+            out = self.redact_bearer_tokens(out);
+            out = self.redact_prefixed_tokens(out);
+            out = self.redact_explicit_secret_values(out, hints);
+            out
+        })
+    }
+
+    fn redact_structured_key_values(&self, input: String, hints: &RedactionHints) -> String {
+        let mut keys = self.policy.sensitive_key_names.clone();
+        for value in &hints.required_secret_names {
+            keys.push(value.to_ascii_lowercase());
+        }
+        let mut out = String::with_capacity(input.len());
+        for line in input.split_inclusive('\n') {
+            let mut redacted_line = line.to_string();
+            for key in &keys {
+                redacted_line = redact_assignment_for_key(&redacted_line, key);
+            }
+            out.push_str(&redacted_line);
+        }
+        if out.is_empty() { input } else { out }
+    }
+
+    fn redact_bearer_tokens(&self, input: String) -> String {
+        redact_keyword_token(input, "bearer ", self.policy.min_token_len)
+    }
+
+    fn redact_prefixed_tokens(&self, input: String) -> String {
+        let mut out = input;
+        for prefix in &self.policy.token_prefixes {
+            out = redact_prefixed_token(out, prefix, self.policy.min_token_len);
+        }
+        out
+    }
+
+    fn redact_explicit_secret_values(&self, input: String, hints: &RedactionHints) -> String {
+        let mut out = input;
+        for value in &hints.secret_values {
+            if value.trim().is_empty() {
+                continue;
+            }
+            out = out.replace(value, REDACTION_TOKEN);
+            if value.contains('\n') {
+                for fragment in value.lines() {
+                    if fragment.trim().len() >= self.policy.min_secret_fragment_len {
+                        out = out.replace(fragment.trim(), REDACTION_TOKEN);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn any_field_contains_secret(output: &PersistableOutput, secret: &str) -> bool {
+        output
+            .gate_output
+            .as_deref()
+            .is_some_and(|v| v.contains(secret))
+            || output
+                .tail_output
+                .as_deref()
+                .is_some_and(|v| v.contains(secret))
+            || output
+                .stderr_tail
+                .as_deref()
+                .is_some_and(|v| v.contains(secret))
+    }
+}
+
+impl OutputRedactor for DefaultOutputRedactor {
+    fn redact(
+        &self,
+        output: RawExecutionOutput,
+        hints: &RedactionHints,
+    ) -> Result<PersistableOutput, RedactionError> {
+        let duration_secs = FiniteF64::try_new(output.duration_secs)
+            .map_err(|_| RedactionError::InvalidDuration)?;
+        Ok(PersistableOutput {
+            outcome: output.outcome,
+            signal: output.signal,
+            exit_code: output.exit_code,
+            duration_secs,
+            gate_output: self.redact_text(output.gate_output, hints),
+            tail_output: self.redact_text(output.tail_output, hints),
+            stderr_tail: self.redact_text(output.stderr_tail, hints),
+            pushed: output.pushed,
+            plan_hash: output.plan_hash,
+            unchecked_tasks: output.unchecked_tasks,
+            spec_modified: output.spec_modified,
+            findings: output.findings,
+            token_usage: output.token_usage,
+        })
+    }
+
+    fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
+        for secret in &hints.secret_values {
+            if secret.trim().is_empty() {
+                continue;
+            }
+            if Self::any_field_contains_secret(output, secret) {
+                return true;
+            }
+            if secret.contains('\n') {
+                for fragment in secret.lines() {
+                    if fragment.trim().len() >= self.policy.min_secret_fragment_len
+                        && Self::any_field_contains_secret(output, fragment.trim())
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+fn redact_assignment_for_key(line: &str, key: &str) -> String {
+    let mut out = line.to_string();
+    let key_lower = key.to_ascii_lowercase();
+    let lower = out.to_ascii_lowercase();
+    let Some(key_index) = lower.find(&key_lower) else {
+        return out;
+    };
+    let mut cursor = key_index + key_lower.len();
+    let bytes = out.as_bytes();
+    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    if cursor >= bytes.len() || (bytes[cursor] != b'=' && bytes[cursor] != b':') {
+        return out;
+    }
+    cursor += 1;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    if cursor >= bytes.len() {
+        return out;
+    }
+    let end = if bytes[cursor] == b'"' || bytes[cursor] == b'\'' {
+        find_quoted_value_end(&out, cursor).unwrap_or(out.len())
+    } else {
+        find_unquoted_value_end(&out, cursor)
+    };
+    out.replace_range(cursor..end, REDACTION_TOKEN);
+    out
+}
+
+fn find_quoted_value_end(value: &str, start: usize) -> Option<usize> {
+    let bytes = value.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+    let quote = bytes[start];
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == quote && bytes[cursor.saturating_sub(1)] != b'\\' {
+            return Some(cursor);
+        }
+        cursor += 1;
+    }
+    Some(value.len())
+}
+
+fn find_unquoted_value_end(value: &str, start: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        let ch = bytes[cursor];
+        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
+            break;
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+fn redact_keyword_token(mut value: String, keyword: &str, min_token_len: usize) -> String {
+    let mut search_from = 0;
+    loop {
+        let lower = value.to_ascii_lowercase();
+        let Some(offset) = lower[search_from..].find(keyword) else {
+            return value;
+        };
+        let index = search_from + offset;
+        let token_start = index + keyword.len();
+        let token_end = find_unquoted_value_end(&value, token_start);
+        if token_end.saturating_sub(token_start) < min_token_len {
+            search_from = token_end.saturating_add(1);
+            continue;
+        }
+        if &value[token_start..token_end] != REDACTION_TOKEN {
+            value.replace_range(token_start..token_end, REDACTION_TOKEN);
+        }
+        search_from = token_start.saturating_add(REDACTION_TOKEN.len());
+    }
+}
+
+fn redact_prefixed_token(mut value: String, prefix: &str, min_token_len: usize) -> String {
+    let mut search_from = 0;
+    loop {
+        let Some(offset) = value[search_from..].find(prefix) else {
+            return value;
+        };
+        let start = search_from + offset;
+        let mut end = start + prefix.len();
+        let bytes = value.as_bytes();
+        while end < bytes.len() {
+            let ch = bytes[end];
+            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
+                break;
+            }
+            end += 1;
+        }
+        if end.saturating_sub(start) < min_token_len {
+            search_from = end.saturating_add(1);
+            continue;
+        }
+        if &value[start..end] != REDACTION_TOKEN {
+            value.replace_range(start..end, REDACTION_TOKEN);
+        }
+        search_from = start.saturating_add(REDACTION_TOKEN.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tanren_domain::Outcome;
+
+    use super::*;
+
+    fn raw_output(text: &str) -> RawExecutionOutput {
+        RawExecutionOutput {
+            outcome: Outcome::Success,
+            signal: None,
+            exit_code: Some(0),
+            duration_secs: 1.0,
+            gate_output: Some(text.into()),
+            tail_output: Some(text.into()),
+            stderr_tail: Some(text.into()),
+            pushed: false,
+            plan_hash: None,
+            unchecked_tasks: 0,
+            spec_modified: false,
+            findings: vec![],
+            token_usage: None,
+        }
+    }
+
+    #[test]
+    fn redacts_bearer_and_prefixed_tokens() {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints::default();
+        let out = redactor
+            .redact(
+                raw_output("Authorization: Bearer sk-super-long-secret-123"),
+                &hints,
+            )
+            .expect("redact");
+        let value = out.gate_output.expect("output");
+        assert!(!value.contains("sk-super-long-secret-123"));
+        assert!(value.contains(REDACTION_TOKEN));
+    }
+
+    #[test]
+    fn redacts_explicit_secret_values_and_multiline_fragments() {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec!["MY_SECRET".into()],
+            secret_values: vec!["line1-secret\nline2-secret".into()],
+        };
+        let out = redactor
+            .redact(
+                raw_output("line1-secret / line2-secret / MY_SECRET=abc"),
+                &hints,
+            )
+            .expect("redact");
+        let gate = out.gate_output.expect("gate");
+        assert!(!gate.contains("line1-secret"));
+        assert!(!gate.contains("line2-secret"));
+        assert!(!gate.contains("abc"));
+    }
+
+    #[test]
+    fn leak_detection_flags_remaining_secret() {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec![],
+            secret_values: vec!["secret-value".into()],
+        };
+        let output = PersistableOutput {
+            outcome: Outcome::Success,
+            signal: None,
+            exit_code: None,
+            duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+            gate_output: Some("still has secret-value".into()),
+            tail_output: None,
+            stderr_tail: None,
+            pushed: false,
+            plan_hash: None,
+            unchecked_tasks: 0,
+            spec_modified: false,
+            findings: vec![],
+            token_usage: None,
+        };
+        assert!(redactor.has_known_secret_leak(&output, &hints));
+    }
+
+    #[test]
+    fn rejects_non_finite_duration() {
+        let redactor = DefaultOutputRedactor::default();
+        let err = redactor
+            .redact(
+                RawExecutionOutput {
+                    duration_secs: f64::NAN,
+                    ..raw_output("ok")
+                },
+                &RedactionHints::default(),
+            )
+            .expect_err("must fail");
+        assert_eq!(err, RedactionError::InvalidDuration);
+    }
+}

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,17 +1,30 @@
 use std::collections::HashSet;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use tanren_domain::FiniteF64;
 
-use crate::execution::{PersistableOutput, RawExecutionOutput};
+use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
+
+pub(crate) mod scanner;
 
 const REDACTION_TOKEN: &str = "[REDACTED]";
+const TRUNCATION_MARKER: &str = "[TRUNCATED_FOR_PERSISTENCE]";
 
 /// Inputs used by redaction policy at capture-time.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct RedactionHints {
-    pub required_secret_names: Vec<String>,
-    pub secret_values: Vec<String>,
+    pub required_secret_names: Vec<SecretName>,
+    pub secret_values: Vec<RedactionSecret>,
+}
+
+impl fmt::Debug for RedactionHints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedactionHints")
+            .field("required_secret_names", &self.required_secret_names)
+            .field("secret_value_count", &self.secret_values.len())
+            .finish()
+    }
 }
 
 /// Deterministic redaction policy used by all adapters unless overridden.
@@ -23,6 +36,7 @@ pub struct RedactionPolicy {
     pub sensitive_key_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub token_prefixes: Vec<String>,
+    pub max_persistable_channel_bytes: usize,
 }
 
 /// Build the default redaction policy for Phase 1 harness adapters.
@@ -58,6 +72,7 @@ pub fn default_redaction_policy() -> RedactionPolicy {
             "xoxp-".into(),
             "AKIA".into(),
         ],
+        max_persistable_channel_bytes: 512 * 1024,
     }
 }
 
@@ -114,7 +129,8 @@ impl DefaultOutputRedactor {
 
     fn redact_text(&self, input: Option<String>, hints: &RedactionHints) -> Option<String> {
         input.map(|value| {
-            let mut out = value;
+            let mut out =
+                truncate_for_persistence(value, self.policy.max_persistable_channel_bytes);
             out = self.redact_structured_key_values(out, hints);
             out = self.redact_bearer_tokens(out);
             out = self.redact_prefixed_tokens(out);
@@ -127,9 +143,8 @@ impl DefaultOutputRedactor {
         let hint_key_names = hints
             .required_secret_names
             .iter()
-            .map(|name| name.trim())
-            .filter(|name| !name.is_empty())
-            .map(str::to_ascii_lowercase)
+            .map(SecretName::as_str)
+            .map(str::to_owned)
             .collect::<HashSet<_>>();
 
         let mut out = String::with_capacity(input.len());
@@ -159,7 +174,8 @@ impl DefaultOutputRedactor {
 
     fn redact_explicit_secret_values(&self, input: String, hints: &RedactionHints) -> String {
         let mut out = input;
-        for value in &hints.secret_values {
+        for secret in &hints.secret_values {
+            let value = secret.expose();
             if value.trim().is_empty() {
                 continue;
             }
@@ -218,6 +234,7 @@ impl OutputRedactor for DefaultOutputRedactor {
 
     fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
         for secret in &hints.secret_values {
+            let secret = secret.expose();
             if secret.trim().is_empty() {
                 continue;
             }
@@ -280,10 +297,14 @@ fn redact_assignments_for_keys(
         }
 
         let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
-            let quoted_end = find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
+            let quoted_end =
+                scanner::find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
             (value_cursor.saturating_add(1), quoted_end)
         } else {
-            (value_cursor, find_unquoted_value_end(line, value_cursor))
+            (
+                value_cursor,
+                scanner::find_unquoted_value_end(line, value_cursor),
+            )
         };
 
         if is_sensitive
@@ -315,73 +336,15 @@ const fn is_key_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
 }
 
-fn find_quoted_value_end(value: &str, start: usize) -> Option<usize> {
-    let bytes = value.as_bytes();
-    if start >= bytes.len() {
-        return None;
-    }
-    let quote = bytes[start];
-    let mut cursor = start + 1;
-    while cursor < bytes.len() {
-        if bytes[cursor] == quote && bytes[cursor.saturating_sub(1)] != b'\\' {
-            return Some(cursor);
-        }
-        cursor += 1;
-    }
-    Some(value.len())
-}
-
-fn find_unquoted_value_end(value: &str, start: usize) -> usize {
-    let bytes = value.as_bytes();
-    let mut cursor = start;
-    while cursor < bytes.len() {
-        let ch = bytes[cursor];
-        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
-            break;
-        }
-        cursor += 1;
-    }
-    cursor
-}
-
-fn find_ascii_case_insensitive(haystack: &str, needle: &str, start: usize) -> Option<usize> {
-    if needle.is_empty() || start >= haystack.len() {
-        return None;
-    }
-
-    let haystack_bytes = haystack.as_bytes();
-    let needle_bytes = needle.as_bytes();
-    if haystack_bytes.len() < needle_bytes.len() {
-        return None;
-    }
-
-    let mut idx = start;
-    while idx + needle_bytes.len() <= haystack_bytes.len() {
-        let mut match_all = true;
-        for offset in 0..needle_bytes.len() {
-            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
-                match_all = false;
-                break;
-            }
-        }
-        if match_all {
-            return Some(idx);
-        }
-        idx += 1;
-    }
-
-    None
-}
-
 fn redact_keyword_token(mut value: String, keyword: &str, min_token_len: usize) -> String {
     let mut search_from = 0;
     loop {
-        let Some(index) = find_ascii_case_insensitive(&value, keyword, search_from) else {
+        let Some(index) = scanner::find_ascii_case_insensitive(&value, keyword, search_from) else {
             return value;
         };
 
         let token_start = index + keyword.len();
-        let token_end = find_unquoted_value_end(&value, token_start);
+        let token_end = scanner::find_unquoted_value_end(&value, token_start);
         if token_end.saturating_sub(token_start) < min_token_len {
             search_from = token_end.saturating_add(1);
             continue;
@@ -396,10 +359,9 @@ fn redact_keyword_token(mut value: String, keyword: &str, min_token_len: usize) 
 fn redact_prefixed_token(mut value: String, prefix: &str, min_token_len: usize) -> String {
     let mut search_from = 0;
     loop {
-        let Some(offset) = value[search_from..].find(prefix) else {
+        let Some(start) = scanner::find_ascii_case_insensitive(&value, prefix, search_from) else {
             return value;
         };
-        let start = search_from + offset;
         let mut end = start + prefix.len();
         let bytes = value.as_bytes();
         while end < bytes.len() {
@@ -418,6 +380,51 @@ fn redact_prefixed_token(mut value: String, prefix: &str, min_token_len: usize) 
         }
         search_from = start.saturating_add(REDACTION_TOKEN.len());
     }
+}
+
+fn truncate_for_persistence(mut input: String, max_bytes: usize) -> String {
+    if input.len() <= max_bytes {
+        return input;
+    }
+
+    if max_bytes == 0 {
+        return TRUNCATION_MARKER.to_owned();
+    }
+
+    let cutoff = nearest_char_boundary(&input, max_bytes);
+    let boundary = nearest_delimiter_before(&input, cutoff);
+    input.truncate(boundary);
+    if !input.ends_with('\n') {
+        input.push('\n');
+    }
+    input.push_str(TRUNCATION_MARKER);
+    input
+}
+
+fn nearest_char_boundary(value: &str, preferred: usize) -> usize {
+    if preferred >= value.len() {
+        return value.len();
+    }
+    let mut idx = preferred;
+    while idx > 0 && !value.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+fn nearest_delimiter_before(value: &str, cutoff: usize) -> usize {
+    let floor = cutoff.saturating_sub(256);
+    let mut idx = cutoff;
+    while idx > floor {
+        let Some(ch) = value[..idx].chars().next_back() else {
+            break;
+        };
+        if ch.is_ascii_whitespace() || matches!(ch, ',' | ';' | '|' | '&') {
+            return idx;
+        }
+        idx = idx.saturating_sub(ch.len_utf8());
+    }
+    cutoff
 }
 
 #[cfg(test)]

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -3,11 +3,16 @@ use std::fmt;
 
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 
+mod hints;
 pub(crate) mod policy;
 pub(crate) mod policy_dataset;
 pub(crate) mod scanner;
 pub(crate) mod secret_matcher;
 
+pub use self::hints::{
+    MAX_REDACTION_HINT_SECRET_BYTES, MAX_REDACTION_HINT_SECRET_COUNT,
+    MAX_REDACTION_HINT_TOTAL_SECRET_BYTES, RedactionHintBoundsError,
+};
 pub use self::policy::{
     RedactionPolicy, RedactionPolicyBuilder, RedactionPolicyError, default_redaction_policy,
     default_redaction_policy_dataset_version,
@@ -36,6 +41,8 @@ impl fmt::Debug for RedactionHints {
 /// Redaction failure classes.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RedactionError {
+    #[error(transparent)]
+    InvalidHints(#[from] RedactionHintBoundsError),
     #[error("redaction policy violation")]
     PolicyViolation,
 }
@@ -105,6 +112,7 @@ pub trait OutputRedactor: Send + Sync {
 pub struct DefaultOutputRedactor {
     policy: RedactionPolicy,
     normalized_sensitive_key_names: HashSet<String>,
+    token_prefix_matcher: scanner::CompiledTokenPrefixMatcher,
 }
 
 impl Default for DefaultOutputRedactor {
@@ -121,9 +129,12 @@ impl DefaultOutputRedactor {
             .iter()
             .map(|value| value.to_ascii_lowercase())
             .collect();
+        let token_prefix_matcher =
+            scanner::CompiledTokenPrefixMatcher::new(policy.token_prefixes());
         Self {
             policy,
             normalized_sensitive_key_names,
+            token_prefix_matcher,
         }
     }
 
@@ -182,6 +193,9 @@ impl OutputRedactor for DefaultOutputRedactor {
     }
 
     fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
+        if hints.validate_bounds().is_err() {
+            return true;
+        }
         let matcher =
             CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len());
         Self::channels(output)
@@ -191,6 +205,9 @@ impl OutputRedactor for DefaultOutputRedactor {
     }
 
     fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
+        if hints.validate_bounds().is_err() {
+            return true;
+        }
         let hint_keys = hints
             .required_secret_names
             .iter()
@@ -200,7 +217,7 @@ impl OutputRedactor for DefaultOutputRedactor {
         let matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
             &hint_keys,
-            self.policy.token_prefixes(),
+            &self.token_prefix_matcher,
             self.policy.min_token_len(),
             REDACTION_TOKEN,
         );
@@ -218,6 +235,7 @@ impl OutputRedactor for DefaultOutputRedactor {
         output: RawExecutionOutput,
         hints: &RedactionHints,
     ) -> Result<RedactionOutcome, RedactionError> {
+        hints.validate_bounds()?;
         let hint_keys = hints
             .required_secret_names
             .iter()
@@ -227,7 +245,7 @@ impl OutputRedactor for DefaultOutputRedactor {
         let channel_matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
             &hint_keys,
-            self.policy.token_prefixes(),
+            &self.token_prefix_matcher,
             self.policy.min_token_len(),
             REDACTION_TOKEN,
         );
@@ -283,7 +301,7 @@ impl OutputRedactor for DefaultOutputRedactor {
 struct CompiledChannelMatcher<'a> {
     policy_keys: &'a HashSet<String>,
     hint_keys: &'a HashSet<String>,
-    token_prefix_matcher: scanner::CompiledTokenPrefixMatcher,
+    token_prefix_matcher: &'a scanner::CompiledTokenPrefixMatcher,
     min_token_len: usize,
     redaction_token: &'a str,
 }
@@ -292,14 +310,14 @@ impl<'a> CompiledChannelMatcher<'a> {
     fn new(
         policy_keys: &'a HashSet<String>,
         hint_keys: &'a HashSet<String>,
-        token_prefixes: &[String],
+        token_prefix_matcher: &'a scanner::CompiledTokenPrefixMatcher,
         min_token_len: usize,
         redaction_token: &'a str,
     ) -> Self {
         Self {
             policy_keys,
             hint_keys,
-            token_prefix_matcher: scanner::CompiledTokenPrefixMatcher::new(token_prefixes),
+            token_prefix_matcher,
             min_token_len,
             redaction_token,
         }
@@ -311,7 +329,7 @@ impl<'a> CompiledChannelMatcher<'a> {
             &scanner::ChannelScanConfig {
                 policy_keys: self.policy_keys,
                 hint_keys: self.hint_keys,
-                token_prefix_matcher: &self.token_prefix_matcher,
+                token_prefix_matcher: self.token_prefix_matcher,
                 min_token_len: self.min_token_len,
                 redaction_token: self.redaction_token,
             },

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,14 +1,17 @@
 use std::collections::HashSet;
 use std::fmt;
+use std::sync::{Arc, RwLock};
 
 use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, SecretName};
 
+mod compiled_hints;
 mod hints;
 pub(crate) mod policy;
 pub(crate) mod policy_dataset;
 pub(crate) mod scanner;
 pub(crate) mod secret_matcher;
 
+use self::compiled_hints::CompiledHintArtifacts;
 pub use self::hints::{
     MAX_REDACTION_HINT_SECRET_BYTES, MAX_REDACTION_HINT_SECRET_COUNT,
     MAX_REDACTION_HINT_TOTAL_SECRET_BYTES, RedactionHintBoundsError,
@@ -113,6 +116,7 @@ pub struct DefaultOutputRedactor {
     policy: RedactionPolicy,
     normalized_sensitive_key_names: HashSet<String>,
     token_prefix_matcher: scanner::CompiledTokenPrefixMatcher,
+    cached_hint_artifacts: Arc<RwLock<Option<CompiledHintArtifacts>>>,
 }
 
 impl Default for DefaultOutputRedactor {
@@ -135,6 +139,7 @@ impl DefaultOutputRedactor {
             policy,
             normalized_sensitive_key_names,
             token_prefix_matcher,
+            cached_hint_artifacts: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -148,16 +153,28 @@ impl DefaultOutputRedactor {
             return ChannelRedactionResult::default();
         };
         let artifacts = channel_matcher.scan(&value);
-        let mut ranges = artifacts.assignment_value_ranges.clone();
-        ranges.extend_from_slice(&artifacts.bearer_token_ranges);
-        ranges.extend_from_slice(&artifacts.prefixed_token_ranges);
-        ranges.extend(explicit_secret_matcher.collect_ranges(&value));
-        let redacted = apply_redaction_ranges(value, ranges);
-        let redacted =
-            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes());
-        let post_scan = channel_matcher.scan(&redacted);
-        let known_secret_leak = !explicit_secret_matcher.collect_ranges(&redacted).is_empty();
-        let policy_residual_leak = post_scan.has_policy_residual_leak();
+        let explicit_secret_ranges = explicit_secret_matcher.collect_ranges(&value);
+        let mut ranges = Vec::with_capacity(
+            artifacts.assignment_value_ranges.len()
+                + artifacts.bearer_token_ranges.len()
+                + artifacts.prefixed_token_ranges.len()
+                + explicit_secret_ranges.len(),
+        );
+        ranges.extend(artifacts.assignment_value_ranges.iter().copied());
+        ranges.extend(artifacts.bearer_token_ranges.iter().copied());
+        ranges.extend(artifacts.prefixed_token_ranges.iter().copied());
+        ranges.extend(explicit_secret_ranges);
+
+        let redaction_result = apply_redaction_ranges(value, ranges);
+        let redacted = truncate_for_persistence(
+            redaction_result.redacted,
+            self.policy.max_persistable_channel_bytes(),
+        );
+        let requires_fallback_verification = redaction_result.had_invalid_ranges;
+        let known_secret_leak = requires_fallback_verification
+            && !explicit_secret_matcher.collect_ranges(&redacted).is_empty();
+        let policy_residual_leak = requires_fallback_verification
+            && channel_matcher.scan(&redacted).has_policy_residual_leak();
 
         ChannelRedactionResult {
             value: Some(redacted),
@@ -175,7 +192,7 @@ impl DefaultOutputRedactor {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 struct ChannelRedactionResult {
     value: Option<String>,
     known_secret_leak: bool,
@@ -196,27 +213,23 @@ impl OutputRedactor for DefaultOutputRedactor {
         if hints.validate_bounds().is_err() {
             return true;
         }
-        let matcher =
-            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len());
-        Self::channels(output)
-            .iter()
-            .flatten()
-            .any(|channel| !matcher.collect_ranges(channel).is_empty())
+        let compiled_hints = self.compiled_hint_artifacts(hints);
+        Self::channels(output).iter().flatten().any(|channel| {
+            !compiled_hints
+                .secret_matcher
+                .collect_ranges(channel)
+                .is_empty()
+        })
     }
 
     fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
         if hints.validate_bounds().is_err() {
             return true;
         }
-        let hint_keys = hints
-            .required_secret_names
-            .iter()
-            .map(SecretName::as_str)
-            .map(str::to_owned)
-            .collect::<HashSet<_>>();
+        let compiled_hints = self.compiled_hint_artifacts(hints);
         let matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
-            &hint_keys,
+            compiled_hints.hint_keys.as_ref(),
             &self.token_prefix_matcher,
             self.policy.min_token_len(),
             REDACTION_TOKEN,
@@ -236,37 +249,59 @@ impl OutputRedactor for DefaultOutputRedactor {
         hints: &RedactionHints,
     ) -> Result<RedactionOutcome, RedactionError> {
         hints.validate_bounds()?;
-        let hint_keys = hints
-            .required_secret_names
-            .iter()
-            .map(SecretName::as_str)
-            .map(str::to_owned)
-            .collect::<HashSet<_>>();
+        let RawExecutionOutput {
+            outcome,
+            signal,
+            exit_code,
+            duration_secs,
+            gate_output,
+            tail_output,
+            stderr_tail,
+            pushed,
+            plan_hash,
+            unchecked_tasks,
+            spec_modified,
+            findings,
+            token_usage,
+        } = output;
+        let gate_tail_same = gate_output.as_deref() == tail_output.as_deref();
+        let gate_stderr_same = gate_output.as_deref() == stderr_tail.as_deref();
+        let tail_stderr_same = tail_output.as_deref() == stderr_tail.as_deref();
+
+        let compiled_hints = self.compiled_hint_artifacts(hints);
         let channel_matcher = CompiledChannelMatcher::new(
             &self.normalized_sensitive_key_names,
-            &hint_keys,
+            compiled_hints.hint_keys.as_ref(),
             &self.token_prefix_matcher,
             self.policy.min_token_len(),
             REDACTION_TOKEN,
         );
-        let explicit_secret_matcher =
-            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len());
 
         let gate = self.redact_channel(
-            output.gate_output,
+            gate_output,
             &channel_matcher,
-            &explicit_secret_matcher,
+            compiled_hints.secret_matcher.as_ref(),
         );
-        let tail = self.redact_channel(
-            output.tail_output,
-            &channel_matcher,
-            &explicit_secret_matcher,
-        );
-        let stderr = self.redact_channel(
-            output.stderr_tail,
-            &channel_matcher,
-            &explicit_secret_matcher,
-        );
+        let tail = if gate_tail_same {
+            gate.clone()
+        } else {
+            self.redact_channel(
+                tail_output,
+                &channel_matcher,
+                compiled_hints.secret_matcher.as_ref(),
+            )
+        };
+        let stderr = if gate_stderr_same {
+            gate.clone()
+        } else if tail_stderr_same {
+            tail.clone()
+        } else {
+            self.redact_channel(
+                stderr_tail,
+                &channel_matcher,
+                compiled_hints.secret_matcher.as_ref(),
+            )
+        };
 
         let audit = RedactionAudit {
             known_secret_leak: gate.known_secret_leak
@@ -279,19 +314,19 @@ impl OutputRedactor for DefaultOutputRedactor {
 
         Ok(RedactionOutcome {
             output: PersistableOutput {
-                outcome: output.outcome,
-                signal: output.signal,
-                exit_code: output.exit_code,
-                duration_secs: output.duration_secs,
+                outcome,
+                signal,
+                exit_code,
+                duration_secs,
                 gate_output: gate.value,
                 tail_output: tail.value,
                 stderr_tail: stderr.value,
-                pushed: output.pushed,
-                plan_hash: output.plan_hash,
-                unchecked_tasks: output.unchecked_tasks,
-                spec_modified: output.spec_modified,
-                findings: output.findings,
-                token_usage: output.token_usage,
+                pushed,
+                plan_hash,
+                unchecked_tasks,
+                spec_modified,
+                findings,
+                token_usage,
             },
             audit,
         })
@@ -337,9 +372,17 @@ impl<'a> CompiledChannelMatcher<'a> {
     }
 }
 
-fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> String {
+struct RedactionApplyResult {
+    redacted: String,
+    had_invalid_ranges: bool,
+}
+
+fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> RedactionApplyResult {
     if ranges.is_empty() {
-        return text;
+        return RedactionApplyResult {
+            redacted: text,
+            had_invalid_ranges: false,
+        };
     }
 
     ranges.sort_unstable_by_key(|(start, _)| *start);
@@ -355,6 +398,7 @@ fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> Stri
     }
 
     let mut redacted = String::with_capacity(text.len());
+    let mut had_invalid_ranges = false;
     let mut cursor = 0;
     for (start, end) in merged {
         if !(start < end
@@ -362,6 +406,7 @@ fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> Stri
             && text.is_char_boundary(start)
             && text.is_char_boundary(end))
         {
+            had_invalid_ranges = true;
             continue;
         }
 
@@ -374,7 +419,10 @@ fn apply_redaction_ranges(text: String, mut ranges: Vec<(usize, usize)>) -> Stri
     if cursor < text.len() {
         redacted.push_str(&text[cursor..]);
     }
-    redacted
+    RedactionApplyResult {
+        redacted,
+        had_invalid_ranges,
+    }
 }
 
 fn truncate_for_persistence(mut input: String, max_bytes: usize) -> String {

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,9 @@ use crate::execution::{PersistableOutput, RawExecutionOutput, RedactionSecret, S
 
 pub(crate) mod policy_dataset;
 pub(crate) mod scanner;
+pub(crate) mod secret_matcher;
+
+use self::secret_matcher::CompiledSecretMatcher;
 
 const REDACTION_TOKEN: &str = "[REDACTED]";
 const TRUNCATION_MARKER: &str = "[TRUNCATED_FOR_PERSISTENCE]";
@@ -73,6 +76,25 @@ pub enum RedactionError {
     PolicyViolation,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedactionAudit {
+    pub known_secret_leak: bool,
+    pub policy_residual_leak: bool,
+}
+
+impl RedactionAudit {
+    #[must_use]
+    pub const fn has_any_leak(&self) -> bool {
+        self.known_secret_leak || self.policy_residual_leak
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RedactionOutcome {
+    pub output: PersistableOutput,
+    pub audit: RedactionAudit,
+}
+
 /// Redacts raw harness output into persistable output.
 pub trait OutputRedactor: Send + Sync {
     /// Apply redaction and normalize the output for durable persistence.
@@ -92,6 +114,26 @@ pub trait OutputRedactor: Send + Sync {
     /// Detect whether normalized output still contains policy-defined secret patterns.
     #[must_use]
     fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool;
+
+    /// Apply redaction and return an audit verdict in one call.
+    ///
+    /// Default implementation preserves compatibility for custom redactors that
+    /// only implement `redact` and leak-detection hooks.
+    ///
+    /// # Errors
+    /// Returns [`RedactionError`] if output cannot be normalized safely.
+    fn redact_with_audit(
+        &self,
+        output: RawExecutionOutput,
+        hints: &RedactionHints,
+    ) -> Result<RedactionOutcome, RedactionError> {
+        let output = self.redact(output, hints)?;
+        let audit = RedactionAudit {
+            known_secret_leak: self.has_known_secret_leak(&output, hints),
+            policy_residual_leak: self.has_policy_residual_leak(&output, hints),
+        };
+        Ok(RedactionOutcome { output, audit })
+    }
 }
 
 /// Default policy-driven output redactor.
@@ -121,36 +163,30 @@ impl DefaultOutputRedactor {
         }
     }
 
-    fn redact_text(
+    fn redact_channel(
         &self,
         input: Option<String>,
         channel_matcher: &CompiledChannelMatcher<'_>,
         explicit_secret_matcher: &CompiledSecretMatcher,
-    ) -> Option<String> {
-        input.map(|value| {
-            let artifacts = channel_matcher.scan(&value);
-            let mut ranges = artifacts.assignment_value_ranges;
-            ranges.extend(artifacts.bearer_token_ranges);
-            ranges.extend(artifacts.prefixed_token_ranges);
-            ranges.extend(explicit_secret_matcher.collect_ranges(&value));
-            let redacted = apply_redaction_ranges(value, ranges);
-            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes)
-        })
-    }
+    ) -> ChannelRedactionResult {
+        let Some(value) = input else {
+            return ChannelRedactionResult::default();
+        };
+        let artifacts = channel_matcher.scan(&value);
+        let mut ranges = artifacts.assignment_value_ranges.clone();
+        ranges.extend_from_slice(&artifacts.bearer_token_ranges);
+        ranges.extend_from_slice(&artifacts.prefixed_token_ranges);
+        ranges.extend(explicit_secret_matcher.collect_ranges(&value));
+        let redacted = apply_redaction_ranges(value, ranges);
+        let redacted =
+            truncate_for_persistence(redacted, self.policy.max_persistable_channel_bytes);
+        let known_secret_leak = !explicit_secret_matcher.collect_ranges(&redacted).is_empty();
 
-    fn any_field_contains_secret(output: &PersistableOutput, secret: &str) -> bool {
-        output
-            .gate_output
-            .as_deref()
-            .is_some_and(|v| v.contains(secret))
-            || output
-                .tail_output
-                .as_deref()
-                .is_some_and(|v| v.contains(secret))
-            || output
-                .stderr_tail
-                .as_deref()
-                .is_some_and(|v| v.contains(secret))
+        ChannelRedactionResult {
+            value: Some(redacted),
+            known_secret_leak,
+            policy_residual_leak: false,
+        }
     }
 
     fn channels(output: &PersistableOutput) -> [Option<&str>; 3] {
@@ -162,76 +198,29 @@ impl DefaultOutputRedactor {
     }
 }
 
+#[derive(Debug, Default)]
+struct ChannelRedactionResult {
+    value: Option<String>,
+    known_secret_leak: bool,
+    policy_residual_leak: bool,
+}
+
 impl OutputRedactor for DefaultOutputRedactor {
     fn redact(
         &self,
         output: RawExecutionOutput,
         hints: &RedactionHints,
     ) -> Result<PersistableOutput, RedactionError> {
-        let hint_keys = hints
-            .required_secret_names
-            .iter()
-            .map(SecretName::as_str)
-            .map(str::to_owned)
-            .collect::<HashSet<_>>();
-        let channel_matcher = CompiledChannelMatcher::new(
-            &self.normalized_sensitive_key_names,
-            &hint_keys,
-            &self.policy.token_prefixes,
-            self.policy.min_token_len,
-            REDACTION_TOKEN,
-        );
-        let explicit_secret_matcher =
-            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
-        Ok(PersistableOutput {
-            outcome: output.outcome,
-            signal: output.signal,
-            exit_code: output.exit_code,
-            duration_secs: output.duration_secs,
-            gate_output: self.redact_text(
-                output.gate_output,
-                &channel_matcher,
-                &explicit_secret_matcher,
-            ),
-            tail_output: self.redact_text(
-                output.tail_output,
-                &channel_matcher,
-                &explicit_secret_matcher,
-            ),
-            stderr_tail: self.redact_text(
-                output.stderr_tail,
-                &channel_matcher,
-                &explicit_secret_matcher,
-            ),
-            pushed: output.pushed,
-            plan_hash: output.plan_hash,
-            unchecked_tasks: output.unchecked_tasks,
-            spec_modified: output.spec_modified,
-            findings: output.findings,
-            token_usage: output.token_usage,
-        })
+        self.redact_with_audit(output, hints)
+            .map(|result| result.output)
     }
 
     fn has_known_secret_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
-        for secret in &hints.secret_values {
-            let secret = secret.expose();
-            if secret.trim().is_empty() {
-                continue;
-            }
-            if Self::any_field_contains_secret(output, secret) {
-                return true;
-            }
-            if secret.contains('\n') {
-                for fragment in secret.lines() {
-                    if fragment.trim().len() >= self.policy.min_secret_fragment_len
-                        && Self::any_field_contains_secret(output, fragment.trim())
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        let matcher = CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
+        Self::channels(output)
+            .iter()
+            .flatten()
+            .any(|channel| !matcher.collect_ranges(channel).is_empty())
     }
 
     fn has_policy_residual_leak(&self, output: &PersistableOutput, hints: &RedactionHints) -> bool {
@@ -255,6 +244,72 @@ impl OutputRedactor for DefaultOutputRedactor {
             }
         }
         false
+    }
+
+    fn redact_with_audit(
+        &self,
+        output: RawExecutionOutput,
+        hints: &RedactionHints,
+    ) -> Result<RedactionOutcome, RedactionError> {
+        let hint_keys = hints
+            .required_secret_names
+            .iter()
+            .map(SecretName::as_str)
+            .map(str::to_owned)
+            .collect::<HashSet<_>>();
+        let channel_matcher = CompiledChannelMatcher::new(
+            &self.normalized_sensitive_key_names,
+            &hint_keys,
+            &self.policy.token_prefixes,
+            self.policy.min_token_len,
+            REDACTION_TOKEN,
+        );
+        let explicit_secret_matcher =
+            CompiledSecretMatcher::from_hints(hints, self.policy.min_secret_fragment_len);
+
+        let gate = self.redact_channel(
+            output.gate_output,
+            &channel_matcher,
+            &explicit_secret_matcher,
+        );
+        let tail = self.redact_channel(
+            output.tail_output,
+            &channel_matcher,
+            &explicit_secret_matcher,
+        );
+        let stderr = self.redact_channel(
+            output.stderr_tail,
+            &channel_matcher,
+            &explicit_secret_matcher,
+        );
+
+        let audit = RedactionAudit {
+            known_secret_leak: gate.known_secret_leak
+                || tail.known_secret_leak
+                || stderr.known_secret_leak,
+            policy_residual_leak: gate.policy_residual_leak
+                || tail.policy_residual_leak
+                || stderr.policy_residual_leak,
+        };
+
+        Ok(RedactionOutcome {
+            output: PersistableOutput {
+                outcome: output.outcome,
+                signal: output.signal,
+                exit_code: output.exit_code,
+                duration_secs: output.duration_secs,
+                gate_output: gate.value,
+                tail_output: tail.value,
+                stderr_tail: stderr.value,
+                pushed: output.pushed,
+                plan_hash: output.plan_hash,
+                unchecked_tasks: output.unchecked_tasks,
+                spec_modified: output.spec_modified,
+                findings: output.findings,
+                token_usage: output.token_usage,
+            },
+            audit,
+        })
     }
 }
 
@@ -294,76 +349,6 @@ impl<'a> CompiledChannelMatcher<'a> {
                 redaction_token: self.redaction_token,
             },
         )
-    }
-}
-
-#[derive(Default)]
-struct CompiledSecretMatcher {
-    by_first_byte: HashMap<u8, Vec<Vec<u8>>>,
-}
-
-impl CompiledSecretMatcher {
-    fn from_hints(hints: &RedactionHints, min_secret_fragment_len: usize) -> Self {
-        let mut literals = HashSet::new();
-        for secret in &hints.secret_values {
-            let value = secret.expose().trim();
-            if value.is_empty() {
-                continue;
-            }
-            literals.insert(value.to_owned());
-            if value.contains('\n') {
-                for fragment in value.lines() {
-                    let trimmed = fragment.trim();
-                    if trimmed.len() >= min_secret_fragment_len {
-                        literals.insert(trimmed.to_owned());
-                    }
-                }
-            }
-        }
-
-        let mut by_first_byte: HashMap<u8, Vec<Vec<u8>>> = HashMap::new();
-        for literal in literals {
-            let bytes = literal.into_bytes();
-            if let Some(first) = bytes.first().copied() {
-                by_first_byte.entry(first).or_default().push(bytes);
-            }
-        }
-        for candidates in by_first_byte.values_mut() {
-            candidates.sort_by_key(|value| std::cmp::Reverse(value.len()));
-        }
-        Self { by_first_byte }
-    }
-
-    fn collect_ranges(&self, text: &str) -> Vec<(usize, usize)> {
-        let mut ranges = Vec::new();
-        let bytes = text.as_bytes();
-        let mut cursor = 0;
-
-        while cursor < bytes.len() {
-            let Some(candidates) = self.by_first_byte.get(&bytes[cursor]) else {
-                cursor += 1;
-                continue;
-            };
-
-            let mut matched = false;
-            for candidate in candidates {
-                let end = cursor.saturating_add(candidate.len());
-                if end <= bytes.len()
-                    && &bytes[cursor..end] == candidate.as_slice()
-                    && text.is_char_boundary(cursor)
-                    && text.is_char_boundary(end)
-                {
-                    ranges.push((cursor, end));
-                    cursor = end;
-                    matched = true;
-                    break;
-                }
-            }
-            if !matched {
-                cursor += 1;
-            }
-        }
-        ranges
     }
 }
 

--- a/crates/tanren-runtime/src/redaction.rs
+++ b/crates/tanren-runtime/src/redaction.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 use tanren_domain::FiniteF64;
 
@@ -6,11 +8,9 @@ use crate::execution::{PersistableOutput, RawExecutionOutput};
 const REDACTION_TOKEN: &str = "[REDACTED]";
 
 /// Inputs used by redaction policy at capture-time.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RedactionHints {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_secret_names: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_values: Vec<String>,
 }
 
@@ -89,20 +89,27 @@ pub trait OutputRedactor: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct DefaultOutputRedactor {
     policy: RedactionPolicy,
+    normalized_sensitive_key_names: HashSet<String>,
 }
 
 impl Default for DefaultOutputRedactor {
     fn default() -> Self {
-        Self {
-            policy: default_redaction_policy(),
-        }
+        Self::new(default_redaction_policy())
     }
 }
 
 impl DefaultOutputRedactor {
     #[must_use]
     pub fn new(policy: RedactionPolicy) -> Self {
-        Self { policy }
+        let normalized_sensitive_key_names = policy
+            .sensitive_key_names
+            .iter()
+            .map(|value| value.to_ascii_lowercase())
+            .collect();
+        Self {
+            policy,
+            normalized_sensitive_key_names,
+        }
     }
 
     fn redact_text(&self, input: Option<String>, hints: &RedactionHints) -> Option<String> {
@@ -117,18 +124,24 @@ impl DefaultOutputRedactor {
     }
 
     fn redact_structured_key_values(&self, input: String, hints: &RedactionHints) -> String {
-        let mut keys = self.policy.sensitive_key_names.clone();
-        for value in &hints.required_secret_names {
-            keys.push(value.to_ascii_lowercase());
-        }
+        let hint_key_names = hints
+            .required_secret_names
+            .iter()
+            .map(|name| name.trim())
+            .filter(|name| !name.is_empty())
+            .map(str::to_ascii_lowercase)
+            .collect::<HashSet<_>>();
+
         let mut out = String::with_capacity(input.len());
         for line in input.split_inclusive('\n') {
-            let mut redacted_line = line.to_string();
-            for key in &keys {
-                redacted_line = redact_assignment_for_key(&redacted_line, key);
-            }
+            let redacted_line = redact_assignments_for_keys(
+                line,
+                &self.normalized_sensitive_key_names,
+                &hint_key_names,
+            );
             out.push_str(&redacted_line);
         }
+
         if out.is_empty() { input } else { out }
     }
 
@@ -225,35 +238,81 @@ impl OutputRedactor for DefaultOutputRedactor {
     }
 }
 
-fn redact_assignment_for_key(line: &str, key: &str) -> String {
-    let mut out = line.to_string();
-    let key_lower = key.to_ascii_lowercase();
-    let lower = out.to_ascii_lowercase();
-    let Some(key_index) = lower.find(&key_lower) else {
-        return out;
-    };
-    let mut cursor = key_index + key_lower.len();
-    let bytes = out.as_bytes();
-    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+fn redact_assignments_for_keys(
+    line: &str,
+    policy_keys: &HashSet<String>,
+    hint_keys: &HashSet<String>,
+) -> String {
+    let bytes = line.as_bytes();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        if !is_key_start(bytes[cursor]) {
+            cursor += 1;
+            continue;
+        }
+
+        let key_start = cursor;
         cursor += 1;
+        while cursor < bytes.len() && is_key_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        let key_end = cursor;
+
+        let mut value_cursor = cursor;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() || !matches!(bytes[value_cursor], b'=' | b':') {
+            continue;
+        }
+
+        let key = line[key_start..key_end].to_ascii_lowercase();
+        let is_sensitive = policy_keys.contains(&key) || hint_keys.contains(&key);
+
+        value_cursor += 1;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() {
+            break;
+        }
+
+        let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
+            let quoted_end = find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
+            (value_cursor.saturating_add(1), quoted_end)
+        } else {
+            (value_cursor, find_unquoted_value_end(line, value_cursor))
+        };
+
+        if is_sensitive
+            && value_start < value_end
+            && &line[value_start..value_end] != REDACTION_TOKEN
+        {
+            ranges.push((value_start, value_end));
+        }
+
+        cursor = value_end.saturating_add(1);
     }
-    if cursor >= bytes.len() || (bytes[cursor] != b'=' && bytes[cursor] != b':') {
-        return out;
+
+    if ranges.is_empty() {
+        return line.to_owned();
     }
-    cursor += 1;
-    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
-        cursor += 1;
+
+    let mut out = line.to_owned();
+    for (start, end) in ranges.into_iter().rev() {
+        out.replace_range(start..end, REDACTION_TOKEN);
     }
-    if cursor >= bytes.len() {
-        return out;
-    }
-    let end = if bytes[cursor] == b'"' || bytes[cursor] == b'\'' {
-        find_quoted_value_end(&out, cursor).unwrap_or(out.len())
-    } else {
-        find_unquoted_value_end(&out, cursor)
-    };
-    out.replace_range(cursor..end, REDACTION_TOKEN);
     out
+}
+
+const fn is_key_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+const fn is_key_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
 }
 
 fn find_quoted_value_end(value: &str, start: usize) -> Option<usize> {
@@ -285,14 +344,42 @@ fn find_unquoted_value_end(value: &str, start: usize) -> usize {
     cursor
 }
 
+fn find_ascii_case_insensitive(haystack: &str, needle: &str, start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+
+    let haystack_bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if haystack_bytes.len() < needle_bytes.len() {
+        return None;
+    }
+
+    let mut idx = start;
+    while idx + needle_bytes.len() <= haystack_bytes.len() {
+        let mut match_all = true;
+        for offset in 0..needle_bytes.len() {
+            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
+                match_all = false;
+                break;
+            }
+        }
+        if match_all {
+            return Some(idx);
+        }
+        idx += 1;
+    }
+
+    None
+}
+
 fn redact_keyword_token(mut value: String, keyword: &str, min_token_len: usize) -> String {
     let mut search_from = 0;
     loop {
-        let lower = value.to_ascii_lowercase();
-        let Some(offset) = lower[search_from..].find(keyword) else {
+        let Some(index) = find_ascii_case_insensitive(&value, keyword, search_from) else {
             return value;
         };
-        let index = search_from + offset;
+
         let token_start = index + keyword.len();
         let token_end = find_unquoted_value_end(&value, token_start);
         if token_end.saturating_sub(token_start) < min_token_len {
@@ -334,100 +421,4 @@ fn redact_prefixed_token(mut value: String, prefix: &str, min_token_len: usize) 
 }
 
 #[cfg(test)]
-mod tests {
-    use tanren_domain::Outcome;
-
-    use super::*;
-
-    fn raw_output(text: &str) -> RawExecutionOutput {
-        RawExecutionOutput {
-            outcome: Outcome::Success,
-            signal: None,
-            exit_code: Some(0),
-            duration_secs: 1.0,
-            gate_output: Some(text.into()),
-            tail_output: Some(text.into()),
-            stderr_tail: Some(text.into()),
-            pushed: false,
-            plan_hash: None,
-            unchecked_tasks: 0,
-            spec_modified: false,
-            findings: vec![],
-            token_usage: None,
-        }
-    }
-
-    #[test]
-    fn redacts_bearer_and_prefixed_tokens() {
-        let redactor = DefaultOutputRedactor::default();
-        let hints = RedactionHints::default();
-        let out = redactor
-            .redact(
-                raw_output("Authorization: Bearer sk-super-long-secret-123"),
-                &hints,
-            )
-            .expect("redact");
-        let value = out.gate_output.expect("output");
-        assert!(!value.contains("sk-super-long-secret-123"));
-        assert!(value.contains(REDACTION_TOKEN));
-    }
-
-    #[test]
-    fn redacts_explicit_secret_values_and_multiline_fragments() {
-        let redactor = DefaultOutputRedactor::default();
-        let hints = RedactionHints {
-            required_secret_names: vec!["MY_SECRET".into()],
-            secret_values: vec!["line1-secret\nline2-secret".into()],
-        };
-        let out = redactor
-            .redact(
-                raw_output("line1-secret / line2-secret / MY_SECRET=abc"),
-                &hints,
-            )
-            .expect("redact");
-        let gate = out.gate_output.expect("gate");
-        assert!(!gate.contains("line1-secret"));
-        assert!(!gate.contains("line2-secret"));
-        assert!(!gate.contains("abc"));
-    }
-
-    #[test]
-    fn leak_detection_flags_remaining_secret() {
-        let redactor = DefaultOutputRedactor::default();
-        let hints = RedactionHints {
-            required_secret_names: vec![],
-            secret_values: vec!["secret-value".into()],
-        };
-        let output = PersistableOutput {
-            outcome: Outcome::Success,
-            signal: None,
-            exit_code: None,
-            duration_secs: FiniteF64::try_new(1.0).expect("finite"),
-            gate_output: Some("still has secret-value".into()),
-            tail_output: None,
-            stderr_tail: None,
-            pushed: false,
-            plan_hash: None,
-            unchecked_tasks: 0,
-            spec_modified: false,
-            findings: vec![],
-            token_usage: None,
-        };
-        assert!(redactor.has_known_secret_leak(&output, &hints));
-    }
-
-    #[test]
-    fn rejects_non_finite_duration() {
-        let redactor = DefaultOutputRedactor::default();
-        let err = redactor
-            .redact(
-                RawExecutionOutput {
-                    duration_secs: f64::NAN,
-                    ..raw_output("ok")
-                },
-                &RedactionHints::default(),
-            )
-            .expect_err("must fail");
-        assert_eq!(err, RedactionError::InvalidDuration);
-    }
-}
+mod tests;

--- a/crates/tanren-runtime/src/redaction/compiled_hints.rs
+++ b/crates/tanren-runtime/src/redaction/compiled_hints.rs
@@ -1,0 +1,50 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::execution::SecretName;
+
+use super::{CompiledSecretMatcher, DefaultOutputRedactor, RedactionHints};
+
+#[derive(Debug, Clone)]
+pub(super) struct CompiledHintArtifacts {
+    pub(super) source_hints: RedactionHints,
+    pub(super) hint_keys: Arc<HashSet<String>>,
+    pub(super) secret_matcher: Arc<CompiledSecretMatcher>,
+}
+
+impl DefaultOutputRedactor {
+    pub(super) fn compiled_hint_artifacts(&self, hints: &RedactionHints) -> CompiledHintArtifacts {
+        if let Some(cached) = self
+            .cached_hint_artifacts
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|cached| cached.source_hints == *hints)
+            .cloned()
+        {
+            return cached;
+        }
+
+        let compiled = CompiledHintArtifacts {
+            source_hints: hints.clone(),
+            hint_keys: Arc::new(
+                hints
+                    .required_secret_names
+                    .iter()
+                    .map(SecretName::as_str)
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            secret_matcher: Arc::new(CompiledSecretMatcher::from_hints(
+                hints,
+                self.policy.min_secret_fragment_len(),
+            )),
+        };
+
+        *self
+            .cached_hint_artifacts
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(compiled.clone());
+        compiled
+    }
+}

--- a/crates/tanren-runtime/src/redaction/hints.rs
+++ b/crates/tanren-runtime/src/redaction/hints.rs
@@ -1,0 +1,133 @@
+use crate::execution::RedactionSecret;
+
+use super::RedactionHints;
+
+pub const MAX_REDACTION_HINT_SECRET_COUNT: usize = 256;
+pub const MAX_REDACTION_HINT_SECRET_BYTES: usize = 4096;
+pub const MAX_REDACTION_HINT_TOTAL_SECRET_BYTES: usize = 65_536;
+
+impl RedactionHints {
+    /// Build redaction hints from request secret data with hard safety bounds.
+    ///
+    /// # Errors
+    /// Returns [`RedactionHintBoundsError`] when count or size limits are exceeded.
+    pub fn try_from_request(
+        required_secret_names: Vec<crate::execution::SecretName>,
+        secret_values_for_redaction: &[RedactionSecret],
+    ) -> Result<Self, RedactionHintBoundsError> {
+        let secret_values =
+            Self::normalize_and_validate_secret_values(secret_values_for_redaction)?;
+        Ok(Self {
+            required_secret_names,
+            secret_values,
+        })
+    }
+
+    /// Validate existing hints against hard safety bounds.
+    ///
+    /// # Errors
+    /// Returns [`RedactionHintBoundsError`] when count or size limits are exceeded.
+    pub fn validate_bounds(&self) -> Result<(), RedactionHintBoundsError> {
+        Self::validate_secret_values(&self.secret_values)
+    }
+
+    fn normalize_and_validate_secret_values(
+        secret_values_for_redaction: &[RedactionSecret],
+    ) -> Result<Vec<RedactionSecret>, RedactionHintBoundsError> {
+        if secret_values_for_redaction.len() > MAX_REDACTION_HINT_SECRET_COUNT {
+            return Err(RedactionHintBoundsError::TooManySecrets {
+                max_count: MAX_REDACTION_HINT_SECRET_COUNT,
+                actual_count: secret_values_for_redaction.len(),
+            });
+        }
+
+        let mut normalized = Vec::with_capacity(secret_values_for_redaction.len());
+        let mut total_bytes = 0_usize;
+        for (index, secret) in secret_values_for_redaction.iter().enumerate() {
+            let trimmed = secret.expose().trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let secret_bytes = trimmed.len();
+            if secret_bytes > MAX_REDACTION_HINT_SECRET_BYTES {
+                return Err(RedactionHintBoundsError::SecretTooLarge {
+                    index,
+                    max_bytes: MAX_REDACTION_HINT_SECRET_BYTES,
+                    actual_bytes: secret_bytes,
+                });
+            }
+
+            total_bytes += secret_bytes;
+            if total_bytes > MAX_REDACTION_HINT_TOTAL_SECRET_BYTES {
+                return Err(RedactionHintBoundsError::TotalBytesExceeded {
+                    max_total_bytes: MAX_REDACTION_HINT_TOTAL_SECRET_BYTES,
+                    actual_total_bytes: total_bytes,
+                });
+            }
+
+            normalized.push(RedactionSecret::from(trimmed));
+        }
+
+        Ok(normalized)
+    }
+
+    fn validate_secret_values(
+        secret_values: &[RedactionSecret],
+    ) -> Result<(), RedactionHintBoundsError> {
+        if secret_values.len() > MAX_REDACTION_HINT_SECRET_COUNT {
+            return Err(RedactionHintBoundsError::TooManySecrets {
+                max_count: MAX_REDACTION_HINT_SECRET_COUNT,
+                actual_count: secret_values.len(),
+            });
+        }
+
+        let mut total_bytes = 0_usize;
+        for (index, secret) in secret_values.iter().enumerate() {
+            let trimmed = secret.expose().trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let secret_bytes = trimmed.len();
+            if secret_bytes > MAX_REDACTION_HINT_SECRET_BYTES {
+                return Err(RedactionHintBoundsError::SecretTooLarge {
+                    index,
+                    max_bytes: MAX_REDACTION_HINT_SECRET_BYTES,
+                    actual_bytes: secret_bytes,
+                });
+            }
+            total_bytes += secret_bytes;
+            if total_bytes > MAX_REDACTION_HINT_TOTAL_SECRET_BYTES {
+                return Err(RedactionHintBoundsError::TotalBytesExceeded {
+                    max_total_bytes: MAX_REDACTION_HINT_TOTAL_SECRET_BYTES,
+                    actual_total_bytes: total_bytes,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Hard bounds errors for explicit redaction hint input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RedactionHintBoundsError {
+    #[error("too many explicit redaction secrets: {actual_count} > {max_count}")]
+    TooManySecrets {
+        max_count: usize,
+        actual_count: usize,
+    },
+    #[error("explicit redaction secret {index} exceeds byte limit: {actual_bytes} > {max_bytes}")]
+    SecretTooLarge {
+        index: usize,
+        max_bytes: usize,
+        actual_bytes: usize,
+    },
+    #[error(
+        "total explicit redaction secret bytes exceed limit: {actual_total_bytes} > {max_total_bytes}"
+    )]
+    TotalBytesExceeded {
+        max_total_bytes: usize,
+        actual_total_bytes: usize,
+    },
+}

--- a/crates/tanren-runtime/src/redaction/policy.rs
+++ b/crates/tanren-runtime/src/redaction/policy.rs
@@ -1,0 +1,268 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::policy_dataset;
+
+const MIN_TOKEN_LEN_LOWER_BOUND: usize = 6;
+const MIN_SECRET_FRAGMENT_LEN_LOWER_BOUND: usize = 3;
+const MIN_PERSISTABLE_CHANNEL_BYTES: usize = 1024;
+
+/// Deterministic redaction policy used by all adapters unless overridden.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RedactionPolicy {
+    min_token_len: usize,
+    min_secret_fragment_len: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    sensitive_key_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    token_prefixes: Vec<String>,
+    max_persistable_channel_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RedactionPolicyError {
+    #[error("min_token_len must be at least {minimum}")]
+    MinTokenLenTooSmall { minimum: usize },
+    #[error(
+        "min_secret_fragment_len must be between {minimum} and min_token_len ({actual_min_token_len})"
+    )]
+    MinSecretFragmentLenOutOfRange {
+        minimum: usize,
+        actual_min_token_len: usize,
+    },
+    #[error("max_persistable_channel_bytes must be at least {minimum}")]
+    MaxPersistableChannelBytesTooSmall { minimum: usize },
+    #[error("sensitive key names must not contain empty entries")]
+    EmptySensitiveKeyName,
+    #[error("token prefixes must not contain empty entries")]
+    EmptyTokenPrefix,
+    #[error("duplicate sensitive key name `{name}`")]
+    DuplicateSensitiveKeyName { name: String },
+    #[error("duplicate token prefix `{prefix}`")]
+    DuplicateTokenPrefix { prefix: String },
+}
+
+impl RedactionPolicy {
+    pub fn try_new(
+        min_token_len: usize,
+        min_secret_fragment_len: usize,
+        sensitive_key_names: Vec<String>,
+        token_prefixes: Vec<String>,
+        max_persistable_channel_bytes: usize,
+    ) -> Result<Self, RedactionPolicyError> {
+        if min_token_len < MIN_TOKEN_LEN_LOWER_BOUND {
+            return Err(RedactionPolicyError::MinTokenLenTooSmall {
+                minimum: MIN_TOKEN_LEN_LOWER_BOUND,
+            });
+        }
+        if !(MIN_SECRET_FRAGMENT_LEN_LOWER_BOUND..=min_token_len).contains(&min_secret_fragment_len)
+        {
+            return Err(RedactionPolicyError::MinSecretFragmentLenOutOfRange {
+                minimum: MIN_SECRET_FRAGMENT_LEN_LOWER_BOUND,
+                actual_min_token_len: min_token_len,
+            });
+        }
+        if max_persistable_channel_bytes < MIN_PERSISTABLE_CHANNEL_BYTES {
+            return Err(RedactionPolicyError::MaxPersistableChannelBytesTooSmall {
+                minimum: MIN_PERSISTABLE_CHANNEL_BYTES,
+            });
+        }
+
+        let normalized_sensitive_key_names = normalize_non_empty_lowercase(
+            sensitive_key_names,
+            || RedactionPolicyError::EmptySensitiveKeyName,
+            |name| RedactionPolicyError::DuplicateSensitiveKeyName { name },
+        )?;
+        let normalized_token_prefixes = normalize_non_empty_lowercase(
+            token_prefixes,
+            || RedactionPolicyError::EmptyTokenPrefix,
+            |prefix| RedactionPolicyError::DuplicateTokenPrefix { prefix },
+        )?;
+
+        Ok(Self {
+            min_token_len,
+            min_secret_fragment_len,
+            sensitive_key_names: normalized_sensitive_key_names,
+            token_prefixes: normalized_token_prefixes,
+            max_persistable_channel_bytes,
+        })
+    }
+
+    #[must_use]
+    pub fn builder() -> RedactionPolicyBuilder {
+        RedactionPolicyBuilder::default()
+    }
+
+    #[must_use]
+    pub const fn min_token_len(&self) -> usize {
+        self.min_token_len
+    }
+
+    #[must_use]
+    pub const fn min_secret_fragment_len(&self) -> usize {
+        self.min_secret_fragment_len
+    }
+
+    #[must_use]
+    pub fn sensitive_key_names(&self) -> &[String] {
+        &self.sensitive_key_names
+    }
+
+    #[must_use]
+    pub fn token_prefixes(&self) -> &[String] {
+        &self.token_prefixes
+    }
+
+    #[must_use]
+    pub const fn max_persistable_channel_bytes(&self) -> usize {
+        self.max_persistable_channel_bytes
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RedactionPolicyBuilder {
+    min_token_len: usize,
+    min_secret_fragment_len: usize,
+    sensitive_key_names: Vec<String>,
+    token_prefixes: Vec<String>,
+    max_persistable_channel_bytes: usize,
+}
+
+impl Default for RedactionPolicyBuilder {
+    fn default() -> Self {
+        let dataset = policy_dataset::default_policy_dataset_v1();
+        Self {
+            min_token_len: dataset.min_token_len,
+            min_secret_fragment_len: dataset.min_secret_fragment_len,
+            sensitive_key_names: dataset
+                .sensitive_key_names
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+            token_prefixes: dataset
+                .token_prefixes
+                .iter()
+                .map(|prefix| (*prefix).to_owned())
+                .collect(),
+            max_persistable_channel_bytes: dataset.max_persistable_channel_bytes,
+        }
+    }
+}
+
+impl RedactionPolicyBuilder {
+    #[must_use]
+    pub fn min_token_len(mut self, value: usize) -> Self {
+        self.min_token_len = value;
+        self
+    }
+
+    #[must_use]
+    pub fn min_secret_fragment_len(mut self, value: usize) -> Self {
+        self.min_secret_fragment_len = value;
+        self
+    }
+
+    #[must_use]
+    pub fn sensitive_key_names(mut self, value: Vec<String>) -> Self {
+        self.sensitive_key_names = value;
+        self
+    }
+
+    #[must_use]
+    pub fn token_prefixes(mut self, value: Vec<String>) -> Self {
+        self.token_prefixes = value;
+        self
+    }
+
+    #[must_use]
+    pub fn max_persistable_channel_bytes(mut self, value: usize) -> Self {
+        self.max_persistable_channel_bytes = value;
+        self
+    }
+
+    pub fn build(self) -> Result<RedactionPolicy, RedactionPolicyError> {
+        RedactionPolicy::try_new(
+            self.min_token_len,
+            self.min_secret_fragment_len,
+            self.sensitive_key_names,
+            self.token_prefixes,
+            self.max_persistable_channel_bytes,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+struct RedactionPolicyWire {
+    min_token_len: usize,
+    min_secret_fragment_len: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    sensitive_key_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    token_prefixes: Vec<String>,
+    max_persistable_channel_bytes: usize,
+}
+
+impl<'de> Deserialize<'de> for RedactionPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = RedactionPolicyWire::deserialize(deserializer)?;
+        Self::try_new(
+            wire.min_token_len,
+            wire.min_secret_fragment_len,
+            wire.sensitive_key_names,
+            wire.token_prefixes,
+            wire.max_persistable_channel_bytes,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Build the default redaction policy for Phase 1 harness adapters.
+#[must_use]
+pub const fn default_redaction_policy_dataset_version() -> &'static str {
+    policy_dataset::DEFAULT_REDACTION_POLICY_DATASET_VERSION
+}
+
+/// Build the default redaction policy for Phase 1 harness adapters.
+#[must_use]
+pub fn default_redaction_policy() -> RedactionPolicy {
+    let dataset = policy_dataset::default_policy_dataset_v1();
+    RedactionPolicy {
+        min_token_len: dataset.min_token_len,
+        min_secret_fragment_len: dataset.min_secret_fragment_len,
+        sensitive_key_names: dataset
+            .sensitive_key_names
+            .iter()
+            .map(|value| (*value).to_ascii_lowercase())
+            .collect(),
+        token_prefixes: dataset
+            .token_prefixes
+            .iter()
+            .map(|value| (*value).to_ascii_lowercase())
+            .collect(),
+        max_persistable_channel_bytes: dataset.max_persistable_channel_bytes,
+    }
+}
+
+fn normalize_non_empty_lowercase(
+    values: Vec<String>,
+    empty_err: impl Fn() -> RedactionPolicyError,
+    duplicate_err: impl Fn(String) -> RedactionPolicyError,
+) -> Result<Vec<String>, RedactionPolicyError> {
+    let mut normalized = Vec::with_capacity(values.len());
+    let mut seen = HashSet::new();
+    for value in values {
+        let normalized_value = value.trim().to_ascii_lowercase();
+        if normalized_value.is_empty() {
+            return Err(empty_err());
+        }
+        if !seen.insert(normalized_value.clone()) {
+            return Err(duplicate_err(normalized_value));
+        }
+        normalized.push(normalized_value);
+    }
+    Ok(normalized)
+}

--- a/crates/tanren-runtime/src/redaction/policy_dataset.rs
+++ b/crates/tanren-runtime/src/redaction/policy_dataset.rs
@@ -1,9 +1,9 @@
-pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_VERSION: &str = "2026-04-21.v1";
+pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_VERSION: &str = "2026-04-21.v2";
 #[cfg(test)]
 pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_PROVENANCE: &str =
     "owner=tanren-runtime;source=curated_phase1_minimum;change_control=version_bump_required";
 #[cfg(test)]
-pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_CHECKSUM_FNV64: u64 = 7_801_268_768_407_722_057;
+pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_CHECKSUM_FNV64: u64 = 5_592_519_109_534_153_128;
 
 pub(crate) struct RedactionPolicyDatasetV1 {
     pub(crate) min_token_len: usize,

--- a/crates/tanren-runtime/src/redaction/policy_dataset.rs
+++ b/crates/tanren-runtime/src/redaction/policy_dataset.rs
@@ -1,4 +1,9 @@
 pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_VERSION: &str = "2026-04-21.v1";
+#[cfg(test)]
+pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_PROVENANCE: &str =
+    "owner=tanren-runtime;source=curated_phase1_minimum;change_control=version_bump_required";
+#[cfg(test)]
+pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_CHECKSUM_FNV64: u64 = 7_801_268_768_407_722_057;
 
 pub(crate) struct RedactionPolicyDatasetV1 {
     pub(crate) min_token_len: usize,
@@ -55,4 +60,45 @@ pub(crate) fn default_policy_dataset_v1() -> RedactionPolicyDatasetV1 {
             "ya29.",
         ],
     }
+}
+
+#[cfg(test)]
+pub(crate) fn canonical_policy_dataset_snapshot_v1() -> String {
+    let dataset = default_policy_dataset_v1();
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "version={DEFAULT_REDACTION_POLICY_DATASET_VERSION}"
+    ));
+    lines.push(format!(
+        "provenance={DEFAULT_REDACTION_POLICY_DATASET_PROVENANCE}"
+    ));
+    lines.push(format!("min_token_len={}", dataset.min_token_len));
+    lines.push(format!(
+        "min_secret_fragment_len={}",
+        dataset.min_secret_fragment_len
+    ));
+    lines.push(format!(
+        "max_persistable_channel_bytes={}",
+        dataset.max_persistable_channel_bytes
+    ));
+    for key in dataset.sensitive_key_names {
+        lines.push(format!("sensitive_key={key}"));
+    }
+    for prefix in dataset.token_prefixes {
+        lines.push(format!("token_prefix={prefix}"));
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+pub(crate) fn policy_dataset_checksum_fnv64(snapshot: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0100_0000_01b3;
+
+    let mut hash = FNV_OFFSET;
+    for byte in snapshot.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
 }

--- a/crates/tanren-runtime/src/redaction/policy_dataset.rs
+++ b/crates/tanren-runtime/src/redaction/policy_dataset.rs
@@ -1,0 +1,58 @@
+pub(crate) const DEFAULT_REDACTION_POLICY_DATASET_VERSION: &str = "2026-04-21.v1";
+
+pub(crate) struct RedactionPolicyDatasetV1 {
+    pub(crate) min_token_len: usize,
+    pub(crate) min_secret_fragment_len: usize,
+    pub(crate) max_persistable_channel_bytes: usize,
+    pub(crate) sensitive_key_names: &'static [&'static str],
+    pub(crate) token_prefixes: &'static [&'static str],
+}
+
+pub(crate) fn default_policy_dataset_v1() -> RedactionPolicyDatasetV1 {
+    RedactionPolicyDatasetV1 {
+        min_token_len: 10,
+        min_secret_fragment_len: 4,
+        max_persistable_channel_bytes: 512 * 1024,
+        sensitive_key_names: &[
+            "api_key",
+            "api-token",
+            "api_token",
+            "auth_token",
+            "access_token",
+            "refresh_token",
+            "session_token",
+            "authorization",
+            "bearer",
+            "cookie",
+            "set-cookie",
+            "password",
+            "secret",
+            "secret_key",
+            "private_key",
+            "client_secret",
+            "id_token",
+            "personal_access_token",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "x-api-key",
+        ],
+        token_prefixes: &[
+            "sk-",
+            "sk-proj-",
+            "sk-ant-",
+            "ghp_",
+            "gho_",
+            "ghu_",
+            "ghs_",
+            "github_pat_",
+            "xoxb-",
+            "xoxp-",
+            "xoxa-",
+            "xoxr-",
+            "AKIA",
+            "ASIA",
+            "AIza",
+            "ya29.",
+        ],
+    }
+}

--- a/crates/tanren-runtime/src/redaction/scanner.rs
+++ b/crates/tanren-runtime/src/redaction/scanner.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 pub(crate) fn find_ascii_case_insensitive(
     haystack: &str,
     needle: &str,
@@ -52,12 +54,32 @@ pub(crate) fn find_unquoted_value_end(value: &str, start: usize) -> usize {
     let mut cursor = start;
     while cursor < bytes.len() {
         let ch = bytes[cursor];
-        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
+        if ch.is_ascii_whitespace() || matches!(ch, b',' | b';' | b'}' | b'|' | b'&') {
             break;
         }
         cursor += 1;
     }
     cursor
+}
+
+pub(crate) fn collect_assignment_value_ranges(
+    text: &str,
+    policy_keys: &HashSet<String>,
+    hint_keys: &HashSet<String>,
+    redaction_token: &str,
+) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    scan_assignments(text, |key, value_start, value_end| {
+        let is_sensitive = policy_keys.contains(key) || hint_keys.contains(key);
+        if is_sensitive
+            && value_end > value_start
+            && &text[value_start..value_end] != redaction_token
+        {
+            ranges.push((value_start, value_end));
+        }
+        false
+    });
+    ranges
 }
 
 pub(crate) fn contains_unredacted_assignment(text: &str, key: &str, redaction_token: &str) -> bool {
@@ -66,68 +88,38 @@ pub(crate) fn contains_unredacted_assignment(text: &str, key: &str, redaction_to
         return false;
     }
 
-    for line in text.lines() {
-        if line_contains_unredacted_assignment(line, &normalized_key, redaction_token) {
+    let mut found = false;
+    scan_assignments(text, |candidate_key, value_start, value_end| {
+        if candidate_key == normalized_key
+            && value_end > value_start
+            && &text[value_start..value_end] != redaction_token
+        {
+            found = true;
             return true;
         }
-    }
-    false
+        false
+    });
+    found
 }
 
-fn line_contains_unredacted_assignment(line: &str, key: &str, redaction_token: &str) -> bool {
-    let bytes = line.as_bytes();
-    let mut cursor = 0;
-
-    while cursor < bytes.len() {
-        if !is_key_start(bytes[cursor]) {
-            cursor += 1;
-            continue;
+pub(crate) fn collect_bearer_token_ranges(
+    text: &str,
+    min_token_len: usize,
+    redaction_token: &str,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut search_from = 0;
+    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
+        let token_start = index + "bearer ".len();
+        let token_end = find_unquoted_value_end(text, token_start);
+        if token_end.saturating_sub(token_start) >= min_token_len
+            && &text[token_start..token_end] != redaction_token
+        {
+            ranges.push((token_start, token_end));
         }
-
-        let key_start = cursor;
-        cursor += 1;
-        while cursor < bytes.len() && is_key_char(bytes[cursor]) {
-            cursor += 1;
-        }
-        let key_end = cursor;
-        if line[key_start..key_end].to_ascii_lowercase() != key {
-            continue;
-        }
-
-        let mut value_cursor = cursor;
-        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
-            value_cursor += 1;
-        }
-        if value_cursor >= bytes.len() || !matches!(bytes[value_cursor], b'=' | b':') {
-            continue;
-        }
-
-        value_cursor += 1;
-        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
-            value_cursor += 1;
-        }
-        if value_cursor >= bytes.len() {
-            return false;
-        }
-
-        let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
-            let quoted_end = find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
-            (value_cursor.saturating_add(1), quoted_end)
-        } else {
-            (value_cursor, find_unquoted_value_end(line, value_cursor))
-        };
-
-        if value_end > value_start {
-            let value = &line[value_start..value_end];
-            if value != redaction_token {
-                return true;
-            }
-        }
-
-        cursor = value_end.saturating_add(1);
+        search_from = token_end.saturating_add(1);
     }
-
-    false
+    ranges
 }
 
 pub(crate) fn contains_unredacted_bearer_token(
@@ -135,19 +127,38 @@ pub(crate) fn contains_unredacted_bearer_token(
     min_token_len: usize,
     redaction_token: &str,
 ) -> bool {
-    let mut search_from = 0;
-    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
-        let token_start = index + "bearer ".len();
-        let token_end = find_unquoted_value_end(text, token_start);
-        if token_end.saturating_sub(token_start) >= min_token_len {
-            let token = &text[token_start..token_end];
-            if token != redaction_token {
-                return true;
+    !collect_bearer_token_ranges(text, min_token_len, redaction_token).is_empty()
+}
+
+pub(crate) fn collect_prefixed_token_ranges(
+    text: &str,
+    prefixes: &[String],
+    min_token_len: usize,
+    redaction_token: &str,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    for prefix in prefixes {
+        let mut search_from = 0;
+        while let Some(start) = find_ascii_case_insensitive(text, prefix, search_from) {
+            let mut end = start + prefix.len();
+            while end < text.len() {
+                let ch = text.as_bytes()[end];
+                if !(ch.is_ascii_alphanumeric()
+                    || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=' | b'.'))
+                {
+                    break;
+                }
+                end += 1;
             }
+
+            if end.saturating_sub(start) >= min_token_len && &text[start..end] != redaction_token {
+                ranges.push((start, end));
+            }
+
+            search_from = end.saturating_add(1);
         }
-        search_from = token_end.saturating_add(1);
     }
-    false
+    ranges
 }
 
 pub(crate) fn contains_unredacted_prefixed_token(
@@ -156,24 +167,78 @@ pub(crate) fn contains_unredacted_prefixed_token(
     min_token_len: usize,
     redaction_token: &str,
 ) -> bool {
-    let mut search_from = 0;
-    while let Some(start) = find_ascii_case_insensitive(text, prefix, search_from) {
-        let mut end = start + prefix.len();
-        while end < text.len() {
-            let ch = text.as_bytes()[end];
-            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
-                break;
-            }
-            end += 1;
+    !collect_prefixed_token_ranges(text, &[prefix.to_owned()], min_token_len, redaction_token)
+        .is_empty()
+}
+
+fn scan_assignments(text: &str, mut visitor: impl FnMut(&str, usize, usize) -> bool) {
+    let bytes = text.as_bytes();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let Some((normalized_key, key_end)) = parse_assignment_key(text, cursor) else {
+            cursor += 1;
+            continue;
+        };
+
+        let mut value_cursor = key_end;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() || !matches!(bytes[value_cursor], b'=' | b':') {
+            cursor = key_end;
+            continue;
         }
 
-        if end.saturating_sub(start) >= min_token_len && &text[start..end] != redaction_token {
-            return true;
+        value_cursor += 1;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() {
+            return;
         }
 
-        search_from = end.saturating_add(1);
+        let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
+            let quoted_end = find_quoted_value_end(text, value_cursor).unwrap_or(text.len());
+            (value_cursor.saturating_add(1), quoted_end)
+        } else {
+            (value_cursor, find_unquoted_value_end(text, value_cursor))
+        };
+
+        if visitor(&normalized_key, value_start, value_end) {
+            return;
+        }
+
+        cursor = key_end;
     }
-    false
+}
+
+fn parse_assignment_key(text: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+
+    if matches!(bytes[start], b'"' | b'\'') {
+        let key_end_quote = find_quoted_value_end(text, start)?;
+        let key_start = start.saturating_add(1);
+        let key = text[key_start..key_end_quote].trim().to_ascii_lowercase();
+        if key.is_empty() {
+            return None;
+        }
+        return Some((key, key_end_quote.saturating_add(1)));
+    }
+
+    if !is_key_start(bytes[start]) {
+        return None;
+    }
+
+    let mut cursor = start + 1;
+    while cursor < bytes.len() && is_key_char(bytes[cursor]) {
+        cursor += 1;
+    }
+    let key = text[start..cursor].to_ascii_lowercase();
+    Some((key, cursor))
 }
 
 const fn is_key_start(byte: u8) -> bool {

--- a/crates/tanren-runtime/src/redaction/scanner.rs
+++ b/crates/tanren-runtime/src/redaction/scanner.rs
@@ -1,0 +1,185 @@
+pub(crate) fn find_ascii_case_insensitive(
+    haystack: &str,
+    needle: &str,
+    start: usize,
+) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+
+    let haystack_bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if haystack_bytes.len() < needle_bytes.len() {
+        return None;
+    }
+
+    let mut idx = start;
+    while idx + needle_bytes.len() <= haystack_bytes.len() {
+        let mut match_all = true;
+        for offset in 0..needle_bytes.len() {
+            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
+                match_all = false;
+                break;
+            }
+        }
+        if match_all {
+            return Some(idx);
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+pub(crate) fn find_quoted_value_end(value: &str, start: usize) -> Option<usize> {
+    let bytes = value.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+    let quote = bytes[start];
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == quote && bytes[cursor.saturating_sub(1)] != b'\\' {
+            return Some(cursor);
+        }
+        cursor += 1;
+    }
+    Some(value.len())
+}
+
+pub(crate) fn find_unquoted_value_end(value: &str, start: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        let ch = bytes[cursor];
+        if ch.is_ascii_whitespace() || ch == b',' || ch == b';' {
+            break;
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+pub(crate) fn contains_unredacted_assignment(text: &str, key: &str, redaction_token: &str) -> bool {
+    let normalized_key = key.trim().to_ascii_lowercase();
+    if normalized_key.is_empty() {
+        return false;
+    }
+
+    for line in text.lines() {
+        if line_contains_unredacted_assignment(line, &normalized_key, redaction_token) {
+            return true;
+        }
+    }
+    false
+}
+
+fn line_contains_unredacted_assignment(line: &str, key: &str, redaction_token: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        if !is_key_start(bytes[cursor]) {
+            cursor += 1;
+            continue;
+        }
+
+        let key_start = cursor;
+        cursor += 1;
+        while cursor < bytes.len() && is_key_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        let key_end = cursor;
+        if line[key_start..key_end].to_ascii_lowercase() != key {
+            continue;
+        }
+
+        let mut value_cursor = cursor;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() || !matches!(bytes[value_cursor], b'=' | b':') {
+            continue;
+        }
+
+        value_cursor += 1;
+        while value_cursor < bytes.len() && bytes[value_cursor].is_ascii_whitespace() {
+            value_cursor += 1;
+        }
+        if value_cursor >= bytes.len() {
+            return false;
+        }
+
+        let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
+            let quoted_end = find_quoted_value_end(line, value_cursor).unwrap_or(line.len());
+            (value_cursor.saturating_add(1), quoted_end)
+        } else {
+            (value_cursor, find_unquoted_value_end(line, value_cursor))
+        };
+
+        if value_end > value_start {
+            let value = &line[value_start..value_end];
+            if value != redaction_token {
+                return true;
+            }
+        }
+
+        cursor = value_end.saturating_add(1);
+    }
+
+    false
+}
+
+pub(crate) fn contains_unredacted_bearer_token(
+    text: &str,
+    min_token_len: usize,
+    redaction_token: &str,
+) -> bool {
+    let mut search_from = 0;
+    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
+        let token_start = index + "bearer ".len();
+        let token_end = find_unquoted_value_end(text, token_start);
+        if token_end.saturating_sub(token_start) >= min_token_len {
+            let token = &text[token_start..token_end];
+            if token != redaction_token {
+                return true;
+            }
+        }
+        search_from = token_end.saturating_add(1);
+    }
+    false
+}
+
+pub(crate) fn contains_unredacted_prefixed_token(
+    text: &str,
+    prefix: &str,
+    min_token_len: usize,
+    redaction_token: &str,
+) -> bool {
+    let mut search_from = 0;
+    while let Some(start) = find_ascii_case_insensitive(text, prefix, search_from) {
+        let mut end = start + prefix.len();
+        while end < text.len() {
+            let ch = text.as_bytes()[end];
+            if !(ch.is_ascii_alphanumeric() || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=')) {
+                break;
+            }
+            end += 1;
+        }
+
+        if end.saturating_sub(start) >= min_token_len && &text[start..end] != redaction_token {
+            return true;
+        }
+
+        search_from = end.saturating_add(1);
+    }
+    false
+}
+
+const fn is_key_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+const fn is_key_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
+}

--- a/crates/tanren-runtime/src/redaction/scanner.rs
+++ b/crates/tanren-runtime/src/redaction/scanner.rs
@@ -197,7 +197,7 @@ fn collect_token_style_ranges(
     let mut prefixed_ranges = Vec::new();
     let bytes = text.as_bytes();
     let mut cursor = 0;
-    let mut previous_token: Option<String> = None;
+    let mut previous_token_is_bearer = false;
 
     while cursor < bytes.len() {
         while cursor < bytes.len() && !is_secret_token_char(bytes[cursor]) {
@@ -212,14 +212,10 @@ fn collect_token_style_ranges(
         }
 
         let token = &text[start..cursor];
-        let normalized = token.to_ascii_lowercase();
         let token_len = cursor.saturating_sub(start);
         let is_redaction_token = token == redaction_token;
 
-        if previous_token.as_deref() == Some("bearer")
-            && token_len >= min_token_len
-            && !is_redaction_token
-        {
+        if previous_token_is_bearer && token_len >= min_token_len && !is_redaction_token {
             bearer_ranges.push((start, cursor));
         }
 
@@ -232,7 +228,7 @@ fn collect_token_style_ranges(
             prefixed_ranges.push((start, cursor));
         }
 
-        previous_token = Some(normalized);
+        previous_token_is_bearer = token.eq_ignore_ascii_case("bearer");
     }
 
     (bearer_ranges, prefixed_ranges)

--- a/crates/tanren-runtime/src/redaction/scanner.rs
+++ b/crates/tanren-runtime/src/redaction/scanner.rs
@@ -3,11 +3,114 @@ use std::collections::HashSet;
 type ByteRange = (usize, usize);
 type TokenRanges = (Vec<ByteRange>, Vec<ByteRange>);
 
+#[derive(Debug, Clone)]
+struct PrefixTrieNode {
+    next: [Option<usize>; 256],
+    terminal: bool,
+}
+
+impl Default for PrefixTrieNode {
+    fn default() -> Self {
+        Self {
+            next: [None; 256],
+            terminal: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledTokenPrefixMatcher {
+    nodes: Vec<PrefixTrieNode>,
+    prefix_count: usize,
+}
+
+impl Default for CompiledTokenPrefixMatcher {
+    fn default() -> Self {
+        Self {
+            nodes: vec![PrefixTrieNode::default()],
+            prefix_count: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TokenPrefixMatcherStats {
+    pub nodes: usize,
+    pub transitions: usize,
+    pub prefixes: usize,
+}
+
+impl CompiledTokenPrefixMatcher {
+    pub(crate) fn new(prefixes: &[String]) -> Self {
+        let mut matcher = Self::default();
+        for prefix in prefixes {
+            matcher.insert(prefix);
+        }
+        matcher
+    }
+
+    pub(crate) fn matches(&self, token: &str) -> bool {
+        let mut state = 0;
+        for byte in token.bytes() {
+            let idx = byte.to_ascii_lowercase() as usize;
+            let Some(next) = self.nodes[state].next[idx] else {
+                return false;
+            };
+            state = next;
+            if self.nodes[state].terminal {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn insert(&mut self, prefix: &str) {
+        let trimmed = prefix.trim().to_ascii_lowercase();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        let mut state = 0;
+        for byte in trimmed.bytes() {
+            let idx = byte as usize;
+            let next = if let Some(existing) = self.nodes[state].next[idx] {
+                existing
+            } else {
+                let created = self.nodes.len();
+                self.nodes.push(PrefixTrieNode::default());
+                self.nodes[state].next[idx] = Some(created);
+                created
+            };
+            state = next;
+        }
+
+        if !self.nodes[state].terminal {
+            self.prefix_count += 1;
+            self.nodes[state].terminal = true;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stats(&self) -> TokenPrefixMatcherStats {
+        let transition_count = self
+            .nodes
+            .iter()
+            .map(|node| node.next.iter().flatten().count())
+            .sum();
+        TokenPrefixMatcherStats {
+            nodes: self.nodes.len(),
+            transitions: transition_count,
+            prefixes: self.prefix_count,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ChannelScanConfig<'a> {
     pub policy_keys: &'a HashSet<String>,
     pub hint_keys: &'a HashSet<String>,
-    pub token_prefixes: &'a [String],
+    pub token_prefix_matcher: &'a CompiledTokenPrefixMatcher,
     pub min_token_len: usize,
     pub redaction_token: &'a str,
 }
@@ -74,7 +177,7 @@ pub(crate) fn scan_channel(text: &str, config: &ChannelScanConfig<'_>) -> Channe
     });
     let (bearer_ranges, prefixed_ranges) = collect_token_style_ranges(
         text,
-        config.token_prefixes,
+        config.token_prefix_matcher,
         config.min_token_len,
         config.redaction_token,
     );
@@ -108,7 +211,9 @@ pub(crate) fn collect_bearer_token_ranges(
     min_token_len: usize,
     redaction_token: &str,
 ) -> Vec<ByteRange> {
-    let (ranges, _) = collect_token_style_ranges(text, &[], min_token_len, redaction_token);
+    let prefix_matcher = CompiledTokenPrefixMatcher::default();
+    let (ranges, _) =
+        collect_token_style_ranges(text, &prefix_matcher, min_token_len, redaction_token);
     ranges
 }
 
@@ -126,7 +231,9 @@ pub(crate) fn collect_prefixed_token_ranges(
     min_token_len: usize,
     redaction_token: &str,
 ) -> Vec<ByteRange> {
-    let (_, ranges) = collect_token_style_ranges(text, prefixes, min_token_len, redaction_token);
+    let prefix_matcher = CompiledTokenPrefixMatcher::new(prefixes);
+    let (_, ranges) =
+        collect_token_style_ranges(text, &prefix_matcher, min_token_len, redaction_token);
     ranges
 }
 
@@ -189,7 +296,7 @@ fn scan_assignments(text: &str, mut visitor: impl FnMut(&str, usize, usize) -> b
 
 fn collect_token_style_ranges(
     text: &str,
-    prefixes: &[String],
+    prefix_matcher: &CompiledTokenPrefixMatcher,
     min_token_len: usize,
     redaction_token: &str,
 ) -> TokenRanges {
@@ -219,12 +326,7 @@ fn collect_token_style_ranges(
             bearer_ranges.push((start, cursor));
         }
 
-        if token_len >= min_token_len
-            && !is_redaction_token
-            && prefixes
-                .iter()
-                .any(|prefix| starts_with_ascii_case_insensitive(token, prefix))
-        {
+        if token_len >= min_token_len && !is_redaction_token && prefix_matcher.matches(token) {
             prefixed_ranges.push((start, cursor));
         }
 
@@ -232,15 +334,6 @@ fn collect_token_style_ranges(
     }
 
     (bearer_ranges, prefixed_ranges)
-}
-
-fn starts_with_ascii_case_insensitive(value: &str, prefix: &str) -> bool {
-    value
-        .as_bytes()
-        .iter()
-        .zip(prefix.as_bytes().iter())
-        .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
-        && value.len() >= prefix.len()
 }
 
 fn parse_assignment_key(text: &str, start: usize) -> Option<(String, usize)> {

--- a/crates/tanren-runtime/src/redaction/scanner.rs
+++ b/crates/tanren-runtime/src/redaction/scanner.rs
@@ -1,36 +1,32 @@
 use std::collections::HashSet;
 
-pub(crate) fn find_ascii_case_insensitive(
-    haystack: &str,
-    needle: &str,
-    start: usize,
-) -> Option<usize> {
-    if needle.is_empty() || start >= haystack.len() {
-        return None;
-    }
+type ByteRange = (usize, usize);
+type TokenRanges = (Vec<ByteRange>, Vec<ByteRange>);
 
-    let haystack_bytes = haystack.as_bytes();
-    let needle_bytes = needle.as_bytes();
-    if haystack_bytes.len() < needle_bytes.len() {
-        return None;
-    }
+#[derive(Debug)]
+pub(crate) struct ChannelScanConfig<'a> {
+    pub policy_keys: &'a HashSet<String>,
+    pub hint_keys: &'a HashSet<String>,
+    pub token_prefixes: &'a [String],
+    pub min_token_len: usize,
+    pub redaction_token: &'a str,
+}
 
-    let mut idx = start;
-    while idx + needle_bytes.len() <= haystack_bytes.len() {
-        let mut match_all = true;
-        for offset in 0..needle_bytes.len() {
-            if !haystack_bytes[idx + offset].eq_ignore_ascii_case(&needle_bytes[offset]) {
-                match_all = false;
-                break;
-            }
-        }
-        if match_all {
-            return Some(idx);
-        }
-        idx += 1;
-    }
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ChannelScanArtifacts {
+    pub assignment_value_ranges: Vec<ByteRange>,
+    pub has_unredacted_sensitive_assignment: bool,
+    pub bearer_token_ranges: Vec<ByteRange>,
+    pub prefixed_token_ranges: Vec<ByteRange>,
+}
 
-    None
+impl ChannelScanArtifacts {
+    #[must_use]
+    pub(crate) fn has_policy_residual_leak(&self) -> bool {
+        self.has_unredacted_sensitive_assignment
+            || !self.bearer_token_ranges.is_empty()
+            || !self.prefixed_token_ranges.is_empty()
+    }
 }
 
 pub(crate) fn find_quoted_value_end(value: &str, start: usize) -> Option<usize> {
@@ -62,24 +58,29 @@ pub(crate) fn find_unquoted_value_end(value: &str, start: usize) -> usize {
     cursor
 }
 
-pub(crate) fn collect_assignment_value_ranges(
-    text: &str,
-    policy_keys: &HashSet<String>,
-    hint_keys: &HashSet<String>,
-    redaction_token: &str,
-) -> Vec<(usize, usize)> {
-    let mut ranges: Vec<(usize, usize)> = Vec::new();
+pub(crate) fn scan_channel(text: &str, config: &ChannelScanConfig<'_>) -> ChannelScanArtifacts {
+    let mut artifacts = ChannelScanArtifacts::default();
     scan_assignments(text, |key, value_start, value_end| {
-        let is_sensitive = policy_keys.contains(key) || hint_keys.contains(key);
-        if is_sensitive
-            && value_end > value_start
-            && &text[value_start..value_end] != redaction_token
-        {
-            ranges.push((value_start, value_end));
+        let is_sensitive = config.policy_keys.contains(key) || config.hint_keys.contains(key);
+        let is_unredacted =
+            value_end > value_start && &text[value_start..value_end] != config.redaction_token;
+        if is_sensitive && is_unredacted {
+            artifacts
+                .assignment_value_ranges
+                .push((value_start, value_end));
+            artifacts.has_unredacted_sensitive_assignment = true;
         }
         false
     });
-    ranges
+    let (bearer_ranges, prefixed_ranges) = collect_token_style_ranges(
+        text,
+        config.token_prefixes,
+        config.min_token_len,
+        config.redaction_token,
+    );
+    artifacts.bearer_token_ranges = bearer_ranges;
+    artifacts.prefixed_token_ranges = prefixed_ranges;
+    artifacts
 }
 
 pub(crate) fn contains_unredacted_assignment(text: &str, key: &str, redaction_token: &str) -> bool {
@@ -106,19 +107,8 @@ pub(crate) fn collect_bearer_token_ranges(
     text: &str,
     min_token_len: usize,
     redaction_token: &str,
-) -> Vec<(usize, usize)> {
-    let mut ranges = Vec::new();
-    let mut search_from = 0;
-    while let Some(index) = find_ascii_case_insensitive(text, "bearer ", search_from) {
-        let token_start = index + "bearer ".len();
-        let token_end = find_unquoted_value_end(text, token_start);
-        if token_end.saturating_sub(token_start) >= min_token_len
-            && &text[token_start..token_end] != redaction_token
-        {
-            ranges.push((token_start, token_end));
-        }
-        search_from = token_end.saturating_add(1);
-    }
+) -> Vec<ByteRange> {
+    let (ranges, _) = collect_token_style_ranges(text, &[], min_token_len, redaction_token);
     ranges
 }
 
@@ -135,29 +125,8 @@ pub(crate) fn collect_prefixed_token_ranges(
     prefixes: &[String],
     min_token_len: usize,
     redaction_token: &str,
-) -> Vec<(usize, usize)> {
-    let mut ranges = Vec::new();
-    for prefix in prefixes {
-        let mut search_from = 0;
-        while let Some(start) = find_ascii_case_insensitive(text, prefix, search_from) {
-            let mut end = start + prefix.len();
-            while end < text.len() {
-                let ch = text.as_bytes()[end];
-                if !(ch.is_ascii_alphanumeric()
-                    || matches!(ch, b'-' | b'_' | b'/' | b'+' | b'=' | b'.'))
-                {
-                    break;
-                }
-                end += 1;
-            }
-
-            if end.saturating_sub(start) >= min_token_len && &text[start..end] != redaction_token {
-                ranges.push((start, end));
-            }
-
-            search_from = end.saturating_add(1);
-        }
-    }
+) -> Vec<ByteRange> {
+    let (_, ranges) = collect_token_style_ranges(text, prefixes, min_token_len, redaction_token);
     ranges
 }
 
@@ -198,6 +167,7 @@ fn scan_assignments(text: &str, mut visitor: impl FnMut(&str, usize, usize) -> b
             return;
         }
 
+        let structured_value = matches!(bytes[value_cursor], b'{' | b'[');
         let (value_start, value_end) = if matches!(bytes[value_cursor], b'"' | b'\'') {
             let quoted_end = find_quoted_value_end(text, value_cursor).unwrap_or(text.len());
             (value_cursor.saturating_add(1), quoted_end)
@@ -209,8 +179,72 @@ fn scan_assignments(text: &str, mut visitor: impl FnMut(&str, usize, usize) -> b
             return;
         }
 
-        cursor = key_end;
+        cursor = if structured_value {
+            value_start.saturating_add(1)
+        } else {
+            value_end.saturating_add(1)
+        };
     }
+}
+
+fn collect_token_style_ranges(
+    text: &str,
+    prefixes: &[String],
+    min_token_len: usize,
+    redaction_token: &str,
+) -> TokenRanges {
+    let mut bearer_ranges = Vec::new();
+    let mut prefixed_ranges = Vec::new();
+    let bytes = text.as_bytes();
+    let mut cursor = 0;
+    let mut previous_token: Option<String> = None;
+
+    while cursor < bytes.len() {
+        while cursor < bytes.len() && !is_secret_token_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        let start = cursor;
+        while cursor < bytes.len() && is_secret_token_char(bytes[cursor]) {
+            cursor += 1;
+        }
+        if start == cursor {
+            continue;
+        }
+
+        let token = &text[start..cursor];
+        let normalized = token.to_ascii_lowercase();
+        let token_len = cursor.saturating_sub(start);
+        let is_redaction_token = token == redaction_token;
+
+        if previous_token.as_deref() == Some("bearer")
+            && token_len >= min_token_len
+            && !is_redaction_token
+        {
+            bearer_ranges.push((start, cursor));
+        }
+
+        if token_len >= min_token_len
+            && !is_redaction_token
+            && prefixes
+                .iter()
+                .any(|prefix| starts_with_ascii_case_insensitive(token, prefix))
+        {
+            prefixed_ranges.push((start, cursor));
+        }
+
+        previous_token = Some(normalized);
+    }
+
+    (bearer_ranges, prefixed_ranges)
+}
+
+fn starts_with_ascii_case_insensitive(value: &str, prefix: &str) -> bool {
+    value
+        .as_bytes()
+        .iter()
+        .zip(prefix.as_bytes().iter())
+        .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
+        && value.len() >= prefix.len()
 }
 
 fn parse_assignment_key(text: &str, start: usize) -> Option<(String, usize)> {
@@ -247,4 +281,8 @@ const fn is_key_start(byte: u8) -> bool {
 
 const fn is_key_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
+}
+
+const fn is_secret_token_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'/' | b'+' | b'=' | b'.')
 }

--- a/crates/tanren-runtime/src/redaction/secret_matcher.rs
+++ b/crates/tanren-runtime/src/redaction/secret_matcher.rs
@@ -15,7 +15,7 @@ struct AutomatonNode {
     outputs: Vec<usize>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct CompiledSecretMatcher {
     nodes: Vec<AutomatonNode>,
     candidates: Vec<SecretCandidate>,

--- a/crates/tanren-runtime/src/redaction/secret_matcher.rs
+++ b/crates/tanren-runtime/src/redaction/secret_matcher.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::redaction::RedactionHints;
 
@@ -8,9 +8,25 @@ struct SecretCandidate {
     contextual_short: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+struct AutomatonNode {
+    next: HashMap<u8, usize>,
+    fail: usize,
+    outputs: Vec<usize>,
+}
+
 #[derive(Default)]
 pub(super) struct CompiledSecretMatcher {
-    by_first_byte: HashMap<u8, Vec<SecretCandidate>>,
+    nodes: Vec<AutomatonNode>,
+    candidates: Vec<SecretCandidate>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SecretMatcherStats {
+    pub states: usize,
+    pub transitions: usize,
+    pub patterns: usize,
 }
 
 impl CompiledSecretMatcher {
@@ -43,73 +59,138 @@ impl CompiledSecretMatcher {
             }
         }
 
-        let mut by_first_byte: HashMap<u8, Vec<SecretCandidate>> = HashMap::new();
+        let mut candidates = Vec::with_capacity(literals.len() + contextual_short_literals.len());
         for literal in literals {
-            let bytes = literal.into_bytes();
-            if let Some(first) = bytes.first().copied() {
-                by_first_byte
-                    .entry(first)
-                    .or_default()
-                    .push(SecretCandidate {
-                        bytes,
-                        contextual_short: false,
-                    });
-            }
+            candidates.push(SecretCandidate {
+                bytes: literal.into_bytes(),
+                contextual_short: false,
+            });
         }
         for literal in contextual_short_literals {
-            let bytes = literal.into_bytes();
-            if let Some(first) = bytes.first().copied() {
-                by_first_byte
-                    .entry(first)
-                    .or_default()
-                    .push(SecretCandidate {
-                        bytes,
-                        contextual_short: true,
-                    });
+            candidates.push(SecretCandidate {
+                bytes: literal.into_bytes(),
+                contextual_short: true,
+            });
+        }
+
+        Self::from_candidates(candidates)
+    }
+
+    fn from_candidates(mut candidates: Vec<SecretCandidate>) -> Self {
+        if candidates.is_empty() {
+            return Self::default();
+        }
+
+        // Sort by length descending so ranges stay deterministic for overlapping outputs.
+        candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.bytes.len()));
+
+        let mut nodes = vec![AutomatonNode::default()];
+        for (idx, candidate) in candidates.iter().enumerate() {
+            let mut state = 0;
+            for &byte in &candidate.bytes {
+                let next = if let Some(existing) = nodes[state].next.get(&byte).copied() {
+                    existing
+                } else {
+                    let created = nodes.len();
+                    nodes.push(AutomatonNode::default());
+                    nodes[state].next.insert(byte, created);
+                    created
+                };
+                state = next;
+            }
+            nodes[state].outputs.push(idx);
+        }
+
+        let mut queue = VecDeque::new();
+        let root_children = nodes[0].next.values().copied().collect::<Vec<_>>();
+        for child in root_children {
+            nodes[child].fail = 0;
+            queue.push_back(child);
+        }
+
+        while let Some(state) = queue.pop_front() {
+            let transitions = nodes[state]
+                .next
+                .iter()
+                .map(|(&byte, &next)| (byte, next))
+                .collect::<Vec<_>>();
+            for (byte, next_state) in transitions {
+                queue.push_back(next_state);
+
+                let mut fail = nodes[state].fail;
+                while fail != 0 && !nodes[fail].next.contains_key(&byte) {
+                    fail = nodes[fail].fail;
+                }
+
+                if let Some(&fallback) = nodes[fail].next.get(&byte) {
+                    nodes[next_state].fail = fallback;
+                }
+
+                let fallback_outputs = nodes[nodes[next_state].fail].outputs.clone();
+                nodes[next_state].outputs.extend(fallback_outputs);
             }
         }
-        for candidates in by_first_byte.values_mut() {
-            candidates.sort_by_key(|value| std::cmp::Reverse(value.bytes.len()));
+
+        for node in &mut nodes {
+            node.outputs
+                .sort_by_key(|idx| std::cmp::Reverse(candidates[*idx].bytes.len()));
+            node.outputs.dedup();
         }
-        Self { by_first_byte }
+
+        Self { nodes, candidates }
     }
 
     pub(super) fn collect_ranges(&self, text: &str) -> Vec<(usize, usize)> {
-        let mut ranges = Vec::new();
+        if self.nodes.is_empty() || self.candidates.is_empty() {
+            return Vec::new();
+        }
+
         let bytes = text.as_bytes();
-        let mut cursor = 0;
+        let mut state = 0;
+        let mut ranges = Vec::new();
 
-        while cursor < bytes.len() {
-            let Some(candidates) = self.by_first_byte.get(&bytes[cursor]) else {
-                cursor += 1;
+        for (idx, &byte) in bytes.iter().enumerate() {
+            while state != 0 && !self.nodes[state].next.contains_key(&byte) {
+                state = self.nodes[state].fail;
+            }
+
+            if let Some(&next) = self.nodes[state].next.get(&byte) {
+                state = next;
+            }
+
+            if self.nodes[state].outputs.is_empty() {
                 continue;
-            };
+            }
 
-            let mut matched = false;
-            for candidate in candidates {
-                let end = cursor.saturating_add(candidate.bytes.len());
-                if end > bytes.len()
-                    || &bytes[cursor..end] != candidate.bytes.as_slice()
-                    || !text.is_char_boundary(cursor)
-                    || !text.is_char_boundary(end)
-                {
+            for &candidate_idx in &self.nodes[state].outputs {
+                let candidate = &self.candidates[candidate_idx];
+                let end = idx.saturating_add(1);
+                let Some(start) = end.checked_sub(candidate.bytes.len()) else {
+                    continue;
+                };
+                if !text.is_char_boundary(start) || !text.is_char_boundary(end) {
                     continue;
                 }
                 if candidate.contextual_short
-                    && !is_contextual_short_fragment_match(bytes, cursor, end)
+                    && !is_contextual_short_fragment_match(bytes, start, end)
                 {
                     continue;
                 }
-                ranges.push((cursor, end));
-                cursor = end;
-                matched = true;
-                break;
-            }
-            if !matched {
-                cursor += 1;
+                ranges.push((start, end));
             }
         }
+
         ranges
+    }
+
+    #[cfg(test)]
+    pub(super) fn stats(&self) -> SecretMatcherStats {
+        let transition_count = self.nodes.iter().map(|node| node.next.len()).sum();
+        SecretMatcherStats {
+            states: self.nodes.len(),
+            transitions: transition_count,
+            patterns: self.candidates.len(),
+        }
     }
 }
 

--- a/crates/tanren-runtime/src/redaction/secret_matcher.rs
+++ b/crates/tanren-runtime/src/redaction/secret_matcher.rs
@@ -231,8 +231,7 @@ const fn is_secret_token_char(byte: u8) -> bool {
 }
 
 fn add_encoded_variants(secret: &str, min_secret_fragment_len: usize, sink: &mut HashSet<String>) {
-    const MAX_ENCODE_SOURCE_LEN: usize = 64;
-    if secret.len() < min_secret_fragment_len || secret.len() > MAX_ENCODE_SOURCE_LEN {
+    if secret.len() < min_secret_fragment_len {
         return;
     }
 

--- a/crates/tanren-runtime/src/redaction/secret_matcher.rs
+++ b/crates/tanren-runtime/src/redaction/secret_matcher.rs
@@ -1,0 +1,241 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::redaction::RedactionHints;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SecretCandidate {
+    bytes: Vec<u8>,
+    contextual_short: bool,
+}
+
+#[derive(Default)]
+pub(super) struct CompiledSecretMatcher {
+    by_first_byte: HashMap<u8, Vec<SecretCandidate>>,
+}
+
+impl CompiledSecretMatcher {
+    pub(super) fn from_hints(hints: &RedactionHints, min_secret_fragment_len: usize) -> Self {
+        let mut literals = HashSet::new();
+        let mut contextual_short_literals = HashSet::new();
+        for secret in &hints.secret_values {
+            let value = secret.expose().trim();
+            if value.is_empty() {
+                continue;
+            }
+            literals.insert(value.to_owned());
+            add_encoded_variants(value, min_secret_fragment_len, &mut literals);
+            if value.contains('\n') {
+                for fragment in value.lines() {
+                    let trimmed = fragment.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if trimmed.len() >= min_secret_fragment_len {
+                        literals.insert(trimmed.to_owned());
+                        add_encoded_variants(trimmed, min_secret_fragment_len, &mut literals);
+                    } else if should_track_contextual_short_fragment(
+                        trimmed,
+                        min_secret_fragment_len,
+                    ) {
+                        contextual_short_literals.insert(trimmed.to_owned());
+                    }
+                }
+            }
+        }
+
+        let mut by_first_byte: HashMap<u8, Vec<SecretCandidate>> = HashMap::new();
+        for literal in literals {
+            let bytes = literal.into_bytes();
+            if let Some(first) = bytes.first().copied() {
+                by_first_byte
+                    .entry(first)
+                    .or_default()
+                    .push(SecretCandidate {
+                        bytes,
+                        contextual_short: false,
+                    });
+            }
+        }
+        for literal in contextual_short_literals {
+            let bytes = literal.into_bytes();
+            if let Some(first) = bytes.first().copied() {
+                by_first_byte
+                    .entry(first)
+                    .or_default()
+                    .push(SecretCandidate {
+                        bytes,
+                        contextual_short: true,
+                    });
+            }
+        }
+        for candidates in by_first_byte.values_mut() {
+            candidates.sort_by_key(|value| std::cmp::Reverse(value.bytes.len()));
+        }
+        Self { by_first_byte }
+    }
+
+    pub(super) fn collect_ranges(&self, text: &str) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let bytes = text.as_bytes();
+        let mut cursor = 0;
+
+        while cursor < bytes.len() {
+            let Some(candidates) = self.by_first_byte.get(&bytes[cursor]) else {
+                cursor += 1;
+                continue;
+            };
+
+            let mut matched = false;
+            for candidate in candidates {
+                let end = cursor.saturating_add(candidate.bytes.len());
+                if end > bytes.len()
+                    || &bytes[cursor..end] != candidate.bytes.as_slice()
+                    || !text.is_char_boundary(cursor)
+                    || !text.is_char_boundary(end)
+                {
+                    continue;
+                }
+                if candidate.contextual_short
+                    && !is_contextual_short_fragment_match(bytes, cursor, end)
+                {
+                    continue;
+                }
+                ranges.push((cursor, end));
+                cursor = end;
+                matched = true;
+                break;
+            }
+            if !matched {
+                cursor += 1;
+            }
+        }
+        ranges
+    }
+}
+
+fn should_track_contextual_short_fragment(fragment: &str, min_secret_fragment_len: usize) -> bool {
+    const MIN_CONTEXTUAL_FRAGMENT_LEN: usize = 3;
+    fragment.len() >= MIN_CONTEXTUAL_FRAGMENT_LEN
+        && fragment.len() < min_secret_fragment_len
+        && fragment
+            .bytes()
+            .any(|byte| byte.is_ascii_digit() || !byte.is_ascii_alphanumeric())
+}
+
+fn is_contextual_short_fragment_match(text: &[u8], start: usize, end: usize) -> bool {
+    let prev = start.checked_sub(1).and_then(|idx| text.get(idx)).copied();
+    let next = text.get(end).copied();
+    let has_boundaries = is_secret_token_boundary(prev) && is_secret_token_boundary(next);
+    let has_context_delimiter = prev.is_some_and(is_secret_context_delimiter)
+        || next.is_some_and(is_secret_context_delimiter);
+    has_boundaries && has_context_delimiter
+}
+
+const fn is_secret_token_boundary(ch: Option<u8>) -> bool {
+    match ch {
+        None => true,
+        Some(byte) => !is_secret_token_char(byte),
+    }
+}
+
+const fn is_secret_context_delimiter(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'=' | b':' | b'"' | b'\'' | b'%' | b'?' | b'&' | b'/' | b'\\' | b'+' | b'.'
+    )
+}
+
+const fn is_secret_token_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'/' | b'+' | b'=' | b'.')
+}
+
+fn add_encoded_variants(secret: &str, min_secret_fragment_len: usize, sink: &mut HashSet<String>) {
+    const MAX_ENCODE_SOURCE_LEN: usize = 64;
+    if secret.len() < min_secret_fragment_len || secret.len() > MAX_ENCODE_SOURCE_LEN {
+        return;
+    }
+
+    let percent_encoded = percent_encode(secret.as_bytes());
+    if percent_encoded.len() >= min_secret_fragment_len {
+        sink.insert(percent_encoded);
+    }
+
+    let standard = base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+        true,
+    );
+    if standard.len() >= min_secret_fragment_len {
+        sink.insert(standard);
+    }
+
+    let urlsafe = base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+        false,
+    );
+    if urlsafe.len() >= min_secret_fragment_len {
+        sink.insert(urlsafe);
+    }
+}
+
+pub(super) fn percent_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(bytes.len().saturating_mul(3));
+    for &byte in bytes {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(char::from(byte));
+        } else {
+            out.push('%');
+            out.push(char::from(HEX[(byte >> 4) as usize]));
+            out.push(char::from(HEX[(byte & 0x0F) as usize]));
+        }
+    }
+    out
+}
+
+pub(super) fn base64_encode(input: &[u8], table: &[u8; 64], include_padding: bool) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3).saturating_mul(4));
+    let mut idx = 0;
+    while idx + 3 <= input.len() {
+        let chunk = u32::from(input[idx]) << 16
+            | u32::from(input[idx + 1]) << 8
+            | u32::from(input[idx + 2]);
+        out.push(char::from(table[((chunk >> 18) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 12) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 6) & 0x3F) as usize]));
+        out.push(char::from(table[(chunk & 0x3F) as usize]));
+        idx += 3;
+    }
+
+    let remainder = input.len().saturating_sub(idx);
+    if remainder == 1 {
+        let chunk = u32::from(input[idx]) << 16;
+        out.push(char::from(table[((chunk >> 18) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 12) & 0x3F) as usize]));
+        if include_padding {
+            out.push('=');
+            out.push('=');
+        }
+    } else if remainder == 2 {
+        let chunk = u32::from(input[idx]) << 16 | u32::from(input[idx + 1]) << 8;
+        out.push(char::from(table[((chunk >> 18) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 12) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 6) & 0x3F) as usize]));
+        if include_padding {
+            out.push('=');
+        }
+    } else if remainder > 2 {
+        // `idx` advances in 3-byte chunks, so this branch is unreachable.
+        // Keep explicit handling to satisfy exhaustive reasoning without panic paths.
+        let chunk = u32::from(input[idx]) << 16
+            | u32::from(input[idx + 1]) << 8
+            | u32::from(input[idx + 2]);
+        out.push(char::from(table[((chunk >> 18) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 12) & 0x3F) as usize]));
+        out.push(char::from(table[((chunk >> 6) & 0x3F) as usize]));
+        out.push(char::from(table[(chunk & 0x3F) as usize]));
+    }
+
+    out
+}

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -1,0 +1,194 @@
+use proptest::prelude::*;
+use tanren_domain::Outcome;
+
+use super::*;
+
+fn raw_output(text: &str) -> RawExecutionOutput {
+    RawExecutionOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: Some(0),
+        duration_secs: 1.0,
+        gate_output: Some(text.into()),
+        tail_output: Some(text.into()),
+        stderr_tail: Some(text.into()),
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    }
+}
+
+#[test]
+fn redacts_bearer_and_prefixed_tokens() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints::default();
+    let out = redactor
+        .redact(
+            raw_output("Authorization: Bearer sk-super-long-secret-123"),
+            &hints,
+        )
+        .expect("redact");
+    let value = out.gate_output.expect("output");
+    assert!(!value.contains("sk-super-long-secret-123"));
+    assert!(value.contains(REDACTION_TOKEN));
+}
+
+#[test]
+fn redacts_explicit_secret_values_and_multiline_fragments() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec!["MY_SECRET".into()],
+        secret_values: vec!["line1-secret\nline2-secret".into()],
+    };
+    let out = redactor
+        .redact(
+            raw_output("line1-secret / line2-secret / MY_SECRET=abc"),
+            &hints,
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains("line1-secret"));
+    assert!(!gate.contains("line2-secret"));
+    assert!(!gate.contains("abc"));
+}
+
+#[test]
+fn redacts_every_assignment_when_same_key_appears_multiple_times_on_line() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec!["API_TOKEN".into()],
+        secret_values: vec![],
+    };
+    let out = redactor
+        .redact(
+            raw_output(
+                "API_TOKEN=first API_TOKEN='second' api_token:\"third\" non_secret=ok API_TOKEN = fourth",
+            ),
+            &hints,
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+
+    assert!(!gate.contains("first"));
+    assert!(!gate.contains("second"));
+    assert!(!gate.contains("third"));
+    assert!(!gate.contains("fourth"));
+    assert!(gate.contains("non_secret=ok"));
+}
+
+#[test]
+fn redacts_assignment_variants_with_colon_and_quotes() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec!["my-secret".into()],
+        secret_values: vec![],
+    };
+    let out = redactor
+        .redact(
+            raw_output("my-secret:abc my-secret : 'quoted' my-secret:\"double\""),
+            &hints,
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+
+    assert!(!gate.contains("abc"));
+    assert!(!gate.contains("quoted"));
+    assert!(!gate.contains("double"));
+}
+
+#[test]
+fn leaves_non_sensitive_assignments_intact() {
+    let redactor = DefaultOutputRedactor::default();
+    let out = redactor
+        .redact(
+            raw_output("project_id=alpha region:us-central"),
+            &RedactionHints::default(),
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(gate.contains("project_id=alpha"));
+    assert!(gate.contains("region:us-central"));
+}
+
+#[test]
+fn leak_detection_flags_remaining_secret() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec!["secret-value".into()],
+    };
+    let output = PersistableOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: None,
+        duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+        gate_output: Some("still has secret-value".into()),
+        tail_output: None,
+        stderr_tail: None,
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    };
+    assert!(redactor.has_known_secret_leak(&output, &hints));
+}
+
+#[test]
+fn rejects_non_finite_duration() {
+    let redactor = DefaultOutputRedactor::default();
+    let err = redactor
+        .redact(
+            RawExecutionOutput {
+                duration_secs: f64::NAN,
+                ..raw_output("ok")
+            },
+            &RedactionHints::default(),
+        )
+        .expect_err("must fail");
+    assert_eq!(err, RedactionError::InvalidDuration);
+}
+
+proptest! {
+    #[test]
+    fn redact_does_not_leave_explicit_secret_values(
+        secret in "[A-Za-z0-9_-]{12,40}",
+        key in "[A-Za-z_][A-Za-z0-9_-]{3,16}"
+    ) {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec![key.clone()],
+            secret_values: vec![secret.clone()],
+        };
+        let payload = format!("{key}={secret} and {secret} and {key}:{secret}");
+        let out = redactor.redact(raw_output(&payload), &hints).expect("redact");
+
+        for channel in [out.gate_output, out.tail_output, out.stderr_tail] {
+            let text = channel.expect("channel");
+            prop_assert!(!text.contains(&secret));
+        }
+    }
+
+    #[test]
+    fn redact_preserves_unrelated_benign_markers(
+        benign in "[a-z]{5,20}",
+        secret in "[A-Za-z0-9_-]{12,40}"
+    ) {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec!["API_TOKEN".into()],
+            secret_values: vec![secret.clone()],
+        };
+        let marker = format!("SAFE_MARKER_{benign}");
+        let payload = format!("API_TOKEN={secret} {marker}");
+        let out = redactor.redact(raw_output(&payload), &hints).expect("redact");
+        let gate = out.gate_output.expect("gate");
+
+        prop_assert!(gate.contains(&marker));
+        prop_assert!(!gate.contains(&secret));
+    }
+}

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -2,6 +2,7 @@ use proptest::prelude::*;
 use tanren_domain::Outcome;
 
 use super::*;
+use crate::execution::{RedactionSecret, SecretName};
 
 fn raw_output(text: &str) -> RawExecutionOutput {
     RawExecutionOutput {
@@ -40,8 +41,8 @@ fn redacts_bearer_and_prefixed_tokens() {
 fn redacts_explicit_secret_values_and_multiline_fragments() {
     let redactor = DefaultOutputRedactor::default();
     let hints = RedactionHints {
-        required_secret_names: vec!["MY_SECRET".into()],
-        secret_values: vec!["line1-secret\nline2-secret".into()],
+        required_secret_names: vec![SecretName::try_new("MY_SECRET").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("line1-secret\nline2-secret")],
     };
     let out = redactor
         .redact(
@@ -59,7 +60,7 @@ fn redacts_explicit_secret_values_and_multiline_fragments() {
 fn redacts_every_assignment_when_same_key_appears_multiple_times_on_line() {
     let redactor = DefaultOutputRedactor::default();
     let hints = RedactionHints {
-        required_secret_names: vec!["API_TOKEN".into()],
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
         secret_values: vec![],
     };
     let out = redactor
@@ -83,7 +84,7 @@ fn redacts_every_assignment_when_same_key_appears_multiple_times_on_line() {
 fn redacts_assignment_variants_with_colon_and_quotes() {
     let redactor = DefaultOutputRedactor::default();
     let hints = RedactionHints {
-        required_secret_names: vec!["my-secret".into()],
+        required_secret_names: vec![SecretName::try_new("my-secret").expect("secret key")],
         secret_values: vec![],
     };
     let out = redactor
@@ -118,7 +119,7 @@ fn leak_detection_flags_remaining_secret() {
     let redactor = DefaultOutputRedactor::default();
     let hints = RedactionHints {
         required_secret_names: vec![],
-        secret_values: vec!["secret-value".into()],
+        secret_values: vec![RedactionSecret::from("secret-value")],
     };
     let output = PersistableOutput {
         outcome: Outcome::Success,
@@ -161,8 +162,8 @@ proptest! {
     ) {
         let redactor = DefaultOutputRedactor::default();
         let hints = RedactionHints {
-            required_secret_names: vec![key.clone()],
-            secret_values: vec![secret.clone()],
+            required_secret_names: vec![SecretName::try_new(key.clone()).expect("secret key")],
+            secret_values: vec![RedactionSecret::from(secret.clone())],
         };
         let payload = format!("{key}={secret} and {secret} and {key}:{secret}");
         let out = redactor.redact(raw_output(&payload), &hints).expect("redact");
@@ -180,8 +181,8 @@ proptest! {
     ) {
         let redactor = DefaultOutputRedactor::default();
         let hints = RedactionHints {
-            required_secret_names: vec!["API_TOKEN".into()],
-            secret_values: vec![secret.clone()],
+            required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+            secret_values: vec![RedactionSecret::from(secret.clone())],
         };
         let marker = format!("SAFE_MARKER_{benign}");
         let payload = format!("API_TOKEN={secret} {marker}");
@@ -191,4 +192,49 @@ proptest! {
         prop_assert!(gate.contains(&marker));
         prop_assert!(!gate.contains(&secret));
     }
+}
+
+#[test]
+fn redacts_prefixed_tokens_case_insensitively() {
+    let redactor = DefaultOutputRedactor::default();
+    let out = redactor
+        .redact(
+            raw_output("token akia123456789012345 and GHP_abcdefghijklmnopqrstuvwxyz"),
+            &RedactionHints::default(),
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains("akia123456789012345"));
+    assert!(!gate.contains("GHP_abcdefghijklmnopqrstuvwxyz"));
+}
+
+#[test]
+fn truncates_large_channel_and_preserves_redaction() {
+    let mut payload = String::with_capacity((512 * 1024) + 128);
+    payload.push_str("API_TOKEN=very-secret-value ");
+    payload.push_str(&"x".repeat((512 * 1024) + 32));
+    let redactor = DefaultOutputRedactor::default();
+    let out = redactor
+        .redact(
+            raw_output(&payload),
+            &RedactionHints {
+                required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+                secret_values: vec![RedactionSecret::from("very-secret-value")],
+            },
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains("very-secret-value"));
+    assert!(gate.contains("[TRUNCATED_FOR_PERSISTENCE]"));
+}
+
+#[test]
+fn redaction_hints_debug_is_redacted() {
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("api_token").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("super-secret")],
+    };
+    let debug = format!("{hints:?}");
+    assert!(debug.contains("secret_value_count"));
+    assert!(!debug.contains("super-secret"));
 }

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -380,7 +380,7 @@ fn scanner_does_not_reenter_nested_assignment_like_value_body() {
 #[test]
 fn policy_dataset_snapshot_and_checksum_are_guarded() {
     let snapshot = policy_dataset::canonical_policy_dataset_snapshot_v1();
-    let expected_snapshot = r"version=2026-04-21.v1
+    let expected_snapshot = r"version=2026-04-21.v2
 provenance=owner=tanren-runtime;source=curated_phase1_minimum;change_control=version_bump_required
 min_token_len=10
 min_secret_fragment_len=4
@@ -437,3 +437,5 @@ token_prefix=ya29.";
         "dataset version must include explicit revision suffix"
     );
 }
+
+mod hardening_tests;

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use tanren_domain::Outcome;
+use tanren_domain::{FiniteF64, Outcome};
 
 use super::*;
 use crate::execution::{RedactionSecret, SecretName};
@@ -9,7 +9,7 @@ fn raw_output(text: &str) -> RawExecutionOutput {
         outcome: Outcome::Success,
         signal: None,
         exit_code: Some(0),
-        duration_secs: 1.0,
+        duration_secs: FiniteF64::try_new(1.0).expect("finite"),
         gate_output: Some(text.into()),
         tail_output: Some(text.into()),
         stderr_tail: Some(text.into()),
@@ -101,6 +101,28 @@ fn redacts_assignment_variants_with_colon_and_quotes() {
 }
 
 #[test]
+fn redacts_json_and_yaml_quoted_secret_keys() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("api_key").expect("secret key")],
+        secret_values: vec![],
+    };
+    let out = redactor
+        .redact(
+            raw_output(
+                "{\"api_key\":\"json-secret\",\"nested\":{\"api_key\":\"inner\"}}\n'api_key': 'yaml-secret'",
+            ),
+            &hints,
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+
+    assert!(!gate.contains("json-secret"), "{gate}");
+    assert!(!gate.contains("inner"), "{gate}");
+    assert!(!gate.contains("yaml-secret"), "{gate}");
+}
+
+#[test]
 fn leaves_non_sensitive_assignments_intact() {
     let redactor = DefaultOutputRedactor::default();
     let out = redactor
@@ -140,18 +162,97 @@ fn leak_detection_flags_remaining_secret() {
 }
 
 #[test]
-fn rejects_non_finite_duration() {
+fn policy_residual_leak_detects_unredacted_pattern_not_in_hints() {
     let redactor = DefaultOutputRedactor::default();
-    let err = redactor
+    let output = PersistableOutput {
+        outcome: Outcome::Success,
+        signal: None,
+        exit_code: None,
+        duration_secs: FiniteF64::try_new(1.0).expect("finite"),
+        gate_output: Some("authorization: Bearer sk-live-raw-token-value".into()),
+        tail_output: None,
+        stderr_tail: None,
+        pushed: false,
+        plan_hash: None,
+        unchecked_tasks: 0,
+        spec_modified: false,
+        findings: vec![],
+        token_usage: None,
+    };
+    assert!(redactor.has_policy_residual_leak(&output, &RedactionHints::default()));
+}
+
+#[test]
+fn conformance_fixture_has_no_leak_after_redaction() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("line1-secret\nline2-secret")],
+    };
+    let out = redactor
         .redact(
             RawExecutionOutput {
-                duration_secs: f64::NAN,
-                ..raw_output("ok")
+                outcome: Outcome::Success,
+                signal: None,
+                exit_code: Some(0),
+                duration_secs: FiniteF64::try_new(1.2).expect("finite"),
+                gate_output: Some("API_TOKEN=abc API_TOKEN='def' SAFE_MARKER".into()),
+                tail_output: Some("Bearer sk-live-secret line1-secret AKIA123456789012345".into()),
+                stderr_tail: Some("aws_secret_access_key=ghi line2-secret".into()),
+                pushed: false,
+                plan_hash: None,
+                unchecked_tasks: 0,
+                spec_modified: false,
+                findings: vec![],
+                token_usage: None,
             },
-            &RedactionHints::default(),
+            &hints,
         )
-        .expect_err("must fail");
-    assert_eq!(err, RedactionError::InvalidDuration);
+        .expect("redact");
+    assert!(
+        !redactor.has_known_secret_leak(&out, &hints),
+        "known leak gate={:?} tail={:?} stderr={:?}",
+        out.gate_output,
+        out.tail_output,
+        out.stderr_tail
+    );
+    let policy = default_redaction_policy();
+    let mut reasons = Vec::new();
+    for channel in [
+        out.gate_output.as_deref(),
+        out.tail_output.as_deref(),
+        out.stderr_tail.as_deref(),
+    ]
+    .iter()
+    .flatten()
+    {
+        for key in &policy.sensitive_key_names {
+            if scanner::contains_unredacted_assignment(channel, key, "[REDACTED]") {
+                reasons.push(format!("assignment:{key}:{channel}"));
+            }
+        }
+        if scanner::contains_unredacted_bearer_token(channel, policy.min_token_len, "[REDACTED]") {
+            reasons.push(format!("bearer:{channel}"));
+        }
+        for prefix in &policy.token_prefixes {
+            if scanner::contains_unredacted_prefixed_token(
+                channel,
+                prefix,
+                policy.min_token_len,
+                "[REDACTED]",
+            ) {
+                reasons.push(format!("prefix:{prefix}:{channel}"));
+            }
+        }
+    }
+    assert!(
+        !redactor.has_policy_residual_leak(&out, &hints),
+        "policy leak gate={:?} tail={:?} stderr={:?} reasons={:?}",
+        out.gate_output,
+        out.tail_output,
+        out.stderr_tail,
+        reasons
+    );
 }
 
 proptest! {
@@ -199,12 +300,12 @@ fn redacts_prefixed_tokens_case_insensitively() {
     let redactor = DefaultOutputRedactor::default();
     let out = redactor
         .redact(
-            raw_output("token akia123456789012345 and GHP_abcdefghijklmnopqrstuvwxyz"),
+            raw_output("token asia123456789012345 and GHP_abcdefghijklmnopqrstuvwxyz"),
             &RedactionHints::default(),
         )
         .expect("redact");
     let gate = out.gate_output.expect("gate");
-    assert!(!gate.contains("akia123456789012345"));
+    assert!(!gate.contains("asia123456789012345"));
     assert!(!gate.contains("GHP_abcdefghijklmnopqrstuvwxyz"));
 }
 

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -339,3 +339,101 @@ fn redaction_hints_debug_is_redacted() {
     assert!(debug.contains("secret_value_count"));
     assert!(!debug.contains("super-secret"));
 }
+
+#[test]
+fn redacts_before_truncation_for_boundary_sensitive_fragments() {
+    let mut payload = "x".repeat((512 * 1024) - 4);
+    payload.push_str("API_TOKEN=boundary-secret");
+    let redactor = DefaultOutputRedactor::default();
+    let out = redactor
+        .redact(
+            raw_output(&payload),
+            &RedactionHints {
+                required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+                secret_values: vec![RedactionSecret::from("boundary-secret")],
+            },
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains("boundary-secret"), "{gate}");
+}
+
+#[test]
+fn scanner_does_not_reenter_nested_assignment_like_value_body() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("api_token").expect("secret key")],
+        secret_values: vec![],
+    };
+    let out = redactor
+        .redact(
+            raw_output("api_token=\"outer value includes inner=still-safe\" marker=ok"),
+            &hints,
+        )
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(gate.contains("marker=ok"), "{gate}");
+    assert!(!gate.contains("outer value"), "{gate}");
+    assert!(!gate.contains("still-safe"), "{gate}");
+}
+
+#[test]
+fn policy_dataset_snapshot_and_checksum_are_guarded() {
+    let snapshot = policy_dataset::canonical_policy_dataset_snapshot_v1();
+    let expected_snapshot = r"version=2026-04-21.v1
+provenance=owner=tanren-runtime;source=curated_phase1_minimum;change_control=version_bump_required
+min_token_len=10
+min_secret_fragment_len=4
+max_persistable_channel_bytes=524288
+sensitive_key=api_key
+sensitive_key=api-token
+sensitive_key=api_token
+sensitive_key=auth_token
+sensitive_key=access_token
+sensitive_key=refresh_token
+sensitive_key=session_token
+sensitive_key=authorization
+sensitive_key=bearer
+sensitive_key=cookie
+sensitive_key=set-cookie
+sensitive_key=password
+sensitive_key=secret
+sensitive_key=secret_key
+sensitive_key=private_key
+sensitive_key=client_secret
+sensitive_key=id_token
+sensitive_key=personal_access_token
+sensitive_key=aws_access_key_id
+sensitive_key=aws_secret_access_key
+sensitive_key=x-api-key
+token_prefix=sk-
+token_prefix=sk-proj-
+token_prefix=sk-ant-
+token_prefix=ghp_
+token_prefix=gho_
+token_prefix=ghu_
+token_prefix=ghs_
+token_prefix=github_pat_
+token_prefix=xoxb-
+token_prefix=xoxp-
+token_prefix=xoxa-
+token_prefix=xoxr-
+token_prefix=AKIA
+token_prefix=ASIA
+token_prefix=AIza
+token_prefix=ya29.";
+    assert_eq!(snapshot, expected_snapshot);
+    let checksum = policy_dataset::policy_dataset_checksum_fnv64(&snapshot);
+    assert_eq!(
+        checksum,
+        policy_dataset::DEFAULT_REDACTION_POLICY_DATASET_CHECKSUM_FNV64
+    );
+    let version = policy_dataset::DEFAULT_REDACTION_POLICY_DATASET_VERSION;
+    let mut parts = version.rsplitn(2, ".v");
+    let revision = parts.next().unwrap_or_default();
+    let has_prefix = parts.next().is_some();
+    assert!(
+        has_prefix && !revision.is_empty() && revision.chars().all(|ch| ch.is_ascii_digit()),
+        "dataset version must include explicit revision suffix"
+    );
+}

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -226,19 +226,20 @@ fn conformance_fixture_has_no_leak_after_redaction() {
     .iter()
     .flatten()
     {
-        for key in &policy.sensitive_key_names {
+        for key in policy.sensitive_key_names() {
             if scanner::contains_unredacted_assignment(channel, key, "[REDACTED]") {
                 reasons.push(format!("assignment:{key}:{channel}"));
             }
         }
-        if scanner::contains_unredacted_bearer_token(channel, policy.min_token_len, "[REDACTED]") {
+        if scanner::contains_unredacted_bearer_token(channel, policy.min_token_len(), "[REDACTED]")
+        {
             reasons.push(format!("bearer:{channel}"));
         }
-        for prefix in &policy.token_prefixes {
+        for prefix in policy.token_prefixes() {
             if scanner::contains_unredacted_prefixed_token(
                 channel,
                 prefix,
-                policy.min_token_len,
+                policy.min_token_len(),
                 "[REDACTED]",
             ) {
                 reasons.push(format!("prefix:{prefix}:{channel}"));
@@ -439,3 +440,4 @@ token_prefix=ya29.";
 }
 
 mod hardening_tests;
+mod policy_validation_tests;

--- a/crates/tanren-runtime/src/redaction/tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests.rs
@@ -294,6 +294,7 @@ proptest! {
         prop_assert!(gate.contains(&marker));
         prop_assert!(!gate.contains(&secret));
     }
+
 }
 
 #[test]

--- a/crates/tanren-runtime/src/redaction/tests/hardening_tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests/hardening_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[test]
+fn redacts_contextual_short_multiline_secret_fragments() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("api_key").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("very-long-secret\nx9-")],
+    };
+    let out = redactor
+        .redact(raw_output("api_key=x9- marker=ok prefixx9-suffix"), &hints)
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains("api_key=x9-"), "{gate}");
+    assert!(gate.contains("prefixx9-suffix"), "{gate}");
+}
+
+#[test]
+fn redacts_url_and_base64_encoded_secret_variants() {
+    let redactor = DefaultOutputRedactor::default();
+    let secret = "s3cr3t+/=";
+    let percent = secret_matcher::percent_encode(secret.as_bytes());
+    let base64_std = secret_matcher::base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+        true,
+    );
+    let base64_url = secret_matcher::base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+        false,
+    );
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec![RedactionSecret::from(secret)],
+    };
+    let payload = format!("{percent} {base64_std} {base64_url}");
+    let out = redactor
+        .redact(raw_output(&payload), &hints)
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains(&percent), "{gate}");
+    assert!(!gate.contains(&base64_std), "{gate}");
+    assert!(!gate.contains(&base64_url), "{gate}");
+}
+
+#[test]
+fn redact_with_audit_returns_single_verdict_for_channels() {
+    let redactor = DefaultOutputRedactor::default();
+    let hints = RedactionHints {
+        required_secret_names: vec![SecretName::try_new("API_TOKEN").expect("secret key")],
+        secret_values: vec![RedactionSecret::from("line1-secret\nline2-secret")],
+    };
+    let result = redactor
+        .redact_with_audit(
+            RawExecutionOutput {
+                outcome: Outcome::Success,
+                signal: None,
+                exit_code: Some(0),
+                duration_secs: FiniteF64::try_new(1.2).expect("finite"),
+                gate_output: Some("API_TOKEN=abc SAFE_MARKER".into()),
+                tail_output: Some("line1-secret".into()),
+                stderr_tail: Some("line2-secret".into()),
+                pushed: false,
+                plan_hash: None,
+                unchecked_tasks: 0,
+                spec_modified: false,
+                findings: vec![],
+                token_usage: None,
+            },
+            &hints,
+        )
+        .expect("redact");
+    assert!(!result.audit.has_any_leak());
+    let gate = result.output.gate_output.expect("gate");
+    assert!(gate.contains("SAFE_MARKER"), "{gate}");
+}

--- a/crates/tanren-runtime/src/redaction/tests/hardening_tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests/hardening_tests.rs
@@ -45,6 +45,35 @@ fn redacts_url_and_base64_encoded_secret_variants() {
 }
 
 #[test]
+fn redacts_encoded_variants_for_long_secrets_within_contract_bounds() {
+    let redactor = DefaultOutputRedactor::default();
+    let secret = format!("{}+/=", "s3cr3t".repeat(30));
+    let percent = secret_matcher::percent_encode(secret.as_bytes());
+    let base64_std = secret_matcher::base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+        true,
+    );
+    let base64_url = secret_matcher::base64_encode(
+        secret.as_bytes(),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+        false,
+    );
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec![RedactionSecret::from(secret.as_str())],
+    };
+    let payload = format!("{percent}\n{base64_std}\n{base64_url}");
+    let out = redactor
+        .redact(raw_output(&payload), &hints)
+        .expect("redact");
+    let gate = out.gate_output.expect("gate");
+    assert!(!gate.contains(&percent), "{gate}");
+    assert!(!gate.contains(&base64_std), "{gate}");
+    assert!(!gate.contains(&base64_url), "{gate}");
+}
+
+#[test]
 fn redact_with_audit_returns_single_verdict_for_channels() {
     let redactor = DefaultOutputRedactor::default();
     let hints = RedactionHints {
@@ -74,4 +103,130 @@ fn redact_with_audit_returns_single_verdict_for_channels() {
     assert!(!result.audit.has_any_leak());
     let gate = result.output.gate_output.expect("gate");
     assert!(gate.contains("SAFE_MARKER"), "{gate}");
+}
+
+#[test]
+fn redaction_hints_validate_count_bounds() {
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec![RedactionSecret::from("x"); MAX_REDACTION_HINT_SECRET_COUNT + 1],
+    };
+    let err = hints
+        .validate_bounds()
+        .expect_err("must reject over-count hints");
+    assert!(matches!(
+        err,
+        RedactionHintBoundsError::TooManySecrets {
+            max_count: MAX_REDACTION_HINT_SECRET_COUNT,
+            actual_count
+        } if actual_count == MAX_REDACTION_HINT_SECRET_COUNT + 1
+    ));
+}
+
+#[test]
+fn redaction_hints_validate_secret_size_bounds() {
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec![RedactionSecret::from(
+            "x".repeat(MAX_REDACTION_HINT_SECRET_BYTES + 1),
+        )],
+    };
+    let err = hints
+        .validate_bounds()
+        .expect_err("must reject oversized secret value");
+    assert!(matches!(
+        err,
+        RedactionHintBoundsError::SecretTooLarge {
+            index: 0,
+            max_bytes: MAX_REDACTION_HINT_SECRET_BYTES,
+            actual_bytes
+        } if actual_bytes == MAX_REDACTION_HINT_SECRET_BYTES + 1
+    ));
+}
+
+#[test]
+fn redaction_hints_validate_total_size_bounds() {
+    let hints = RedactionHints {
+        required_secret_names: vec![],
+        secret_values: vec![RedactionSecret::from("a".repeat(MAX_REDACTION_HINT_SECRET_BYTES)); 17],
+    };
+    let err = hints
+        .validate_bounds()
+        .expect_err("must reject total bytes overflow");
+    assert!(matches!(
+        err,
+        RedactionHintBoundsError::TotalBytesExceeded {
+            max_total_bytes: MAX_REDACTION_HINT_TOTAL_SECRET_BYTES,
+            actual_total_bytes
+        } if actual_total_bytes > MAX_REDACTION_HINT_TOTAL_SECRET_BYTES
+    ));
+}
+
+proptest! {
+    #[test]
+    fn redaction_stress_handles_high_hint_cardinality(
+        secrets in prop::collection::vec("[A-Za-z0-9_\\-]{4,32}", 1..=128),
+        payload_noise in prop::collection::vec("[A-Za-z0-9_\\-]{0,16}", 0..=64)
+    ) {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec![],
+            secret_values: secrets
+                .iter()
+                .map(|secret| RedactionSecret::from(secret.as_str()))
+                .collect(),
+        };
+        prop_assert!(hints.validate_bounds().is_ok());
+
+        let mut payload = secrets.join(" ");
+        if !payload_noise.is_empty() {
+            payload.push(' ');
+            payload.push_str(&payload_noise.join(" "));
+        }
+        let out = redactor.redact(raw_output(&payload), &hints).expect("redact");
+        let joined = format!(
+            "{} {} {}",
+            out.gate_output.unwrap_or_default(),
+            out.tail_output.unwrap_or_default(),
+            out.stderr_tail.unwrap_or_default(),
+        );
+
+        for secret in &secrets {
+            prop_assert!(!joined.contains(secret));
+        }
+    }
+
+    #[test]
+    fn redaction_stress_handles_boundary_hint_sizes(
+        payload in ".{0,24000}",
+        secrets in prop::collection::vec("[A-Za-z0-9_\\-]{1,256}", 0..=256)
+    ) {
+        let redactor = DefaultOutputRedactor::default();
+        let hints = RedactionHints {
+            required_secret_names: vec![],
+            secret_values: secrets
+                .iter()
+                .map(|secret| RedactionSecret::from(secret.as_str()))
+                .collect(),
+        };
+        prop_assert!(hints.validate_bounds().is_ok());
+        let outcome = redactor
+            .redact_with_audit(raw_output(&payload), &hints)
+            .expect("redact");
+
+        for channel in [
+            outcome.output.gate_output.as_deref(),
+            outcome.output.tail_output.as_deref(),
+            outcome.output.stderr_tail.as_deref(),
+        ]
+        .iter()
+        .flatten()
+        {
+            prop_assert!(
+                channel.len() <= default_redaction_policy().max_persistable_channel_bytes()
+                    + TRUNCATION_MARKER.len()
+                    + 1
+            );
+        }
+    }
 }

--- a/crates/tanren-runtime/src/redaction/tests/policy_validation_tests.rs
+++ b/crates/tanren-runtime/src/redaction/tests/policy_validation_tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[test]
+fn redaction_policy_rejects_invalid_thresholds() {
+    let err = RedactionPolicy::try_new(4, 3, vec!["api_key".into()], vec!["sk-".into()], 2048)
+        .expect_err("min token len below secure floor must fail");
+    assert!(matches!(
+        err,
+        RedactionPolicyError::MinTokenLenTooSmall { .. }
+    ));
+
+    let err = RedactionPolicy::try_new(10, 11, vec!["api_key".into()], vec!["sk-".into()], 2048)
+        .expect_err("secret fragment len above token len must fail");
+    assert!(matches!(
+        err,
+        RedactionPolicyError::MinSecretFragmentLenOutOfRange { .. }
+    ));
+}
+
+#[test]
+fn redaction_policy_normalizes_and_validates_duplicates() {
+    let policy = RedactionPolicy::try_new(
+        10,
+        4,
+        vec![" API_KEY ".into(), "client_secret".into()],
+        vec![" SK- ".into(), "ghp_".into()],
+        2048,
+    )
+    .expect("valid policy");
+
+    let keys = policy
+        .sensitive_key_names()
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(keys, vec!["api_key", "client_secret"]);
+
+    let prefixes = policy
+        .token_prefixes()
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(prefixes, vec!["sk-", "ghp_"]);
+
+    let duplicate = RedactionPolicy::try_new(
+        10,
+        4,
+        vec!["api_key".into(), "API_KEY".into()],
+        vec!["sk-".into()],
+        2048,
+    )
+    .expect_err("duplicate key names must be rejected");
+    assert!(matches!(
+        duplicate,
+        RedactionPolicyError::DuplicateSensitiveKeyName { .. }
+    ));
+}
+
+#[test]
+fn redaction_policy_deserialization_fails_for_invalid_payloads() {
+    let payload = serde_json::json!({
+        "min_token_len": 2,
+        "min_secret_fragment_len": 1,
+        "sensitive_key_names": ["api_key"],
+        "token_prefixes": ["sk-"],
+        "max_persistable_channel_bytes": 2048
+    });
+    let err = serde_json::from_value::<RedactionPolicy>(payload).expect_err("must reject");
+    assert!(
+        err.to_string().contains("min_token_len"),
+        "unexpected deserialization error: {err}"
+    );
+}
+
+#[test]
+fn redaction_matchers_compile_to_bounded_state_machines() {
+    let prefixes = (0..200)
+        .map(|idx| format!("p{idx:03}_"))
+        .collect::<Vec<_>>();
+    let prefix_matcher = scanner::CompiledTokenPrefixMatcher::new(&prefixes);
+    let prefix_stats = prefix_matcher.stats();
+    assert_eq!(prefix_stats.prefixes, 200);
+    assert!(prefix_stats.nodes <= 1001);
+    assert!(prefix_stats.transitions <= 1000);
+
+    let hints = RedactionHints {
+        required_secret_names: Vec::new(),
+        secret_values: (0..120)
+            .map(|idx| RedactionSecret::from(format!("secret-{idx:03}-abcdefghijklmnop")))
+            .collect(),
+    };
+    let matcher = CompiledSecretMatcher::from_hints(&hints, 4);
+    let matcher_stats = matcher.stats();
+    assert!(matcher_stats.patterns >= 120);
+    assert!(matcher_stats.states > 1);
+    assert!(matcher_stats.transitions >= matcher_stats.patterns);
+}

--- a/crates/tanren-runtime/tests/compile_fail.rs
+++ b/crates/tanren-runtime/tests/compile_fail.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn harness_failure_new_is_not_public_outside_crate() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let workspace = std::env::temp_dir().join(format!(
+        "tanren-runtime-compile-fail-{}-{nanos}",
+        std::process::id()
+    ));
+    let src_dir = workspace.join("src");
+    assert!(
+        fs::create_dir_all(&src_dir).is_ok(),
+        "failed to create temporary compile-fail workspace"
+    );
+
+    let manifest = format!(
+        "[package]\nname = \"compile-fail-harness-new\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ntanren-runtime = {{ path = \"{}\" }}\n",
+        manifest_dir.display()
+    );
+    assert!(
+        fs::write(workspace.join("Cargo.toml"), manifest).is_ok(),
+        "failed to write compile-fail Cargo.toml"
+    );
+    assert!(
+        fs::write(
+            src_dir.join("main.rs"),
+            "use tanren_runtime::{HarnessFailure, ProviderFailureCode};\n\nfn main() {\n    let _ = HarnessFailure::new(ProviderFailureCode::Fatal, \"unsanitized\");\n}\n",
+        )
+        .is_ok(),
+        "failed to write compile-fail source"
+    );
+
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let output = Command::new(cargo)
+        .arg("check")
+        .arg("--manifest-path")
+        .arg(workspace.join("Cargo.toml"))
+        .output();
+    let _ = fs::remove_dir_all(&workspace);
+
+    assert!(
+        output.is_ok(),
+        "failed to invoke cargo for compile-fail test"
+    );
+    let Some(output) = output.ok() else {
+        return;
+    };
+
+    assert!(
+        !output.status.success(),
+        "calling HarnessFailure::new outside the crate must not compile"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("HarnessFailure::new")
+            || stderr.contains("private associated function")
+            || stderr.contains("no function or associated item named `new`"),
+        "unexpected compiler stderr: {stderr}"
+    );
+}

--- a/crates/tanren-runtime/tests/compile_fail.rs
+++ b/crates/tanren-runtime/tests/compile_fail.rs
@@ -3,15 +3,14 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[test]
-fn harness_failure_new_is_not_public_outside_crate() {
+fn assert_compile_fail(test_name: &str, source: &str, stderr_expectations: &[&str]) {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let workspace = std::env::temp_dir().join(format!(
-        "tanren-runtime-compile-fail-{}-{nanos}",
+        "tanren-runtime-compile-fail-{test_name}-{}-{nanos}",
         std::process::id()
     ));
     let src_dir = workspace.join("src");
@@ -21,7 +20,7 @@ fn harness_failure_new_is_not_public_outside_crate() {
     );
 
     let manifest = format!(
-        "[package]\nname = \"compile-fail-harness-new\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ntanren-runtime = {{ path = \"{}\" }}\n",
+        "[package]\nname = \"compile-fail-{test_name}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ntanren-runtime = {{ path = \"{}\" }}\n",
         manifest_dir.display()
     );
     assert!(
@@ -29,11 +28,7 @@ fn harness_failure_new_is_not_public_outside_crate() {
         "failed to write compile-fail Cargo.toml"
     );
     assert!(
-        fs::write(
-            src_dir.join("main.rs"),
-            "use tanren_runtime::{HarnessFailure, ProviderFailureCode};\n\nfn main() {\n    let _ = HarnessFailure::new(ProviderFailureCode::Fatal, \"unsanitized\");\n}\n",
-        )
-        .is_ok(),
+        fs::write(src_dir.join("main.rs"), source).is_ok(),
         "failed to write compile-fail source"
     );
 
@@ -55,14 +50,40 @@ fn harness_failure_new_is_not_public_outside_crate() {
 
     assert!(
         !output.status.success(),
-        "calling HarnessFailure::new outside the crate must not compile"
+        "compile-fail fixture `{test_name}` unexpectedly compiled"
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("HarnessFailure::new")
-            || stderr.contains("private associated function")
-            || stderr.contains("no function or associated item named `new`"),
-        "unexpected compiler stderr: {stderr}"
+        stderr_expectations
+            .iter()
+            .any(|needle| stderr.contains(needle)),
+        "unexpected compiler stderr for `{test_name}`: {stderr}"
+    );
+}
+
+#[test]
+fn harness_failure_new_is_not_public_outside_crate() {
+    assert_compile_fail(
+        "harness-new",
+        "use tanren_runtime::{HarnessFailure, ProviderFailureCode};\n\nfn main() {\n    let _ = HarnessFailure::new(ProviderFailureCode::Fatal, \"unsanitized\");\n}\n",
+        &[
+            "HarnessFailure::new",
+            "private associated function",
+            "no function or associated item named `new`",
+        ],
+    );
+}
+
+#[test]
+fn contract_call_token_cannot_be_constructed_outside_crate() {
+    assert_compile_fail(
+        "contract-call-token",
+        "use tanren_runtime::ContractCallToken;\n\nfn main() {\n    let _ = ContractCallToken { };\n}\n",
+        &[
+            "cannot construct",
+            "private field",
+            "initializer of inaccessible field",
+        ],
     );
 }

--- a/crates/tanren-runtime/tests/lane_scope_docs.rs
+++ b/crates/tanren-runtime/tests/lane_scope_docs.rs
@@ -1,0 +1,23 @@
+#[test]
+fn lane_1_1_scope_boundary_is_explicitly_documented() {
+    let lane_1_1 = include_str!("../../../docs/rewrite/tasks/LANE-1.1-HARNESS.md");
+    assert!(
+        lane_1_1.contains("This lane does **not** ship concrete provider adapters."),
+        "Lane 1.1 must explicitly state concrete adapter implementation is out of scope"
+    );
+    assert!(
+        lane_1_1.contains(
+            "Lane 1.1 audits must score adapter implementation completeness as out-of-scope"
+        ),
+        "Lane 1.1 must include explicit audit-scope guardrail"
+    );
+}
+
+#[test]
+fn lane_1_2_scope_requires_concrete_adapter_parity() {
+    let lane_1_2 = include_str!("../../../docs/rewrite/tasks/LANE-1.2-BRIEF.md");
+    assert!(
+        lane_1_2.contains("All three Phase 1 harnesses are mandatory scope for this lane."),
+        "Lane 1.2 must continue to require concrete adapter completeness"
+    );
+}

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -45,6 +45,10 @@ Approval denials are now represented only by reachable states:
 `HarnessExecutionRequest` is the normalized request shape.
 
 - `required_secret_names` is strongly typed (`SecretName`).
+- explicit redaction hint values are hard-bounded:
+  - max secret count: `256`
+  - max per-secret bytes: `4096`
+  - max total bytes: `65536`
 - redaction secret values are in-memory only (`RedactionSecret`) and excluded
   from serialized payloads.
 
@@ -57,6 +61,7 @@ execution:
 4. single-pass redaction audit verdict (known-secret + residual policy)
 5. metadata sanitization and allowlist validation
    (`provider_run_id`, `provider_code`, `provider_kind`, fail-closed)
+   with typed `ProviderRunId` / `ProviderIdentifier` parsing
 6. persistable output release
 
 Adapters must not bypass this wrapper when producing persistable output.
@@ -98,8 +103,8 @@ Policy behavior:
 - encoded secret variant redaction (URL/base64 forms derived from known hints)
 - bounded per-channel persistence with deterministic truncation marker
 - validated immutable policy schema (`RedactionPolicy::try_new` / builder)
-- compiled prefix trie and multi-pattern secret matcher (Aho-Corasick style)
-  for scalable hint/prefix cardinality
+- precompiled prefix trie and multi-pattern secret matcher (Aho-Corasick style)
+  for scalable hint/prefix cardinality and per-call reuse
 
 `RedactionHints` is secret-safe:
 
@@ -135,6 +140,8 @@ Required adapter evidence:
   runtime registry patterns.
 - provider metadata is sanitized and validated under a strict fail-closed policy
   before exposure/persistence.
+- adapter failure payload sanitization emits a dedicated
+  `FailurePathRedactionLeakDetected` contract error on residual leaks.
 - default redaction policy/patterns are sourced from a versioned dataset.
 - test-only customization for contract internals is crate-scoped.
 - `HarnessExecutionEvent` is source-tagged (`contract` vs `adapter`) and adapter

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -23,7 +23,7 @@ Capability metadata is immutable and type-level in the adapter contract;
 preflight checks read static capability data rather than invoking adapter
 instance logic.
 
-`HarnessRequirements` defines dispatch requirements and now supports explicit
+`HarnessRequirements` defines dispatch requirements and supports explicit
 least-privilege bounds:
 
 - capability minimums (for required features)
@@ -31,6 +31,8 @@ least-privilege bounds:
 - dual approval ordering:
   - minimum approval uses strictness (`never < on_escalation < on_demand`)
   - maximum approval uses privilege risk (`on_demand < on_escalation < never`)
+- validated bound types (`SandboxModeBounds`, `ApprovalModeBounds`) plus
+  builder-based construction prevent invalid range objects at creation time.
 
 `ensure_admissible` performs preflight checks and returns typed
 `CompatibilityDenialKind` before side effects.
@@ -53,7 +55,8 @@ execution:
 2. sealed adapter invocation (contract-only call token)
 3. contract-owned redaction (not caller-injected)
 4. single-pass redaction audit verdict (known-secret + residual policy)
-5. metadata sanitization and allowlist validation (`provider_run_id`, fail-closed)
+5. metadata sanitization and allowlist validation
+   (`provider_run_id`, `provider_code`, `provider_kind`, fail-closed)
 6. persistable output release
 
 Adapters must not bypass this wrapper when producing persistable output.
@@ -69,9 +72,10 @@ contract wrapper is the only normalization boundary to `HarnessFailure`.
 `ProviderFailureContext` supports typed/normalized classification:
 
 - mandatory typed adapter code (`ProviderFailureCode`) for terminal failures
-- `typed_code=unknown` is forbidden for terminal failures
+- terminal typed code is strict and has no `unknown` variant
 - deterministic typed mapping only for semantic normalization
 - optional audit-only fallback utility (`classify_provider_failure_for_audit`)
+  is carried by `AuditProviderFailureContext`/`AuditProviderFailureCode`.
 
 ### Redaction Contract
 
@@ -104,12 +108,16 @@ Lane 1.2+ adapter crates must reuse `tanren-runtime` conformance helpers:
 - `assert_capability_denial_is_preflight`
 - `assert_redaction_before_persistence`
 - `assert_failure_classification`
+- `assert_provider_metadata_fail_closed`
+- `assert_terminal_typed_code_mapping`
 
 Required adapter evidence:
 
 1. capability denial is preflight-only
 2. redaction completes before persistence
 3. failure mapping is stable across provider-native payloads
+4. provider metadata sanitization is fail-closed
+5. terminal typed-code semantics remain deterministic
 
 ## Implementation Notes
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,625 +1,103 @@
-# Adapter Architecture
-
-The tanren-core library uses protocol-based dependency injection to keep its core
-orchestration logic decoupled from concrete infrastructure. Every external
-concern -- git operations, process spawning, environment validation, event
-storage -- is accessed through a `typing.Protocol` interface. The `Worker`
-class accepts injected adapters; when omitted, it falls back to built-in
-defaults that cover the common case (local subprocess execution against a
-git repository with dotenv-based secrets).
-
-This design follows the principle of **opinionated defaults, pluggable
-internals**: the built-in adapters handle the 90% case out of the box, while
-the protocol boundaries let you swap in alternatives (Docker, remote VM, Vault,
-Postgres) without modifying core orchestration code.
-
-All protocol classes are defined in `adapters/protocols.py` and decorated with
-`@runtime_checkable`, so custom implementations can be validated at startup
-with `isinstance()`.
-
-
-## Adapter Categories
-
-The table below lists every integration category in the tanren ecosystem.
-The tanren-core library directly owns protocols for the first six categories. The
-remaining categories (CI/CD, Secret Management, Token Usage, Coordinator
-Interface) are handled by other components but listed here for completeness.
-
-| Category | Built-in | Also Supports |
-|---|---|---|
-| Issue Source | GitHub Issues | Linear, Jira, custom |
-| Source Control | GitHub | GitHub Enterprise, GitLab, Bitbucket |
-| Execution Environment | Local subprocess | Docker, remote VM via SSH, cloud VM w/ lifecycle |
-| CI/CD | GitHub Actions | GitLab CI, Jenkins, CircleCI |
-| Secret Management | Flat file (`~/.config/tanren/secrets.env`) | Vault, AWS/GCP Secret Manager |
-| Event/Metrics Storage | SQLite | Postgres, BigQuery, custom |
-| Token Usage Collection | Log parsing (ccusage-style) | Metering proxy |
-| Coordinator Interface | Web dashboard + CLI (built-in) | Messaging platforms (pluggable) |
-
-
-## Current Protocol Interfaces
-
-The tanren-core library defines eight protocols. Each one covers a single
-responsibility and has exactly one built-in concrete implementation.
-
-### WorktreeManager
-
-Create, register, and clean up git worktrees for isolated agent workspaces.
-
-```python
-class WorktreeManager(Protocol):
-    async def create(self, project: str, issue: int, branch: str, github_dir: str) -> Path: ...
-    async def register(
-        self,
-        registry_path: Path,
-        workflow_id: str,
-        project: str,
-        issue: int,
-        branch: str,
-        worktree_path: Path,
-        github_dir: str,
-    ) -> None: ...
-    async def cleanup(self, workflow_id: str, registry_path: Path, github_dir: str) -> None: ...
-```
-
-**Lifecycle:** `create` is called during the SETUP phase to produce an isolated
-working directory. `register` records it in a JSON registry so the coordinator
-knows where each workflow lives. `cleanup` removes the worktree and its
-registry entry during the CLEANUP phase.
-
-**Default:** `GitWorktreeManager` -- delegates to `git worktree add/remove`.
-
-### PreflightRunner
-
-Run pre-flight checks before an agent process is spawned.
-
-```python
-class PreflightRunner(Protocol):
-    async def run(
-        self, worktree_path: Path, branch: str, spec_folder: Path, phase: str
-    ) -> PreflightResult: ...
-```
-
-**Lifecycle:** Called before every work phase. Returns a `PreflightResult`
-containing `passed`, `error`, `repairs` (auto-fixed issues), `file_hashes`
-(snapshot for postflight diff), and `file_backups` (originals of protected
-files).
-
-**Default:** `GitPreflightRunner` -- verifies branch state, snapshots
-protected files, clears stale status markers.
-
-### PostflightRunner
-
-Run post-flight integrity checks after an agent process exits.
-
-```python
-class PostflightRunner(Protocol):
-    async def run(
-        self,
-        worktree_path: Path,
-        branch: str,
-        phase: str,
-        preflight_hashes: dict[str, str],
-        preflight_backups: dict[str, str],
-        *,
-        skip_push: bool = False,
-    ) -> PostflightResult: ...
-```
-
-**Lifecycle:** Called after work phases that produce commits (DO_TASK,
-AUDIT_TASK, RUN_DEMO, AUDIT_SPEC). Compares file hashes against preflight
-snapshots, restores protected files if they were modified, and pushes the
-branch. When `skip_push=True` (error/timeout outcomes), the push is skipped
-but integrity checks still run.
-
-**Default:** `GitPostflightRunner` -- delegates to `postflight.run_postflight()`.
-
-### ProcessSpawner
-
-Spawn CLI processes for dispatched work.
-
-```python
-class ProcessSpawner(Protocol):
-    async def spawn(
-        self,
-        dispatch: Dispatch,
-        worktree_path: Path,
-        config: Config,
-        *,
-        task_env: dict[str, str] | None = None,
-    ) -> ProcessResult: ...
-```
-
-**Lifecycle:** Called inside the retry loop. Receives the full `Dispatch`
-(workflow ID, phase, CLI tool, branch, spec folder) and returns a
-`ProcessResult` with `exit_code`, `stdout`, `duration_secs`, and `timed_out`.
-
-**Default:** `SubprocessSpawner` -- wraps `asyncio.create_subprocess_exec`
-with timeout handling.
-
-### EnvValidator
-
-Validate environment requirements before work phases.
-
-```python
-class EnvValidator(Protocol):
-    async def load_and_validate(self, project_root: Path) -> tuple[EnvReport, dict[str, str]]: ...
-```
-
-**Lifecycle:** Called at the start of every work phase, before preflight. Loads
-the project's `tanren.yml` env schema, resolves values from `.env` files and
-the secrets store, and returns an `EnvReport` (pass/fail with diagnostics) plus
-a `dict` of resolved key-value pairs to inject into the agent process.
-
-**Default:** `DotenvEnvValidator` -- reads `tanren.yml` env requirements and
-resolves from `.env` + `~/.config/tanren/secrets.env`.
-
-### EnvProvisioner
-
-Provision `.env` files in worktrees during setup.
-
-```python
-class EnvProvisioner(Protocol):
-    def provision(self, worktree_path: Path, project_dir: Path) -> int: ...
-```
-
-**Lifecycle:** Called during SETUP after the worktree is created. Copies or
-symlinks `.env` files from the main project directory into the worktree.
-Returns the number of variables provisioned. This is a **sync** method; the
-caller wraps it in `asyncio.to_thread()`.
-
-**Default:** `DotenvEnvProvisioner` -- copies `.env` from project root into
-the worktree.
-
-### EventStore
-
-Append structured events and query the event log for observability and
-debugging. Defined in `store/protocols.py`.
-
-```python
-class EventStore(Protocol):
-    async def append(self, event: Event) -> None: ...
-    async def query_events(
-        self, *, dispatch_id=None, event_type=None, since=None, until=None, limit=50, offset=0
-    ) -> EventQueryResult: ...
-    async def close(self) -> None: ...
-```
-
-**Lifecycle:** `append` is called at key points throughout dispatch handling
-(DispatchReceived, PhaseStarted, PhaseCompleted, PreflightCompleted,
-PostflightCompleted, RetryScheduled, ErrorOccurred). `query_events` supports
-paginated, filterable reads over the event log. `close` is called during
-graceful shutdown.
-
-**Implementation:**
-- `Store` (`tanren_core.store.repository`) -- unified SQLAlchemy 2.0 ORM
-  implementation that supports both SQLite (via aiosqlite) and Postgres
-  (via asyncpg). Schema is defined in `store/models.py` with ORM-mapped
-  classes; `store/engine.py` handles async engine creation; and
-  `store/converters.py` bridges ORM rows to domain views. Schema migrations
-  are managed by Alembic (see `packages/tanren-core/alembic/`).
-
-### ExecutionEnvironment
-
-The highest-level adapter. Encapsulates the full lifecycle of where and how
-agent work runs. See the deep dive below.
-
-```python
-class ExecutionEnvironment(Protocol):
-    async def provision(self, dispatch: Dispatch, config: Config) -> EnvironmentHandle: ...
-    async def execute(
-        self, handle: EnvironmentHandle, dispatch: Dispatch, config: Config
-    ) -> PhaseResult: ...
-    async def get_access_info(self, handle: EnvironmentHandle) -> AccessInfo: ...
-    async def teardown(self, handle: EnvironmentHandle) -> None: ...
-```
-
-**Defaults:**
-- `LocalExecutionEnvironment` -- local subprocess execution (default when
-  no `remote_config_path` is set).
-- `SSHExecutionEnvironment` -- remote VM execution via SSH (used when
-  `WM_REMOTE_CONFIG` points to a `remote.yml` file).
-
-
-## ExecutionEnvironment Deep Dive
-
-The `ExecutionEnvironment` protocol is the primary extension point for
-running agent work in different contexts -- local subprocesses, Docker
-containers, remote VMs, or cloud-managed instances.
-
-### Lifecycle
-
-```
-provision() --> EnvironmentHandle
-     |
-     v
-execute()   --> PhaseResult    (includes retry loop, heartbeat, postflight)
-     |
-     v
-get_access_info() --> AccessInfo   (optional, for debugging)
-     |
-     v
-teardown()  --> cleanup
-```
-
-1. **provision()** validates the environment (env vars, preflight checks) and
-   returns an `EnvironmentHandle` that carries context through the remaining
-   steps. Raises `ProvisionError` if validation or preflight fails.
-
-2. **execute()** runs the agent process with heartbeat monitoring, transient
-   error retry (up to 3 retries with backoff), and postflight integrity checks.
-   Returns a `PhaseResult` with outcome, signal, duration, and metrics.
-
-3. **get_access_info()** returns connection details for debugging a running
-   environment -- SSH commands, VS Code remote URIs, working directory.
-
-4. **teardown()** cleans up resources. No-op for local; would destroy
-   containers or VMs for other environment types.
-
-### Data Types
-
-```python
-class EnvironmentHandle(BaseModel):
-    env_id: str  # UUID identifying this environment instance
-    worktree_path: Path  # Where the code lives
-    branch: str  # Git branch
-    project: str  # Project name
-    runtime: LocalEnvironmentRuntime | RemoteEnvironmentRuntime
-
-
-class AccessInfo(BaseModel):
-    ssh: str | None  # e.g., "ssh dev@10.0.1.42"
-    vscode: str | None  # e.g., "code --remote ssh-remote+tanren-vm-3 /workspace"
-    working_dir: str | None  # Local path or remote mount point
-    status: str  # "running", "local", "stopped", etc.
-
-
-class PhaseResult(BaseModel):
-    outcome: Outcome  # SUCCESS, ERROR, TIMEOUT, etc.
-    signal: str | None  # Extracted signal from agent output
-    exit_code: int
-    stdout: str | None
-    duration_secs: int
-    preflight_passed: bool
-    postflight_result: PostflightResult | None
-    env_report: EnvReport | None
-    gate_output: str | None
-    unchecked_tasks: int
-    plan_hash: str
-    retries: int
-```
-
-### LocalExecutionEnvironment
-
-The built-in implementation composes the fine-grained adapters (EnvValidator,
-PreflightRunner, PostflightRunner, ProcessSpawner, HeartbeatWriter) into the
-four-method lifecycle:
-
-```python
-class LocalExecutionEnvironment:
-    def __init__(self, *, env_validator, preflight, postflight, spawner, heartbeat, config): ...
-
-    async def provision(self, dispatch, config) -> EnvironmentHandle:
-        # 1. env_validator.load_and_validate()
-        # 2. preflight.run()
-        # 3. Return EnvironmentHandle with preflight state
-
-    async def execute(self, handle, dispatch, config) -> PhaseResult:
-        # 1. Start heartbeat
-        # 2. Retry loop: spawner.spawn() -> extract signal -> map outcome
-        # 3. Compute plan metrics
-        # 4. postflight.run() for push phases
-        # 5. Stop heartbeat, return PhaseResult
-
-    async def get_access_info(self, handle) -> AccessInfo:
-        # Returns AccessInfo(working_dir=worktree_path, status="local")
-
-    async def teardown(self, handle) -> None:
-        # No-op (heartbeat already stopped in execute)
-```
-
-### SSHExecutionEnvironment
-
-The remote implementation composes sub-adapters for VM provisioning,
-bootstrapping, workspace management, agent execution, and state persistence:
-
-```python
-class SSHExecutionEnvironment:
-    def __init__(self, *, vm_provisioner, bootstrapper, workspace_mgr,
-                 runner, state_store, secret_loader,
-                 ssh_config_defaults, repo_urls): ...
-
-    async def provision(self, dispatch, config) -> EnvironmentHandle:
-        # 1. Read tanren.yml LOCALLY for environment profile
-        # 2. Acquire VM from pool
-        # 3. Create SSH connection
-        # 4. Bootstrap VM (idempotent — docker, node, uv, claude)
-        # 5. Setup workspace (git clone + branch checkout)
-        # 6. Inject secrets (developer + project .env)
-        # 7. Record assignment in SQLite
-        # 8. Return EnvironmentHandle with VM metadata
-        # On failure at any step: release VM (no orphans)
-
-    async def execute(self, handle, dispatch, config) -> PhaseResult:
-        # 1. Upload prompt, build CLI command with secret sourcing
-        # 2. Execute via SSH with timeout
-        # 3. Extract signal from remote filesystem
-        # 4. Retry on transient errors (same logic as local)
-        # 5. Push on push phases via SSH
-
-    async def get_access_info(self, handle) -> AccessInfo:
-        # Returns SSH command + VS Code Remote URI
-
-    async def teardown(self, handle) -> None:
-        # Guaranteed VM release with try/finally at every level:
-        # 1. Run teardown commands from profile
-        # 2. Cleanup workspace (remove secrets)
-        # 3. Close SSH connection
-        # 4. Release VM (MUST happen — no orphaned VMs)
-        # 5. Record release in SQLite
-```
-
-**Sub-adapters:**
-
-| Adapter | Protocol | Default | Purpose |
-|---------|----------|---------|---------|
-| `ManualVMProvisioner` | `VMProvisioner` | -- | Acquire/release from static VM list |
-| `HetznerVMProvisioner` | `VMProvisioner` | -- | Create/delete/list Hetzner Cloud servers |
-| `UbuntuBootstrapper` | `EnvironmentBootstrapper` | -- | Install dev tools (docker, node, uv, claude) |
-| `GitWorkspaceManager` | `WorkspaceManager` | -- | Clone/pull, secret injection, cleanup |
-| `RemoteAgentRunner` | -- | -- | Upload prompt, execute CLI, extract signal |
-| `SqliteVMStateStore` | `VMStateStore` | -- | Persist VM assignments for recovery |
-| `SecretLoader` | -- | -- | Load and bundle secrets for injection |
-
-**Configuration via `remote.yml`:**
-
-```yaml
-execution_mode: remote
-ssh:
-  user: root
-  key_path: ~/.ssh/tanren_vm
-  key_content_env: WM_SSH_PRIVATE_KEY  # optional; env var holding the SSH private key
-  port: 22
-  connect_timeout: 10
-git:
-  auth: token
-  token_env: GIT_TOKEN
-provisioner:
-  type: manual  # manual | hetzner | gcp
-  settings:
-    vms:
-      - vm_id: vm-1
-        host: 203.0.113.10
-      - vm_id: vm-2
-        host: 203.0.113.11
-bootstrap:
-  extra_script: ./scripts/vm-setup.sh  # optional — file path (resolved by CLI)
-  # extra_script_url: https://example.com/setup.sh  # alternative: fetch from URL at provision time
-  # extra_script_url: gs://my-bucket/scripts/setup.sh  # also supports GCS
-secrets:
-  developer_secrets_path: ~/.config/tanren/secrets.env
-repos:
-  - project: my-project
-    repo_url: https://github.com/org/my-project.git
-    metadata: {}
-```
-
-When `ssh.key_content_env` is set and the named environment variable is non-empty,
-the private key is loaded from the variable (supporting Ed25519, RSA, and ECDSA).
-This takes precedence over `ssh.key_path` and avoids writing key files in
-containerized deployments. If the env var is absent or empty, `key_path` is used.
-
-GCP provisioner settings accept a `network_tags` list for firewall rule scoping:
-
-```yaml
-provisioner:
-  type: gcp
-  settings:
-    project_id: my-project
-    zone: us-central1-a
-    default_machine_type: e2-standard-4
-    image_family: ubuntu-2404-lts-amd64
-    network_tags:
-      - allow-iap-ssh
-      - allow-http
-```
-
-`bootstrap.extra_script` (file path) and `bootstrap.extra_script_url` (HTTPS or GCS URL)
-are mutually exclusive — set only one. When `extra_script_url` is set, the script is fetched
-at provision time by the daemon, making it suitable for containerized deployments (Cloud Run,
-Docker) where no project filesystem is available. Supported URL schemes: `https://`, `gs://`
-(requires `uv sync --extra gcp`).
-
-Set `WM_REMOTE_CONFIG=/path/to/remote.yml` to enable remote execution.
-For Hetzner support, install optional dependency: `uv sync --extra hetzner`.
-For GCP support: `uv sync --extra gcp`.
-Secrets are loaded explicitly from `remote.yml.secrets.developer_secrets_path`
-during remote environment initialization (no global startup autoload).
-
-### Dispatch-Aware vs. Generic Signatures
-
-The tanren-core `ExecutionEnvironment` protocol takes `Dispatch` and
-`Config` arguments, making it dispatch-aware. This is intentional: the
-worker always has a dispatch context when it provisions and executes
-environments.
-
-The tanren architecture document defines a more generic version intended for
-the future standalone orchestration engine:
-
-```python
-class ExecutionEnvironment(Protocol):
-    async def provision(self, spec: EnvironmentSpec) -> EnvironmentHandle: ...
-    async def execute(self, handle, cmd, env) -> ExecResult: ...
-    async def observe(self, handle, query) -> ObservationResult: ...
-    async def get_access_info(self, handle) -> AccessInfo: ...
-    async def teardown(self, handle) -> None: ...
-```
-
-The generic version adds `observe()` for real-time monitoring and uses an
-`EnvironmentSpec` (derived from `tanren.yml`) instead of `Dispatch`:
-
-```yaml
-environment:
-  type: vm
-  resources:
-    cpu: 4
-    memory: 16GB
-    gpu: false
-  compose: true
-  setup:
-    - docker compose up -d
-    - ./scripts/seed-db.sh
-```
-
-When the standalone orchestration engine is built, it will use the generic
-protocol. The tanren-core dispatch-aware version will remain as a
-specialization that bridges dispatch semantics into the generic interface.
-
-
-## Writing a Custom Adapter
-
-To add a new execution environment (e.g., Docker), implement the
-`ExecutionEnvironment` protocol. The example below shows the structure:
-
-```python
-import uuid
-from pathlib import Path
-
-from tanren_core.adapters.protocols import ExecutionEnvironment
-from tanren_core.adapters.types import (
-    AccessInfo,
-    CustomEnvironmentRuntime,
-    EnvironmentHandle,
-    PhaseResult,
-    ProvisionError,
-)
-from tanren_core.worker_config import WorkerConfig
-from tanren_core.schemas import Dispatch, Outcome
-
-
-class DockerExecutionEnvironment:
-    """Run agent work inside Docker containers."""
-
-    def __init__(self, *, image: str = "tanren-worker:latest", network: str = "tanren") -> None:
-        self._image = image
-        self._network = network
-
-    async def provision(self, dispatch: Dispatch, config: Config) -> EnvironmentHandle:
-        container_id = await self._create_container(dispatch, config)
-        worktree_path = Path("/workspace") / dispatch.project
-
-        return EnvironmentHandle(
-            env_id=str(uuid.uuid4()),
-            worktree_path=worktree_path,
-            branch=dispatch.branch,
-            project=dispatch.project,
-            runtime=CustomEnvironmentRuntime(
-                adapter="docker",
-                metadata={"container_id": container_id},
-            ),
-        )
-
-    async def execute(
-        self, handle: EnvironmentHandle, dispatch: Dispatch, config: Config
-    ) -> PhaseResult:
-        container_id = handle.runtime.metadata["container_id"]
-        exit_code, stdout = await self._docker_exec(container_id, dispatch)
-
-        return PhaseResult(
-            outcome=Outcome.SUCCESS if exit_code == 0 else Outcome.ERROR,
-            signal=None,
-            exit_code=exit_code,
-            stdout=stdout,
-            duration_secs=0,
-            preflight_passed=True,
-            postflight_result=None,
-            env_report=None,
-            gate_output=None,
-        )
-
-    async def get_access_info(self, handle: EnvironmentHandle) -> AccessInfo:
-        container_id = handle.runtime.metadata["container_id"]
-        return AccessInfo(
-            ssh=f"docker exec -it {container_id} /bin/bash",
-            working_dir=str(handle.worktree_path),
-            status="running",
-        )
-
-    async def teardown(self, handle: EnvironmentHandle) -> None:
-        container_id = handle.runtime.metadata["container_id"]
-        await self._destroy_container(container_id)
-
-    # -- private helpers (implement these) --
-
-    async def _create_container(self, dispatch: Dispatch, config: Config) -> str:
-        """Pull image, create and start container, clone repo, checkout branch."""
-        raise NotImplementedError
-
-    async def _docker_exec(self, container_id: str, dispatch: Dispatch) -> tuple[int, str]:
-        """Run the agent command inside the container."""
-        raise NotImplementedError
-
-    async def _destroy_container(self, container_id: str) -> None:
-        """Stop and remove the container."""
-        raise NotImplementedError
-```
-
-The typed `runtime` field on `EnvironmentHandle` is the extension point for
-carrying environment-specific state (for example local preflight context or
-remote VM connection/workspace state) through the lifecycle.
-
-For simpler adapters (e.g., a custom `EventStore` that forwards to an
-external system), the pattern is the same: implement the protocol methods
-and inject via the `Worker` constructor.
-
-
-## Injecting Custom Adapters
-
-All adapters are injected through the `Worker` constructor. Any
-parameter left as `None` gets its built-in default:
-
-```python
-from tanren_core.worker import Worker
-from tanren_core.worker_config import WorkerConfig
-
-# Use all defaults
-worker = Worker()
-
-# Inject a custom execution environment
-worker = Worker(
-    execution_env=DockerExecutionEnvironment(image="my-image:v2"),
-)
-
-# Inject a custom event store alongside the default everything else
-worker = Worker(
-    event_store=my_custom_event_store,
-)
-
-# Override fine-grained adapters (these feed into LocalExecutionEnvironment
-# when no execution_env is provided)
-worker = Worker(
-    preflight=CustomPreflightRunner(),
-    postflight=CustomPostflightRunner(),
-    env_validator=VaultEnvValidator(vault_addr="https://vault.internal"),
-)
-```
-
-The constructor signature:
-
-```python
-class Worker:
-    def __init__(
-        self,
-        *,
-        config: WorkerConfig,
-        event_store: EventStore,
-        job_queue: JobQueue,
-        state_store: StateStore,
-        execution_env: ExecutionEnvironment,
-    ) -> None: ...
-```
-
-The `Worker` requires explicit store and execution environment injection.
-Use the store factory (`tanren_core.store.factory.create_store(db_url)`)
-to construct the unified `Store` backend (SQLite or Postgres) and pass the
-three store protocols along with an `ExecutionEnvironment` implementation.
+# Adapter Architecture (Rust Runtime Contract)
+
+This document is the canonical runtime adapter reference for Lane 1.1+.
+
+The canonical implementation lives in `crates/tanren-runtime` and defines the
+provider-agnostic harness contract that all concrete harness adapters must use
+(Claude, Codex, OpenCode, and future adapters).
+
+## Contract Surface
+
+### Capability Contract
+
+`HarnessCapabilities` declares adapter support across:
+
+- output streaming
+- tool use
+- patch apply level
+- session resume level
+- sandbox mode
+- approval mode
+
+`HarnessRequirements` defines dispatch requirements and now supports explicit
+least-privilege bounds:
+
+- capability minimums (for required features)
+- privilege maximums (for sandbox/approval ceilings)
+
+`ensure_admissible` performs preflight checks and returns typed
+`CompatibilityDenialKind` before side effects.
+
+### Execution Contract
+
+`HarnessExecutionRequest` is the normalized request shape.
+
+- `required_secret_names` is strongly typed (`SecretName`).
+- redaction secret values are in-memory only (`RedactionSecret`) and excluded
+  from serialized payloads.
+
+`execute_with_contract` is the required contract wrapper for persistence-bound
+execution:
+
+1. capability preflight
+2. adapter invocation
+3. contract-owned redaction (not caller-injected)
+4. known-secret leak check
+5. persistable output release
+
+Adapters must not bypass this wrapper when producing persistable output.
+
+### Failure Contract
+
+`HarnessFailureClass` is the stable taxonomy consumed by orchestrator retry
+policy (`to_domain_error_class`).
+
+`ProviderFailureContext` supports typed/normalized classification:
+
+- typed adapter code first (`ProviderFailureCode`)
+- normalized provider identifiers (`ProviderIdentifier`)
+- deterministic signal/exit-code mapping
+- boundary-aware text fallback last
+
+### Redaction Contract
+
+Redaction runs before persistence on all channels:
+
+- `gate_output`
+- `tail_output`
+- `stderr_tail`
+
+Policy behavior:
+
+- sensitive assignment redaction by normalized key
+- bearer token redaction
+- case-insensitive prefixed token redaction
+- explicit secret value redaction (including multiline fragments)
+- bounded per-channel persistence with deterministic truncation marker
+
+`RedactionHints` is secret-safe:
+
+- debug output redacts secret contents
+- secret material uses secrecy-backed wrappers (no plain-text debug dumps)
+
+## Conformance Contract
+
+Lane 1.2+ adapter crates must reuse `tanren-runtime` conformance helpers:
+
+- `assert_capability_denial_is_preflight`
+- `assert_redaction_before_persistence`
+- `assert_failure_classification`
+
+Required adapter evidence:
+
+1. capability denial is preflight-only
+2. redaction completes before persistence
+3. failure mapping is stable across provider-native payloads
+
+## Implementation Notes
+
+- `OutputRedactor` remains a runtime abstraction, but persistence-bound policy
+  enforcement is sealed inside `execute_with_contract`.
+- test-only customization for contract internals is crate-scoped.
+- contract event ordering is observable through `HarnessObserver` for
+  deterministic tests and telemetry.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -35,6 +35,9 @@ least-privilege bounds:
 `ensure_admissible` performs preflight checks and returns typed
 `CompatibilityDenialKind` before side effects.
 
+Approval denials are now represented only by reachable states:
+`approval_mode_below_minimum` and `approval_mode_exceeds_maximum`.
+
 ### Execution Contract
 
 `HarnessExecutionRequest` is the normalized request shape.
@@ -47,10 +50,11 @@ least-privilege bounds:
 execution:
 
 1. capability preflight
-2. adapter invocation
+2. sealed adapter invocation (contract-only call token)
 3. contract-owned redaction (not caller-injected)
-4. known-secret + policy residual leak checks
-5. persistable output release
+4. single-pass redaction audit verdict (known-secret + residual policy)
+5. metadata sanitization and allowlist validation (`provider_run_id`, fail-closed)
+6. persistable output release
 
 Adapters must not bypass this wrapper when producing persistable output.
 
@@ -64,10 +68,10 @@ contract wrapper is the only normalization boundary to `HarnessFailure`.
 
 `ProviderFailureContext` supports typed/normalized classification:
 
-- typed adapter code first (`ProviderFailureCode`)
-- normalized provider identifiers (`ProviderIdentifier`)
-- deterministic signal/exit-code mapping
-- bounded boundary-aware text fallback last
+- mandatory typed adapter code (`ProviderFailureCode`) for terminal failures
+- `typed_code=unknown` is forbidden for terminal failures
+- deterministic typed mapping only for semantic normalization
+- optional audit-only fallback utility (`classify_provider_failure_for_audit`)
 
 ### Redaction Contract
 
@@ -84,6 +88,8 @@ Policy behavior:
 - bearer token redaction
 - case-insensitive prefixed token redaction
 - explicit secret value redaction (including multiline fragments)
+- context-aware short multiline-fragment redaction (bounded rules)
+- encoded secret variant redaction (URL/base64 forms derived from known hints)
 - bounded per-channel persistence with deterministic truncation marker
 
 `RedactionHints` is secret-safe:
@@ -109,6 +115,10 @@ Required adapter evidence:
 
 - `OutputRedactor` remains a runtime abstraction, but persistence-bound policy
   enforcement is sealed inside `execute_with_contract`.
+- `HarnessAdapter::execute` requires an unconstructable contract token so
+  callers cannot directly invoke adapter execution from outside the contract.
+- provider metadata is sanitized and validated under a strict fail-closed policy
+  before exposure/persistence.
 - default redaction policy/patterns are sourced from a versioned dataset.
 - test-only customization for contract internals is crate-scoped.
 - `HarnessExecutionEvent` is source-tagged (`contract` vs `adapter`) and adapter

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -19,9 +19,9 @@ provider-agnostic harness contract that all concrete harness adapters must use
 - sandbox mode
 - approval mode
 
-Capability metadata is immutable and type-level in the adapter contract;
-preflight checks read static capability data rather than invoking adapter
-instance logic.
+Capability metadata is immutable in the adapter contract and exposed through
+`HarnessAdapter::capabilities()`.
+Preflight checks read adapter-declared data before execution side effects.
 
 `HarnessRequirements` defines dispatch requirements and supports explicit
 least-privilege bounds:
@@ -68,6 +68,8 @@ policy (`to_domain_error_class`).
 
 Adapters now return provider-native failures (`ProviderFailure`) and the
 contract wrapper is the only normalization boundary to `HarnessFailure`.
+`HarnessFailure` construction is crate-internal; callers cannot mint terminal
+failures directly.
 
 `ProviderFailureContext` supports typed/normalized classification:
 
@@ -95,6 +97,9 @@ Policy behavior:
 - context-aware short multiline-fragment redaction (bounded rules)
 - encoded secret variant redaction (URL/base64 forms derived from known hints)
 - bounded per-channel persistence with deterministic truncation marker
+- validated immutable policy schema (`RedactionPolicy::try_new` / builder)
+- compiled prefix trie and multi-pattern secret matcher (Aho-Corasick style)
+  for scalable hint/prefix cardinality
 
 `RedactionHints` is secret-safe:
 
@@ -118,6 +123,7 @@ Required adapter evidence:
 3. failure mapping is stable across provider-native payloads
 4. provider metadata sanitization is fail-closed
 5. terminal typed-code semantics remain deterministic
+6. contract event checks enforce exact cardinality and ordering (no duplicates)
 
 ## Implementation Notes
 
@@ -125,6 +131,8 @@ Required adapter evidence:
   enforcement is sealed inside `execute_with_contract`.
 - `HarnessAdapter::execute` requires an unconstructable contract token so
   callers cannot directly invoke adapter execution from outside the contract.
+- `HarnessAdapterRegistry` enables trait-object adapter registration/lookup for
+  runtime registry patterns.
 - provider metadata is sanitized and validated under a strict fail-closed policy
   before exposure/persistence.
 - default redaction policy/patterns are sourced from a versioned dataset.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -19,6 +19,10 @@ provider-agnostic harness contract that all concrete harness adapters must use
 - sandbox mode
 - approval mode
 
+Capability metadata is immutable and type-level in the adapter contract;
+preflight checks read static capability data rather than invoking adapter
+instance logic.
+
 `HarnessRequirements` defines dispatch requirements and now supports explicit
 least-privilege bounds:
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -24,6 +24,9 @@ least-privilege bounds:
 
 - capability minimums (for required features)
 - privilege maximums (for sandbox/approval ceilings)
+- dual approval ordering:
+  - minimum approval uses strictness (`never < on_escalation < on_demand`)
+  - maximum approval uses privilege risk (`on_demand < on_escalation < never`)
 
 `ensure_admissible` performs preflight checks and returns typed
 `CompatibilityDenialKind` before side effects.
@@ -42,7 +45,7 @@ execution:
 1. capability preflight
 2. adapter invocation
 3. contract-owned redaction (not caller-injected)
-4. known-secret leak check
+4. known-secret + policy residual leak checks
 5. persistable output release
 
 Adapters must not bypass this wrapper when producing persistable output.
@@ -52,12 +55,15 @@ Adapters must not bypass this wrapper when producing persistable output.
 `HarnessFailureClass` is the stable taxonomy consumed by orchestrator retry
 policy (`to_domain_error_class`).
 
+Adapters now return provider-native failures (`ProviderFailure`) and the
+contract wrapper is the only normalization boundary to `HarnessFailure`.
+
 `ProviderFailureContext` supports typed/normalized classification:
 
 - typed adapter code first (`ProviderFailureCode`)
 - normalized provider identifiers (`ProviderIdentifier`)
 - deterministic signal/exit-code mapping
-- boundary-aware text fallback last
+- bounded boundary-aware text fallback last
 
 ### Redaction Contract
 
@@ -70,6 +76,7 @@ Redaction runs before persistence on all channels:
 Policy behavior:
 
 - sensitive assignment redaction by normalized key
+- JSON/YAML-style quoted-key assignment redaction
 - bearer token redaction
 - case-insensitive prefixed token redaction
 - explicit secret value redaction (including multiline fragments)
@@ -98,6 +105,8 @@ Required adapter evidence:
 
 - `OutputRedactor` remains a runtime abstraction, but persistence-bound policy
   enforcement is sealed inside `execute_with_contract`.
+- default redaction policy/patterns are sourced from a versioned dataset.
 - test-only customization for contract internals is crate-scoped.
-- contract event ordering is observable through `HarnessObserver` for
-  deterministic tests and telemetry.
+- `HarnessExecutionEvent` is source-tagged (`contract` vs `adapter`) and adapter
+  emissions are proxied as adapter-source events so conformance ordering cannot
+  be polluted by adapter-generated contract-like events.

--- a/docs/rewrite/ORIENTATION.md
+++ b/docs/rewrite/ORIENTATION.md
@@ -64,13 +64,19 @@ implementation. Lane 0.5 is also merged; Phase 0 proof packaging now lives in:
 - `docs/rewrite/PHASE0_PROOF_RUNBOOK.md`
 - `scripts/proof/phase0/run.sh` + `scripts/proof/phase0/verify.sh`
 
-**Phase 1+ is sketched, not planned in depth.** Stubs exist at:
-- `docs/rewrite/tasks/LANE-1.1-HARNESS.md` — harness contract + output redaction
-- `docs/rewrite/tasks/LANE-1.2-RUNTIME.md` — runtime substrate + `runtime_type` typing
-- `docs/rewrite/tasks/LANE-2.1-PLANNING-GRAPH.md` — graph revision enforcement + non-dispatch events
+**Phase 1 execution is framed from a behavioral proof baseline.**
+Lane 1.1 contract implementation now lives in `crates/tanren-runtime`
+on `rewrite/lane-1-1` (pending merge).
+Reference docs:
+- `docs/rewrite/PHASE1_PROOF_BDD.md`
+- `docs/rewrite/tasks/LANE-1.1-HARNESS.md` + `LANE-1.1-BRIEF.md`
+- `docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md` + `LANE-1.2-BRIEF.md`
+- `docs/rewrite/tasks/LANE-1.3-ENV-CONTRACT.md` + `LANE-1.3-BRIEF.md`
+- `docs/rewrite/tasks/LANE-1.4-ENV-ADAPTERS.md` + `LANE-1.4-BRIEF.md`
+- `docs/rewrite/tasks/LANE-1.5-WORKER-RUNTIME.md` + `LANE-1.5-BRIEF.md`
 
-These stubs carry forward unresolved items from earlier audits — they
-are notes for when those phases begin, not ready-to-dispatch briefs.
+Phase 2+ remains stubbed:
+- `docs/rewrite/tasks/LANE-2.1-PLANNING-GRAPH.md`
 
 ---
 
@@ -85,7 +91,7 @@ Organized by purpose. Read lazily — fetch a file when a task needs it.
 
 ### Lane briefs (`docs/rewrite/tasks/`)
 
-Each lane has three files:
+Lanes typically have three files:
 
 | Suffix | Audience | Purpose |
 |--------|----------|---------|
@@ -93,11 +99,19 @@ Each lane has three files:
 | `-BRIEF.md` | Implementation agent | Concise handoff: scope, deliverables, "done when" |
 | `-AUDIT.md` | Audit agent | Audit dimensions, process, output format |
 
+Some planned lanes may be staged with spec + brief first, then gain
+`-AUDIT.md` as they become audit-ready.
+
 Current lane briefs:
 - `LANE-0.2-DOMAIN.md` + `LANE-0.2-BRIEF.md` + `LANE-0.2-AUDIT.md` + `LANE-0.2-AUDIT-FINAL.md`
 - `LANE-0.3-STORE.md` + `LANE-0.3-BRIEF.md` + `LANE-0.3-AUDIT.md`
 - `LANE-0.4-CLI-WIRING.md` + `LANE-0.4-BRIEF.md` + `LANE-0.4-AUDIT.md`
 - `LANE-0.5-METHODOLOGY.md` + `LANE-0.5-BRIEF.md` + `LANE-0.5-AUDIT.md` + `LANE-0.5-DESIGN-NOTES.md`
+- `LANE-1.1-HARNESS.md` + `LANE-1.1-BRIEF.md`
+- `LANE-1.2-HARNESS-ADAPTERS.md` + `LANE-1.2-BRIEF.md`
+- `LANE-1.3-ENV-CONTRACT.md` + `LANE-1.3-BRIEF.md`
+- `LANE-1.4-ENV-ADAPTERS.md` + `LANE-1.4-BRIEF.md`
+- `LANE-1.5-WORKER-RUNTIME.md` + `LANE-1.5-BRIEF.md`
 - `ADDON-SEAORM.md` — delta brief explaining the sqlx→SeaORM shift
 - `README.md` — lane execution order and parallelization strategy
 
@@ -243,9 +257,10 @@ You are responsible for:
 - **Dispatching the right agent with the right brief.** Implementation
   gets `*-BRIEF.md`. Audit gets `*-AUDIT.md`. Neither gets Python code.
 - **Tracking unresolved items from past audits.** Carry them forward
-  into later lane briefs. The Phase 1+ stubs (`LANE-1.1-HARNESS.md`,
-  `LANE-1.2-RUNTIME.md`, `LANE-2.1-PLANNING-GRAPH.md`) are where
-  audit follow-ups live until their phase begins.
+  into later lane briefs. For runtime-substrate work, use the Phase 1
+  BDD and lane set (`LANE-1.1` through `LANE-1.5`) as the active
+  follow-up sink; keep Phase 2+ items in `LANE-2.1-PLANNING-GRAPH.md`
+  until that phase begins.
 - **Keeping `docs/rewrite/tasks/README.md` in sync** with lane status
   (✅ merged, 🔵 in progress, ⏳ blocked).
 - **Surfacing blockers to the user.** If `just ci` stays red for more

--- a/docs/rewrite/PHASE1_PROOF_BDD.md
+++ b/docs/rewrite/PHASE1_PROOF_BDD.md
@@ -1,0 +1,173 @@
+# Phase 1 Proof (BDD)
+
+## Purpose
+
+This document defines the expected **Phase 1 behavior** in usage terms.
+It intentionally avoids implementation details.
+
+Audience: technical teammates validating runtime-substrate outcomes from an
+operator point of view.
+
+---
+
+## Phase 1 Story
+
+By the end of Phase 1, Tanren should behave like a reliable
+**execution substrate** for the control plane shipped in Phase 0:
+
+- the same dispatch contract can execute across multiple harnesses
+- the same dispatch contract can execute across multiple environment types
+- execution signals and errors are normalized regardless of adapter internals
+- lease lifecycle is safe under success, failure, cancellation, and crash recovery
+- worker execution is durable and policy-driven (including retries)
+
+Phase 1 is **not** claiming planner-native graph orchestration,
+advanced governance, or full interface parity. Those remain later-phase scope.
+
+---
+
+## Proof Model
+
+Each Phase 1 promise is accepted only when both witnesses exist:
+
+1. **Positive witness**: expected behavior works in a realistic flow.
+2. **Falsification witness**: invalid or unsafe behavior is rejected safely.
+
+---
+
+## BDD Proof Scenarios
+
+## Feature 1: Harness choice does not change dispatch semantics
+
+### Scenario 1.1: A valid dispatch executes through Harness A
+**Given** a dispatch ready for execution
+**When** it runs through one supported harness
+**Then** the dispatch reaches a coherent terminal outcome
+**And** operator-visible execution evidence is produced
+
+### Scenario 1.2: Equivalent dispatch executes through Harness B
+**Given** equivalent dispatch intent and inputs
+**When** it runs through a different supported harness
+**Then** resulting domain semantics are equivalent to Harness A
+**And** differences are limited to harness-specific presentation details
+
+### Scenario 1.3: Unsupported harness action is denied safely
+**Given** a dispatch requiring a capability the selected harness does not provide
+**When** execution is requested
+**Then** execution is rejected with a typed capability/compatibility denial
+**And** no partial side effects are committed
+
+---
+
+## Feature 2: Environment choice does not change dispatch semantics
+
+### Scenario 2.1: Dispatch executes in one environment type
+**Given** a dispatch with valid environment requirements
+**When** it executes in one supported environment type
+**Then** terminal domain outcome is coherent
+**And** execution evidence links to the acquired lease
+
+### Scenario 2.2: Equivalent dispatch executes in a second environment type
+**Given** equivalent dispatch intent and inputs
+**When** it executes in another supported environment type
+**Then** resulting domain semantics are equivalent
+**And** differences are limited to environment-specific telemetry details
+
+### Scenario 2.3: Unavailable/incompatible environment is rejected safely
+**Given** a dispatch targeting an unavailable or policy-incompatible environment
+**When** execution is requested
+**Then** the request is rejected with a typed denial/failure reason
+**And** no partial execution state is committed
+
+---
+
+## Feature 3: Execution evidence is normalized and safe to persist
+
+### Scenario 3.1: Operators receive normalized lifecycle signals
+**Given** executions from different harness and environment combinations
+**When** operators inspect progress and terminal state
+**Then** lifecycle status classes are consistent across runs
+**And** operators do not need adapter-specific decoding
+
+### Scenario 3.2: Adapter-specific failures map to typed Tanren failure classes
+**Given** provider/runtime-specific failures during execution
+**When** the dispatch fails
+**Then** the surfaced failure class is typed and stable
+**And** raw provider-only failure formats do not leak as the primary contract
+
+### Scenario 3.3: Sensitive output is redacted before durable persistence
+**Given** execution output containing secrets or credential material
+**When** evidence is captured and persisted
+**Then** sensitive material is redacted in persisted artifacts
+**And** no unredacted secret appears in durable event history
+
+---
+
+## Feature 4: Lease lifecycle is safe across all terminal paths
+
+### Scenario 4.1: Success releases environment lease cleanly
+**Given** a successful execution
+**When** terminal state is reached
+**Then** the lease is released/closed deterministically
+**And** no orphaned allocation remains
+
+### Scenario 4.2: Failure or cancellation still releases lease cleanly
+**Given** a failed or user-cancelled execution
+**When** terminal state is reached
+**Then** lease cleanup still occurs deterministically
+**And** cleanup failure is visible as explicit operational evidence
+
+### Scenario 4.3: Crash recovery prevents orphaned or duplicate execution
+**Given** a worker/process crash during active execution
+**When** the system recovers
+**Then** orphaned leases are reconciled safely
+**And** duplicate terminal execution is prevented
+
+---
+
+## Feature 5: Worker execution is durable and policy-driven
+
+### Scenario 5.1: Accepted work is consumed and completed durably
+**Given** accepted dispatch work in queue/state storage
+**When** worker capacity is available
+**Then** work is consumed and progresses to a terminal outcome
+**And** terminal evidence remains queryable after process restart
+
+### Scenario 5.2: Retryable failures follow explicit retry policy
+**Given** a failure class marked retryable by policy
+**When** execution fails
+**Then** retry attempts follow configured limits/backoff semantics
+**And** retry history is visible to operators
+
+### Scenario 5.3: Non-retryable failures stop without hidden retries
+**Given** a failure class marked non-retryable
+**When** execution fails
+**Then** execution transitions to terminal failure without silent extra retries
+**And** remediation is explicit rather than implicit loop behavior
+
+---
+
+## Feature 6: Phase 1 end-to-end reliability can be demonstrated
+
+### Scenario 6.1: Cross-matrix execution demonstrates semantic equivalence
+**Given** a representative dispatch matrix
+**When** it is executed across at least two harnesses and two environment types
+**Then** domain-level outcomes remain semantically equivalent where expected
+**And** divergence is reported explicitly when policy/capability requires it
+
+### Scenario 6.2: Proof artifacts are reproducible by another engineer
+**Given** documented proof run instructions
+**When** another engineer reruns the Phase 1 proof process
+**Then** they can reproduce the evidence pack and verdicts
+**And** no Phase 1 claim depends on tribal knowledge
+
+---
+
+## Phase 2 Entry Gate (Behavioral)
+
+Move to Phase 2 only when all are true:
+
+1. Every scenario above has both positive and falsification witnesses.
+2. Cross-harness and cross-environment equivalence is demonstrably stable.
+3. Lease cleanup and crash recovery behavior are reproducible.
+4. Remaining gaps are explicitly classified as Phase 2+ scope.

--- a/docs/rewrite/tasks/LANE-1.1-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.1-BRIEF.md
@@ -20,6 +20,7 @@ provider-agnostic execution semantics for Phase 1.
 | Contract | Harness capability model and normalized execution/failure contract |
 | Safety | Redaction policy requirements enforced before durable persistence |
 | Conformance | Reusable contract test suite proving adapter conformance |
+| Scope Guard | Explicit boundary that concrete harness adapters/parity belong to Lane 1.2 |
 | Docs | Lane and planning docs updated to reflect final contract guarantees |
 
 ## Non-negotiables
@@ -29,6 +30,8 @@ provider-agnostic execution semantics for Phase 1.
 3. Raw provider failure formats are mapped to typed contract classes.
 4. Redaction is applied before output is durably stored.
 5. Conformance criteria are executable, not prose-only.
+6. Lane verification is gated by `just ci` from repo root (`make`-based checks are legacy and non-authoritative for acceptance).
+7. Lane 1.1 acceptance does not require concrete harness adapter crates; adapter implementation and cross-harness parity are Lane 1.2 deliverables.
 
 ## Done when
 
@@ -36,3 +39,4 @@ provider-agnostic execution semantics for Phase 1.
 2. Contract tests encode both positive and falsification expectations.
 3. Redaction safety requirements are contractually testable.
 4. Lane artifacts are ready for adapter implementation lanes.
+5. Lane scope boundary to Lane 1.2 is explicit and testable in docs.

--- a/docs/rewrite/tasks/LANE-1.1-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.1-BRIEF.md
@@ -1,0 +1,38 @@
+# Lane 1.1 — Harness Adapter Contract — Agent Brief
+
+## Task
+
+Define and land the harness contract layer that guarantees transport- and
+provider-agnostic execution semantics for Phase 1.
+
+## Read first
+
+1. [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) (Feature 1, 3, 6)
+2. [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md)
+3. [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
+4. [../CRATE_GUIDE.md](../CRATE_GUIDE.md)
+5. [../../../CLAUDE.md](../../../CLAUDE.md)
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| Contract | Harness capability model and normalized execution/failure contract |
+| Safety | Redaction policy requirements enforced before durable persistence |
+| Conformance | Reusable contract test suite proving adapter conformance |
+| Docs | Lane and planning docs updated to reflect final contract guarantees |
+
+## Non-negotiables
+
+1. Harness choice cannot alter domain-level terminal semantics.
+2. Unsupported capabilities are denied before side effects.
+3. Raw provider failure formats are mapped to typed contract classes.
+4. Redaction is applied before output is durably stored.
+5. Conformance criteria are executable, not prose-only.
+
+## Done when
+
+1. Contract is sufficient to evaluate harness compatibility pre-execution.
+2. Contract tests encode both positive and falsification expectations.
+3. Redaction safety requirements are contractually testable.
+4. Lane artifacts are ready for adapter implementation lanes.

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -1,70 +1,107 @@
-# Lane 1.1 — Harness Contract
+# Lane 1.1 — Harness Adapter Contract
 
-> **Status:** Stub. Full brief to be written at the start of Phase 1.
-> This file captures requirements carried forward from earlier lane
-> audits so they are not lost.
+## Status
+
+Implemented on `rewrite/lane-1-1` (pending merge to foundation).
+
+## Purpose
+
+Define one canonical harness contract so dispatch semantics stay stable
+across providers (Claude Code, Codex, OpenCode, future adapters).
+
+Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+Feature 1, Feature 3, and Feature 6.
 
 ## Scope
 
-Defines the contract that harness adapters (`tanren-harness-claude`,
-`tanren-harness-codex`, `tanren-harness-opencode`, `tanren-harness-bash`)
-must satisfy when producing an `ExecuteResult` from a CLI invocation.
+This lane ships (in `crates/tanren-runtime`):
 
-## Carried-Forward Requirements
+- typed capability model and preflight compatibility checks
+- normalized execution request/result surfaces
+- normalized typed harness failure taxonomy + mapping to domain retry class
+- redaction-before-persistence runtime contract
+- reusable adapter conformance test helpers for Lane 1.2
 
-### Output redaction (from Lane 0.2 audit)
+This lane does **not** ship concrete provider adapters.
 
-`ExecuteResult::tail_output`, `ExecuteResult::stderr_tail`, and
-`ExecuteResult::gate_output` are captured verbatim and serialized into
-`StepCompleted` events, which are persisted to the event log
-indefinitely. A secret that leaks into an event log is effectively
-unrecoverable.
+## Contract Surfaces
 
-**Harness adapters MUST redact known secret patterns before producing
-an `ExecuteResult`.** At minimum:
+### Capability Contract
 
-1. **API keys, bearer tokens, cookies, and session identifiers.**
-   Match the common patterns (`sk-…`, `Bearer …`, `xoxb-…`,
-   `AKIA…`, `ghp_…`, `AIza…`) before capturing stdout/stderr.
-2. **Values of environment variables listed in
-   `dispatch.required_secrets`.** The harness has access to the
-   dispatch snapshot and the resolved secret values; any occurrence of
-   those values in captured output must be replaced before the tail
-   strings are populated.
-3. **Contents of known credential files.** If the harness tails logs
-   that may include file content (`~/.aws/credentials`, `~/.netrc`,
-   `~/.config/gcloud/*`, `id_rsa`), those files must be filtered.
-4. **Multi-line secrets.** Redaction must operate on the full captured
-   output, not only line-by-line, so multi-line PEM keys cannot slip
-   through.
+- `HarnessCapabilities` advertises adapter support for:
+  - output streaming class
+  - tool-use support
+  - patch-apply support
+  - session-resume support
+  - sandbox mode
+  - approval mode
+- `HarnessRequirements` describes what a dispatch needs.
+- `ensure_admissible` performs preflight checks and returns typed
+  `CompatibilityDenial` when unsupported.
 
-The domain crate cannot enforce this contract — it has no harness
-context — so this lane MUST implement redaction at the capture site
-and add unit tests exercising each redaction pattern.
+### Execution Contract
 
-### Runtime type tagging (from Lane 0.2 audit)
+- `HarnessExecutionRequest` is the provider-agnostic input shape.
+- `HarnessAdapter::execute` returns `ExecutionSignal` with raw output.
+- `execute_with_contract` enforces:
+  1. preflight capability check
+  2. adapter execution
+  3. redaction to `PersistableOutput`
+  4. known-secret leak check before persistence
 
-`LeaseCapabilities.runtime_type` is currently `NonEmptyString`
-(e.g. `"local"`, `"docker"`, `"dood"`, `"remote"`). A string tag keeps
-third-party runtime adapters extensible without touching the domain
-crate but trades compile-time safety.
+### Failure Contract
 
-**Action for this lane:** Once the built-in runtime set is stable,
-re-evaluate whether to introduce a `RuntimeKind::{Local, Docker, DooD,
-Remote, Custom(String)}` enum. The `Custom(String)` variant preserves
-third-party extensibility while giving the built-ins compile-time
-coverage.
+- `HarnessFailureClass` is the stable failure taxonomy.
+- `classify_provider_failure` maps provider-native context into
+  `HarnessFailureClass`.
+- `HarnessFailureClass::to_domain_error_class` maps to
+  `tanren_domain::ErrorClass` for retry policy consistency.
+
+### Redaction Contract
+
+- `OutputRedactor` is the contract adapters use.
+- `DefaultOutputRedactor` + `RedactionPolicy` provide the shared baseline.
+- `RedactionHints` carries required secret names and resolved secret values.
+- Redaction is applied to all persistable output channels:
+  `gate_output`, `tail_output`, `stderr_tail`.
+
+## Behavioral Requirements
+
+1. Harness choice must not change domain-level terminal semantics.
+2. Unsupported capability requirements are denied before adapter side effects.
+3. Raw provider failures map to typed contract classes.
+4. Persisted output is redacted before durable storage.
+5. Conformance is executable through reusable tests, not prose-only.
+
+## Redaction Minimum Coverage
+
+The default policy must cover, at minimum:
+
+1. common credential/token patterns
+2. explicit secret values resolved for runtime injection
+3. credential-file content style patterns (key/value forms)
+4. multiline secret fragments
+
+## Conformance Expectations
+
+Lane 1.2 adapter crates must reuse `tanren-runtime` conformance helpers:
+
+- `assert_capability_denial_is_preflight`
+- `assert_redaction_before_persistence`
+- `assert_failure_classification`
+
+Each adapter must prove:
+
+1. capability denial happens before side effects
+2. redaction is complete before persistence
+3. provider-specific failures normalize to stable failure classes
 
 ## Dependencies
 
-- Lane 0.2 (domain model) — requires `ExecuteResult`, `DispatchSnapshot`,
-  `EnvironmentHandle`, `LeaseCapabilities`
-- Lane 0.3 (store) — harness outputs end up in the event log via the
-  store
+- Phase 0 foundation complete (`0.1` through `0.5`)
 
-## Open Questions
+## Out of Scope
 
-- Does redaction happen in the harness adapter or in a separate
-  `output-redactor` crate that every harness depends on?
-- Do we want a policy-driven allowlist/denylist of redaction patterns
-  per org?
+- provider CLI command wiring
+- environment lease contract/implementations
+- worker retry orchestration and crash recovery runtime

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -43,9 +43,11 @@ execution; parity proof is accepted only in Lane 1.2.
   - session-resume support
   - sandbox mode
   - approval mode
-- `HarnessRequirements` describes what a dispatch needs.
-- Sandbox and approval requirements support both minimum capability and maximum
-  privilege bounds.
+- `HarnessRequirements` describes what a dispatch needs and is constructed via
+  validated builder APIs.
+- Sandbox and approval requirements use validated bound types
+  (`SandboxModeBounds`, `ApprovalModeBounds`) for minimum capability and maximum
+  privilege constraints.
 - Approval bounds are dual-axis:
   - minimum approval uses strictness (`never < on_escalation < on_demand`)
   - maximum approval uses privilege risk (`on_demand < on_escalation < never`)
@@ -66,7 +68,8 @@ execution; parity proof is accepted only in Lane 1.2.
   2. sealed adapter execution (contract-only call token)
   3. redaction hints derived from request data (not caller-provided)
   4. contract-owned redaction + single-pass leak audit to `PersistableOutput`
-  5. fail-closed metadata sanitization for `provider_run_id`
+  5. fail-closed metadata sanitization for `provider_run_id`,
+     `provider_code`, and `provider_kind`
   6. source-tagged event emission (`contract` vs `adapter`) for conformance-safe
      ordering assertions
 
@@ -76,11 +79,12 @@ execution; parity proof is accepted only in Lane 1.2.
 - `HarnessFailure` is constructor-normalized with invariant-safe class/code
   states; conflicting class/typed-code combinations are rejected at
   deserialization boundaries.
-- `ProviderFailureContext.typed_code` is mandatory for terminal adapter failures;
-  `typed_code=unknown` is rejected at the contract boundary.
+- `ProviderFailureContext.typed_code` is mandatory for terminal adapter
+  failures and uses terminal-only `ProviderFailureCode` (no `unknown` variant).
 - `classify_provider_failure` maps terminal provider failures deterministically
   from typed adapter code only.
-- `classify_provider_failure_for_audit` remains available as an explicit
+- `classify_provider_failure_for_audit` remains available via
+  `AuditProviderFailureContext`/`AuditProviderFailureCode` as an explicit
   telemetry utility for bounded fallback heuristics.
 - `HarnessFailureClass::to_domain_error_class` maps to
   `tanren_domain::ErrorClass` for retry policy consistency.
@@ -124,12 +128,16 @@ Lane 1.2 adapter crates must reuse `tanren-runtime` conformance helpers:
 - `assert_capability_denial_is_preflight`
 - `assert_redaction_before_persistence`
 - `assert_failure_classification`
+- `assert_provider_metadata_fail_closed`
+- `assert_terminal_typed_code_mapping`
 
 Each adapter must prove:
 
 1. capability denial happens before side effects
 2. redaction is complete before persistence
 3. provider-specific failures normalize to stable failure classes
+4. unsafe provider metadata is rejected fail-closed
+5. typed terminal failure code mappings remain stable
 
 Lane 1.2 acceptance also requires parity scenarios for
 [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) Feature 1, Feature 3, and

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -65,6 +65,8 @@ execution; parity proof is accepted only in Lane 1.2.
 - `HarnessExecutionRequest` is the provider-agnostic input shape.
 - Secret material in `HarnessExecutionRequest` is carried as secrecy-backed
   values and never serialized.
+- Explicit redaction hints are hard-bounded at contract entry:
+  max count `256`, max per-secret bytes `4096`, max total bytes `65536`.
 - `HarnessAdapter::execute` returns `ExecutionSignal` with raw output and
   provider-native failure payloads (`ProviderFailure`).
 - `execute_with_contract` enforces:
@@ -72,7 +74,7 @@ execution; parity proof is accepted only in Lane 1.2.
   2. sealed adapter execution (contract-only call token)
   3. redaction hints derived from request data (not caller-provided)
   4. contract-owned redaction + single-pass leak audit to `PersistableOutput`
-  5. fail-closed metadata sanitization for `provider_run_id`,
+  5. fail-closed typed metadata sanitization for `provider_run_id`,
      `provider_code`, and `provider_kind`
   6. source-tagged event emission (`contract` vs `adapter`) for conformance-safe
      ordering assertions
@@ -92,6 +94,8 @@ execution; parity proof is accepted only in Lane 1.2.
   telemetry utility for bounded fallback heuristics.
 - `HarnessFailureClass::to_domain_error_class` maps to
   `tanren_domain::ErrorClass` for retry policy consistency.
+- Failure-payload sanitization leaks are surfaced via dedicated contract error
+  `FailurePathRedactionLeakDetected`.
 
 ### Redaction Contract
 
@@ -105,8 +109,9 @@ execution; parity proof is accepted only in Lane 1.2.
   request secrets by the contract wrapper.
 - Redaction matcher coverage includes context-aware short multiline fragments
   and encoded secret variants (URL/base64 forms) derived from known hints.
-- Prefix matching uses a compiled trie and secret matching uses a compiled
-  multi-pattern automaton (Aho-Corasick style) for scalable cardinality.
+- Prefix matching uses a precompiled trie cached on the redactor instance and
+  secret matching uses a compiled multi-pattern automaton (Aho-Corasick style)
+  for scalable cardinality.
 - Redaction is applied to all persistable output channels:
   `gate_output`, `tail_output`, `stderr_tail`.
 
@@ -119,6 +124,7 @@ execution; parity proof is accepted only in Lane 1.2.
 5. Conformance is executable through reusable tests, not prose-only.
 6. Verification for this lane is executed with `just ci` from repo root (`make`-based checks are legacy and non-authoritative for acceptance).
 7. Lane 1.1 audits must score adapter implementation completeness as out-of-scope and defer that criterion to Lane 1.2.
+8. Redaction perf gate enforces both relative regression budget and absolute SLO ceilings.
 
 ## Redaction Minimum Coverage
 
@@ -136,6 +142,7 @@ Lane 1.2 adapter crates must reuse `tanren-runtime` conformance helpers:
 - `assert_capability_denial_is_preflight`
 - `assert_redaction_before_persistence`
 - `assert_failure_classification`
+- `assert_failure_path_leak_detected`
 - `assert_provider_metadata_fail_closed`
 - `assert_terminal_typed_code_mapping`
 

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -12,6 +12,10 @@ across providers (Claude Code, Codex, OpenCode, future adapters).
 Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
 Feature 1, Feature 3, and Feature 6.
 
+Lane 1.1 establishes the canonical contract and executable conformance
+checks required to validate those features. Cross-harness semantic
+equivalence evidence is accepted in Lane 1.2, where concrete adapters exist.
+
 ## Scope
 
 This lane ships (in `crates/tanren-runtime`):
@@ -42,18 +46,22 @@ This lane does **not** ship concrete provider adapters.
 ### Execution Contract
 
 - `HarnessExecutionRequest` is the provider-agnostic input shape.
+- Secret material in `HarnessExecutionRequest` is carried as secrecy-backed
+  values and never serialized.
 - `HarnessAdapter::execute` returns `ExecutionSignal` with raw output.
 - `execute_with_contract` enforces:
   1. preflight capability check
   2. adapter execution
-  3. redaction to `PersistableOutput`
-  4. known-secret leak check before persistence
+  3. redaction hints derived from request data (not caller-provided)
+  4. redaction to `PersistableOutput`
+  5. known-secret leak check before persistence
 
 ### Failure Contract
 
 - `HarnessFailureClass` is the stable failure taxonomy.
 - `classify_provider_failure` maps provider-native context into
-  `HarnessFailureClass`.
+  `HarnessFailureClass`, preferring typed adapter codes and structured
+  context before text fallback heuristics.
 - `HarnessFailureClass::to_domain_error_class` maps to
   `tanren_domain::ErrorClass` for retry policy consistency.
 
@@ -61,7 +69,8 @@ This lane does **not** ship concrete provider adapters.
 
 - `OutputRedactor` is the contract adapters use.
 - `DefaultOutputRedactor` + `RedactionPolicy` provide the shared baseline.
-- `RedactionHints` carries required secret names and resolved secret values.
+- `RedactionHints` is an internal capture-time representation derived from
+  request secrets by the contract wrapper.
 - Redaction is applied to all persistable output channels:
   `gate_output`, `tail_output`, `stderr_tail`.
 
@@ -95,6 +104,10 @@ Each adapter must prove:
 1. capability denial happens before side effects
 2. redaction is complete before persistence
 3. provider-specific failures normalize to stable failure classes
+
+Lane 1.2 acceptance also requires parity scenarios for
+[../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) Feature 1, Feature 3, and
+Feature 6 across all shipped harness adapters.
 
 ## Dependencies
 

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -43,6 +43,10 @@ execution; parity proof is accepted only in Lane 1.2.
   - session-resume support
   - sandbox mode
   - approval mode
+- `HarnessAdapter` is object-safe and exposes capabilities via
+  `HarnessAdapter::capabilities()`.
+- `HarnessAdapterRegistry` supports runtime trait-object registration and
+  lookup by adapter name.
 - `HarnessRequirements` describes what a dispatch needs and is constructed via
   validated builder APIs.
 - Sandbox and approval requirements use validated bound types
@@ -76,8 +80,8 @@ execution; parity proof is accepted only in Lane 1.2.
 ### Failure Contract
 
 - `HarnessFailureClass` is the stable failure taxonomy.
-- `HarnessFailure` is constructor-normalized with invariant-safe class/code
-  states; conflicting class/typed-code combinations are rejected at
+- `HarnessFailure` normalization is contract-owned and constructor-sealed from
+  external callers; conflicting class/typed-code combinations are rejected at
   deserialization boundaries.
 - `ProviderFailureContext.typed_code` is mandatory for terminal adapter
   failures and uses terminal-only `ProviderFailureCode` (no `unknown` variant).
@@ -95,10 +99,14 @@ execution; parity proof is accepted only in Lane 1.2.
   the contract-owned default redactor.
 - `DefaultOutputRedactor` + `RedactionPolicy` provide the shared baseline.
 - Default redaction policy data is sourced from a versioned dataset.
+- `RedactionPolicy` is immutable and validated (`try_new`/builder) to reject
+  unsafe threshold or duplicate-pattern configurations.
 - `RedactionHints` is an internal capture-time representation derived from
   request secrets by the contract wrapper.
 - Redaction matcher coverage includes context-aware short multiline fragments
   and encoded secret variants (URL/base64 forms) derived from known hints.
+- Prefix matching uses a compiled trie and secret matching uses a compiled
+  multi-pattern automaton (Aho-Corasick style) for scalable cardinality.
 - Redaction is applied to all persistable output channels:
   `gate_output`, `tail_output`, `stderr_tail`.
 
@@ -138,6 +146,7 @@ Each adapter must prove:
 3. provider-specific failures normalize to stable failure classes
 4. unsafe provider metadata is rejected fail-closed
 5. typed terminal failure code mappings remain stable
+6. contract lifecycle events satisfy strict cardinality + ordering invariants
 
 Lane 1.2 acceptance also requires parity scenarios for
 [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) Feature 1, Feature 3, and

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -15,6 +15,8 @@ Feature 1, Feature 3, and Feature 6.
 Lane 1.1 establishes the canonical contract and executable conformance
 checks required to validate those features. Cross-harness semantic
 equivalence evidence is accepted in Lane 1.2, where concrete adapters exist.
+Lane 1.1 acceptance explicitly excludes shipping concrete harness adapter
+implementations; those are mandatory Lane 1.2 deliverables.
 
 ## Scope
 
@@ -27,6 +29,8 @@ This lane ships (in `crates/tanren-runtime`):
 - reusable adapter conformance test helpers for Lane 1.2
 
 This lane does **not** ship concrete provider adapters.
+This lane also does **not** claim cross-harness parity proof based on adapter
+execution; parity proof is accepted only in Lane 1.2.
 
 ## Contract Surfaces
 
@@ -94,6 +98,8 @@ This lane does **not** ship concrete provider adapters.
 3. Raw provider failures map to typed contract classes.
 4. Persisted output is redacted before durable storage.
 5. Conformance is executable through reusable tests, not prose-only.
+6. Verification for this lane is executed with `just ci` from repo root (`make`-based checks are legacy and non-authoritative for acceptance).
+7. Lane 1.1 audits must score adapter implementation completeness as out-of-scope and defer that criterion to Lane 1.2.
 
 ## Redaction Minimum Coverage
 

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -49,6 +49,8 @@ execution; parity proof is accepted only in Lane 1.2.
 - Approval bounds are dual-axis:
   - minimum approval uses strictness (`never < on_escalation < on_demand`)
   - maximum approval uses privilege risk (`on_demand < on_escalation < never`)
+- Approval denials are modeled with reachable states only:
+  `approval_mode_below_minimum` and `approval_mode_exceeds_maximum`.
 - `ensure_admissible` performs preflight checks and returns typed
   `CompatibilityDenial` when unsupported.
 
@@ -61,10 +63,10 @@ execution; parity proof is accepted only in Lane 1.2.
   provider-native failure payloads (`ProviderFailure`).
 - `execute_with_contract` enforces:
   1. preflight capability check
-  2. adapter execution
+  2. sealed adapter execution (contract-only call token)
   3. redaction hints derived from request data (not caller-provided)
-  4. contract-owned redaction to `PersistableOutput`
-  5. known-secret + policy residual leak checks before persistence
+  4. contract-owned redaction + single-pass leak audit to `PersistableOutput`
+  5. fail-closed metadata sanitization for `provider_run_id`
   6. source-tagged event emission (`contract` vs `adapter`) for conformance-safe
      ordering assertions
 
@@ -74,9 +76,12 @@ execution; parity proof is accepted only in Lane 1.2.
 - `HarnessFailure` is constructor-normalized with invariant-safe class/code
   states; conflicting class/typed-code combinations are rejected at
   deserialization boundaries.
-- `classify_provider_failure` maps provider-native context into
-  `HarnessFailureClass`, preferring typed adapter codes and structured
-  context before bounded text fallback heuristics.
+- `ProviderFailureContext.typed_code` is mandatory for terminal adapter failures;
+  `typed_code=unknown` is rejected at the contract boundary.
+- `classify_provider_failure` maps terminal provider failures deterministically
+  from typed adapter code only.
+- `classify_provider_failure_for_audit` remains available as an explicit
+  telemetry utility for bounded fallback heuristics.
 - `HarnessFailureClass::to_domain_error_class` maps to
   `tanren_domain::ErrorClass` for retry policy consistency.
 
@@ -88,6 +93,8 @@ execution; parity proof is accepted only in Lane 1.2.
 - Default redaction policy data is sourced from a versioned dataset.
 - `RedactionHints` is an internal capture-time representation derived from
   request secrets by the contract wrapper.
+- Redaction matcher coverage includes context-aware short multiline fragments
+  and encoded secret variants (URL/base64 forms) derived from known hints.
 - Redaction is applied to all persistable output channels:
   `gate_output`, `tail_output`, `stderr_tail`.
 

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -40,6 +40,8 @@ This lane does **not** ship concrete provider adapters.
   - sandbox mode
   - approval mode
 - `HarnessRequirements` describes what a dispatch needs.
+- Sandbox and approval requirements support both minimum capability and maximum
+  privilege bounds.
 - `ensure_admissible` performs preflight checks and returns typed
   `CompatibilityDenial` when unsupported.
 
@@ -53,7 +55,7 @@ This lane does **not** ship concrete provider adapters.
   1. preflight capability check
   2. adapter execution
   3. redaction hints derived from request data (not caller-provided)
-  4. redaction to `PersistableOutput`
+  4. contract-owned redaction to `PersistableOutput`
   5. known-secret leak check before persistence
 
 ### Failure Contract
@@ -67,7 +69,8 @@ This lane does **not** ship concrete provider adapters.
 
 ### Redaction Contract
 
-- `OutputRedactor` is the contract adapters use.
+- `OutputRedactor` defines redaction behavior; persistence-bound execution uses
+  the contract-owned default redactor.
 - `DefaultOutputRedactor` + `RedactionPolicy` provide the shared baseline.
 - `RedactionHints` is an internal capture-time representation derived from
   request secrets by the contract wrapper.

--- a/docs/rewrite/tasks/LANE-1.1-HARNESS.md
+++ b/docs/rewrite/tasks/LANE-1.1-HARNESS.md
@@ -42,6 +42,9 @@ This lane does **not** ship concrete provider adapters.
 - `HarnessRequirements` describes what a dispatch needs.
 - Sandbox and approval requirements support both minimum capability and maximum
   privilege bounds.
+- Approval bounds are dual-axis:
+  - minimum approval uses strictness (`never < on_escalation < on_demand`)
+  - maximum approval uses privilege risk (`on_demand < on_escalation < never`)
 - `ensure_admissible` performs preflight checks and returns typed
   `CompatibilityDenial` when unsupported.
 
@@ -50,20 +53,26 @@ This lane does **not** ship concrete provider adapters.
 - `HarnessExecutionRequest` is the provider-agnostic input shape.
 - Secret material in `HarnessExecutionRequest` is carried as secrecy-backed
   values and never serialized.
-- `HarnessAdapter::execute` returns `ExecutionSignal` with raw output.
+- `HarnessAdapter::execute` returns `ExecutionSignal` with raw output and
+  provider-native failure payloads (`ProviderFailure`).
 - `execute_with_contract` enforces:
   1. preflight capability check
   2. adapter execution
   3. redaction hints derived from request data (not caller-provided)
   4. contract-owned redaction to `PersistableOutput`
-  5. known-secret leak check before persistence
+  5. known-secret + policy residual leak checks before persistence
+  6. source-tagged event emission (`contract` vs `adapter`) for conformance-safe
+     ordering assertions
 
 ### Failure Contract
 
 - `HarnessFailureClass` is the stable failure taxonomy.
+- `HarnessFailure` is constructor-normalized with invariant-safe class/code
+  states; conflicting class/typed-code combinations are rejected at
+  deserialization boundaries.
 - `classify_provider_failure` maps provider-native context into
   `HarnessFailureClass`, preferring typed adapter codes and structured
-  context before text fallback heuristics.
+  context before bounded text fallback heuristics.
 - `HarnessFailureClass::to_domain_error_class` maps to
   `tanren_domain::ErrorClass` for retry policy consistency.
 
@@ -72,6 +81,7 @@ This lane does **not** ship concrete provider adapters.
 - `OutputRedactor` defines redaction behavior; persistence-bound execution uses
   the contract-owned default redactor.
 - `DefaultOutputRedactor` + `RedactionPolicy` provide the shared baseline.
+- Default redaction policy data is sourced from a versioned dataset.
 - `RedactionHints` is an internal capture-time representation derived from
   request secrets by the contract wrapper.
 - Redaction is applied to all persistable output channels:

--- a/docs/rewrite/tasks/LANE-1.2-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.2-BRIEF.md
@@ -1,0 +1,39 @@
+# Lane 1.2 — Initial Harness Adapters — Agent Brief
+
+## Task
+
+Ship initial harness adapters using the Lane 1.1 contract and prove
+cross-harness semantic equivalence for Phase 1 workloads.
+
+## Read first
+
+1. [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) (Feature 1, 3, 6)
+2. [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md)
+3. [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md)
+4. [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
+5. [../../../CLAUDE.md](../../../CLAUDE.md)
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| Adapters | Claude Code, Codex, and OpenCode harness adapters implementing Lane 1.1 contract |
+| Parity | Cross-harness parity suite for positive and falsification expectations |
+| Errors | Stable typed failure mapping for adapter-specific failures |
+| Safety | Verified redaction behavior in persisted execution evidence |
+
+## Non-negotiables
+
+1. Adapter parity is measured at domain semantics, not provider wording.
+2. Capability denial behavior is preflight-safe and side-effect-free.
+3. Redaction guarantees apply consistently across all shipped adapters.
+4. All three Phase 1 harnesses are mandatory scope for this lane.
+5. Evidence artifacts are reproducible by another engineer.
+6. Adapter tests reuse Lane 1.1 conformance helpers from `tanren-runtime`.
+
+## Done when
+
+1. Claude Code, Codex, and OpenCode adapters pass shared contract conformance tests.
+2. Cross-harness matrix evidence covers pairwise equivalence across all three.
+3. Typed denial/failure behavior is stable across adapter-specific faults.
+4. Lane output satisfies its mapped BDD scenarios.

--- a/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
+++ b/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
@@ -20,14 +20,13 @@ This lane ships:
 - three production harness adapters: Claude Code, Codex, and OpenCode
 - capability reporting for each shipped adapter
 - typed failure mapping from harness-native errors into Tanren classes
-- shared redaction contract usage via `OutputRedactor`
+- shared redaction contract enforcement via `execute_with_contract`
 - conformance and parity evidence across the shipped harnesses
 
 Lane 1.2 adapters must consume the Lane 1.1 runtime contract APIs in
 `crates/tanren-runtime`, especially:
 
 - `execute_with_contract` for preflight + redaction enforcement
-- `DefaultOutputRedactor` for output safety
 - `assert_capability_denial_is_preflight`
 - `assert_redaction_before_persistence`
 - `assert_failure_classification`

--- a/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
+++ b/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
@@ -27,10 +27,16 @@ Lane 1.2 adapters must consume the Lane 1.1 runtime contract APIs in
 `crates/tanren-runtime`, especially:
 
 - `execute_with_contract` for preflight + redaction enforcement
-- `DefaultOutputRedactor` / `RedactionHints` for output safety
+- `DefaultOutputRedactor` for output safety
 - `assert_capability_denial_is_preflight`
 - `assert_redaction_before_persistence`
 - `assert_failure_classification`
+
+Lane 1.2 adapter acceptance is blocked until each shipped adapter proves:
+
+- mandatory reuse of Lane 1.1 conformance helpers
+- parity coverage for [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+  Feature 1, Feature 3, and Feature 6 scenarios
 
 ## Behavioral requirements
 
@@ -39,6 +45,8 @@ Lane 1.2 adapters must consume the Lane 1.1 runtime contract APIs in
 2. Capability mismatches produce typed denials, not partial execution.
 3. Failure classes are stable and operator-readable across adapters.
 4. Redaction requirements from Lane 1.1 remain enforced in every adapter.
+5. Cross-harness semantic equivalence proof is delivered in this lane,
+   not inferred from Lane 1.1 contract shape alone.
 
 ## Dependencies
 

--- a/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
+++ b/docs/rewrite/tasks/LANE-1.2-HARNESS-ADAPTERS.md
@@ -1,0 +1,51 @@
+# Lane 1.2 — Initial Harness Adapters
+
+## Status
+
+Planned for Phase 1.
+
+## Purpose
+
+Implement the first set of harness adapters on top of the Lane 1.1
+contract and prove that harness choice does not change domain-level
+execution semantics.
+
+Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+Feature 1, Feature 3, and Feature 6.
+
+## Scope
+
+This lane ships:
+
+- three production harness adapters: Claude Code, Codex, and OpenCode
+- capability reporting for each shipped adapter
+- typed failure mapping from harness-native errors into Tanren classes
+- shared redaction contract usage via `OutputRedactor`
+- conformance and parity evidence across the shipped harnesses
+
+Lane 1.2 adapters must consume the Lane 1.1 runtime contract APIs in
+`crates/tanren-runtime`, especially:
+
+- `execute_with_contract` for preflight + redaction enforcement
+- `DefaultOutputRedactor` / `RedactionHints` for output safety
+- `assert_capability_denial_is_preflight`
+- `assert_redaction_before_persistence`
+- `assert_failure_classification`
+
+## Behavioral requirements
+
+1. Equivalent dispatches produce equivalent domain outcomes across
+   all three shipped harnesses.
+2. Capability mismatches produce typed denials, not partial execution.
+3. Failure classes are stable and operator-readable across adapters.
+4. Redaction requirements from Lane 1.1 remain enforced in every adapter.
+
+## Dependencies
+
+- [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md)
+
+## Out of scope
+
+- environment lease contract and adapters
+- worker retry/recovery orchestration
+- adding a fourth harness adapter in this lane

--- a/docs/rewrite/tasks/LANE-1.2-RUNTIME.md
+++ b/docs/rewrite/tasks/LANE-1.2-RUNTIME.md
@@ -1,40 +1,12 @@
-# Lane 1.2 — Runtime Substrate
+# Lane 1.2 Runtime Stub (Legacy Pointer)
 
-> **Status:** Stub. Full brief to be written at the start of Phase 1.
+This earlier stub has been superseded by the Phase 1 lane split:
 
-## Scope
+- [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md)
+- [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md)
+- [LANE-1.4-ENV-ADAPTERS.md](LANE-1.4-ENV-ADAPTERS.md)
+- [LANE-1.5-WORKER-RUNTIME.md](LANE-1.5-WORKER-RUNTIME.md)
 
-Implements concrete execution runtimes (`tanren-runtime-local`,
-`tanren-runtime-docker`, `tanren-runtime-remote`) behind the
-`ExecutionRuntime` trait defined in `tanren-runtime`.
+Behavioral source of truth for Phase 1 expectations:
 
-## Carried-Forward Notes from Lane 0.2 Audit
-
-### `LeaseCapabilities.runtime_type` typing
-
-Currently a `NonEmptyString`. Decision to leave it stringly-typed was
-deliberate: keeps third-party runtime adapters extensible without
-touching the domain crate. Re-evaluate once the built-in runtime set is
-stable and we have usage data from real dispatches.
-
-If the decision is to type it, the recommended shape is:
-
-```rust
-pub enum RuntimeKind {
-    Local,
-    Docker,
-    DooD,
-    Remote,
-    Custom(String),
-}
-```
-
-The `Custom(String)` variant preserves the current extensibility path
-while giving the built-ins compile-time coverage. Migration: change
-`LeaseCapabilities.runtime_type` from `NonEmptyString` to `RuntimeKind`
-and bump `SCHEMA_VERSION` per the domain module-level policy.
-
-## Dependencies
-
-- Lane 0.2 (domain model)
-- Lane 1.1 (harness contract)
+- [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)

--- a/docs/rewrite/tasks/LANE-1.3-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.3-BRIEF.md
@@ -1,0 +1,40 @@
+# Lane 1.3 — Environment Lease Contract — Agent Brief
+
+## Task
+
+Define and land the environment lease contract that provides safe,
+consistent lifecycle behavior across environment types.
+
+## Read first
+
+1. [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) (Feature 2, 4)
+2. [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md)
+3. [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
+4. [../CRATE_GUIDE.md](../CRATE_GUIDE.md)
+5. [../../../CLAUDE.md](../../../CLAUDE.md)
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| Contract | Lease lifecycle contract and compatibility model |
+| Safety | Deterministic cleanup semantics for all terminal paths |
+| Recovery | Crash-recovery behavioral contract (orphan reconciliation, duplicate prevention) |
+| Conformance | Executable contract tests for environment adapter compliance |
+| Extensibility | Container-topology-agnostic semantics that preserve future DooD adapter support |
+
+## Non-negotiables
+
+1. Cleanup semantics are explicit for success, failure, and cancellation.
+2. Incompatible environment selection fails before partial execution.
+3. Recovery expectations are testable and deterministic.
+4. Contract remains adapter-agnostic and extensible.
+5. Contract semantics do not assume a local Docker daemon or shared
+   host/container filesystem identity.
+
+## Done when
+
+1. Lease lifecycle and denial/failure classes are unambiguous.
+2. Cleanup and recovery invariants are covered by contract tests.
+3. Lane output is ready for concrete environment adapter implementation.
+4. Future DooD-style adapter compatibility constraints are explicit and testable.

--- a/docs/rewrite/tasks/LANE-1.3-ENV-CONTRACT.md
+++ b/docs/rewrite/tasks/LANE-1.3-ENV-CONTRACT.md
@@ -1,0 +1,58 @@
+# Lane 1.3 — Environment Lease Contract
+
+## Status
+
+Planned for Phase 1.
+
+## Purpose
+
+Define the environment lease contract that normalizes acquisition,
+execution context exposure, cleanup, and recovery semantics across
+environment types.
+
+Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+Feature 2 and Feature 4.
+
+## Scope
+
+This lane defines:
+
+- lease lifecycle states and transition semantics
+- compatibility/capability checks for environment selection
+- typed denial and failure classes for lease operations
+- cleanup invariants for success, failure, cancellation, and crash recovery
+- conformance expectations every environment adapter must satisfy
+- container-topology-agnostic semantics so containerized execution is not
+  coupled to one daemon placement model
+
+This lane does **not** ship concrete environment adapters.
+
+## Behavioral requirements
+
+1. Environment choice must not change domain-level execution semantics.
+2. Incompatible environment requests are denied safely before execution.
+3. Lease cleanup is deterministic across all terminal paths.
+4. Crash recovery semantics prevent orphaned or duplicate execution.
+5. Contract semantics must remain compatible with future DooD-style
+   container adapters without breaking existing adapter contracts.
+
+## Guardrails for Future Container Adapters
+
+When defining contract semantics, do not assume:
+
+- container execution always uses a local Docker daemon
+- host and container filesystem identity is always shared
+- network/process visibility semantics are identical across adapters
+
+Compatibility and behavior guarantees should be expressed via typed
+capabilities and lease metadata, not implicit adapter-specific defaults.
+
+## Dependencies
+
+- [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md)
+- [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md)
+
+## Out of scope
+
+- implementing concrete environment adapters
+- queue worker orchestration and retry policy

--- a/docs/rewrite/tasks/LANE-1.4-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.4-BRIEF.md
@@ -1,0 +1,41 @@
+# Lane 1.4 — Initial Environment Adapters — Agent Brief
+
+## Task
+
+Ship initial environment adapters using the Lane 1.3 lease contract and
+prove cross-environment semantic equivalence for Phase 1 workloads.
+
+## Read first
+
+1. [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) (Feature 2, 4, 6)
+2. [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md)
+3. [LANE-1.4-ENV-ADAPTERS.md](LANE-1.4-ENV-ADAPTERS.md)
+4. [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
+5. [../../../CLAUDE.md](../../../CLAUDE.md)
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| Adapters | Local worktree and local-daemon containerized environment adapters |
+| Cleanup | Deterministic cleanup behavior on all terminal paths |
+| Recovery | Verified interruption/recovery behavior |
+| Parity | Cross-environment parity matrix evidence |
+| Extensibility | Evidence that baseline adapter behavior keeps the contract compatible with future DooD support |
+
+## Non-negotiables
+
+1. Cross-environment parity is evaluated by domain semantics.
+2. Cleanup and recovery are validated as first-class outcomes.
+3. Incompatible environment requests fail safely before execution.
+4. Baseline containerized adapter behavior must not encode assumptions
+   that block future DooD-style adapters.
+5. Evidence is reproducible by another engineer.
+
+## Done when
+
+1. At least two environment adapters pass shared conformance tests.
+2. Cross-environment equivalence evidence is produced for representative flows.
+3. Cleanup/recovery falsification cases are demonstrated and pass.
+4. Extensibility checks confirm no baseline assumptions block DooD support.
+5. Lane output satisfies its mapped BDD scenarios.

--- a/docs/rewrite/tasks/LANE-1.4-ENV-ADAPTERS.md
+++ b/docs/rewrite/tasks/LANE-1.4-ENV-ADAPTERS.md
@@ -1,0 +1,44 @@
+# Lane 1.4 — Initial Environment Adapters
+
+## Status
+
+Planned for Phase 1.
+
+## Purpose
+
+Implement the first environment adapters on top of the Lane 1.3 lease
+contract and prove cross-environment semantic equivalence.
+
+Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+Feature 2, Feature 4, and Feature 6.
+
+## Scope
+
+This lane ships:
+
+- initial environment adapters for local worktree plus local-daemon
+  containerized execution
+- compatibility signaling per adapter
+- typed lease acquisition/cleanup failure mapping
+- conformance and parity evidence across shipped environment types
+- validation that Phase 1 baseline adapters do not introduce assumptions
+  that block future DooD-style container adapters
+
+## Behavioral requirements
+
+1. Equivalent dispatches produce equivalent domain outcomes across
+   supported environment types.
+2. Incompatible/unavailable environments produce typed denials or failures.
+3. Cleanup guarantees hold for success, failure, cancellation, and timeout.
+4. Recovery behavior is observable and safe after unexpected interruption.
+5. Baseline containerized adapter behavior does not rely on assumptions
+   that would invalidate future DooD support.
+
+## Dependencies
+
+- [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md)
+
+## Out of scope
+
+- queue worker retry orchestration and global scheduling policy
+- implementing the DooD adapter itself in this lane

--- a/docs/rewrite/tasks/LANE-1.5-BRIEF.md
+++ b/docs/rewrite/tasks/LANE-1.5-BRIEF.md
@@ -1,0 +1,37 @@
+# Lane 1.5 — Worker Runtime — Agent Brief
+
+## Task
+
+Ship the Phase 1 worker runtime and produce Phase 1 proof artifacts that
+demonstrate durable execution, retry policy behavior, and safe recovery.
+
+## Read first
+
+1. [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md) (Feature 4, 5, 6)
+2. [LANE-1.5-WORKER-RUNTIME.md](LANE-1.5-WORKER-RUNTIME.md)
+3. [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
+4. [../CRATE_GUIDE.md](../CRATE_GUIDE.md)
+5. [../../../CLAUDE.md](../../../CLAUDE.md)
+
+## Deliverables
+
+| Area | Deliverable |
+|------|-------------|
+| Runtime | Durable worker flow from claim to terminal outcome |
+| Retries | Typed retry-policy execution with visible attempt history |
+| Recovery | Restart/crash recovery behavior that avoids duplicate terminalization |
+| Evidence | Reproducible Phase 1 proof-pack generation and verification path |
+
+## Non-negotiables
+
+1. Work reaches one coherent terminal outcome per accepted execution path.
+2. Retry policy behavior is explicit, bounded, and observable.
+3. Recovery behavior is deterministic and test-verified.
+4. Phase 1 proof claims are reproducible by another engineer.
+
+## Done when
+
+1. Worker runtime covers success/failure/cancel/retry/recovery paths.
+2. Retry and non-retry classifications behave per policy expectations.
+3. Recovery falsification cases pass with no duplicate terminal side effects.
+4. Phase 1 proof pack can be generated and verified from documented commands.

--- a/docs/rewrite/tasks/LANE-1.5-WORKER-RUNTIME.md
+++ b/docs/rewrite/tasks/LANE-1.5-WORKER-RUNTIME.md
@@ -1,0 +1,41 @@
+# Lane 1.5 — Worker Runtime
+
+## Status
+
+Planned for Phase 1.
+
+## Purpose
+
+Deliver the durable worker execution runtime that consumes accepted work,
+coordinates harness and environment adapters, and enforces retry/recovery
+semantics required for Phase 1 completion.
+
+Behavioral baseline: [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+Feature 4, Feature 5, and Feature 6.
+
+## Scope
+
+This lane ships:
+
+- queue/claim execution flow from accepted dispatch to terminal outcome
+- typed retry-policy handling and operator-visible attempt history
+- recovery behavior for worker interruption/restart
+- durable terminal evidence capture and replay-safe state transitions
+- Phase 1 proof-pack collection and verification hooks
+
+## Behavioral requirements
+
+1. Accepted work progresses to a single coherent terminal outcome.
+2. Retryable vs non-retryable failures are handled per explicit policy.
+3. Recovery after interruption avoids orphaned or duplicate terminal results.
+4. Operator-facing evidence remains queryable across restarts.
+
+## Dependencies
+
+- [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md)
+- [LANE-1.4-ENV-ADAPTERS.md](LANE-1.4-ENV-ADAPTERS.md)
+
+## Out of scope
+
+- planner-native graph orchestration
+- policy/governance expansion beyond Phase 1 runtime needs

--- a/docs/rewrite/tasks/README.md
+++ b/docs/rewrite/tasks/README.md
@@ -73,15 +73,52 @@ Phase 0 proof closure is now tracked and reproducible via:
 - [../PHASE0_PROOF_RUNBOOK.md](../PHASE0_PROOF_RUNBOOK.md)
 - `scripts/proof/phase0/run.sh` and `scripts/proof/phase0/verify.sh`
 
-## Future Phases
+## Phase 1: Runtime Substrate (Planned)
 
-Stubs below carry forward requirements from earlier audits so the
-follow-up work is not lost. Full briefs will be fleshed out at the
-start of each phase.
+Behavioral source of truth:
 
-- **Phase 1**: Runtime substrate (harness traits, environment leases, worker)
-  - [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md) — harness contract + output redaction requirement
-  - [LANE-1.2-RUNTIME.md](LANE-1.2-RUNTIME.md) — runtime substrate + `runtime_type` typing decision
+- [../PHASE1_PROOF_BDD.md](../PHASE1_PROOF_BDD.md)
+
+### Lane Plan
+
+| Lane | Area | Depends On | Status | Spec | Brief |
+|------|------|------------|--------|------|-------|
+| 1.1 | Harness contract | 0.5 | ✅ implemented on `rewrite/lane-1-1` (pending merge) | [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md) | [LANE-1.1-BRIEF.md](LANE-1.1-BRIEF.md) |
+| 1.2 | Initial harness adapters (Claude Code, Codex, OpenCode) | 1.1 | ⏳ planned | [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md) | [LANE-1.2-BRIEF.md](LANE-1.2-BRIEF.md) |
+| 1.3 | Environment lease contract | 1.1, 1.2 | ⏳ planned | [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md) | [LANE-1.3-BRIEF.md](LANE-1.3-BRIEF.md) |
+| 1.4 | Initial environment adapters (local worktree + local-daemon containerized, DooD-ready constraints) | 1.3 | ⏳ planned | [LANE-1.4-ENV-ADAPTERS.md](LANE-1.4-ENV-ADAPTERS.md) | [LANE-1.4-BRIEF.md](LANE-1.4-BRIEF.md) |
+| 1.5 | Worker runtime + proof closure | 1.2, 1.4 | ⏳ planned | [LANE-1.5-WORKER-RUNTIME.md](LANE-1.5-WORKER-RUNTIME.md) | [LANE-1.5-BRIEF.md](LANE-1.5-BRIEF.md) |
+
+Legacy pointer retained for compatibility:
+
+- [LANE-1.2-RUNTIME.md](LANE-1.2-RUNTIME.md)
+
+### Execution Order
+
+```
+Lane 1.1 (Harness Contract)
+         │
+         ▼
+Lane 1.2 (Harness Adapters)
+         │
+         ▼
+Lane 1.3 (Environment Contract)
+         │
+         ▼
+Lane 1.4 (Environment Adapters)
+         │
+         ▼
+Lane 1.5 (Worker Runtime + Proof Closure)
+```
+
+### Phase 1 Exit Theme
+
+By Phase 1 close, the same dispatch contract must run across multiple
+harnesses and environments with normalized lifecycle/error semantics and
+reproducible proof artifacts.
+
+## Future Phases (Beyond Phase 1)
+
 - **Phase 2**: Planner-native orchestration (task graphs, scheduler, replanning)
   - [LANE-2.1-PLANNING-GRAPH.md](LANE-2.1-PLANNING-GRAPH.md) — graph revision enforcement + non-dispatch events
 - **Phase 3**: Policy and governance (auth, budgets, placement)

--- a/docs/rewrite/tasks/README.md
+++ b/docs/rewrite/tasks/README.md
@@ -83,7 +83,7 @@ Behavioral source of truth:
 
 | Lane | Area | Depends On | Status | Spec | Brief |
 |------|------|------------|--------|------|-------|
-| 1.1 | Harness contract | 0.5 | ✅ implemented on `rewrite/lane-1-1` (pending merge) | [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md) | [LANE-1.1-BRIEF.md](LANE-1.1-BRIEF.md) |
+| 1.1 | Harness contract | 0.5 | ✅ implemented on `rewrite/lane-1-1` (pending merge); contract-level guarantees only | [LANE-1.1-HARNESS.md](LANE-1.1-HARNESS.md) | [LANE-1.1-BRIEF.md](LANE-1.1-BRIEF.md) |
 | 1.2 | Initial harness adapters (Claude Code, Codex, OpenCode) | 1.1 | ⏳ planned | [LANE-1.2-HARNESS-ADAPTERS.md](LANE-1.2-HARNESS-ADAPTERS.md) | [LANE-1.2-BRIEF.md](LANE-1.2-BRIEF.md) |
 | 1.3 | Environment lease contract | 1.1, 1.2 | ⏳ planned | [LANE-1.3-ENV-CONTRACT.md](LANE-1.3-ENV-CONTRACT.md) | [LANE-1.3-BRIEF.md](LANE-1.3-BRIEF.md) |
 | 1.4 | Initial environment adapters (local worktree + local-daemon containerized, DooD-ready constraints) | 1.3 | ⏳ planned | [LANE-1.4-ENV-ADAPTERS.md](LANE-1.4-ENV-ADAPTERS.md) | [LANE-1.4-BRIEF.md](LANE-1.4-BRIEF.md) |
@@ -116,6 +116,11 @@ Lane 1.5 (Worker Runtime + Proof Closure)
 By Phase 1 close, the same dispatch contract must run across multiple
 harnesses and environments with normalized lifecycle/error semantics and
 reproducible proof artifacts.
+
+Lane boundary note: Lane 1.1 defines and hardens the harness contract and
+conformance helpers; cross-harness semantic equivalence evidence for Feature 1,
+Feature 3, and Feature 6 is accepted in Lane 1.2 when concrete adapters are
+implemented.
 
 ## Future Phases (Beyond Phase 1)
 

--- a/justfile
+++ b/justfile
@@ -493,6 +493,15 @@ check-suppression:
 bench:
     {{ cargo }} bench --workspace
 
+# Run redaction benchmark scenarios used by the perf regression gate.
+bench-redaction:
+    @{{ cargo }} bench -p tanren-runtime --bench redaction -- --noplot
+
+# Enforce benchmark thresholds for redaction scenarios.
+check-redaction-perf:
+    @just bench-redaction
+    @UV_CACHE_DIR="${UV_CACHE_DIR:-$PWD/.uv-cache}" uv run python scripts/check_redaction_perf.py
+
 # ============================================================================
 # Maintenance
 # ============================================================================
@@ -542,6 +551,8 @@ ci:
     @just machete
     @echo "==> Strict Rust CI"
     @just ci-rust-strict
+    @echo "==> Redaction perf regression gate"
+    @just check-redaction-perf
     @echo "==> Installer drift guard"
     @just install-commands-check
     @echo "==> All CI checks passed!"

--- a/profiles/python-uv/testing/bdd-for-integration-quality.md
+++ b/profiles/python-uv/testing/bdd-for-integration-quality.md
@@ -1,93 +1,34 @@
-# BDD for Integration & Quality Tests
+# BDD Across All Test Tiers
 
-Integration and quality tests must use BDD-style (Given/When/Then). Unit tests can use direct assertions.
-
-```python
-# ✓ Good: BDD-style for integration/quality tests
-from pytest_bdd import given, when, then, scenarios
-
-
-@given("a configured pipeline with sample script")
-def configured_pipeline(tmp_path):
-    return setup_pipeline(tmp_path, sample_script)
-
-
-@when("the pipeline runs to completion")
-async def run_pipeline(configured_pipeline):
-    configured_pipeline.result = await configured_pipeline.run()
-
-
-@then("the pipeline produces a valid output")
-def check_output(configured_pipeline):
-    assert configured_pipeline.result.success is True
-    assert (configured_pipeline.output_dir / "output.json").exists()
-
-
-# Integration tests: Use mock model adapter (no real LLMs)
-# Quality tests: Use real model adapter (actual LLMs)
-
-
-# ✗ Bad: Direct assertions in integration/quality tests
-def test_pipeline_completion():
-    pipeline = setup_pipeline()
-    result = await pipeline.run()
-    assert result.success is True  # Not BDD-style
-```
-
-**BDD structure:**
-
-**Given:** Setup test state
-- Arrange test data and fixtures
-- Configure system under test
-- Document preconditions
-
-**When:** Perform action
-- Execute the behavior being tested
-- Single action or small sequence
-- Document trigger
-
-**Then:** Verify outcome
-- Assert expected results
-- Validate post-conditions
-- Document expected behavior
-
-**Integration tests:**
-- BDD-style required
-- Real services (storage, vector store, file system)
-- Mock model adapters (NO real LLMs)
-- <5s per test
-
-**Quality tests:**
-- BDD-style required
-- Real services (storage, vector store, file system)
-- Real model adapters (REAL LLMs)
-- <30s per test
-
-**Unit tests:**
-- Direct assertions allowed (no BDD requirement)
-- Focus on isolated logic
-- <250ms per test
-
-**BDD benefits:**
-- Tests read like documentation/specs
-- Easier to understand for new developers
-- Focuses on behavior and scenarios, not implementation
-- Clear Given/When/Then structure
-
-**Example scenario:**
+All executable tests are behavior tests and must be authored as Gherkin scenarios. There is no non-BDD test tier in CI.
 
 ```gherkin
-Scenario: Pipeline processes item with context
-  Given a configured pipeline with sample script
-    And context layer with reference data
-  When the pipeline runs to completion
-  Then the pipeline produces a valid output
-    And outputs respect reference data
+Feature: Pipeline execution
+
+  @behavior(BEH-PROC-001) @tier(unit)
+  Scenario: Processor rejects unsupported format
+    Given a processor configured for "json" input
+    When input format is "xml"
+    Then processing is rejected with error code "unsupported_format"
+
+  @behavior(BEH-PROC-002) @tier(integration)
+  Scenario: Pipeline stores normalized result
+    Given a configured pipeline with sample data
+    When the pipeline runs to completion
+    Then the normalized result is written to storage
+
+  @behavior(BEH-PROC-003) @tier(quality)
+  Scenario: Prompted summary satisfies quality threshold
+    Given a production prompt and a real model adapter
+    When summary generation completes
+    Then the summary contains required sections
 ```
 
-**Never use BDD for:**
-- Unit tests (direct assertions are fine)
-- Performance benchmarks (different format)
-- One-off validation scripts
+**Rules:**
+- Use `pytest-bdd` for unit, integration, and quality tiers
+- Every scenario must include a stable behavior tag: `@behavior(BEH-...)`
+- Every scenario must include exactly one tier tag: `@tier(unit|integration|quality)`
+- Step implementations may call helper functions, but scenario behavior is the source of truth
+- If a behavior exists, it must exist as at least one scenario
 
-**Why:** Tests read like documentation/specs (easier to understand) and focuses on behavior and scenarios instead of implementation details.
+**Why:** A single executable format keeps behavioral intent, implementation checks, and review language aligned.

--- a/profiles/python-uv/testing/behavior-inventory-and-scenario-traceability.md
+++ b/profiles/python-uv/testing/behavior-inventory-and-scenario-traceability.md
@@ -1,0 +1,12 @@
+# Behavior Inventory and Scenario Traceability
+
+Maintain an explicit behavior inventory and require every behavior to map to executable scenarios.
+
+**Rules:**
+- Each behavior has a stable ID (for example `BEH-PIPE-001`)
+- Each scenario includes `@behavior(<id>)`
+- New or modified behavior cannot merge without scenario mapping
+- Deprecated behavior must remove or archive its scenarios intentionally
+- PRs must include a behavior mapping diff for changed behaviors
+
+**Why:** Behavior IDs make coverage, audits, and demo evidence explicit and reviewable.

--- a/profiles/python-uv/testing/coverage-as-scenario-proxy.md
+++ b/profiles/python-uv/testing/coverage-as-scenario-proxy.md
@@ -1,0 +1,11 @@
+# Coverage as Scenario Proxy
+
+Coverage is a proxy for missing scenarios, not a standalone quality target.
+
+**Rules:**
+- Discuss coverage shortfalls as missing behavior scenarios first
+- If no behavior is missing, classify uncovered code as removable or non-scenario support
+- Keep a written rationale for intentional uncovered support code
+- Do not use coverage percentage alone as acceptance evidence
+
+**Why:** The right question is "which behavior is unproven?" not "how do we raise a number?"

--- a/profiles/python-uv/testing/gherkin-quality-rules.md
+++ b/profiles/python-uv/testing/gherkin-quality-rules.md
@@ -1,0 +1,13 @@
+# Gherkin Quality Rules
+
+Gherkin files must be strict, readable, and machine-checkable.
+
+**Rules:**
+- One `Feature` per file
+- Scenario titles are outcome-oriented and specific
+- Prefer `Scenario Outline` for data variation instead of copy-paste scenarios
+- Steps must describe observable behavior, not implementation internals
+- Use stable behavior tags and tier tags on every scenario
+- Keep Background sections short and reusable
+
+**Why:** High-quality Gherkin keeps behavior specs durable and enforceable over time.

--- a/profiles/python-uv/testing/make-all-gate.md
+++ b/profiles/python-uv/testing/make-all-gate.md
@@ -1,16 +1,17 @@
-# Make All Gate
+# Scenario Gates
 
-`make all` is the local verification gate. `make ci` is the CI PR gate.
+`make check`, `make ci`, and `make all` must execute scenario suites, not mixed free-form tests.
 
 Gate tiers:
-- `make check` — Task gate (format, lint, type, unit)
-- `make ci` — CI PR gate (format, lint, type, unit, integration)
-- `make all` — Spec gate (format, lint, type, unit, integration, quality)
+- `make check` — unit + integration BDD scenario gates
+- `make ci` — full CI BDD scenario gates (+ mutation gate when configured)
+- `make all` — local full gate including quality scenarios
 
-Rules:
-- Agents run `make all` locally before finalizing work (agents have API keys)
-- CI runs `make ci` on PRs — quality tests require paid API keys unavailable in CI
-- `make all` fails hard if quality tests can't run (no silent skipping)
-- Fix failures and re-run until green
-- Do not skip steps or substitute partial commands
-- Human feedback on gate scope overrides spec non-negotiables
+**Rules:**
+- Gate commands run `.feature`-backed suites for all enabled tiers
+- CI must fail if behavior scenarios are missing for changed behavior IDs
+- CI must fail if mutation gate configured by the profile fails
+- CI must fail if scenario-only coverage gate fails
+- No bypassing scenario suites with ad-hoc direct test commands
+
+**Why:** Gate outcomes should answer one question: did declared behaviors execute and pass?

--- a/profiles/python-uv/testing/mandatory-coverage.md
+++ b/profiles/python-uv/testing/mandatory-coverage.md
@@ -1,78 +1,20 @@
-# Mandatory Coverage
+# Coverage from Behavior Scenarios
 
-Coverage is mandatory for features. Tests must directly exercise intended behavior.
+Coverage is measured from BDD scenario execution and interpreted as a scenario-gap signal.
 
-```python
-# ✓ Good: Tests exercise actual behavior
-# tests/unit/core/processor.py
-async def test_processes_item_with_context(given_item, given_context):
-    """Test that processing applies context to output."""
-    result = await process_item(given_item, given_context)
-
-    # Directly exercises processing behavior
-    assert "character_name" in result.text
-    assert result.context_used == given_context.id
-
-
-# ✗ Bad: Tests don't exercise behavior
-async def test_processor_initialization():
-    """Just tests constructor, not behavior - NO COVERAGE VALUE."""
-    processor = Processor()
-    assert processor is not None  # No behavior tested
+```bash
+# Example: run only scenario suites, then collect coverage
+uv run pytest tests/unit/features tests/integration/features tests/quality/features \
+  --cov=src --cov-report=term-missing
 ```
 
-**Coverage requirements:**
+**Rules:**
+- Coverage must be generated from scenario-backed test runs
+- Uncovered code must be triaged as one of:
+  - missing behavior scenario
+  - dead/removable code
+  - non-scenario support code (explicitly justified)
+- PR review must discuss uncovered paths in behavior terms, not only percentage terms
+- Coverage thresholds are required, but scenario completeness discussion is primary
 
-**For every feature:**
-- Tests must directly exercise intended behavior
-- All code paths must be covered (happy path, error cases, edge cases)
-- No uncovered production code
-- Coverage must pass in CI before merging
-
-**CI enforcement:**
-- Run `pytest --cov=src/`
-- Fail PRs below coverage threshold (e.g., 80%)
-- Block merging new features without tests
-- Generate coverage reports for review
-
-**What counts as coverage:**
-
-**✓ Direct behavior testing:**
-- Unit tests calling functions with real inputs
-- Integration tests running full workflows
-- Quality tests validating end-to-end behavior
-- Error path and edge case testing
-
-**✗ NOT coverage:**
-- Constructor-only tests (no behavior)
-- Property access tests (no behavior)
-- Mock-only tests (no real logic)
-- Tests that bypass or stub out production code
-
-**Coverage strategies:**
-
-**Unit tests:**
-- Test isolated functions and methods
-- Mock external dependencies
-- Cover all branches and error paths
-- Use parametrization for edge cases
-
-**Integration tests:**
-- Test workflows and component interaction
-- Use real services (storage, vector store)
-- Cover cross-component code paths
-- Validate end-to-end behavior
-
-**Quality tests:**
-- Test with real LLMs
-- Validate actual outputs, not mocks
-- Cover model integration paths
-- Ensure prompt/response handling
-
-**Never merge:**
-- New features without tests
-- Tests that don't exercise behavior
-- Uncovered code paths
-- Failing coverage checks in CI
-
-**Why:** Catches regressions early by testing actual behavior; ensures code quality and test hygiene by preventing untested production code.
+**Why:** Coverage becomes evidence about behavior completeness instead of a shallow line-count game.

--- a/profiles/python-uv/testing/mock-execution-boundary.md
+++ b/profiles/python-uv/testing/mock-execution-boundary.md
@@ -1,38 +1,35 @@
 # Mock at the Execution Boundary
 
-Mock where execution actually happens, not where you think it happens. Verify the mock was invoked.
+In BDD suites, mocks are allowed only where a scenario crosses an external execution boundary.
 
-## Rule
-
-Before writing a mock, trace the call path from your test entry point to the real side-effect. Patch at the last internal boundary before the external call.
-
-## Per-Tier Boundaries
-
-- **Unit tests** — Mock direct dependencies (e.g., function args, injected services). Can mock low-level internals.
-- **Integration tests** — Mock at `Agent.run()` for agent execution. Never mock pydantic-ai internals or CLI factory functions (`_build_llm_runtime`). Return schema-valid output matching the agent's `_output_type`.
-- **Quality tests** — No mocks. Real LLMs only (see `no-mocks-for-quality-tests`).
-
-## Agent Mock Pattern
-
-```python
-async def mock_agent_run(self: Agent, payload: object) -> object:
-    call_count["count"] += 1
-    output_type = self._output_type
-    if output_type == ItemSummary:
-        return ItemSummary(item_id="item_001", summary="...", characters=[])
-    # ... per-agent-type returns
+```gherkin
+@behavior(BEH-PIPE-011) @tier(integration)
+Scenario: Pipeline retries failed model call
+  Given the model boundary returns a transient failure once
+  When the pipeline executes
+  Then the second attempt succeeds
 ```
 
-## Verification
-
-Always assert the mock was called:
-
 ```python
-call_count = {"count": 0}
-# ... run test ...
-assert call_count["count"] > 0, "Mock was never invoked"
+# Step binding patches the boundary that executes the side effect.
+@given("the model boundary returns a transient failure once")
+def model_boundary_retry(monkeypatch):
+    calls = {"count": 0}
+
+    async def boundary_call(*_args, **_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("transient")
+        return {"ok": True}
+
+    monkeypatch.setattr("myproj.adapters.model_client.ModelClient.generate", boundary_call)
+    return calls
 ```
 
-## Why
+**Rules:**
+- Patch at the last internal boundary before the external side effect
+- Do not mock internal helpers to make scenarios pass
+- Verify boundary mocks were exercised
+- Quality tier scenarios use no model mocks
 
-Patching the wrong boundary (e.g., a factory function) leaves the real execution path untouched. Tests pass on setup but fail on execution, creating confusing audit loops.
+**Why:** Scenario truth depends on realistic execution flow, not internal stubbing.

--- a/profiles/python-uv/testing/mutation-strength-gate.md
+++ b/profiles/python-uv/testing/mutation-strength-gate.md
@@ -1,0 +1,17 @@
+# Mutation Strength Gate (mutmut)
+
+Mutation testing is required to verify that behavior scenarios actually detect faults.
+
+```bash
+# Example command shape (project-specific wrapper may differ)
+uv run mutmut run
+uv run mutmut results
+```
+
+**Rules:**
+- CI must run `mutmut` for the profile-defined scope
+- Surviving mutants must be triaged and either fixed with new scenarios/steps or explicitly justified
+- Mutation regressions fail CI
+- Mutation evidence must reference impacted behavior IDs when possible
+
+**Why:** Passing scenarios are only strong if they fail under realistic code mutations.

--- a/profiles/python-uv/testing/no-mocks-for-quality-tests.md
+++ b/profiles/python-uv/testing/no-mocks-for-quality-tests.md
@@ -1,87 +1,27 @@
-# No Mocks for Quality Tests
+# No Model Mocks in Quality Scenarios
 
-Quality tests use real LLMs (actual model calls). Integration tests must mock LLMs.
+Quality-tier BDD scenarios validate real model behavior. Model mocks are forbidden in this tier.
 
-```python
-# ✓ Good: Quality test with real LLM
-# tests/quality/core/processing.py
-from myproject.adapters.llm_client import LLMClient
-
-
-async def test_output_quality_with_real_llm(given_request):
-    """Test output quality with actual model call."""
-    client = LLMClient(base_url="https://api.openai.com/v1", api_key="test-key")
-    result = await client.generate(given_request)
-
-    # Validate actual model output, not mocked response
-    assert result.text is not None
-    assert len(result.text) > 0
-
-
-# ✓ Good: Integration test with mocked LLM
-# tests/integration/core/processing.py
-from unittest.mock import AsyncMock
-
-
-async def test_processing_flow(given_task_request):
-    """Test processing flow with mocked LLM (no real calls)."""
-    mock_client = AsyncMock()
-    mock_client.process.return_value = TaskResult(text="mocked text", model="gpt-4")
-
-    result = await mock_client.process(given_task_request)
-    assert result.text == "mocked text"  # Verify mock, not real model
-
-
-# ✗ Bad: Quality test with mocked LLM
-async def test_output_quality(given_task_request):
-    """Quality test must NOT mock LLM."""
-    mock_client = AsyncMock()
-    mock_client.process.return_value = TaskResult(text="mocked text")
-    # This validates mock, not real model behavior - FAILS QA PURPOSE
+```gherkin
+@behavior(BEH-QUAL-001) @tier(quality)
+Scenario: Summary quality with production model
+  Given a real model adapter with valid credentials
+  When summary generation runs
+  Then the output includes all required sections
 ```
 
-**Quality tests:**
-- **REAL LLMs** - actual model calls, not mocked
-- BDD-style (Given/When/Then)
-- Real services (storage, vector store, file system)
-- Minimal mocks (only when unavoidable)
-- <30s per test
-- Validates actual model behavior and quality, not mocked responses
+```gherkin
+@behavior(BEH-INT-001) @tier(integration)
+Scenario: Pipeline orchestration without real model cost
+  Given a mocked model boundary
+  When the pipeline executes
+  Then orchestration succeeds and outputs are persisted
+```
 
-**Integration tests:**
-- **NO LLMs** - mock model adapters for LLM calls
-- BDD-style (Given/When/Then)
-- Real services (storage, vector store, file system)
-- Minimal mocks (only when unavoidable)
-- <5s per test
-- Tests pipeline flow, not model behavior
+**Rules:**
+- Quality tier: real model adapters only
+- Integration tier: mocked model boundary allowed
+- Unit tier: mocked model boundary required
+- Quality scenarios failing due to model behavior must be fixed, not bypassed
 
-**Why real LLMs in quality tests:**
-- Validates actual model behavior and quality
-- Catches regressions when models change or update
-- Ensures prompts and schemas work with real models
-- Tests error handling for real API responses
-
-**Why mock LLMs in integration tests:**
-- Fast feedback (<5s vs <30s)
-- Avoids LLM API rate limits and costs
-- Tests pipeline flow, not model behavior
-- Makes integration tests deterministic and fast
-
-**Never mock LLMs for:**
-- Quality tests (defeats purpose)
-- Validating model-specific behavior
-- Testing prompt engineering effectiveness
-- Validating actual output quality
-
-**Never use real LLMs for:**
-- Unit tests (should be <250ms)
-- Integration tests (should be <5s)
-
-**API key management for quality tests:**
-- Use test API keys with rate limits
-- Cache LLM responses when possible (within <30s bound)
-- Document API key setup in test docs
-- CI should have API key configured for quality tier
-
-**Why:** Validates actual model behavior and quality, not mocked responses; ensures prompts and schemas work with real models and tests error handling for real API responses.
+**Why:** Quality behavior claims are only trustworthy if executed against real model behavior.

--- a/profiles/python-uv/testing/no-test-skipping.md
+++ b/profiles/python-uv/testing/no-test-skipping.md
@@ -1,104 +1,12 @@
-# No Test Skipping
+# No Scenario Skipping
 
-Never skip tests within a tier. Tests either run and pass or run and fail.
+Scenarios either execute and pass, or execute and fail. Skipping is not allowed.
 
-```python
-# ✓ Good: Test runs and passes or runs and fails
-async def test_processing_with_context(given_item, given_context):
-    """Test runs and validates result."""
-    result = await process_item(given_item, given_context)
+**Rules:**
+- No `@pytest.mark.skip`, no conditional `pytest.skip()` in step code
+- No ignored feature files in CI selection
+- No "temporary" scenario bypasses
+- If a scenario is flaky, fix determinism or remove it
+- If behavior is obsolete, delete the scenario and behavior mapping in the same change
 
-    if result.success:
-        assert "character_name" in result.text
-    else:
-        raise AssertionError(f"Processing failed: {result.error}")  # Test fails
-
-
-# ✗ Bad: Skip test instead of fixing
-import pytest
-
-
-@pytest.mark.skip(reason="Flaky test, will fix later")  # NEVER DO THIS
-async def test_processing_with_context(given_item, given_context):
-    result = await process_item(given_item, given_context)
-    assert "character_name" in result.text
-```
-
-**Test execution philosophy:**
-
-**Within a tier:**
-- Tests either run and pass ✓
-- Or run and fail ✗
-- Never skip or bypass
-
-**Tier-level execution:**
-- Run full unit tier with zero skips
-- Run full integration tier with zero skips
-- Run full quality tier with zero skips
-
-**No skipping means:**
-
-**No `@pytest.mark.skip`:**
-- No "will fix later" skips
-- No flaky test skips
-- No platform-specific skips (fix test or skip entire tier)
-- No configuration skips (make tests work with all configs)
-
-**No conditionals that skip tests:**
-- No `if not has_feature: pytest.skip()`
-- No `if not on_platform: pytest.skip()`
-- No `if not has_credentials: pytest.skip()`
-
-**No CI-level skips:**
-- Don't skip test tiers in CI
-- Don't skip tests based on conditions
-- Run all tiers with `--no-skips` flag
-
-**When tests fail:**
-
-**Fix the test or fix the code:**
-- If test is wrong: fix the test
-- If code is broken: fix the code
-- If test is flaky: make it deterministic or delete it
-
-**Never:**
-- Skip failing tests
-- Comment out failing tests
-- Use `@pytest.mark.xfail` as loophole
-
-**Why tests fail:**
-
-**Flaky tests:**
-- Make deterministic (remove randomness, fix race conditions)
-- Use explicit setup/teardown
-- Delete test if can't be made reliable
-
-**Platform-specific:**
-- Fix test to work across platforms or skip entire tier on incompatible platforms
-- Document platform-specific behavior in test name, don't skip individual tests
-
-**Configuration-specific:**
-- Make tests work with all configurations
-- Test multiple configs if needed
-- Don't skip based on config state
-
-**CI enforcement:**
-
-**Fail CI on skips:**
-- Block PRs that introduce test skips
-- Fail entire CI run if any test is skipped
-- Use `pytest --no-skips` to ensure no bypass
-
-**CI tier exception:**
-- CI skips `make quality` (requires paid API keys). All other tiers run with zero skips.
-
-**Alert on skips:**
-- CI should fail loudly if tests are skipped
-- Require explicit override to merge with skips (extremely rare)
-
-**Never:**
-- Use test skips as bandage for broken tests
-- "Will fix later" mentality
-- Silent test bypasses
-
-**Why:** Tests either work or fail; no silent bypasses ensures test suite is reliable and trustworthy; prevents accumulation of broken/flaky tests.
+**Why:** Skipped scenarios silently corrupt behavior confidence.

--- a/profiles/python-uv/testing/test-timing-rules.md
+++ b/profiles/python-uv/testing/test-timing-rules.md
@@ -1,60 +1,16 @@
-# Test Timing Rules
+# Scenario Timing Rules
 
-Enforce strict timing limits per tier. Tests exceeding limits must be rewritten.
+Timing limits apply per executed scenario.
 
-```python
-# pytest.ini or pyproject.toml
-[tool.pytest.ini_options]
-markers = [
-    "unit: Unit tests (<250ms)",
-    "integration: Integration tests (<5s)",
-    "quality: Quality tests (<30s)",
-]
+**Limits:**
+- Unit scenarios: <250ms
+- Integration scenarios: <5s
+- Quality scenarios: <30s
 
-# CI configuration
-# pytest -m unit --durations=0  # Show slowest unit tests
-# pytest -m integration --durations=0  # Show slowest integration tests
-# pytest -m quality --durations=0  # Show slowest quality tests
-```
+**Rules:**
+- Tier tags define expected runtime (`@tier(unit|integration|quality)`)
+- Slow scenarios must be split or moved to the correct tier
+- CI surfaces slowest scenarios and fails repeated violations
+- Do not create a "slow" loophole marker to bypass these limits
 
-**Timing limits:**
-
-**Unit tests:** <250ms per test
-- Isolated logic and algorithms only
-- No external services (network, I/O, databases)
-- If test exceeds 250ms, it's not a unit test - move to integration or refactor
-
-**Integration tests:** <5s per test
-- Real services (storage, vector store, file system)
-- Minimal mocks
-- If test exceeds 5s, it's doing too much - split into multiple tests or optimize
-
-**Quality tests:** <30s per test
-- Real LLMs (actual model calls)
-- Real services (storage, vector store, file system)
-- If test exceeds 30s, it's doing too much - split into multiple tests or use cached results
-
-**Enforcement:**
-
-**CI:**
-- Fail tests that exceed timing limits
-- Use `--durations=0` to flag slow tests
-- Block PRs that introduce slow tests
-
-**Locally:**
-- Run `pytest --durations=0` to identify slow tests
-- Refactor or split slow tests immediately
-- Don't ignore timing warnings
-
-**Refactoring strategies:**
-- Split large tests into smaller, focused tests
-- Cache expensive operations (setup, data loading)
-- Remove unnecessary external service calls
-- Optimize test data (smaller datasets, fewer iterations)
-
-**Never:**
-- Ignore timing warnings or failures
-- Comment out slow tests instead of fixing
-- Add `@pytest.mark.slow` as loophole (no such marker exists)
-
-**Why:** Fast feedback loop - failing tests identified quickly, prevents test suite from becoming slow and painful to run.
+**Why:** Fast, deterministic scenario feedback keeps behavior validation usable in daily development.

--- a/profiles/python-uv/testing/three-tier-test-structure.md
+++ b/profiles/python-uv/testing/three-tier-test-structure.md
@@ -1,57 +1,35 @@
-# Three-Tier Test Structure
+# Three-Tier BDD Structure
 
-All tests live under `tests/unit`, `tests/integration`, or `tests/quality`. No exceptions.
+All executable tests are scenario-driven and organized by runtime tier. Each tier still uses `.feature` files and BDD step bindings.
 
 ```
 tests/
-├── unit/           # <250ms per test, mocks only, no external services
-│   ├── core/
-│   ├── cli/
-│   └── tui/
-├── integration/    # <5s per test, minimal mocks, real services, NO LLMs
-│   ├── core/
-│   ├── cli/
-│   └── tui/
-└── quality/        # <30s per test, minimal mocks, real services, REAL LLMs
-    ├── core/
-    └── cli/
+├── unit/
+│   ├── features/
+│   │   └── processor.feature
+│   └── steps/
+│       └── test_processor_steps.py
+├── integration/
+│   ├── features/
+│   │   └── pipeline.feature
+│   └── steps/
+│       └── test_pipeline_steps.py
+└── quality/
+    ├── features/
+    │   └── model_quality.feature
+    └── steps/
+        └── test_model_quality_steps.py
 ```
 
 **Tier definitions:**
+- `unit`: <250ms per scenario, isolated logic, no external services
+- `integration`: <5s per scenario, real services, mocked model adapters
+- `quality`: <30s per scenario, real services, real model adapters
 
-**Unit tests** (`tests/unit/`):
-- Fast: <250ms per test
-- Mocks allowed and encouraged
-- No external services (no network, no LLMs, no databases)
-- Test isolated logic and algorithms
+**Rules:**
+- All scenarios live in `features/*.feature`
+- All step bindings live in `steps/test_*_steps.py`
+- No free-form executable tests outside scenario bindings
+- Every scenario has a behavior tag and a tier tag
 
-**Integration tests** (`tests/integration/`):
-- Moderate speed: <5s per test
-- Minimal mocks (only when unavoidable)
-- Real services (storage, vector store, file system)
-- **NO LLMs** - use mock model adapters for LLM calls
-- BDD-style (Given/When/Then)
-
-**Quality tests** (`tests/quality/`):
-- Slower but bounded: <30s per test
-- Minimal mocks (only when unavoidable)
-- Real services (storage, vector store, file system)
-- **REAL LLMs** - actual model calls, not mocked
-- BDD-style (Given/When/Then)
-
-**Package structure mirrors source:**
-- `tests/unit/core/` tests `src/core/`
-- `tests/integration/cli/` tests `src/cli/`
-- Mirror your source package layout
-
-**Never place tests:**
-- Outside the three tier folders
-- In source code directories
-- In ad-hoc locations (scripts, benchmarks, etc.)
-
-**CI execution:**
-- Unit tests: Run on every PR, fast feedback
-- Integration tests: Run on every PR or schedule
-- Quality tests: Run on schedule or manual trigger (slower)
-
-**Why:** Clear purpose and scope for each test tier, and enables selective execution by tier (unit fast/run frequently, integration/quality slower/run selectively).
+**Why:** Runtime tiers remain useful for speed and environment control while preserving a single behavior-first testing model.

--- a/profiles/python-uv/testing/validate-generated-artifacts.md
+++ b/profiles/python-uv/testing/validate-generated-artifacts.md
@@ -1,38 +1,19 @@
-# Validate Generated Artifacts Against Target Schemas
+# Validate Generated Artifacts Against Consuming Schemas
 
-When code produces data consumed by another component, test it against the consuming schema — not just syntax.
+When a behavior scenario generates an artifact consumed elsewhere, validate against the real consumer schema.
 
-## Rule
-
-If a function generates config, data files, fixtures, or any artifact that another component will parse, the test must:
-
-1. Generate the artifact
-2. Validate it against the consuming component's schema (e.g., `RunConfig.model_validate()`, `SourceLine.model_validate()`)
-3. Verify path references resolve correctly (file paths, input_path, output_dir)
-
-## Examples
-
-```python
-# BAD: only checks syntax
-config = generate_project(answers, target_dir)
-assert (target_dir / "config.toml").exists()
-
-# GOOD: validates against consuming schema
-config = generate_project(answers, target_dir)
-data = tomllib.loads((target_dir / "config.toml").read_text())
-validated = RunConfig.model_validate(data)  # schema validation
-
-# GOOD: verifies path alignment
-assert (target_dir / validated.project.paths.input_path).exists()  # path resolves
+```gherkin
+@behavior(BEH-CONFIG-004) @tier(integration)
+Scenario: Generated config is consumable by runtime
+  Given a generated project config artifact
+  When the runtime loads that config
+  Then schema validation succeeds
+  And all referenced paths resolve
 ```
 
-## Common Failures
+**Rules:**
+- Validate generated artifacts with the consuming schema type
+- Assert path/reference alignment, not only parse validity
+- Keep this validation in behavior scenarios tied to behavior IDs
 
-- Field names don't match schema (e.g., `original_text` vs `text`)
-- ID patterns don't match regex validators (e.g., `"001"` vs `"line_001"`)
-- File paths in config don't match generated file locations
-- Schema validation passes but runtime execution fails (validate + execute)
-
-## Why
-
-Syntactic tests (file exists, TOML parses) miss semantic mismatches. The consuming component's schema is the contract — test against it directly.
+**Why:** "File exists" checks are weak; scenario proof requires real consumer compatibility.

--- a/profiles/react-ts-pnpm/testing/behavior-inventory-and-scenario-traceability.md
+++ b/profiles/react-ts-pnpm/testing/behavior-inventory-and-scenario-traceability.md
@@ -1,0 +1,11 @@
+# Behavior Inventory and Scenario Traceability
+
+Behavior IDs are mandatory and must map directly to executable scenarios.
+
+**Rules:**
+- Each behavior has a stable ID (`BEH-...`)
+- Each scenario includes one behavior ID tag
+- Behavior changes must include scenario updates in the same PR
+- Scenario mapping is required evidence in review
+
+**Why:** Traceability keeps "what the product does" testable and reviewable.

--- a/profiles/react-ts-pnpm/testing/component-testing-via-storybook.md
+++ b/profiles/react-ts-pnpm/testing/component-testing-via-storybook.md
@@ -1,86 +1,29 @@
-# Component Testing via Storybook
+# Storybook as Visual Support, Not Behavior Authority
 
-Storybook stories are the source of truth for component rendering tests. Never use `render()` from Testing Library in unit tests for components.
+Storybook remains required for component documentation, visual states, interaction exploration, and accessibility checks. Behavior proof comes from Playwright+Cucumber scenarios.
 
 ```tsx
-// ✓ Good: Storybook story with play function
-import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, userEvent, within } from "@storybook/test";
-import { Button } from "./button";
-
-const meta: Meta<typeof Button> = {
-  component: Button,
-};
-export default meta;
-
-type Story = StoryObj<typeof Button>;
-
-export const Default: Story = {
-  args: {
-    children: "Click me",
-    variant: "default",
-  },
-};
-
-export const ClickHandler: Story = {
-  args: {
-    children: "Submit",
-    onClick: fn(),
-  },
-  play: async ({ canvasElement, args }) => {
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole("button", { name: "Submit" });
-
-    await userEvent.click(button);
-    await expect(args.onClick).toHaveBeenCalledOnce();
-  },
-};
-
+// Storybook remains valuable for visual contracts and a11y checks.
 export const Disabled: Story = {
-  args: {
-    children: "Disabled",
-    disabled: true,
-  },
+  args: { disabled: true, children: "Submit" },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const button = canvas.getByRole("button");
-
-    await expect(button).toBeDisabled();
+    await expect(canvas.getByRole("button")).toBeDisabled();
   },
 };
 ```
 
-```tsx
-// ✗ Bad: Unit test using render() for component output
-import { render, screen } from "@testing-library/react";
-import { Button } from "./button";
-
-test("renders button", () => {
-  render(<Button>Click me</Button>);
-  expect(screen.getByRole("button")).toBeInTheDocument();
-});
+```gherkin
+@behavior(BEH-AUTH-021) @tier(integration)
+Scenario: User cannot submit disabled login form
+  Given the login form is disabled
+  When the user attempts submission
+  Then submission is blocked and an explanatory message is shown
 ```
 
 **Rules:**
-- One story per meaningful component state (default, loading, error, disabled, each variant)
-- Use `play` functions for interaction testing — never use `fireEvent`, always use `userEvent`
-- Test accessibility in play functions via Storybook's a11y addon (powered by axe-core)
-- Storybook Vitest addon runs all stories as tests in CI
-- Stories serve dual purpose: documentation and tests
-- Query elements by role (`getByRole`), label, or text — never by test ID or CSS selector
+- Storybook is not the source of truth for shipped behavior
+- Behavior claims require `.feature` scenarios
+- Keep Storybook stories and BDD scenarios aligned for major UI states
 
-**What goes in Storybook vs unit tests:**
-- **Storybook:** Component rendering, visual states, user interactions, accessibility checks
-- **Unit tests:** Pure logic — hooks, utilities, data transforms, state machines. Anything that doesn't need a DOM
-
-**Story organization:**
-- Co-locate `*.stories.tsx` next to the component file
-- Group stories by component variant and interaction
-- Tag automation-only stories with `!autodocs` and `!dev`
-
-**CI integration:**
-- Use `@storybook/experimental-addon-test` (Vitest addon) to run stories as Vitest tests
-- Stories run as part of the unit + component test gate on every PR
-- Zero story failures allowed before merge
-
-**Why:** Storybook provides a real rendering environment with visual feedback. Testing component rendering in unit tests with jsdom misses CSS, layout, and visual regressions. Stories as tests eliminate duplicate test effort — one artifact serves documentation, visual review, and automated testing.
+**Why:** Storybook is great for visual and interaction confidence, but user behavior proof belongs to executable scenarios.

--- a/profiles/react-ts-pnpm/testing/coverage-as-scenario-proxy.md
+++ b/profiles/react-ts-pnpm/testing/coverage-as-scenario-proxy.md
@@ -1,0 +1,10 @@
+# Coverage as Scenario Proxy
+
+Coverage signals missing behavior scenarios and dead code opportunities.
+
+**Rules:**
+- Treat uncovered lines as possible missing scenarios first
+- If behavior is complete, classify uncovered code as dead or non-scenario support
+- Coverage reports must be discussed with behavior mapping context
+
+**Why:** This prevents coverage targets from replacing behavior thinking.

--- a/profiles/react-ts-pnpm/testing/gherkin-quality-rules.md
+++ b/profiles/react-ts-pnpm/testing/gherkin-quality-rules.md
@@ -1,0 +1,12 @@
+# Gherkin Quality Rules
+
+Gherkin quality is enforceable and required.
+
+**Rules:**
+- One feature per file
+- Clear, user-observable scenario titles
+- Use scenario outlines for data variation
+- Keep steps declarative and behavior-oriented
+- Require behavior and tier tags on each scenario
+
+**Why:** Clean Gherkin is easier to maintain, review, and automate.

--- a/profiles/react-ts-pnpm/testing/mock-boundaries.md
+++ b/profiles/react-ts-pnpm/testing/mock-boundaries.md
@@ -1,82 +1,25 @@
-# Mock Boundaries
+# Mock Boundaries in BDD Scenarios
 
-Mock at the network boundary only. Never mock React hooks, component internals, or browser APIs.
+Use MSW/network-boundary mocking in scenario step execution. Do not mock internal hooks/components to force behavior outcomes.
 
-```typescript
-// ✓ Good: MSW handler mocks the network boundary
-import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
-
-const handlers = [
-  http.get("/api/users/:id", ({ params }) => {
-    return HttpResponse.json({
-      id: params.id,
-      name: "Jane Doe",
-      email: "jane@example.com",
-    });
-  }),
-];
-
-const server = setupServer(...handlers);
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+```gherkin
+@behavior(BEH-API-002) @tier(integration)
+Scenario: Profile screen renders API error state
+  Given the profile API returns status 500
+  When the user opens the profile page
+  Then an error banner is displayed
 ```
 
 ```typescript
-// ✗ Bad: Mocking hooks or internal modules
-vi.mock("../hooks/use-auth", () => ({
-  useAuth: () => ({ user: mockUser, isLoading: false }),
-}));
-
-vi.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: mockData, isLoading: false }),
-}));
+// Step setup uses MSW boundary mocks.
+server.use(
+  http.get('/api/profile', () => HttpResponse.json({ message: 'error' }, { status: 500 })),
+);
 ```
 
 **Rules:**
-- Use **MSW** (Mock Service Worker) for all API mocking — intercept at the network level, not the import level
-- Never `vi.mock()` React hooks, components, or internal modules
-- Never mock browser APIs (`localStorage`, `fetch`, `IntersectionObserver`) unless absolutely unavoidable — prefer MSW for network and real APIs for the rest
-- Never mock TanStack Query, TanStack Router, or other framework internals
+- Mock at network boundary with MSW
+- Avoid `vi.mock()` for hooks, router internals, and query internals
+- Scenario assertions must target observable UI behavior
 
-**Test data factories:**
-Use factory functions for test data — never inline object literals:
-
-```typescript
-// ✓ Good: Factory function for consistent test data
-function createUser(overrides?: Partial<User>): User {
-  return {
-    id: crypto.randomUUID(),
-    name: "Jane Doe",
-    email: "jane@example.com",
-    role: "member",
-    ...overrides,
-  };
-}
-
-const adminUser = createUser({ role: "admin" });
-
-// ✗ Bad: Inline object literal in every test
-const user = { id: "1", name: "Jane", email: "jane@example.com", role: "member" };
-```
-
-**Per-tier mock rules:**
-- **Unit tests:** MSW for network. Direct dependency injection for services. Mocks are encouraged for isolation.
-- **Component tests (Storybook):** MSW for network. Storybook decorators for providers (theme, i18n, router). Real component rendering.
-- **Integration tests:** MSW for network. Real browser, real DOM, real routing. Minimal mocks.
-
-**Mock verification:**
-Always verify mocks were actually invoked:
-
-```typescript
-// ✓ Good: Verify the handler was called
-const handler = http.get("/api/users", () => HttpResponse.json([]));
-server.use(handler);
-
-// ... run test ...
-// MSW will warn if handlers aren't matched — treat warnings as errors
-```
-
-**Why:** Mocking internals creates a parallel reality where tests pass but the real code breaks. Network-level mocks (MSW) exercise the full code path — fetch calls, response parsing, error handling, state updates — while only replacing the external dependency.
+**Why:** Boundary-level mocking preserves realistic behavior paths.

--- a/profiles/react-ts-pnpm/testing/mutation-strength-gate.md
+++ b/profiles/react-ts-pnpm/testing/mutation-strength-gate.md
@@ -1,0 +1,16 @@
+# Mutation Strength Gate (StrykerJS)
+
+Mutation testing is required to prove that behavior scenarios are robust.
+
+```bash
+# Example command shape
+pnpm stryker run
+```
+
+**Rules:**
+- CI must run Stryker for the profile-defined scope
+- Surviving mutants require scenario or step-strength improvements, or explicit rationale
+- Mutation score regressions fail CI
+- Mutation review should reference affected behavior IDs
+
+**Why:** Mutation testing detects weak tests that still pass despite meaningful logic faults.

--- a/profiles/react-ts-pnpm/testing/no-test-skipping.md
+++ b/profiles/react-ts-pnpm/testing/no-test-skipping.md
@@ -1,66 +1,10 @@
-# No Test Skipping
+# No Scenario Skipping
 
-Never skip tests. Tests either run and pass or run and fail.
+BDD scenarios must run or fail. Skip paths are disallowed.
 
-```typescript
-// ✓ Good: Test runs and validates result
-test("validates user input", () => {
-  const result = validateEmail("invalid");
-  expect(result.success).toBe(false);
-  expect(result.error).toBe("Invalid email format");
-});
+**Rules:**
+- No `it.skip`, `describe.skip`, `test.todo`, or conditional skip logic in CI suites
+- No tag-based exclusion used to hide failing behavior scenarios
+- Fix flaky scenarios or remove them with explicit behavior deprecation changes
 
-// ✗ Bad: Skip test instead of fixing
-it.skip("validates user input", () => {
-  // "will fix later" — NEVER DO THIS
-  const result = validateEmail("invalid");
-  expect(result.success).toBe(false);
-});
-
-// ✗ Bad: Conditional skip
-test("validates user input", ({ skip }) => {
-  if (!process.env.CI) skip();
-  // ...
-});
-```
-
-**No skipping means:**
-
-**No `it.skip` / `describe.skip` / `xit`:**
-- No "will fix later" skips
-- No flaky test skips
-- No platform-specific skips
-- No environment-specific skips
-
-**No `test.todo` in committed code:**
-- Tests either exist and pass, or don't exist yet
-- `test.todo` is for local development only — never committed
-
-**No conditional skips:**
-- No `if (!process.env.CI) skip()`
-- No `if (!hasFeature) return`
-- No `skipIf(platform === "linux")`
-
-**When tests fail:**
-
-**Fix the test or fix the code:**
-- If the test is wrong: fix the test
-- If the code is broken: fix the code
-- If the test is flaky: make it deterministic or delete it
-
-**Never:**
-- Skip failing tests
-- Comment out failing tests
-- Wrap assertions in try/catch to swallow errors
-
-**Flaky tests:**
-- Identify the source of nondeterminism (timing, network, random data)
-- Fix with explicit waits, MSW for network, seeded random data
-- If it can't be made reliable: delete it. A flaky test is worse than no test
-
-**CI enforcement:**
-- CI must fail if any test has a skip marker
-- Block PRs that introduce test skips
-- Run all tiers with zero skips
-
-**Why:** Tests either work or fail — no silent bypasses. Skipped tests rot silently and create a false sense of coverage. A test suite with skips is a test suite you can't trust.
+**Why:** Skipping scenarios breaks the behavior contract and invalidates confidence signals.

--- a/profiles/react-ts-pnpm/testing/three-tier-test-structure.md
+++ b/profiles/react-ts-pnpm/testing/three-tier-test-structure.md
@@ -1,62 +1,30 @@
-# Three-Tier Test Structure
+# Three-Tier BDD Structure
 
-All tests fall into one of three tiers: unit, integration, or component (Storybook). No exceptions.
+TypeScript testing is tiered by runtime, but behavior proof is always Gherkin-driven through Playwright + Cucumber.
 
 ```
-src/
-├── features/
-│   └── auth/
-│       ├── components/
-│       │   ├── login-form.tsx
-│       │   ├── login-form.test.tsx      # Unit tests (logic only)
-│       │   └── login-form.stories.tsx   # Component tests (render + interaction)
-│       ├── hooks/
-│       │   ├── use-auth.ts
-│       │   └── use-auth.test.ts         # Unit tests
-│       └── utils/
-│           ├── validate-token.ts
-│           └── validate-token.test.ts   # Unit tests
-tests/
-└── integration/                         # Integration tests
-    └── auth/
-        └── login-flow.test.ts
+apps/web/tests/
+├── unit/
+│   ├── features/
+│   │   └── auth-validation.feature
+│   └── steps/
+│       └── auth-validation.steps.ts
+├── integration/
+│   ├── features/
+│   │   └── login-flow.feature
+│   └── steps/
+│       └── login-flow.steps.ts
+└── e2e/
+    ├── features/
+    │   └── checkout.feature
+    └── steps/
+        └── checkout.steps.ts
 ```
 
-**Tier definitions:**
+**Rules:**
+- Canonical behavior runner: Playwright + Cucumber
+- Every scenario includes a stable behavior ID tag
+- No executable non-BDD-only tests in CI behavior gates
+- Unit/integration/e2e tiers are runtime categories, not format categories
 
-**Unit tests** (`*.test.ts(x)` co-located with source):
-- Fast: <500ms per test
-- Environment: Vitest + jsdom
-- Mocks allowed and encouraged
-- Test isolated logic: hooks, utilities, state transitions, data transforms
-- Never render components in unit tests — use Storybook for that
-- Co-located next to the file they test
-
-**Integration tests** (`tests/integration/`):
-- Moderate speed: <5s per test
-- Environment: Vitest Browser Mode (Playwright)
-- Real browser rendering, real DOM, real CSS
-- Test multi-component flows: form submission, navigation, API round-trips
-- MSW for network mocking — real everything else
-- Separate directory, mirrors feature structure
-
-**Component tests** (`*.stories.tsx` co-located with source):
-- Fast: <2s per test
-- Environment: Storybook with Vitest addon
-- Test component rendering, visual states, and user interactions
-- One story per meaningful component state
-- Play functions for interaction assertions
-- axe-core for accessibility checks
-- Storybook is the source of truth for how components render
-
-**CI execution:**
-- Unit + component tests: Run on every PR (fast feedback)
-- Integration tests: Run on every PR or on schedule (slower)
-- All tiers must pass before merge
-
-**Never place tests:**
-- Outside the three tier locations
-- In ad-hoc directories (scripts, benchmarks, etc.)
-- In a flat `__tests__/` directory disconnected from source
-
-**Why:** Clear purpose and scope for each tier. Unit tests verify logic, Storybook verifies rendering, integration tests verify flows. Selective execution by tier keeps feedback loops fast.
+**Why:** One behavior format keeps product intent and test evidence aligned across frontend layers.

--- a/profiles/rust-cargo/testing/behavior-inventory-and-scenario-traceability.md
+++ b/profiles/rust-cargo/testing/behavior-inventory-and-scenario-traceability.md
@@ -1,0 +1,11 @@
+# Behavior Inventory and Scenario Traceability
+
+Maintain explicit behavior IDs and enforce scenario traceability.
+
+**Rules:**
+- Every shipped behavior has a stable ID (`BEH-...`)
+- Every scenario includes exactly one behavior ID tag
+- Behavior-changing PRs must add/update/remove matching scenarios
+- Scenario IDs and behavior IDs must remain stable across refactors
+
+**Why:** Stable identifiers make behavior audits, demos, and mutation analysis actionable.

--- a/profiles/rust-cargo/testing/coverage-as-scenario-proxy.md
+++ b/profiles/rust-cargo/testing/coverage-as-scenario-proxy.md
@@ -1,0 +1,10 @@
+# Coverage as Scenario Proxy
+
+Use coverage to find unproven behavior, not to maximize a number.
+
+**Rules:**
+- Treat uncovered paths as missing scenario candidates first
+- If no behavior is missing, document whether code is dead or supporting-only
+- Keep scenario-focused coverage review notes in PRs
+
+**Why:** Coverage is strongest when it drives behavior completeness decisions.

--- a/profiles/rust-cargo/testing/gherkin-quality-rules.md
+++ b/profiles/rust-cargo/testing/gherkin-quality-rules.md
@@ -1,0 +1,12 @@
+# Gherkin Quality Rules
+
+Gherkin quality is enforceable and part of the Rust testing standard.
+
+**Rules:**
+- One `Feature` per file
+- Scenario titles must describe user-observable outcomes
+- Use `Scenario Outline` for parameter variation
+- Keep steps outcome-focused, not implementation-focused
+- Include behavior and tier tags on every scenario
+
+**Why:** Precise Gherkin lowers ambiguity and prevents scenario drift.

--- a/profiles/rust-cargo/testing/mandatory-coverage.md
+++ b/profiles/rust-cargo/testing/mandatory-coverage.md
@@ -1,51 +1,19 @@
-# Mandatory Coverage
+# Coverage from Behavior Scenarios
 
-Coverage is mandatory. Use `cargo-llvm-cov` for measurement. Tests must exercise behavior, not just construction.
+Coverage must be interpreted through behavior scenarios, not isolated line-count targets.
 
 ```bash
-# ✓ Good: Generate coverage report
-just coverage   # Runs: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
-```
-
-```rust
-// ✓ Good: Test that validates behavior
-#[test]
-fn rejects_expired_token() {
-    let token = Token::new(Utc::now() - Duration::hours(1));
-    let result = validate_token(&token);
-    assert!(matches!(result, Err(AuthError::TokenExpired { .. })));
-}
-```
-
-```rust
-// ✗ Bad: Test that only checks construction
-#[test]
-fn creates_config() {
-    let config = Config::default();
-    assert!(config.is_ok());  // Doesn't test any behavior
-}
+# Example: collect coverage from scenario-driven execution
+cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
 ```
 
 **Rules:**
-- `cargo llvm-cov nextest` for coverage measurement (combines nextest with LLVM instrumentation)
-- Output as lcov for CI integration: `--lcov --output-path lcov.info`
-- Upload to Codecov (or equivalent) in CI for tracking trends
-- Tests must exercise:
-  - Happy path with expected output validation
-  - Error cases with specific error variant checks
-  - Edge cases (empty input, boundary values, concurrent access)
-- Coverage is a signal, not a target — 100% line coverage with shallow assertions is worse than 80% with deep behavioral tests
+- Coverage discussion is behavior-first: which behavior scenarios are missing?
+- Uncovered code must be classified as:
+  - missing behavior scenario
+  - dead/removable code
+  - non-scenario support code with explicit rationale
+- Coverage thresholds remain required, but they are secondary to scenario completeness
+- Do not claim behavior support without scenario evidence
 
-**CI pipeline:**
-
-```yaml
-# GitHub Actions coverage job
-- name: Coverage
-  run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
-- name: Upload
-  uses: codecov/codecov-action@v4
-  with:
-    files: lcov.info
-```
-
-**Why:** Coverage measurement identifies untested code paths before they become production bugs. Behavioral testing (vs construction testing) ensures tests catch regressions in actual logic, not just compilation.
+**Why:** Coverage is useful when it highlights unproven behavior, not when treated as a vanity metric.

--- a/profiles/rust-cargo/testing/mock-boundaries.md
+++ b/profiles/rust-cargo/testing/mock-boundaries.md
@@ -1,80 +1,30 @@
-# Mock Boundaries
+# Mock Boundaries in BDD Scenarios
 
-Mock at trait boundaries only. Never mock standard library types or internal implementation details. Use dependency injection.
+In Rust BDD suites, mock only trait-based external boundaries while keeping observable behavior realistic.
 
 ```rust
-// ✓ Good: Define a trait for the external dependency
 pub trait Clock: Send + Sync {
     fn now(&self) -> DateTime<Utc>;
 }
 
-pub struct SystemClock;
-impl Clock for SystemClock {
-    fn now(&self) -> DateTime<Utc> { Utc::now() }
-}
-
-// In production: inject SystemClock
-// In tests: inject a mock
-pub struct Scheduler<C: Clock> {
-    clock: C,
-    // ...
-}
-```
-
-```rust
-// ✓ Good: Mock the trait in tests
 struct FixedClock(DateTime<Utc>);
 impl Clock for FixedClock {
     fn now(&self) -> DateTime<Utc> { self.0 }
 }
-
-#[test]
-fn schedules_task_at_next_window() {
-    let clock = FixedClock(Utc.with_ymd_and_hms(2025, 1, 15, 9, 0, 0).unwrap());
-    let scheduler = Scheduler::new(clock);
-    let next = scheduler.next_window();
-    assert_eq!(next.hour(), 10);
-}
 ```
 
-```rust
-// ✗ Bad: Mocking internals
-// Don't mock reqwest::Client directly — use wiremock instead
-// Don't mock std::fs functions — use a trait abstraction
-// Don't mock private helper functions
+```gherkin
+@behavior(BEH-SCHED-003) @tier(unit)
+Scenario: Scheduler picks next hourly window
+  Given a fixed clock at "2026-01-15T09:00:00Z"
+  When scheduling runs
+  Then the next window is "2026-01-15T10:00:00Z"
 ```
 
-**Dependency injection patterns:**
+**Rules:**
+- Mock at trait boundaries only
+- Do not mock private helper internals
+- Scenario steps must assert observable outcomes, not internal calls
+- Prefer wiremock/testcontainers for integration behavior
 
-```rust
-// ✓ Good: Constructor injection with impl Trait
-pub fn new_service(
-    store: impl EventStore,
-    notifier: impl Notifier,
-    clock: impl Clock,
-) -> Service { /* ... */ }
-
-// ✓ Good: Constructor injection with dyn Trait (when needed for object safety)
-pub fn new_service(
-    store: Box<dyn EventStore>,
-) -> Service { /* ... */ }
-```
-
-**Per-tier mock rules:**
-- **Unit tests**: mock trait dependencies freely; focus on isolated logic
-- **Integration tests**: use real implementations where possible; wiremock for HTTP, in-memory databases
-- **Builder pattern for test data**: create test fixture factories, not mock objects
-
-```rust
-// ✓ Good: Test data factory
-fn test_dispatch() -> Dispatch {
-    Dispatch {
-        id: DispatchId::new(),
-        status: DispatchStatus::Pending,
-        created_at: Utc::now(),
-        ..Default::default()
-    }
-}
-```
-
-**Why:** Mocking at trait boundaries tests real behavior while isolating external dependencies. Mocking internals creates brittle tests that break on refactoring. Dependency injection keeps production code testable without test-specific conditional logic.
+**Why:** Boundary-focused mocking keeps behavior scenarios stable under refactor.

--- a/profiles/rust-cargo/testing/mutation-strength-gate.md
+++ b/profiles/rust-cargo/testing/mutation-strength-gate.md
@@ -1,0 +1,16 @@
+# Mutation Strength Gate (cargo-mutants)
+
+`cargo-mutants` is required to validate scenario effectiveness.
+
+```bash
+# Example command shape
+cargo mutants --workspace
+```
+
+**Rules:**
+- CI must run `cargo-mutants` for the profile-defined scope
+- Surviving mutants require either new/improved scenarios or explicit rationale
+- Mutation regressions fail CI
+- Mutation findings should reference affected behavior IDs
+
+**Why:** Mutation testing catches weak scenarios that pass without actually protecting behavior.

--- a/profiles/rust-cargo/testing/nextest-configuration.md
+++ b/profiles/rust-cargo/testing/nextest-configuration.md
@@ -1,54 +1,19 @@
 # Nextest Configuration
 
-Use `cargo-nextest` for all test execution. Never use `cargo test`. Configure default and CI profiles with timeouts and retry policies.
+`cucumber-rs` scenarios are the authoritative behavior tests. `cargo-nextest` remains the required Rust test runner for applicable test binaries and support checks in the CI gate.
 
 ```bash
-# ✓ Good: Run tests with nextest
-cargo nextest run              # Or: cargo t (alias)
-just test                      # Wrapper that uses nextest
-just test -p myapp-core        # Single crate
+# Behavior scenarios (authoritative)
+cargo cucumber
 
-# ✗ Bad: Using cargo test
-cargo test                     # Missing: parallel control, timeouts, output filtering
-```
-
-**Required `.config/nextest.toml`:**
-
-```toml
-[profile.default]
-slow-timeout = { period = "60s", terminate-after = 2 }
-failure-output = "immediate"
-success-output = "never"
-status-level = "slow"
-
-[profile.ci]
-fail-fast = false
-failure-output = "immediate-final"
-status-level = "all"
-retries = 2
-slow-timeout = { period = "120s", terminate-after = 3 }
-```
-
-**Test groups for serialized database tests:**
-
-```toml
-[test-groups]
-postgres-integration = { max-threads = 1 }
-
-[[profile.default.overrides]]
-filter = "binary(postgres_integration)"
-test-group = "postgres-integration"
-
-[[profile.ci.overrides]]
-filter = "binary(postgres_integration)"
-test-group = "postgres-integration"
+# Fast Rust test gate execution where applicable
+cargo nextest run --workspace --profile ci
 ```
 
 **Rules:**
-- Default profile: 60s slow-timeout, immediate failure output, hide success output
-- CI profile: 120s slow-timeout, 2 retries, no fail-fast (run all tests even after failure)
-- Database integration tests: serialize with `max-threads = 1` to prevent schema race conditions
-- SQLite tests remain parallel (separate database files per test)
-- CI runs with `cargo nextest run --profile ci`
+- Behavior proof comes from `.feature` scenarios executed via `cucumber-rs`
+- Nextest remains mandatory for workspace Rust test execution where applicable
+- CI must run both behavior scenarios and nextest gate checks
+- Do not replace scenario execution with direct non-BDD-only suites
 
-**Why:** Nextest provides parallel execution, structured output, timeout enforcement, and retry policies that `cargo test` lacks. Slow-timeout catches tests that hang or regress in performance. CI retries handle transient failures without masking real bugs.
+**Why:** BDD scenarios prove behavior, while nextest preserves fast, structured Rust test execution discipline.

--- a/profiles/rust-cargo/testing/no-test-skipping.md
+++ b/profiles/rust-cargo/testing/no-test-skipping.md
@@ -1,56 +1,11 @@
-# No Test Skipping
+# No Scenario Skipping
 
-Never use `#[ignore]` on tests. Tests either run and pass or don't exist yet. Zero skips allowed.
-
-```rust
-// ✓ Good: Test that runs and asserts
-#[test]
-fn parses_valid_config() {
-    let config = Config::parse(VALID_TOML).unwrap();
-    assert_eq!(config.max_retries, 3);
-}
-```
-
-```rust
-// ✗ Bad: Ignored test
-#[test]
-#[ignore]  // "too slow" — fix it or delete it
-fn test_full_pipeline() { /* ... */ }
-```
-
-```rust
-// ✗ Bad: Conditional skip
-#[test]
-fn test_with_postgres() {
-    if std::env::var("DATABASE_URL").is_err() {
-        return;  // Silent skip — hides untested code
-    }
-    // ...
-}
-```
-
-```rust
-// ✗ Bad: Feature-gated test exclusion
-#[cfg(feature = "expensive-tests")]
-#[test]
-fn test_expensive_operation() { /* ... */ }
-```
+No ignored tests and no skipped scenarios. Behavior evidence requires full execution.
 
 **Rules:**
-- No `#[ignore]` attribute on any test
-- No early `return` based on environment detection
-- No feature-gated test exclusion (use separate test binaries or nextest filters instead)
-- Flaky tests: make deterministic or delete — never ignore
-- Slow tests: optimize or move to integration tier — never skip
+- No `#[ignore]`, no conditional early-return skips
+- No feature-flag loophole that silently excludes behavior scenarios
+- If a scenario is flaky, fix determinism or remove it with behavior-map updates
+- CI fails on any skip-like suppression
 
-**Handling external dependencies:**
-- Database tests: use in-memory SQLite by default, gate Postgres behind a feature + separate CI job
-- HTTP tests: use `wiremock` for local mock servers
-- Time-dependent tests: inject a `Clock` trait, mock in tests
-
-**Enforcement:**
-- `just check-suppression` greps source directories for `#[ignore]`
-- CI quality-gates job fails on any `#[ignore]` occurrence
-- Code review catches conditional skips
-
-**Why:** Skipped tests are invisible failures. They accumulate silently, giving false confidence in test coverage. A test that doesn't run provides zero value and should either be fixed or removed.
+**Why:** Unexecuted scenarios provide zero behavior proof.

--- a/profiles/rust-cargo/testing/test-timing-rules.md
+++ b/profiles/rust-cargo/testing/test-timing-rules.md
@@ -1,56 +1,17 @@
-# Test Timing Rules
+# Scenario Timing Rules
 
-Enforce timing limits per tier. Unit tests under 250ms with no I/O. Integration tests under 5 seconds. Nextest slow-timeout catches violators.
+Timing limits apply to BDD scenario execution tiers.
 
-```rust
-// ✓ Good: Fast unit test — pure logic, no I/O
-#[test]
-fn validates_cron_expression() {
-    let result = CronExpr::parse("0 9 * * 1-5");
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap().next_fire().weekday(), Weekday::Mon);
-}
-// Runs in <1ms
-```
+| Tier | Max Time | I/O Allowed |
+|------|----------|-------------|
+| Unit scenario | 250ms | No |
+| Integration scenario | 5s | Yes |
+| Doc/API scenario examples | 250ms | No |
 
-```rust
-// ✗ Bad: Unit test with hidden I/O
-#[test]
-fn loads_config_from_disk() {
-    let config = Config::from_file("test_config.toml");  // File I/O in unit test
-    assert!(config.is_ok());
-}
-// Slow, flaky, depends on filesystem state
-```
+**Rules:**
+- Scenario tier tagging must match runtime behavior
+- Slow scenarios must be split or moved to the correct tier
+- Nextest slow-timeout configuration still applies to Rust test binaries in CI
+- No skip-based workaround for slow scenarios
 
-```rust
-// ✓ Good: Integration test with real service, bounded time
-#[tokio::test]
-async fn appends_event_to_store() {
-    let store = EventStore::in_memory().await.unwrap();
-    store.append(test_event()).await.unwrap();
-    let events = store.replay_all().await.unwrap();
-    assert_eq!(events.len(), 1);
-}
-// Runs in ~50ms with in-memory SQLite
-```
-
-**Timing limits:**
-
-| Tier | Max Time | I/O Allowed | Network Allowed |
-|------|----------|-------------|-----------------|
-| Unit | 250ms | No | No |
-| Integration | 5s | Yes | Yes (wiremock/testcontainers) |
-| Doc tests | 250ms | No | No |
-
-**Nextest enforcement:**
-- Default profile: `slow-timeout = { period = "60s", terminate-after = 2 }` — flags slow tests, kills after 2 periods
-- CI profile: `slow-timeout = { period = "120s", terminate-after = 3 }` — more lenient for CI runners
-
-**Refactoring slow tests:**
-- Extract I/O behind a trait, mock in unit tests
-- Use in-memory databases instead of file-backed
-- Reduce test data size while maintaining coverage
-- Parallelize independent assertions
-
-**Why:** Fast tests enable tight feedback loops. A test suite that runs in seconds gets run frequently; one that takes minutes gets skipped. Timing limits prevent gradual test suite slowdown that erodes developer productivity.
+**Why:** Fast behavior feedback prevents test rot and gate avoidance.

--- a/profiles/rust-cargo/testing/test-tooling.md
+++ b/profiles/rust-cargo/testing/test-tooling.md
@@ -1,73 +1,25 @@
-# Test Tooling
+# Test Tooling for BDD-Only Rust
 
-Use `insta` for snapshot testing, `proptest` for property-based testing, and `wiremock` for HTTP mocking. Each tool has a specific purpose — use the right one.
+`cucumber-rs` is the canonical behavior runner. Supporting tools strengthen scenario quality.
 
-**Snapshot testing with insta:**
+**Core tooling:**
+- `cucumber-rs`: executable Gherkin behavior scenarios
+- `wiremock`: network boundary simulation in integration scenarios
+- `testcontainers`: real service integration scenarios
+- `insta`: snapshot assertions inside step implementations when output shape is complex
+- `proptest`: invariant/property checks invoked from scenario-bound step code where needed
 
-```rust
-// ✓ Good: Snapshot test for complex output
-use insta::assert_yaml_snapshot;
-
-#[test]
-fn serializes_dispatch_event() {
-    let event = DispatchEvent::started(agent_id, task_id);
-    assert_yaml_snapshot!(event);
-}
-// Snapshot stored in snapshots/module__serializes_dispatch_event.snap
-// Review with: cargo insta review
-```
-
-**Property-based testing with proptest:**
-
-```rust
-// ✓ Good: Roundtrip property test
-use proptest::prelude::*;
-
-proptest! {
-    #[test]
-    fn json_roundtrip(event in arb_event()) {
-        let json = serde_json::to_string(&event).unwrap();
-        let decoded: Event = serde_json::from_str(&json).unwrap();
-        prop_assert_eq!(event, decoded);
-    }
-}
-
-// Define strategies for domain types
-fn arb_event() -> impl Strategy<Value = Event> {
-    (arb_event_kind(), any::<u64>()).prop_map(|(kind, seq)| {
-        Event { kind, sequence: seq }
-    })
-}
-```
-
-**HTTP mocking with wiremock:**
-
-```rust
-// ✓ Good: Mock external API with wiremock
-use wiremock::{MockServer, Mock, ResponseTemplate};
-use wiremock::matchers::{method, path};
-
-#[tokio::test]
-async fn fetches_remote_config() {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/config"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(test_config()))
-        .mount(&server)
-        .await;
-
-    let client = ConfigClient::new(&server.uri());
-    let config = client.fetch().await.unwrap();
-    assert_eq!(config.version, 2);
-}
+```gherkin
+@behavior(BEH-DISPATCH-004) @tier(integration)
+Scenario: Dispatch event is persisted and replayable
+  Given a running event store
+  When a dispatch is created
+  Then replay returns the created dispatch event
 ```
 
 **Rules:**
-- `insta`: use for serialized output, error messages, complex struct snapshots
-- `proptest`: use for parsing, serialization roundtrips, invariant validation
-- `wiremock`: use for HTTP mocking — prefer over trait-mocking for HTTP clients
-- `testcontainers`: use for database integration tests against real Postgres
-- Review insta snapshots with `cargo insta review` before committing
-- Define proptest strategies for all domain types used in property tests
+- Behavior assertions start from `.feature` scenarios
+- Supporting tools may be used in step implementations, not as replacement for scenario coverage
+- Scenario tags must include stable behavior IDs
 
-**Why:** Each tool targets a specific testing need. Snapshot tests catch unexpected output changes. Property tests find edge cases humans miss. wiremock tests HTTP integration without flaky network dependencies.
+**Why:** One behavior format with focused supporting tools keeps tests both readable and technically strong.

--- a/profiles/rust-cargo/testing/three-tier-test-structure.md
+++ b/profiles/rust-cargo/testing/three-tier-test-structure.md
@@ -1,72 +1,32 @@
-# Three-Tier Test Structure
+# Three-Tier BDD Structure
 
-Tests organized into unit, integration, and doc tests following Rust's native test layout. Each tier has clear boundaries and timing limits.
+Rust tests are organized by runtime tier, but all executable behavior proof is scenario-driven.
 
 ```
 crates/myapp-core/
-├── src/
-│   ├── dispatch.rs           # Source code
-│   └── dispatch.rs           # Unit tests at bottom: #[cfg(test)] mod tests
 ├── tests/
-│   ├── dispatch_lifecycle.rs  # Integration tests: full public API
-│   └── common/
-│       └── mod.rs            # Shared test utilities
+│   ├── unit/
+│   │   ├── features/
+│   │   │   └── scheduler.feature
+│   │   └── steps/
+│   │       └── scheduler_steps.rs
+│   ├── integration/
+│   │   ├── features/
+│   │   │   └── dispatch_flow.feature
+│   │   └── steps/
+│   │       └── dispatch_flow_steps.rs
+│   └── support/
+│       └── common.rs
 ```
 
 **Tier definitions:**
-
-**Unit tests** (`#[cfg(test)] mod tests` in source files):
-- Fast: <250ms per test
-- Mocks allowed and encouraged for external dependencies
-- No I/O, no network, no database
-- Test isolated logic, algorithms, and state transitions
-- Colocated with the code they test
-
-```rust
-// ✓ Good: Unit test at bottom of source file
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn validates_dispatch_command() {
-        let cmd = DispatchCommand::builder()
-            .agent_id(AgentId::new())
-            .build();
-        assert!(cmd.validate().is_ok());
-    }
-}
-```
-
-**Integration tests** (`tests/` directory):
-- Moderate speed: <5s per test
-- Real services via wiremock or testcontainers
-- Test the crate's public API as an external consumer would
-- May use shared test utilities from `tests/common/mod.rs`
-
-```rust
-// ✓ Good: Integration test in tests/ directory
-// tests/event_append.rs
-use myapp_store::EventStore;
-
-#[tokio::test]
-async fn appends_and_replays_events() {
-    let store = EventStore::in_memory().await.unwrap();
-    store.append(test_event()).await.unwrap();
-    let events = store.replay(stream_id).await.unwrap();
-    assert_eq!(events.len(), 1);
-}
-```
-
-**Doc tests** (`///` examples in public API):
-- Minimal, focused on API usage
-- Must compile and run
-- Not a substitute for unit or integration tests
+- Unit scenarios: isolated behavior, no external I/O
+- Integration scenarios: public API behavior with real service boundaries
+- Spec-level scenarios: end-to-end behavior across crate boundaries
 
 **Rules:**
-- Unit tests live in `#[cfg(test)]` modules colocated with source (Rust convention)
-- Integration tests live in `tests/` at the crate root
-- Never place business logic in test helpers
-- Mirror module structure in integration test file naming
+- Every scenario includes `@behavior(BEH-...)`
+- No standalone executable tests that are not mapped to scenarios
+- Keep helper code in support modules, not as free-form untracked tests
 
-**Why:** Rust's native test layout provides natural tier separation. Colocated unit tests keep test code close to the code it validates. Integration tests in `tests/` exercise the public API boundary, catching issues that unit tests miss.
+**Why:** Tiered runtime control and single-format behavior proof can coexist without ambiguity.

--- a/scripts/check_ci_parity.py
+++ b/scripts/check_ci_parity.py
@@ -38,6 +38,8 @@ WORKFLOW_REQUIRED = [
     "cargo build -p tanren-mcp --locked --quiet",
     "Build tanren-mcp for CLI parity integration tests",
     "TANREN_MCP_BIN: ${{ github.workspace }}/target/debug/tanren-mcp",
+    "Check redaction perf regression thresholds",
+    "run: just check-redaction-perf",
     "Check pinned Rust toolchain sync",
 ]
 
@@ -56,6 +58,9 @@ JUST_REQUIRED = [
     'TANREN_MCP_BIN="$tanren_mcp_bin" {{ cargo }} nextest run --workspace',
     "./scripts/run_postgres_integration.sh",
     "check-ci-parity:",
+    "bench-redaction:",
+    "check-redaction-perf:",
+    'UV_CACHE_DIR="${UV_CACHE_DIR:-$PWD/.uv-cache}" uv run python scripts/check_redaction_perf.py',
 ]
 
 WRAPPER_REQUIRED = [

--- a/scripts/check_ci_parity.py
+++ b/scripts/check_ci_parity.py
@@ -48,9 +48,10 @@ JUST_REQUIRED = [
     "@just check-rust-toolchain-sync",
     (
         'RUSTFLAGS="-D warnings" {{ cargo }} clippy --workspace --all-targets '
-        "--features tanren-store/test-hooks,tanren-orchestrator/test-hooks --locked --quiet -- -D warnings"
+        "--features tanren-store/test-hooks,tanren-orchestrator/test-hooks "
+        "--locked --quiet -- -D warnings"
     ),
-    '{{ cargo }} build -p tanren-mcp --locked --quiet',
+    "{{ cargo }} build -p tanren-mcp --locked --quiet",
     'RUSTFLAGS="-D warnings" TANREN_MCP_BIN="$tanren_mcp_bin" {{ cargo }} nextest run --workspace',
     'TANREN_MCP_BIN="$tanren_mcp_bin" {{ cargo }} nextest run --workspace',
     "./scripts/run_postgres_integration.sh",

--- a/scripts/check_redaction_perf.py
+++ b/scripts/check_redaction_perf.py
@@ -1,0 +1,92 @@
+"""Fail CI when redaction benchmark means exceed configured thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_thresholds(path: Path) -> dict[str, float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    scenarios = payload.get("scenarios")
+    if not isinstance(scenarios, dict):
+        raise ValueError("threshold file must contain a 'scenarios' object")
+
+    thresholds: dict[str, float] = {}
+    for scenario, value in scenarios.items():
+        if not isinstance(scenario, str) or not isinstance(value, (int, float)):
+            raise ValueError("scenario thresholds must be string -> numeric")
+        thresholds[scenario] = float(value)
+    return thresholds
+
+
+def read_benchmark_mean_ns(criterion_dir: Path, scenario: str) -> float:
+    parts = scenario.split("/")
+    candidate_paths = [
+        criterion_dir.joinpath(*parts, "new", "estimates.json"),
+        criterion_dir.joinpath(scenario.replace("/", "_"), "new", "estimates.json"),
+    ]
+    if len(parts) >= 3:
+        candidate_paths.append(
+            criterion_dir.joinpath("_".join(parts[:-1]), parts[-1], "new", "estimates.json")
+        )
+    if len(parts) == 2:
+        candidate_paths.append(
+            criterion_dir.joinpath("_".join(parts), "new", "estimates.json")
+        )
+    estimate_path = next((path for path in candidate_paths if path.exists()), None)
+    if estimate_path is None:
+        raise FileNotFoundError(
+            f"missing criterion output for '{scenario}' (checked: {candidate_paths})"
+        )
+
+    payload = json.loads(estimate_path.read_text(encoding="utf-8"))
+    mean = payload.get("mean")
+    if not isinstance(mean, dict) or not isinstance(mean.get("point_estimate"), (int, float)):
+        raise ValueError(f"invalid estimate payload in {estimate_path}")
+    return float(mean["point_estimate"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--thresholds",
+        type=Path,
+        default=Path("crates/tanren-runtime/benches/baselines/redaction-thresholds.json"),
+        help="path to scenario mean thresholds (nanoseconds)",
+    )
+    parser.add_argument(
+        "--criterion-dir",
+        type=Path,
+        default=Path("target/criterion"),
+        help="criterion output root directory",
+    )
+    args = parser.parse_args()
+
+    thresholds = load_thresholds(args.thresholds)
+
+    failures: list[str] = []
+    for scenario, max_mean_ns in thresholds.items():
+        observed_mean_ns = read_benchmark_mean_ns(args.criterion_dir, scenario)
+        status = "PASS" if observed_mean_ns <= max_mean_ns else "FAIL"
+        print(
+            f"[{status}] {scenario}: observed={observed_mean_ns:.0f}ns max={max_mean_ns:.0f}ns"
+        )
+        if observed_mean_ns > max_mean_ns:
+            failures.append(
+                f"{scenario} observed={observed_mean_ns:.0f}ns exceeds max={max_mean_ns:.0f}ns"
+            )
+
+    if failures:
+        print("\nRedaction performance regression gate failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("\nRedaction performance gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_redaction_perf.py
+++ b/scripts/check_redaction_perf.py
@@ -1,24 +1,63 @@
-"""Fail CI when redaction benchmark means exceed configured thresholds."""
+"""Fail CI when redaction benchmark means exceed configured budgets."""
 
 from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 
-def load_thresholds(path: Path) -> dict[str, float]:
+@dataclass(frozen=True)
+class ScenarioBudget:
+    baseline_mean_ns: float
+    max_mean_ns: float
+
+
+@dataclass(frozen=True)
+class PerfBudget:
+    max_regression_pct: float
+    scenarios: dict[str, ScenarioBudget]
+
+
+def load_budget(path: Path) -> PerfBudget:
     payload = json.loads(path.read_text(encoding="utf-8"))
+    raw_max_regression_pct = payload.get("max_regression_pct")
+    if not isinstance(raw_max_regression_pct, (int, float)):
+        raise ValueError("threshold file must contain numeric 'max_regression_pct'")
+    max_regression_pct = float(raw_max_regression_pct)
+    if max_regression_pct < 0:
+        raise ValueError("'max_regression_pct' must be >= 0")
+
     scenarios = payload.get("scenarios")
     if not isinstance(scenarios, dict):
         raise ValueError("threshold file must contain a 'scenarios' object")
 
-    thresholds: dict[str, float] = {}
-    for scenario, value in scenarios.items():
-        if not isinstance(scenario, str) or not isinstance(value, (int, float)):
-            raise ValueError("scenario thresholds must be string -> numeric")
-        thresholds[scenario] = float(value)
-    return thresholds
+    parsed: dict[str, ScenarioBudget] = {}
+    for scenario, spec in scenarios.items():
+        if not isinstance(scenario, str) or not isinstance(spec, dict):
+            raise ValueError("scenario budget must be string -> object")
+
+        baseline = spec.get("baseline_mean_ns")
+        absolute = spec.get("max_mean_ns")
+        if not isinstance(baseline, (int, float)) or not isinstance(absolute, (int, float)):
+            raise ValueError(
+                f"scenario '{scenario}' must define numeric baseline_mean_ns and max_mean_ns"
+            )
+        baseline_ns = float(baseline)
+        max_mean_ns = float(absolute)
+        if baseline_ns <= 0 or max_mean_ns <= 0:
+            raise ValueError(f"scenario '{scenario}' budgets must be > 0")
+        if max_mean_ns < baseline_ns:
+            raise ValueError(
+                f"scenario '{scenario}' max_mean_ns must be >= baseline_mean_ns"
+            )
+        parsed[scenario] = ScenarioBudget(
+            baseline_mean_ns=baseline_ns,
+            max_mean_ns=max_mean_ns,
+        )
+
+    return PerfBudget(max_regression_pct=max_regression_pct, scenarios=parsed)
 
 
 def read_benchmark_mean_ns(criterion_dir: Path, scenario: str) -> float:
@@ -32,9 +71,7 @@ def read_benchmark_mean_ns(criterion_dir: Path, scenario: str) -> float:
             criterion_dir.joinpath("_".join(parts[:-1]), parts[-1], "new", "estimates.json")
         )
     if len(parts) == 2:
-        candidate_paths.append(
-            criterion_dir.joinpath("_".join(parts), "new", "estimates.json")
-        )
+        candidate_paths.append(criterion_dir.joinpath("_".join(parts), "new", "estimates.json"))
     estimate_path = next((path for path in candidate_paths if path.exists()), None)
     if estimate_path is None:
         raise FileNotFoundError(
@@ -54,7 +91,7 @@ def main() -> int:
         "--thresholds",
         type=Path,
         default=Path("crates/tanren-runtime/benches/baselines/redaction-thresholds.json"),
-        help="path to scenario mean thresholds (nanoseconds)",
+        help="path to scenario performance budgets",
     )
     parser.add_argument(
         "--criterion-dir",
@@ -64,19 +101,42 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    thresholds = load_thresholds(args.thresholds)
+    budget = load_budget(args.thresholds)
 
     failures: list[str] = []
-    for scenario, max_mean_ns in thresholds.items():
+    for scenario, scenario_budget in budget.scenarios.items():
         observed_mean_ns = read_benchmark_mean_ns(args.criterion_dir, scenario)
-        status = "PASS" if observed_mean_ns <= max_mean_ns else "FAIL"
-        print(
-            f"[{status}] {scenario}: observed={observed_mean_ns:.0f}ns max={max_mean_ns:.0f}ns"
+        relative_limit_ns = scenario_budget.baseline_mean_ns * (
+            1 + (budget.max_regression_pct / 100.0)
         )
-        if observed_mean_ns > max_mean_ns:
-            failures.append(
-                f"{scenario} observed={observed_mean_ns:.0f}ns exceeds max={max_mean_ns:.0f}ns"
-            )
+        regression_pct = (
+            ((observed_mean_ns / scenario_budget.baseline_mean_ns) - 1) * 100
+            if scenario_budget.baseline_mean_ns > 0
+            else 0.0
+        )
+        relative_ok = observed_mean_ns <= relative_limit_ns
+        absolute_ok = observed_mean_ns <= scenario_budget.max_mean_ns
+        status = "PASS" if relative_ok and absolute_ok else "FAIL"
+
+        print(
+            f"[{status}] {scenario}: observed={observed_mean_ns:.0f}ns "
+            f"baseline={scenario_budget.baseline_mean_ns:.0f}ns "
+            f"delta={regression_pct:+.1f}% "
+            f"relative_max={relative_limit_ns:.0f}ns "
+            f"absolute_max={scenario_budget.max_mean_ns:.0f}ns"
+        )
+
+        if not (relative_ok and absolute_ok):
+            reasons = []
+            if not relative_ok:
+                reasons.append(
+                    f"relative regression {regression_pct:+.1f}% exceeds +{budget.max_regression_pct:.1f}%"
+                )
+            if not absolute_ok:
+                reasons.append(
+                    f"absolute mean {observed_mean_ns:.0f}ns exceeds {scenario_budget.max_mean_ns:.0f}ns"
+                )
+            failures.append(f"{scenario}: " + "; ".join(reasons))
 
     if failures:
         print("\nRedaction performance regression gate failed:")

--- a/scripts/proof/phase0/mint_actor_token.py
+++ b/scripts/proof/phase0/mint_actor_token.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 @dataclass(frozen=True)
-class Claims:
+class _Claims:
     iss: str
     aud: str
     exp: int
@@ -32,19 +32,19 @@ class Claims:
     user_id: str
 
 
-def b64url(data: bytes) -> str:
+def _b64url(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
 
 
-def load_private_key(path: Path) -> Ed25519PrivateKey:
+def _load_private_key(path: Path) -> Ed25519PrivateKey:
     key_bytes = path.read_bytes()
     key = serialization.load_pem_private_key(key_bytes, password=None)
     if not isinstance(key, Ed25519PrivateKey):
-        raise ValueError("private key is not Ed25519")
+        raise TypeError("private key is not Ed25519")
     return key
 
 
-def sign_jwt(private_key: Ed25519PrivateKey, claims: Claims, kid: str) -> str:
+def _sign_jwt(private_key: Ed25519PrivateKey, claims: _Claims, kid: str) -> str:
     header = {"alg": "EdDSA", "typ": "JWT", "kid": kid}
     payload = {
         "iss": claims.iss,
@@ -57,15 +57,15 @@ def sign_jwt(private_key: Ed25519PrivateKey, claims: Claims, kid: str) -> str:
         "user_id": claims.user_id,
     }
 
-    header_segment = b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
-    payload_segment = b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
-    signing_input = f"{header_segment}.{payload_segment}".encode("utf-8")
+    header_segment = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_segment = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_segment}.{payload_segment}".encode()
     signature = private_key.sign(signing_input)
-    signature_segment = b64url(signature)
+    signature_segment = _b64url(signature)
     return f"{header_segment}.{payload_segment}.{signature_segment}"
 
 
-def parse_args() -> argparse.Namespace:
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Mint proof actor tokens")
     parser.add_argument("--private-key-pem", type=Path, required=True)
     parser.add_argument("--issuer", required=True)
@@ -93,8 +93,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
-    args = parse_args()
+def _main() -> int:
+    args = _parse_args()
 
     now = int(time.time())
     iat = args.iat if args.iat is not None else now
@@ -143,7 +143,7 @@ def main() -> int:
         )
         return 2
 
-    claims = Claims(
+    claims = _Claims(
         iss=iss,
         aud=aud,
         exp=exp,
@@ -154,8 +154,8 @@ def main() -> int:
         user_id=args.user_id,
     )
 
-    private_key = load_private_key(args.private_key_pem)
-    token = sign_jwt(private_key, claims, args.kid)
+    private_key = _load_private_key(args.private_key_pem)
+    token = _sign_jwt(private_key, claims, args.kid)
 
     if args.token_only:
         print(token)
@@ -178,4 +178,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_main())


### PR DESCRIPTION
## Summary
This PR hardens Lane 1.1 runtime contract surfaces to close the recent audit findings across scalability, compile-time enforcement, redaction robustness, and typed metadata strictness.

### Key changes
- add `ProviderRunId` newtype and replace stringly `provider_run_id` contract fields
- add hard bounded validation for redaction hints (`count`, `per-secret bytes`, `total bytes`) with typed errors
- add dedicated contract error for failure-path leak detection
- precompile/cached prefix matcher reuse in `DefaultOutputRedactor`
- remove encoded-variant 64-byte cap and rely on bounded input contract
- upgrade perf gate to enforce **relative regression + absolute SLO** budgets
- add compile-fail integration tests for sealing (`ContractCallToken`, `HarnessFailure::new`)
- add stress/property redaction tests and update lane/docs contract guarantees

## Validation
- `just ci` (passed)
- `lefthook run pre-commit` (passed)

## Notes
- branch: `rewrite/lane-1-1`
- target: `rewrite/tanren-2-foundation`
