### PR TITLE
fix: retry bootstrap network downloads

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,10 +33,16 @@ bootstrap:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    curl_retry() {
+        curl --retry 10 --retry-delay 2 --retry-all-errors "$@"
+    }
+
+    failed=""
+
     echo "==> Checking for rustup..."
     if ! command -v rustup &>/dev/null; then
         echo "Installing rustup..."
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        curl_retry --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         echo "Run 'source ~/.cargo/env' or restart your shell, then re-run 'just bootstrap'"
         exit 1
     fi
@@ -53,12 +59,14 @@ bootstrap:
 
     echo "==> Installing cargo-binstall..."
     if ! command -v cargo-binstall &>/dev/null; then
-        curl -L --proto '=https' --tlsv1.2 -sSf \
-            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        if ! curl_retry -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash; then
+            echo "  FAIL: cargo-binstall"
+            failed="$failed cargo-binstall"
+        fi
     fi
 
     echo "==> Installing cargo tools (skipping already-installed)..."
-    failed=""
 
     # Remaining tools via binstall (install one at a time so one failure doesn't abort the rest)
     tools=(
@@ -73,17 +81,21 @@ bootstrap:
         "rumdl:rumdl"
         "just:just"
     )
-    for entry in "${tools[@]}"; do
-        bin="${entry%%:*}"
-        pkg="${entry##*:}"
-        if ! command -v "$bin" &>/dev/null; then
-            echo "  Installing $pkg..."
-            if ! cargo binstall --no-confirm "$pkg"; then
-                echo "  FAIL: $pkg"
-                failed="$failed $pkg"
+    if command -v cargo-binstall &>/dev/null; then
+        for entry in "${tools[@]}"; do
+            bin="${entry%%:*}"
+            pkg="${entry##*:}"
+            if ! command -v "$bin" &>/dev/null; then
+                echo "  Installing $pkg..."
+                if ! cargo binstall --no-confirm "$pkg"; then
+                    echo "  FAIL: $pkg"
+                    failed="$failed $pkg"
+                fi
             fi
-        fi
-    done
+        done
+    else
+        echo "  Skipping cargo tools because cargo-binstall is unavailable."
+    fi
 
     echo "==> Installing actionlint..."
     if ! command -v actionlint &>/dev/null; then
@@ -108,7 +120,7 @@ bootstrap:
     echo "==> Installing lefthook..."
     if ! command -v lefthook &>/dev/null; then
         if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get &>/dev/null; then
-            if curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash \
+            if curl_retry -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash \
                 && sudo apt-get install -y lefthook \
                 && command -v lefthook &>/dev/null; then
                 true


### PR DESCRIPTION
## Problem

Fresh VM bootstrap can fail on transient GitHub/raw CDN errors. The latest failure happened while downloading the `cargo-binstall` installer and returned HTTP 503. Because that fetch ran under `set -e`, the recipe aborted immediately instead of retrying or reporting it through the normal bootstrap failure summary.

## Implementation summary

- Adds a `curl_retry` helper with retry behavior for bootstrap network downloads.
- Uses it for rustup, cargo-binstall, and Lefthook repository setup fetches.
- Moves `failed` initialization before cargo-binstall setup.
- Reports `cargo-binstall` install failure through the bootstrap failure summary instead of hard-aborting.
- Skips cargo tool installation if `cargo-binstall` remains unavailable, avoiding noisy cascading failures.

## Executed command results

- `just --list` passed
- shell syntax check for the bootstrap recipe passed
- `just check` passed
- `just ci` passed
- pre-push Lefthook test hook passed

## Config or secret implications

No secrets or runtime configuration changes. This only hardens local developer bootstrap tooling against transient network failures.