### PR TITLE
fix: repair lefthook bootstrap install

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,12 +107,20 @@ bootstrap:
 
     echo "==> Installing lefthook..."
     if ! command -v lefthook &>/dev/null; then
-        # Official install script works on Linux, macOS, and WSL — no brew/go required
-        if curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.shell.sh' | bash 2>/dev/null \
-            && command -v lefthook &>/dev/null; then
-            true
+        if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get &>/dev/null; then
+            if curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash \
+                && sudo apt-get install -y lefthook \
+                && command -v lefthook &>/dev/null; then
+                true
+            else
+                echo "  FAIL: lefthook"
+                failed="$failed lefthook"
+            fi
         elif command -v brew &>/dev/null; then
-            brew install lefthook
+            if ! brew install lefthook; then
+                echo "  FAIL: lefthook"
+                failed="$failed lefthook"
+            fi
         else
             echo "  FAIL: lefthook"
             failed="$failed lefthook"


### PR DESCRIPTION
## Problem

Fresh Ubuntu bootstrap currently fails at the Lefthook step because `just bootstrap` uses the stale Cloudsmith `setup.shell.sh` URL and suppresses the installer error, hiding the underlying failure.

## Implementation summary

- Switches Linux apt-based Lefthook setup to Cloudsmith's current `setup.deb.sh` installer.
- Runs `sudo apt-get install -y lefthook` after adding the repository.
- Keeps installer errors visible instead of redirecting them away.
- Preserves the Homebrew fallback for systems with `brew`.

## Executed command results

- `just check` passed
- `just ci` passed
- pre-push Lefthook test hook passed

## Config or secret implications

No secrets or runtime configuration changes. This only repairs local developer bootstrap tooling.