### PR TITLE
feat: land F-0002 — foundation correction (HTTP MCP, BDD convention, validators)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,18 @@ Run commands from the repo root.
 
 ## Testing Guidelines
 
-- `just tests` is the behavior proof path and runs BDD, mutation, and coverage classification stages.
-- New behavior should include positive and falsification coverage in BDD-owned scenarios.
-- `tests/bdd/phase0` remains the accepted Phase 0 behavior suite.
+- `just tests` is the behavior proof path; it runs the cucumber-rs BDD
+  harness and the runner binary. Mutation testing is intentionally
+  separated into `just mutation` and runs nightly only.
+- All scenarios live under `tests/bdd/features/B-XXXX-<slug>.feature`.
+  Follow the canonical convention in
+  [`docs/architecture/subsystems/behavior-proof.md`](docs/architecture/subsystems/behavior-proof.md)
+  ("BDD Tagging And File Convention"): one feature per behavior;
+  scenario tags from a closed allowlist
+  (`@positive | @falsification | @web | @api | @mcp | @cli | @tui`);
+  per-interface positive + falsification coverage.
+- `xtask check-bdd-tags` (wired into `just check`) hard-fails any
+  feature file that strays from the convention.
 - Do not add skipped or ignored behavior scenarios.
 
 ## Documentation Source of Truth
@@ -51,7 +60,7 @@ Run commands from the repo root.
   `docs/behaviors/`; roadmap DAG guidance lives under `docs/roadmap/`.
 - Architecture details live under `docs/architecture/`.
 - Methodology and command installation details live under `docs/architecture/`.
-- Runtime implementation details live in `docs/architecture/subsystems/adapters.md`.
+- Runtime implementation details live in `docs/architecture/subsystems/runtime.md`.
 - If behavior, interfaces, lifecycle, or security model changes, update the relevant doc in the same PR.
 
 ## Commit and Pull Request Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ behavior slice depends on come from F-0001.
   [`tests/bdd/features/`](tests/bdd/) and step definitions in the
   `tanren-bdd` crate. No `#[cfg(test)]` modules or `#[test]` functions
   outside the BDD crate — `xtask check-rust-test-surface` enforces this.
+- **Follow the BDD convention.** One `.feature` per behavior, named
+  `B-XXXX-<slug>.feature`; closed tag allowlist; strict per-interface
+  positive + falsification coverage. Canonical contract:
+  [`docs/architecture/subsystems/behavior-proof.md`](docs/architecture/subsystems/behavior-proof.md)
+  ("BDD Tagging And File Convention"). Enforced by
+  `xtask check-bdd-tags` (wired into `just check`).
 - **No inline lint suppressions.** Workspace policy denies `allow_attributes`
   and `allow_attributes_without_reason`. Relax a lint in the owning crate's
   `[lints.clippy]` section with a comment explaining why; never use inline
@@ -86,8 +92,11 @@ After any change to `docs/roadmap/dag.json` or `docs/behaviors/B-*.md`, run
 
 - structural validity and acyclicity;
 - every accepted behavior is completed by exactly one node;
-- every behavior node transitively depends on F-0001;
+- every behavior node transitively depends on the current
+  `foundation_spec_id` (F-0002 since the foundation correction landed);
 - evidence-item interfaces match the behavior frontmatter (no drift);
+- every `tests/bdd/features/B-XXXX-*.feature` file maps to an accepted
+  behavior with a DAG node;
 - no transitively redundant `depends_on` edges.
 
 The validator also surfaces a non-blocking warning for nodes whose playbook

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +245,27 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -336,6 +366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,12 +382,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -458,9 +488,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -487,7 +517,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -581,33 +611,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -633,6 +647,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "cucumber"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,7 +674,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.14.0",
+ "itertools",
  "linked-hash-map",
  "pin-project",
  "ref-cast",
@@ -667,7 +691,7 @@ checksum = "ed2fc8a8bbb73af3230db699e8690c5c786655f75eb89e5f18d76055fa1a9a4d"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -683,7 +707,7 @@ checksum = "6401038de3af44fe74e6fccdb8a5b7db7ba418f480c8e9ad584c6f65c05a27a6"
 dependencies = [
  "derive_more",
  "either",
- "nom",
+ "nom 8.0.0",
  "nom_locate",
  "regex",
  "regex-syntax",
@@ -756,6 +780,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
@@ -888,6 +918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,10 +938,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
@@ -926,6 +998,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1064,13 +1142,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -1089,7 +1179,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "textwrap",
- "thiserror",
+ "thiserror 2.0.18",
  "typed-builder",
 ]
 
@@ -1118,7 +1208,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "ignore",
  "walkdir",
 ]
@@ -1140,7 +1230,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1512,15 +1613,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1545,6 +1637,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1579,7 +1688,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -1597,16 +1706,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1643,11 +1755,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1693,6 +1805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1824,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1725,11 +1849,21 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1749,7 +1883,7 @@ checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -1794,6 +1928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1966,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1898,12 +2052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,12 +2100,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pgvector"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2018,6 +2261,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2137,6 +2386,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2196,23 +2451,87 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
- "indoc",
  "instability",
- "itertools 0.13.0",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
  "lru",
- "paste",
- "strum",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2221,7 +2540,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2230,7 +2549,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2356,7 +2675,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2426,27 +2745,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2573,8 +2879,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
- "thiserror",
+ "strum 0.26.3",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -2674,7 +2980,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2896,6 +3202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,7 +3312,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -3057,7 +3369,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -3088,7 +3400,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -3104,7 +3416,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -3131,7 +3443,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -3158,7 +3470,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -3212,20 +3524,25 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.117",
 ]
 
@@ -3329,7 +3646,7 @@ dependencies = [
  "serde",
  "tanren-contract",
  "tanren-store",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3337,7 +3654,7 @@ name = "tanren-assessment"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3354,7 +3671,7 @@ name = "tanren-behavior-proof"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3372,7 +3689,7 @@ name = "tanren-client-integrations"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3381,7 +3698,7 @@ version = "0.0.0"
 dependencies = [
  "secrecy",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3389,7 +3706,7 @@ name = "tanren-contract"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3397,7 +3714,7 @@ name = "tanren-domain"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3406,7 +3723,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3414,7 +3731,7 @@ name = "tanren-identity-policy"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3439,7 +3756,7 @@ dependencies = [
 name = "tanren-observability"
 version = "0.0.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3450,7 +3767,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3458,7 +3775,7 @@ name = "tanren-orchestrator"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3466,7 +3783,7 @@ name = "tanren-planner"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3474,7 +3791,7 @@ name = "tanren-policy"
 version = "0.0.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3483,7 +3800,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3492,7 +3809,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3501,7 +3818,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3510,7 +3827,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3524,7 +3841,7 @@ dependencies = [
  "sea-orm-migration",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -3541,7 +3858,7 @@ name = "tanren-tui"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "crossterm 0.29.0",
+ "crossterm",
  "ratatui",
  "tanren-app-services",
 ]
@@ -3579,8 +3896,71 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -3591,7 +3971,16 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3600,7 +3989,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3631,7 +4031,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -3783,7 +4185,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "http",
  "http-body",
@@ -3908,6 +4310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,20 +4356,14 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4011,6 +4413,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -4034,6 +4437,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -4149,7 +4561,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4171,6 +4583,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -4494,7 +4978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +517,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1051,6 +1071,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1761,7 +1782,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2134,7 +2155,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2144,7 +2176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2155,6 +2187,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2304,18 +2342,27 @@ checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2344,7 +2391,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2361,7 +2408,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -2771,7 +2818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2782,7 +2829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2839,7 +2886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3032,7 +3079,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -3076,7 +3123,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -3116,6 +3163,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3362,9 +3422,16 @@ name = "tanren-mcp"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "rmcp",
+ "serde",
+ "serde_json",
+ "tanren-app-services",
  "tanren-observability",
  "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
  "tracing",
 ]
 
@@ -3485,6 +3552,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde_json",
  "walkdir",
 ]
 
@@ -3658,6 +3726,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ sea-orm-migration = { version = "1.1", features = [
 clap = { version = "4", features = ["derive"] }
 
 # TUI
-ratatui = "0.29"
+ratatui = "0.30"
 crossterm = "0.29"
 
 # BDD harness. Shipped in F-0001 with zero feature files; the first feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,15 +132,22 @@ schemars = { version = "1", features = ["chrono04", "uuid1"] }
 # Model Context Protocol SDK. License verified via `cargo info rmcp`
 # (Apache-2.0, in deny.toml allowlist) before this dep was added.
 # `server` enables `#[tool_router]`/`#[tool]` macros and the derive
-# path; `transport-io` wires the active stdio transport;
-# `macros` brings the attribute-macro surface; `schemars` re-export
-# ensures contract types produce the JSON Schemas rmcp registers.
+# path; `transport-streamable-http-server` wires the network MCP
+# transport mandated by the architecture (see
+# docs/architecture/subsystems/interfaces.md#mcp); `macros` brings
+# the attribute-macro surface; `schemars` re-export ensures
+# contract types produce the JSON Schemas rmcp registers.
 rmcp = { version = "1", features = [
   "server",
-  "transport-io",
+  "transport-streamable-http-server",
   "macros",
   "schemars",
 ] }
+
+# Cancellation primitives — needed by rmcp's StreamableHttpService for
+# session-graceful shutdown coordination. License: MIT (in deny.toml
+# allowlist).
+tokio-util = { version = "0.7", features = ["rt"] }
 
 # Error handling
 thiserror = "2"

--- a/bin/tanren-mcp/Cargo.toml
+++ b/bin/tanren-mcp/Cargo.toml
@@ -6,14 +6,21 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false
-description = "Tanren MCP (Model Context Protocol) server. F-0001 ships an empty tool registry; behavior tools arrive with R-* slices."
+description = "Tanren MCP (Model Context Protocol) server. F-0002 ships an HTTP+API-key surface with an empty rmcp tool registry; behavior tools arrive with R-* slices."
 
 [lints]
 workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 rmcp = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tanren-app-services = { path = "../../crates/tanren-app-services" }
 tanren-observability = { path = "../../crates/tanren-observability" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/bin/tanren-mcp/src/main.rs
+++ b/bin/tanren-mcp/src/main.rs
@@ -39,6 +39,15 @@ use tower_http::cors::{Any, CorsLayer};
 const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:8081";
 const BIND_ADDRESS_ENV: &str = "TANREN_MCP_BIND";
 const API_KEY_ENV: &str = "TANREN_MCP_API_KEY";
+/// Comma-separated extra hostnames / `host:port` authorities to add to
+/// rmcp's `allowed_hosts` Host-header allowlist. rmcp's defaults
+/// (`localhost`, `127.0.0.1`, `::1`) are kept; this env var appends to
+/// them. Set to `*` to disable Host-header validation entirely (auth
+/// remains the only gate). Operators deploying MCP behind a load
+/// balancer or under a real hostname must set this — see
+/// `docs/architecture/subsystems/interfaces.md` and
+/// `docs/architecture/operations.md`.
+const ALLOWED_HOSTS_ENV: &str = "TANREN_MCP_ALLOWED_HOSTS";
 
 /// Empty tool surface. Behavior tools land with R-* slices via
 /// `#[rmcp::tool]` annotations on this type.
@@ -107,23 +116,28 @@ async fn require_api_key(
     request: Request,
     next: Next,
 ) -> Response {
-    let Some(presented) = AuthConfig::extract_credential(request.headers()) else {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(error_body(
-                "auth_required",
-                "Missing Authorization: Bearer <api-key> or X-API-Key header.",
-            )),
-        )
-            .into_response();
-    };
-
+    // Operator-config check first: an unconfigured server is in an
+    // outage state, not an auth-failure state. Reporting 401 to an
+    // unauthenticated probe in that case would misclassify the outage
+    // as a client-credential failure and route operators away from
+    // the actual cause.
     let Some(expected) = config.bootstrap_key.as_deref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(error_body(
                 "unavailable",
                 "MCP credential store is not configured. Set TANREN_MCP_API_KEY (bootstrap key) until R-0008 lands the real store.",
+            )),
+        )
+            .into_response();
+    };
+
+    let Some(presented) = AuthConfig::extract_credential(request.headers()) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(error_body(
+                "auth_required",
+                "Missing Authorization: Bearer <api-key> or X-API-Key header.",
             )),
         )
             .into_response();
@@ -155,11 +169,12 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 fn build_router(auth_config: Arc<AuthConfig>, cancellation: CancellationToken) -> Router {
+    let config = streamable_http_config(cancellation);
     let mcp_service: StreamableHttpService<TanrenMcp, LocalSessionManager> =
         StreamableHttpService::new(
             || Ok(TanrenMcp),
             Arc::new(LocalSessionManager::default()),
-            StreamableHttpServerConfig::default().with_cancellation_token(cancellation),
+            config,
         );
 
     let mcp_with_auth = ServiceBuilder::new()
@@ -175,6 +190,40 @@ fn build_router(auth_config: Arc<AuthConfig>, cancellation: CancellationToken) -
         .route("/health", get(health))
         .nest_service("/mcp", mcp_with_auth)
         .layer(cors)
+}
+
+/// Build rmcp's `StreamableHttpServerConfig` honouring the
+/// `TANREN_MCP_ALLOWED_HOSTS` env var. rmcp ships loopback-only Host
+/// validation by default for DNS-rebind protection; non-local
+/// deployments must extend the allowlist (or set `*` to disable Host
+/// validation entirely and rely solely on the API-key middleware).
+fn streamable_http_config(cancellation: CancellationToken) -> StreamableHttpServerConfig {
+    let base = StreamableHttpServerConfig::default().with_cancellation_token(cancellation);
+    let raw = env::var(ALLOWED_HOSTS_ENV).ok().filter(|s| !s.is_empty());
+    let Some(value) = raw else {
+        return base;
+    };
+    if value.trim() == "*" {
+        tracing::warn!(
+            target: "tanren_mcp",
+            env_var = ALLOWED_HOSTS_ENV,
+            "Host-header validation disabled by `*`; relying on API-key auth as the sole gate."
+        );
+        return base.disable_allowed_hosts();
+    }
+    let mut hosts: Vec<String> = vec!["localhost".into(), "127.0.0.1".into(), "::1".into()];
+    for host in value.split(',') {
+        let trimmed = host.trim();
+        if !trimmed.is_empty() {
+            hosts.push(trimmed.to_owned());
+        }
+    }
+    tracing::info!(
+        target: "tanren_mcp",
+        allowed_hosts = ?hosts,
+        "Host-header validation extended via {ALLOWED_HOSTS_ENV}"
+    );
+    base.with_allowed_hosts(hosts)
 }
 
 #[tokio::main]

--- a/bin/tanren-mcp/src/main.rs
+++ b/bin/tanren-mcp/src/main.rs
@@ -1,32 +1,232 @@
 //! Tanren MCP (Model Context Protocol) server.
 //!
-//! F-0001 ships an empty tool registry; the rmcp framework's default
-//! [`ServerHandler`] impl serves a `list-tools` response with `[]`.
-//! Behavior tools arrive with R-* slices, each adding `#[rmcp::tool]`
-//! routes that route through `tanren-app-services`.
+//! F-0002 corrects F-0001's stdio scaffolding: the architecture mandates
+//! MCP Streamable HTTP with scoped credentials (see
+//! `docs/architecture/subsystems/interfaces.md#mcp` and
+//! `docs/architecture/technology.md`). This binary wraps an `rmcp`
+//! `StreamableHttpService` in `axum`, gates `/mcp` behind an API-key
+//! middleware that emits the shared
+//! `auth_required` / `permission_denied` taxonomy from the interfaces
+//! contract, and exposes the same `/health` shape as `tanren-api`.
+//!
+//! The bootstrap key is sourced from `TANREN_MCP_API_KEY`; the real
+//! credential store lands with R-0008 (B-0048 / B-0125) and replaces
+//! the env-sourced placeholder. The tool registry is empty — R-* slices
+//! add `#[rmcp::tool]` routes that route through `tanren-app-services`.
 
 use anyhow::{Context, Result};
+use axum::Json;
+use axum::Router;
+use axum::extract::Request;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
 use rmcp::ServerHandler;
-use rmcp::ServiceExt;
-use rmcp::transport::io::stdio;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+use std::sync::Arc;
+use tanren_app_services::Handlers;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceBuilder;
+use tower_http::cors::{Any, CorsLayer};
 
+const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:8081";
+const BIND_ADDRESS_ENV: &str = "TANREN_MCP_BIND";
+const API_KEY_ENV: &str = "TANREN_MCP_API_KEY";
+
+/// Empty tool surface. Behavior tools land with R-* slices via
+/// `#[rmcp::tool]` annotations on this type.
 #[derive(Debug, Clone, Default)]
 struct TanrenMcp;
 
 impl ServerHandler for TanrenMcp {}
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HealthResponse {
+    status: String,
+    version: String,
+    contract_version: u32,
+}
+
+async fn health() -> Json<HealthResponse> {
+    let report = Handlers::new().health(env!("CARGO_PKG_VERSION"));
+    Json(HealthResponse {
+        status: report.status.to_owned(),
+        version: report.version.to_owned(),
+        contract_version: report.contract_version.value(),
+    })
+}
+
+/// Shared error response shape per
+/// `docs/architecture/subsystems/interfaces.md` "Error Taxonomy".
+fn error_body(code: &str, summary: &str) -> serde_json::Value {
+    json!({
+        "code": code,
+        "summary": summary,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct AuthConfig {
+    /// Bootstrap API key. F-0002 sources this from `TANREN_MCP_API_KEY`;
+    /// R-0008 will route through the real credential store.
+    bootstrap_key: Option<String>,
+}
+
+impl AuthConfig {
+    fn from_env() -> Self {
+        let bootstrap_key = env::var(API_KEY_ENV).ok().filter(|s| !s.is_empty());
+        Self { bootstrap_key }
+    }
+
+    fn extract_credential(headers: &HeaderMap) -> Option<&str> {
+        if let Some(value) = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            && let Some(token) = value
+                .strip_prefix("Bearer ")
+                .or_else(|| value.strip_prefix("bearer "))
+        {
+            return Some(token.trim());
+        }
+        if let Some(value) = headers.get("x-api-key").and_then(|v| v.to_str().ok()) {
+            return Some(value.trim());
+        }
+        None
+    }
+}
+
+async fn require_api_key(
+    axum::extract::State(config): axum::extract::State<Arc<AuthConfig>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(presented) = AuthConfig::extract_credential(request.headers()) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(error_body(
+                "auth_required",
+                "Missing Authorization: Bearer <api-key> or X-API-Key header.",
+            )),
+        )
+            .into_response();
+    };
+
+    let Some(expected) = config.bootstrap_key.as_deref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(error_body(
+                "unavailable",
+                "MCP credential store is not configured. Set TANREN_MCP_API_KEY (bootstrap key) until R-0008 lands the real store.",
+            )),
+        )
+            .into_response();
+    };
+
+    if !constant_time_eq(presented.as_bytes(), expected.as_bytes()) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(error_body(
+                "permission_denied",
+                "Presented credential is not authorized for this MCP service.",
+            )),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn build_router(auth_config: Arc<AuthConfig>, cancellation: CancellationToken) -> Router {
+    let mcp_service: StreamableHttpService<TanrenMcp, LocalSessionManager> =
+        StreamableHttpService::new(
+            || Ok(TanrenMcp),
+            Arc::new(LocalSessionManager::default()),
+            StreamableHttpServerConfig::default().with_cancellation_token(cancellation),
+        );
+
+    let mcp_with_auth = ServiceBuilder::new()
+        .layer(middleware::from_fn_with_state(auth_config, require_api_key))
+        .service(mcp_service);
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    Router::new()
+        .route("/health", get(health))
+        .nest_service("/mcp", mcp_with_auth)
+        .layer(cors)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tanren_observability::init().context("install tracing subscriber")?;
-    tracing::info!(target: "tanren_mcp", "tanren-mcp starting on stdio transport");
 
-    let service = TanrenMcp
-        .serve(stdio())
+    let bind = env::var(BIND_ADDRESS_ENV).unwrap_or_else(|_| DEFAULT_BIND_ADDRESS.to_owned());
+    let auth_config = Arc::new(AuthConfig::from_env());
+    if auth_config.bootstrap_key.is_none() {
+        tracing::warn!(
+            target: "tanren_mcp",
+            env_var = API_KEY_ENV,
+            "TANREN_MCP_API_KEY is not set — every /mcp request will be rejected with `unavailable` until a bootstrap key is provided."
+        );
+    }
+
+    let cancellation = CancellationToken::new();
+    let router = build_router(auth_config, cancellation.clone());
+
+    let listener = TcpListener::bind(&bind)
         .await
-        .context("start mcp server on stdio")?;
-    service
-        .waiting()
+        .with_context(|| format!("bind {bind}"))?;
+    tracing::info!(target: "tanren_mcp", address = %bind, "tanren-mcp listening on streamable HTTP");
+
+    let cancel = cancellation.clone();
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            cancel.cancel();
+        })
         .await
-        .context("mcp server exited unexpectedly")?;
+        .context("axum serve")?;
     Ok(())
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+    let sigterm = signal(SignalKind::terminate()).ok();
+    if let Some(mut sigterm) = sigterm {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    } else {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+    tracing::info!(target: "tanren_mcp", "shutdown signal received");
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!(target: "tanren_mcp", "shutdown signal received");
 }

--- a/docs/architecture/subsystems/behavior-proof.md
+++ b/docs/architecture/subsystems/behavior-proof.md
@@ -3,7 +3,7 @@ schema: tanren.subsystem_architecture.v0
 subsystem: behavior-proof
 status: accepted
 owner_command: architect-system
-updated_at: 2026-04-29
+updated_at: 2026-05-02
 ---
 
 # Behavior Proof Architecture
@@ -69,10 +69,12 @@ an accepted behavior.
 
 ## Behavior-To-Proof Linkage
 
-Each behavior proof target links to one accepted behavior ID. A feature file
-should normally prove one behavior. Exceptions are allowed only when a single
-observable scenario necessarily demonstrates a tightly coupled behavior set,
-and the linkage must remain explicit.
+Each behavior proof target links to one accepted behavior ID. F-0002 closes
+the original "tightly coupled behavior set" exception: every `.feature`
+proves exactly one behavior. Roadmap nodes that complete more than one
+behavior ship one feature file per completed behavior — bundling lives at
+the node level, not the feature level. The mechanical rules are documented
+under "BDD Tagging And File Convention" below.
 
 Proof linkage records:
 
@@ -255,13 +257,92 @@ Events include:
 Proof events do not store secret values or raw runtime logs. They store
 behavior-level proof results, metadata, and references needed for assessment.
 
+## BDD Tagging And File Convention
+
+This section is the mechanical contract that
+[`xtask check-bdd-tags`](../../../xtask/src/bdd_tags/) enforces and that
+[`scripts/roadmap_check.py`](../../../scripts/roadmap_check.py)
+cross-references. It was locked in F-0002 to close drift between
+`tests/bdd/README.md`, `interfaces.md`, and three competing R-0001
+attempts. Future authors should not relitigate; if the convention truly
+needs to change, change it here first and then update both validators.
+
+### File granularity
+
+- One `.feature` file per behavior, named
+  `tests/bdd/features/B-XXXX-<slug>.feature`. The slug is human-readable
+  (kebab-case) and is informational only — `xtask check-bdd-tags` keys
+  off the `B-XXXX` prefix.
+- Multi-behavior R-* nodes (43 of 231 today, e.g. R-0007 = B-0059 +
+  B-0060) ship one feature file per completed behavior. Each behavior is
+  validated independently.
+- A feature file's behavior must exist in `docs/behaviors/` with
+  `product_status: accepted`.
+
+### Tag rules
+
+- **Feature-level**: exactly one tag, `@B-XXXX`, matching the filename
+  prefix. No other feature-level tags.
+- **Scenario-level**: exactly one of `@positive` / `@falsification`,
+  plus 1–2 interface tags drawn from `@web | @api | @mcp | @cli | @tui`.
+- **Closed allowlist**: the seven scenario tags above are the only tags
+  permitted anywhere in the suite. `@skip`, `@wip`, `@ignore`, phase
+  tags, wave tags, and proof IDs are rejected.
+- **Two-interface scenarios** (e.g., create-via-CLI verify-via-web)
+  require a `# rationale: <one line>` comment immediately above the
+  scenario's tag block. Three or more interface tags on a single
+  scenario is a hard error.
+
+### Forbidden Gherkin constructs
+
+- `Scenario Outline` and `Examples:` blocks are forbidden. Outlines
+  generate synthetic scenario names that destabilize assessment and
+  mutation IDs and break the one-witness-per-scenario rule.
+- `Background:` and `Rule:` are allowed. `Rule:` is encouraged as the
+  natural seam for grouping scenarios per interface inside one file.
+
+### Coverage rules (strict equality)
+
+A behavior is binary: fully asserted or not. There is no "partially
+asserted" lane.
+
+- The union of interface tags across the feature's scenarios must
+  **equal** the behavior's frontmatter `interfaces:` set. Any tag
+  outside that set is a hard error (surface drift); any frontmatter
+  interface with no tagged scenario is a hard error (incomplete proof).
+- For each interface in the behavior's `interfaces:` set, the feature
+  must contain at least one `@positive` scenario tagged for that
+  interface.
+- When the R-* node's `expected_evidence.witnesses` for the behavior
+  includes `falsification`, the feature must additionally contain at
+  least one `@falsification` scenario tagged for **every** interface in
+  the behavior's `interfaces:` set. F-0002 deliberately elevates
+  falsification to per-interface coverage, stricter than the
+  "where meaningful" framing in core invariant 5 above; the elevation
+  is the contract because every surface needs an independent negative
+  witness, not just the behavior as a whole.
+- The validator already enforces that
+  `expected_evidence.interfaces` equals the behavior's
+  `interfaces:`; this convention rides on top.
+
+### Validator wiring
+
+`xtask check-bdd-tags` parses every `tests/bdd/features/**/*.feature`,
+applies the rules above, and exits non-zero on any violation with a
+file:line message naming the rule. It is wired into `just check` after
+`check-rust-test-surface`, so every PR runs it. The inverse check —
+that every `B-XXXX-*.feature` references an accepted behavior with a
+DAG node — runs in `scripts/roadmap_check.py` so an orphan feature
+file is caught even if the xtask validator has not been touched.
+
 ## Accepted Behavior Proof Decisions
 
 - The subsystem is named behavior proof.
 - Tanren rejects a general artifact-vault architecture as the core proof
   model.
 - BDD feature files are the primary executable behavior proof mechanism.
-- A feature file should normally prove one accepted behavior.
+- A feature file proves exactly one accepted behavior. F-0002 closes the
+  original "normally one, exceptions allowed" wording.
 - Asserted behavior requires active behavior-level proof.
 - Behavior records do not store verification or assertion status.
 - Positive witnesses are required for behavior assertion.

--- a/docs/roadmap/dag.json
+++ b/docs/roadmap/dag.json
@@ -5,7 +5,7 @@
   "behavior_root": "docs/behaviors",
   "architecture_root": "docs/architecture",
   "implementation_ref": null,
-  "foundation_spec_id": "F-0001",
+  "foundation_spec_id": "F-0002",
   "completion_definition": "A behavior spec node is complete IFF (a) BDD scenarios with positive and falsification witnesses exist and pass for every behavior listed in completes_behaviors on every interface declared by that behavior, and (b) the subjective playbook has been walked end-to-end with a human accepting each step on every declared interface. Foundation spec nodes are complete IFF the definition_of_done in the foundation spec passes; they intentionally complete zero behaviors.",
   "parallelization_strategy": {
     "phase_1_foundation_sequential": [
@@ -300,8 +300,81 @@
       ],
       "risks": [
         "Foundation is large by necessity. Estimate 3-5 weeks for a small team (web frontend stack adds to the original kernel-only estimate). We accept this as a one-time cost.",
-        "F-0001 must produce auth primitives (session model, credential verification trait) without committing to a specific mechanism — the architecture commits to local + OIDC (technology.md), but mechanism wiring is deferred to R-0001 because Foundation has no user identity. Care is needed to avoid baking in shape that R-0001 must then unwind.",
-        "Workspace lint policy (deny unwrap/panic/todo/print, forbid unsafe, deny allow_attributes) is the most likely cause of mid-Foundation churn — every stub crate must compile clean under the strict ruleset on first commit. Plan for time to reshape early stubs that fall foul of clippy::pedantic."
+        "F-0001 must produce auth primitives (session model, credential verification trait) without committing to a specific mechanism \u2014 the architecture commits to local + OIDC (technology.md), but mechanism wiring is deferred to R-0001 because Foundation has no user identity. Care is needed to avoid baking in shape that R-0001 must then unwind.",
+        "Workspace lint policy (deny unwrap/panic/todo/print, forbid unsafe, deny allow_attributes) is the most likely cause of mid-Foundation churn \u2014 every stub crate must compile clean under the strict ruleset on first commit. Plan for time to reshape early stubs that fall foul of clippy::pedantic."
+      ]
+    },
+    {
+      "id": "F-0002",
+      "kind": "foundation",
+      "milestone": "M-0001",
+      "status": "planned",
+      "evidence_ref": "docs/roadmap/evidence/F-0002.md",
+      "title": "Foundation Correction \u2014 HTTP MCP, BDD convention, validators",
+      "completes_behaviors": [],
+      "supports_behaviors": [],
+      "depends_on": [
+        "F-0001"
+      ],
+      "scope": "One-time correction of four F-0001 misalignments with the accepted architecture under docs/architecture/, applied before any R-* node lands. (1) Replaces the empty rmcp stdio entry point in bin/tanren-mcp with an axum-hosted Streamable HTTP service gated behind an API-key middleware that emits the shared auth_required / permission_denied error taxonomy from interfaces.md. The bootstrap key reads from the TANREN_MCP_API_KEY environment variable; the real credential store lands with R-0008 (B-0048 / B-0125). (2) Adds the xtask check-bdd-tags validator: walks tests/bdd/features for filename to feature-tag match, the closed tag allowlist, strict-equality interface coverage against docs/behaviors and docs/roadmap/dag.json, and the forbidden Gherkin-construct list. Wired into just check. (3) Locks the BDD .feature convention in docs/architecture/subsystems/behavior-proof.md (BDD Tagging And File Convention): one .feature per behavior, feature-level B-XXXX tag, scenario-level positive or falsification plus 1 to 2 interface tags, no Scenario Outline or Examples, and per-interface positive plus falsification coverage when the DAG node lists falsification witnesses. (4) Tightens scripts/roadmap_check.py with a feature-file inventory check (every B-XXXX-*.feature maps to an accepted behavior with a DAG node) and tightens just check-deps with a positive assertion that tanren-mcp depends on axum (mechanical guard against accidental reversion to stdio). Updates the foundation_spec_id pointer from F-0001 to F-0002 so every R-* behavior node transitively depends on the corrected foundation.",
+      "boundary_with_neighbors": "F-0001 owned the initial scaffolding (workspace, crates, five interface scaffolds, BDD harness, postgres + migrations). F-0002 corrects four specific architectural misalignments left in F-0001 (stdio MCP, missing tag enforcement, missing BDD convention, dependency-shape drift). All R-* behavior nodes \u2014 starting with R-0001 \u2014 depend on F-0002 (which transitively pulls in F-0001) so they inherit the corrected foundation. The real MCP credential store, including organisation- and project-scoped service-account keys, is owned by R-0008 (B-0048 / B-0125); F-0002 ships the enforcement point with a single env-sourced bootstrap key as a placeholder.",
+      "expected_evidence": [
+        {
+          "kind": "build",
+          "description": "cargo build --workspace --locked succeeds; tanren-mcp links axum, rmcp (transport-streamable-http-server), tower, tower-http; cargo tree -p tanren-mcp shows no stdio transport feature on rmcp."
+        },
+        {
+          "kind": "ci",
+          "description": "just ci exits 0 with all aggregator stages including the new bdd tags step (xtask check-bdd-tags) and the tightened dependency boundaries step (axum-required for tanren-mcp)."
+        },
+        {
+          "kind": "manual",
+          "description": "Start tanren-mcp with TANREN_MCP_API_KEY set; curl /health returns 200 with the tanren-app-services HealthReport shape; curl /mcp without Authorization returns 401 with auth_required; curl /mcp with a wrong key returns 403 with permission_denied; curl /mcp with the correct key returns the Streamable HTTP MCP greeting and tools/list resolves to an empty array."
+        },
+        {
+          "kind": "validator",
+          "description": "xtask check-bdd-tags runs against an empty tests/bdd/features tree and exits 0 with the vacuous-pass message; runs against a malformed B-XXXX-*.feature fixture and hard-fails with precise per-violation messages; runs against a partial-coverage fixture and hard-fails listing the uncovered interfaces (no soft-coverage lane)."
+        },
+        {
+          "kind": "validator",
+          "description": "python3 scripts/roadmap_check.py exits 0 against the post-merge DAG; foundation_spec_id is F-0002; every R-* node transitively reaches F-0002."
+        }
+      ],
+      "playbook": [
+        "Migrate bin/tanren-mcp from rmcp stdio to rmcp Streamable HTTP server hosted under axum, mirroring tanren-api posture.",
+        "Add an axum middleware that requires Authorization: Bearer <key> (or X-API-Key) on /mcp and rejects with auth_required / permission_denied per interfaces.md error taxonomy.",
+        "Source the bootstrap key from TANREN_MCP_API_KEY; emit a startup warning when unset.",
+        "Drop rmcp transport-io feature in workspace deps; enable transport-streamable-http-server.",
+        "Add tokio-util to workspace deps for rmcp CancellationToken.",
+        "Add the check-bdd-tags xtask subcommand with a closed tag allowlist, strict-equality interface coverage, behavior-catalog cross-check, and DAG-evidence cross-check.",
+        "Wire check-bdd-tags into just check (after check-rust-test-surface).",
+        "Tighten just check-deps with a positive assertion that tanren-mcp depends on axum.",
+        "Extend scripts/roadmap_check.py with a tests/bdd/features inventory check (every B-XXXX-*.feature maps to accepted behavior + DAG evidence).",
+        "Document the BDD convention in docs/architecture/subsystems/behavior-proof.md (new BDD Tagging And File Convention section).",
+        "Rewrite tests/bdd/README.md to point at the canonical convention and the validator commands.",
+        "Add a one-line BDD-convention pointer to CLAUDE.md and AGENTS.md.",
+        "Add F-0002 to docs/roadmap/dag.json; switch foundation_spec_id from F-0001 to F-0002; repoint R-0001 and R-0023 from F-0001 to F-0002 (other R-* nodes already reach F-0002 transitively through their R-* parents).",
+        "Run python3 scripts/roadmap_check.py and just ci; both must exit 0.",
+        "Manually verify the MCP HTTP service end-to-end: spin up postgres, run tanren-cli migrate up, start tanren-mcp with a bootstrap key, exercise /health and /mcp with curl.",
+        "Manually exercise check-bdd-tags with malformed and partial-coverage fixtures; confirm the failures are precise and the green path stays green."
+      ],
+      "rationale": "F-0001 set up scaffolding for every subsystem and interface but baked four small mismatches against the architecture record \u2014 most visibly an MCP service running over stdio when docs/architecture/subsystems/interfaces.md and docs/architecture/technology.md (rejected-alternatives section) mandate Streamable HTTP. Three R-0001 attempts on top of F-0001 each invented their own BDD convention because tests/bdd/README declared the contract but no validator enforced it. F-0002 closes those gaps before any behavior slice lands so the first wave of R-* nodes (R-0001 through R-0010) inherits a corrected, mechanically-enforced foundation. Foundation no-completes-behaviors carve-out remains: F-0002 produces tooling and corrected scaffolding, not behavior assertion.",
+      "definition_of_done": [
+        "tanren-mcp serves MCP Streamable HTTP under axum on the configured port; cargo tree -p tanren-mcp contains axum and excludes rmcp stdio transport feature.",
+        "Auth middleware: /mcp without a credential returns 401 auth_required; with a wrong credential returns 403 permission_denied; with the bootstrap key returns the empty Streamable HTTP MCP surface.",
+        "xtask check-bdd-tags exists and is wired into just check (visible in just ci).",
+        "scripts/roadmap_check.py enforces tests/bdd/features to DAG to behavior alignment; running it post-merge exits 0 with foundation_spec_id == F-0002.",
+        "just check-deps requires axum in tanren-mcp direct deps and continues to reject domain/policy/store from any transport binary.",
+        "docs/architecture/subsystems/behavior-proof.md contains the BDD Tagging And File Convention section.",
+        "tests/bdd/README.md is rewritten to point at the convention and the validator commands; CLAUDE.md and AGENTS.md carry a one-line pointer.",
+        "docs/roadmap/dag.json contains F-0002, foundation_spec_id is F-0002, and R-0001 + R-0023 depend on F-0002 (not F-0001).",
+        "just ci exits 0; python3 scripts/roadmap_check.py exits 0."
+      ],
+      "risks": [
+        "rmcp Streamable HTTP server transport is a network surface \u2014 binding to 0.0.0.0 by default makes the service reachable from any container on the host network. Mitigation: the axum middleware refuses every request without an exact bootstrap-key match (constant-time compare); the bind address is overridable via TANREN_MCP_BIND for operators that prefer 127.0.0.1.",
+        "The bootstrap-key auth is a placeholder, not the real credential store. Mitigation: the placeholder shape is deliberately narrow (one env var, single-tenant) so R-0008 can swap it for the per-actor service-account model without re-shaping the middleware contract.",
+        "F-0002 closes the multi-behavior-feature exception in behavior-proof.md (one .feature proves exactly one behavior). Future authors might reach for the closed exception when they encounter genuinely-coupled behavior pairs (e.g., R-0007 owns B-0059 + B-0060). Mitigation: the convention requires multi-behavior R-* nodes to ship one feature file per completed behavior \u2014 the bundling lives at the node level, not the feature level.",
+        "Per-interface falsification coverage is stricter than behavior-proof.md where meaningful framing. Some R-* nodes will need to write five falsification scenarios per behavior. Mitigation: the validator emits precise per-interface error messages so authors know exactly which falsification scenarios are missing; the convention section in behavior-proof.md flags the elevation explicitly."
       ]
     },
     {
@@ -313,7 +386,7 @@
       ],
       "supports_behaviors": [],
       "depends_on": [
-        "F-0001"
+        "F-0002"
       ],
       "scope": "Add the account-create + sign-in surface on every interface declared by B-0043 (web, api, mcp, cli, tui). Cover both creation pathways (self-signup and invitation-based-creation), the multi-account-per-person rule, the personal-orphans-no-org rule, and the sign-in flow that produces an authenticated session. Invitation-based-creation scenarios use a fixtured invitation record (the user-facing invite-creation flow is R-0005). Foundation has already established the bones of each interface, the API server, the auth primitives, the event log, and the BDD harness \u2014 this spec adds account events + projections, the create/sign-in endpoints/pages/commands/tools/screens, and the BDD scenarios that prove all observable outcomes on every interface.",
       "boundary_with_neighbors": "R-0003 owns switching between multiple accounts. R-0002 owns organization creation. R-0005 owns the invite-sending flow. R-0006 owns invitation acceptance for an EXISTING account. F-0001 already established the kernel + interface scaffolding; this node only adds the account-specific behavior on top.",
@@ -1392,7 +1465,7 @@
       ],
       "supports_behaviors": [],
       "depends_on": [
-        "F-0001"
+        "F-0002"
       ],
       "scope": "The CLI install flow: from a local repository path and a chosen standards profile, install the methodology assets (commands, agent integrations, standards) into the repo. Two sub-modes bundled because they share most of the install code: (1) install everything for the chosen profile (B-0068), (2) install only selected agent integrations (B-0070). Cover the re-install rules (replaces generated assets, removes stale generated assets, preserves user-edited standards, restores missing standards) and the validation rule (invalid bootstrap input is rejected before any write).",
       "boundary_with_neighbors": "R-0024 owns drift detection (read-only check on the install output). R-0025 owns the runtime use of installed standards. R-0026 owns upgrade. R-0027 owns uninstall. R-0019 owns the orthogonal account-level project registration (different layer). F-0001 already established the cli binary; this node adds the install subcommand, the profile readers, and the asset writers.",

--- a/docs/roadmap/evidence/F-0002.md
+++ b/docs/roadmap/evidence/F-0002.md
@@ -1,0 +1,147 @@
+---
+schema: tanren.evidence.v0
+spec_id: F-0002
+status: planned
+captured_at: 2026-05-02
+---
+
+# F-0002 Sign-off Evidence
+
+This document captures the evidence for [F-0002](../dag.json) — the
+foundation correction spec that closes four F-0001 misalignments with the
+accepted architecture under [`docs/architecture/`](../../architecture/)
+before any R-* node lands. Each entry below maps to a step in F-0002's
+`playbook` and an item in its `definition_of_done`.
+
+## What changed and why
+
+F-0001 stood up the workspace bones, but four small mismatches against
+the architecture record carried through to merge:
+
+1. `bin/tanren-mcp` ran an empty rmcp tool registry over **stdio** when
+   [`subsystems/interfaces.md:53-54`](../../architecture/subsystems/interfaces.md)
+   and
+   [`technology.md:459-460`](../../architecture/technology.md)
+   mandate **MCP Streamable HTTP** with scoped credentials.
+2. [`tests/bdd/README.md`](../../../tests/bdd/README.md) declared an
+   `@B-XXXX` ↔ behavior contract but no validator enforced it.
+3. The BDD `.feature`-vs-interface granularity was undefined; three
+   R-0001 attempts on F-0001 each invented a different convention.
+4. The dependency footprint of `bin/tanren-mcp` reflected the stdio
+   choice (no axum / tower-http; rmcp's `transport-io` feature on
+   instead of `transport-streamable-http-server`).
+
+F-0002 corrects each in a single shot. The specifics of how the BDD
+convention was chosen (one feature per behavior, strict-equality
+interface coverage, per-interface falsification, closed tag allowlist,
+forbidden Scenario Outline, two-interface scenarios with rationale)
+are documented in
+[`docs/architecture/subsystems/behavior-proof.md`](../../architecture/subsystems/behavior-proof.md)
+under "BDD Tagging And File Convention".
+
+## Evidence
+
+### 1. MCP transport — stdio out, Streamable HTTP in
+
+- [`bin/tanren-mcp/src/main.rs`](../../../bin/tanren-mcp/src/main.rs)
+  no longer references `rmcp::transport::io::stdio`. The binary builds
+  an `axum::Router` with a `nest_service("/mcp", StreamableHttpService)`
+  branch (gated by API-key middleware) and a public `/health` route
+  whose body shape mirrors [`tanren-api`](../../../bin/tanren-api/src/main.rs).
+- [`bin/tanren-mcp/Cargo.toml`](../../../bin/tanren-mcp/Cargo.toml)
+  pulls `axum`, `tower`, `tower-http`, `tokio-util`, and routes through
+  `tanren-app-services` for the health-report shape.
+- Workspace [`Cargo.toml`](../../../Cargo.toml) flips the `rmcp` feature
+  set from `transport-io` to `transport-streamable-http-server` and
+  adds `tokio-util` (required by `rmcp` for graceful shutdown).
+- Manual verification (see "Manual run" below) confirms `/health`
+  returns 200, `/mcp` returns 401 / `auth_required` without a
+  credential, 403 / `permission_denied` with a wrong key, and the
+  Streamable HTTP MCP greeting with the bootstrap key.
+
+### 2. BDD tag enforcement — `xtask check-bdd-tags`
+
+- New subcommand in [`xtask`](../../../xtask/src/main.rs) backed by a
+  hand-rolled feature-file scanner under
+  [`xtask/src/bdd_tags/`](../../../xtask/src/bdd_tags/). Validates:
+  filename ↔ feature-tag match; closed tag allowlist
+  (`@B-XXXX | @positive | @falsification | @web | @api | @mcp | @cli | @tui`);
+  no `Scenario Outline` / `Examples`; per-scenario witness count and
+  interface tag count; required `# rationale:` comment for
+  two-interface scenarios; behavior catalog cross-check; strict
+  per-interface coverage against
+  `docs/roadmap/dag.json:nodes[].expected_evidence`.
+- Wired into [`justfile`](../../../justfile) as `just check-bdd-tags`,
+  invoked by `just check` after `check-rust-test-surface`.
+- Empty-tree run prints the vacuous-pass message; green-path,
+  malformed, and partial-coverage fixtures are exercised in the
+  validator-fixture verification step.
+
+### 3. Canonical BDD convention — locked in `behavior-proof.md`
+
+- [`docs/architecture/subsystems/behavior-proof.md`](../../architecture/subsystems/behavior-proof.md)
+  gains a "BDD Tagging And File Convention" section that codifies the
+  rules `xtask check-bdd-tags` enforces, calls out the per-interface
+  falsification elevation, and notes that the multi-behavior-feature
+  exception in line 72 is closed by F-0002.
+- [`tests/bdd/README.md`](../../../tests/bdd/README.md) is rewritten to
+  point at the convention and the validator commands.
+- [`CLAUDE.md`](../../../CLAUDE.md) and [`AGENTS.md`](../../../AGENTS.md)
+  carry a one-line pointer so contributors don't relitigate.
+
+### 4. Dependency hygiene + roadmap inverse check
+
+- [`justfile`](../../../justfile) `check-deps` recipe gains a positive
+  assertion: `tanren-mcp` must depend on `axum`. Mechanical guard
+  against future reversion to a stdio-only build.
+- [`scripts/roadmap_check.py`](../../../scripts/roadmap_check.py) gains
+  `check_feature_files`: every `tests/bdd/features/B-XXXX-*.feature`
+  must reference an accepted behavior with a DAG node in
+  `expected_evidence`. Inverse of the xtask validator's check; catches
+  orphan feature files after deletes/renames.
+- `cargo machete` is clean; `cargo tree -p tanren-mcp` shows the
+  `transport-streamable-http-server` feature on rmcp and no stdio
+  transport surface.
+
+## Roadmap state
+
+- `foundation_spec_id` is now `F-0002` in
+  [`docs/roadmap/dag.json`](../dag.json).
+- `R-0001` and `R-0023` (the only R-* nodes that previously depended
+  directly on F-0001) now depend on `F-0002`. All other R-* nodes
+  reach F-0002 transitively through their R-* parents.
+- `python3 scripts/roadmap_check.py` exits 0; the new
+  `check_feature_files` step is a no-op against the empty
+  `tests/bdd/features` tree.
+- Critical path is 16 nodes (was 15): the F-0001 → F-0002 → R-0001 prefix
+  replaces the previous F-0001 → R-0001.
+
+## Manual run (HTTP MCP)
+
+```text
+$ DATABASE_URL=postgres://… target/debug/tanren-cli migrate up
+$ TANREN_MCP_API_KEY=local-bootstrap-key target/debug/tanren-mcp &
+INFO tanren_mcp: tanren-mcp listening on streamable HTTP address=0.0.0.0:8081
+
+$ curl -sS http://localhost:8081/health
+{"status":"ok","version":"0.0.0","contract_version":0}
+
+$ curl -sS -o /dev/null -w "%{http_code}\n" http://localhost:8081/mcp
+401
+
+$ curl -sS http://localhost:8081/mcp -H "Authorization: Bearer wrong"
+{"code":"permission_denied","summary":"Presented credential is not authorized for this MCP service."}
+
+$ curl -sS http://localhost:8081/mcp \
+    -H "Authorization: Bearer local-bootstrap-key" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"local","version":"0"}}}'
+# Streamable HTTP greeting follows.
+```
+
+## Closing
+
+F-0002 introduces no behavior assertions. It produces tooling and
+corrected scaffolding so that R-0001 and every subsequent R-* node
+inherits a foundation that matches the architecture record exactly.

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,6 +1,6 @@
 # Tanren Roadmap
 
-**Generated:** 2026-05-01
+**Generated:** 2026-05-02
 **Source of truth:** [`docs/roadmap/dag.json`](dag.json)
 
 ## What this is
@@ -18,22 +18,25 @@ human-friendly rendering.
 | | |
 |---|---|
 | Milestones | 27 |
-| Spec nodes | 232 (1 foundation + 231 behavior) |
+| Spec nodes | 233 (2 foundation + 231 behavior) |
 | Accepted behaviors | 282 |
 | Behaviors covered | 282 (100%) |
-| Longest dependency path | 15 nodes |
+| Longest dependency path | 16 nodes |
 | Max parallel width | 70 nodes |
 
 Validate with: `python3 scripts/roadmap_check.py`
 
 ## Methodology
 
-**Foundation-then-thin-slices.** F-0001 is a one-time scaffolding spec that
-brings the repo from "scaffolding only" to "minimum buildable Tanren" with
-every subsystem stubbed and every public interface (web, api, mcp, cli, tui)
-hosting a hello-world surface. Foundation completes zero behaviors by design.
-Every roadmap spec (R-0001 onwards) is a thin behavior slice that fully
-completes its declared behaviors on every interface those behaviors
+**Foundation-then-thin-slices.** F-0001 is the original scaffolding spec
+that brings the repo from "scaffolding only" to "minimum buildable Tanren"
+with every subsystem stubbed and every public interface (web, api, mcp, cli,
+tui) hosting a hello-world surface. F-0002 is a one-time correction node
+that closes four F-0001 misalignments (HTTP MCP transport, mechanical BDD
+tag enforcement, locked `.feature` convention, dependency-shape drift)
+before any R-* node lands. Both foundation specs complete zero behaviors by
+design. Every roadmap spec (R-0001 onwards) is a thin behavior slice that
+fully completes its declared behaviors on every interface those behaviors
 declare — no future spec is gated on "an interface doesn't exist yet".
 
 **Completion definition.** A behavior spec is complete IFF (a) BDD scenarios
@@ -115,11 +118,11 @@ The closing-the-loop and intelligence layer.
 
 ## Critical path
 
-15 nodes — the longest sequential chain through the DAG:
+16 nodes — the longest sequential chain through the DAG:
 
 ```
-F-0001 → R-0001 → R-0019 → R-0073 → R-0076 → R-0081 → R-0120 → R-0123 →
-R-0133 → R-0134 → R-0136 → R-0138 → R-0139 → R-0141 → R-0142
+F-0001 → F-0002 → R-0001 → R-0019 → R-0073 → R-0076 → R-0081 → R-0120 →
+R-0123 → R-0133 → R-0134 → R-0136 → R-0138 → R-0139 → R-0141 → R-0142
 ```
 
 This is the full deliver loop end-to-end: scaffold → account → project →
@@ -182,8 +185,8 @@ python3 scripts/roadmap_check.py --reduce
 - **`supports_behaviors`** lists behaviors this spec partially exercises
   but doesn't own completion of.
 - **`depends_on`** is acyclic and minimal — transitively redundant edges are
-  removed by `--reduce`. Every behavior node has F-0001 as a transitive
-  ancestor.
+  removed by `--reduce`. Every behavior node has F-0002 as a transitive
+  ancestor (and F-0002 has F-0001).
 - **`expected_evidence`** lists per-behavior BDD coverage with witnesses
   (`positive` + `falsification`) and the interfaces the proof must cover.
 - **`playbook`** is the human-walked acceptance sequence. Subjective; one

--- a/justfile
+++ b/justfile
@@ -251,6 +251,7 @@ check:
     run_stage "suppression guard" just check-suppression
     run_stage "dependency boundaries" just check-deps
     run_stage "rust test surface" just check-rust-test-surface
+    run_stage "bdd tags" just check-bdd-tags
     run_stage "cargo check" bash -c 'CARGO_INCREMENTAL=0 {{ cargo }} check --workspace --all-targets --locked --quiet'
     run_stage "clippy" bash -c 'CARGO_INCREMENTAL=0 {{ cargo }} clippy --workspace --all-targets --locked --quiet -- -D warnings'
     total_elapsed="$(( $(now_ms) - total_start ))"
@@ -472,6 +473,19 @@ check-deps:
         echo "FAIL: crates/tanren-store/src/entity/mod.rs exposes row-shape modules publicly"
         failed=1
     fi
+
+    # F-0002: tanren-mcp must serve over HTTP (axum-based stack), per
+    # docs/architecture/subsystems/interfaces.md#mcp and
+    # docs/architecture/technology.md (rejected-alternatives: stdio MCP).
+    # The presence of axum in the dependency closure is the mechanical
+    # signal that the binary is wired to the HTTP transport rather than
+    # rmcp's stdio transport.
+    mcp_deps=$(echo "$metadata" | jq -r '.packages[] | select(.name == "tanren-mcp") | .dependencies[] | select(.kind == null) | .name' 2>/dev/null || true)
+    if ! echo "$mcp_deps" | grep -qx "axum"; then
+        echo "FAIL: tanren-mcp must depend on axum (HTTP transport mandated by architecture)"
+        failed=1
+    fi
+
     if [[ "$failed" -eq 1 ]]; then
         echo "Dependency/boundary rule violations detected."
         exit 1
@@ -480,6 +494,14 @@ check-deps:
 # Enforce BDD-only Rust test surface and retired gate names.
 check-rust-test-surface:
     @{{ cargo }} run --quiet -p tanren-xtask -- check-rust-test-surface
+
+# Enforce the F-0002 BDD `.feature` convention: filename↔@B-XXXX, closed
+# tag allowlist, strict-equality interface coverage against
+# docs/behaviors and docs/roadmap/dag.json. See
+# docs/architecture/subsystems/behavior-proof.md (BDD Tagging And File
+# Convention).
+check-bdd-tags:
+    @{{ cargo }} run --quiet -p tanren-xtask -- check-bdd-tags
 
 # Verify active rustc/clippy match the pinned toolchain in rust-toolchain.toml.
 check-rust-toolchain-sync:

--- a/justfile
+++ b/justfile
@@ -176,6 +176,31 @@ deps-upgrade-major:
     {{ cargo }} update -w
     just ci
 
+# Read-only audit of Rust + Node deps that have newer releases on
+# crates.io / npm. Surfaces:
+#   - Rust workspace pins that would shift under `just deps-upgrade`
+#     (semver-compatible) or `just deps-upgrade-major` (incompatible).
+#   - npm catalog pins (pnpm-workspace.yaml) and pnpm overrides whose
+#     installed versions trail the registry's latest.
+# Pure read; never mutates Cargo.lock or pnpm-lock.yaml. Use the
+# upgrade recipes above to actually apply changes.
+deps-outdated:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    have() { command -v "$1" &>/dev/null; }
+
+    echo "==> Rust workspace (cargo upgrade --dry-run)"
+    if ! have cargo-upgrade; then
+        echo "  cargo-upgrade unavailable — run 'just bootstrap' to install cargo-edit" >&2
+    else
+        {{ cargo }} upgrade --dry-run --incompatible 2>&1 | sed 's/^/  /'
+    fi
+
+    echo
+    echo "==> Node workspace (pnpm outdated)"
+    pnpm outdated -r --format list 2>&1 | sed 's/^/  /' || true
+
 # ============================================================================
 # Methodology self-hosting (tanren-repo specific)
 #

--- a/package.json
+++ b/package.json
@@ -15,5 +15,11 @@
     "format": "pnpm --filter ./apps/web format",
     "format:check": "pnpm --filter ./apps/web format:check"
   },
-  "packageManager": "pnpm@10.19.0"
+  "packageManager": "pnpm@10.19.0",
+  "pnpm": {
+    "//": "Override transitive pins where the upstream tracker is behind a security advisory. postcss < 8.5.10 is GHSA-qx2v-qp2m-jg93 (XSS via unescaped </style>); next 16.2.4 still pins 8.4.31 transitively. Drop this override once next bumps its postcss range.",
+    "overrides": {
+      "postcss": "^8.5.10"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ catalogs:
       specifier: 4.1.5
       version: 4.1.5
 
+overrides:
+  postcss: ^8.5.10
+
 importers:
 
   .: {}
@@ -770,10 +773,6 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1406,7 +1405,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.25
       caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
+      postcss: 8.5.13
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
@@ -1453,12 +1452,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.13:
     dependencies:

--- a/scripts/roadmap_check.py
+++ b/scripts/roadmap_check.py
@@ -32,6 +32,10 @@ Checks:
   - Every behavior node has the foundation spec as a transitive ancestor
   - Each `expected_evidence[].interfaces` matches the behavior's frontmatter
     `interfaces:` declaration (catches drift between catalog and DAG)
+  - Each `tests/bdd/features/B-XXXX-*.feature` file references a behavior
+    that has a corresponding R-* node `expected_evidence` entry
+    (inverse of the `xtask check-bdd-tags` cross-check; catches deletes
+    or renames that orphan a feature file from the DAG)
   - (Warn) No transitively redundant `depends_on` edges
   - (Warn) Playbook count vs. declared interfaces — flags suspiciously thin
     playbooks for nodes with 5 declared interfaces
@@ -50,6 +54,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DAG_PATH = REPO_ROOT / "docs" / "roadmap" / "dag.json"
 BEHAVIORS_DIR = REPO_ROOT / "docs" / "behaviors"
+FEATURES_DIR = REPO_ROOT / "tests" / "bdd" / "features"
 
 NODE_REQUIRED = (
     "id",
@@ -167,6 +172,49 @@ def check_evidence_interfaces(
                     f"do not match behavior frontmatter {sorted(declared)} "
                     f"({'; '.join(parts)})"
                 )
+
+
+def check_feature_files(
+    dag: dict,
+    accepted: set[str],
+    errors: list[str],
+) -> None:
+    """Each `B-XXXX-*.feature` file under tests/bdd/features must point at
+    an accepted behavior that some R-* node lists in its
+    `expected_evidence`. F-0002 BDD convention says one feature per
+    behavior; this check is the inverse of `xtask check-bdd-tags` and
+    catches the case where a feature exists but no DAG node owns it.
+    """
+    if not FEATURES_DIR.exists():
+        return
+    name_re = re.compile(r"^B-(\d{4})-")
+    evidence_owners: dict[str, str] = {}
+    for n in dag.get("nodes", []):
+        nid = n.get("id", "<?>")
+        for ev in n.get("expected_evidence", []) or []:
+            bid = ev.get("behavior_id")
+            if bid:
+                evidence_owners[bid] = nid
+    for f in sorted(FEATURES_DIR.glob("B-*.feature")):
+        m = name_re.match(f.name)
+        if not m:
+            errors.append(
+                f"{f.relative_to(REPO_ROOT)}: filename does not match "
+                "B-XXXX-<slug>.feature"
+            )
+            continue
+        bid = f"B-{m.group(1)}"
+        if bid not in accepted:
+            errors.append(
+                f"{f.relative_to(REPO_ROOT)}: behavior {bid} is not "
+                "accepted in docs/behaviors"
+            )
+            continue
+        if bid not in evidence_owners:
+            errors.append(
+                f"{f.relative_to(REPO_ROOT)}: behavior {bid} has a feature "
+                "file but no DAG node lists it in expected_evidence"
+            )
 
 
 def find_thin_playbooks(
@@ -515,6 +563,7 @@ def main() -> int:
     milestone_ids, node_ids = check_schema(dag, errors)
     check_references(dag, accepted, deprecated, node_ids, errors)
     check_evidence_interfaces(dag, behavior_interfaces, errors)
+    check_feature_files(dag, accepted, errors)
 
     nodes_by_id = {n["id"]: n for n in dag.get("nodes", []) if "id" in n}
     topo = topo_sort(nodes_by_id, errors) if not errors else None

--- a/scripts/roadmap_check.py
+++ b/scripts/roadmap_check.py
@@ -195,7 +195,11 @@ def check_feature_files(
             bid = ev.get("behavior_id")
             if bid:
                 evidence_owners[bid] = nid
-    for f in sorted(FEATURES_DIR.glob("B-*.feature")):
+    # Recursive walk so nested feature directories (R-* slices may
+    # group features by milestone or area) match the
+    # `tests/bdd/features/**/*.feature` walk that
+    # `xtask check-bdd-tags` performs. Plain glob() is non-recursive.
+    for f in sorted(FEATURES_DIR.rglob("B-*.feature")):
         m = name_re.match(f.name)
         if not m:
             errors.append(

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -1,14 +1,42 @@
 # Tanren Behavior Features
 
-Active behavior proof lives under `tests/bdd/features`.
+Active behavior proof lives under `tests/bdd/features/`. The canonical
+convention is documented in
+[`docs/architecture/subsystems/behavior-proof.md`](../../docs/architecture/subsystems/behavior-proof.md)
+under "BDD Tagging And File Convention". Read that section before adding
+or editing a `.feature` file — it is the contract every R-* slice must
+match.
 
-Every active scenario must reference exactly one asserted `B-XXXX` behavior ID
-from `docs/behaviors` and exactly one witness tag: `@positive` or
-`@falsification`.
+## Quick reference
 
-Phase names, wave names, proof IDs such as `BEH-P0-*`, and skipped or pending
-scenario tags are not allowed in the active behavior suite.
+- One file per behavior:
+  `tests/bdd/features/B-XXXX-<slug>.feature`.
+- Feature-level tag: exactly `@B-XXXX` matching the filename.
+- Each scenario carries exactly one of `@positive` / `@falsification`
+  and 1–2 interface tags from `@web | @api | @mcp | @cli | @tui`.
+- Two-interface scenarios require `# rationale: <one line>` immediately
+  above the scenario's tags.
+- `Scenario Outline` and `Examples:` are forbidden. `Background:` and
+  `Rule:` are allowed.
+- Closed tag allowlist — `@skip`, `@wip`, `@ignore`, and phase/wave
+  tags are rejected.
+- Coverage is strict-equality: every interface in the behavior's
+  frontmatter `interfaces:` must have a `@positive` scenario, and a
+  `@falsification` scenario when the R-* node lists falsification
+  witnesses.
 
-`just tests` runs inventory validation, the BDD suite, and behavior coverage.
-Mutation is intentionally separated into `just mutation` and scheduled CI
-because full product mutation is too expensive for every PR gate.
+## Validators
+
+```bash
+# Tag and coverage validator (file → behavior → DAG):
+just check-bdd-tags
+
+# Inverse check (orphan feature files / DAG drift):
+python3 scripts/roadmap_check.py
+```
+
+`just check` runs both as part of the standard PR gate. `just tests`
+runs the cucumber-rs harness and the BDD runner binary; with zero
+feature files shipped under F-0001/F-0002 it exits 0 with no scenarios.
+Mutation testing is intentionally separated into `just mutation` and
+nightly CI.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,4 +18,5 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+serde_json = { workspace = true }
 walkdir = "2"

--- a/xtask/src/bdd_tags/data.rs
+++ b/xtask/src/bdd_tags/data.rs
@@ -1,0 +1,166 @@
+//! Loaders for the behavior catalog (`docs/behaviors/B-*.md`) and the
+//! roadmap DAG (`docs/roadmap/dag.json`). Both are surfaced as plain
+//! `HashMap` keyed on behavior ID; `xtask check-bdd-tags` cross-references
+//! these against parsed `.feature` files.
+
+use anyhow::{Context, Result};
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub(super) struct BehaviorRecord {
+    pub interfaces: BTreeSet<String>,
+    pub product_status: String,
+}
+
+pub(super) fn load_behaviors(dir: &Path) -> Result<HashMap<String, BehaviorRecord>> {
+    let mut map = HashMap::new();
+    if !dir.exists() {
+        return Ok(map);
+    }
+    for entry in fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if !is_behavior_file(&path) {
+            continue;
+        }
+        let content =
+            fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let Some(id) = scan_field(&content, "id") else {
+            continue;
+        };
+        let product_status = scan_field(&content, "product_status").unwrap_or_default();
+        let interfaces = scan_list(&content, "interfaces")
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        map.insert(
+            id,
+            BehaviorRecord {
+                interfaces,
+                product_status,
+            },
+        );
+    }
+    Ok(map)
+}
+
+fn is_behavior_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !name.starts_with("B-") {
+        return false;
+    }
+    Path::new(name)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+}
+
+fn scan_field(text: &str, field: &str) -> Option<String> {
+    let prefix = format!("{field}:");
+    let mut in_frontmatter = false;
+    for line in text.lines() {
+        let raw = line.trim_end();
+        let trimmed = raw.trim_start();
+        if raw == "---" {
+            if in_frontmatter {
+                break;
+            }
+            in_frontmatter = true;
+            continue;
+        }
+        if !in_frontmatter {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix(&prefix) {
+            return Some(rest.trim().trim_matches('"').to_owned());
+        }
+    }
+    None
+}
+
+fn scan_list(text: &str, field: &str) -> Vec<String> {
+    let prefix = format!("{field}:");
+    let mut in_frontmatter = false;
+    for line in text.lines() {
+        let raw = line.trim_end();
+        let trimmed = raw.trim_start();
+        if raw == "---" {
+            if in_frontmatter {
+                break;
+            }
+            in_frontmatter = true;
+            continue;
+        }
+        if !in_frontmatter {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix(&prefix) {
+            let rest = rest.trim();
+            if let Some(inner) = rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                return inner
+                    .split(',')
+                    .map(|p| p.trim().trim_matches('"').to_owned())
+                    .filter(|p| !p.is_empty())
+                    .collect();
+            }
+        }
+    }
+    Vec::new()
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct EvidenceRecord {
+    pub interfaces: BTreeSet<String>,
+    pub witnesses: BTreeSet<String>,
+    pub node_id: String,
+}
+
+pub(super) fn load_dag_evidence(path: &Path) -> Result<HashMap<String, EvidenceRecord>> {
+    let mut map = HashMap::new();
+    if !path.exists() {
+        return Ok(map);
+    }
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&content).with_context(|| format!("parse {}", path.display()))?;
+    let Some(nodes) = value.get("nodes").and_then(|n| n.as_array()) else {
+        return Ok(map);
+    };
+    for node in nodes {
+        let Some(node_id) = node.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(evidence) = node.get("expected_evidence").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for ev in evidence {
+            let Some(behavior_id) = ev.get("behavior_id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let interfaces = collect_str_array(ev.get("interfaces"));
+            let witnesses = collect_str_array(ev.get("witnesses"));
+            map.insert(
+                behavior_id.to_owned(),
+                EvidenceRecord {
+                    interfaces,
+                    witnesses,
+                    node_id: node_id.to_owned(),
+                },
+            );
+        }
+    }
+    Ok(map)
+}
+
+fn collect_str_array(value: Option<&serde_json::Value>) -> BTreeSet<String> {
+    value
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/xtask/src/bdd_tags/mod.rs
+++ b/xtask/src/bdd_tags/mod.rs
@@ -292,9 +292,18 @@ fn check_scenario(
             interface_tags.len()
         ));
     }
-    if interface_tags.len() == 2 && scenario.rationale.is_none() {
+    // Reject both missing rationale and empty `# rationale:` (the parser
+    // captures `# rationale:` with no body as `Some("")` — without this
+    // empty-string guard a bare `# rationale:` would silently satisfy
+    // the convention that calls for a one-line justification).
+    if interface_tags.len() == 2
+        && scenario
+            .rationale
+            .as_deref()
+            .is_none_or(|s| s.trim().is_empty())
+    {
         violations.push(format!(
-            "{}:{line}: 2-interface scenario requires a preceding `# rationale: <one line>` comment",
+            "{}:{line}: 2-interface scenario requires a non-empty preceding `# rationale: <one line>` comment",
             rel.display()
         ));
     }

--- a/xtask/src/bdd_tags/mod.rs
+++ b/xtask/src/bdd_tags/mod.rs
@@ -54,12 +54,19 @@ pub(crate) fn run(workspace_root: &Path) -> Result<()> {
     let dag_evidence = load_dag_evidence(&dag_path)?;
 
     let mut violations: Vec<String> = Vec::new();
+    // Track which behavior IDs already have a feature file so the
+    // convention's "one .feature per behavior" rule fails fast across
+    // files (each file otherwise validates in isolation, so two files
+    // like `B-0123-a.feature` and `B-0123-b.feature` would each pass
+    // their own checks and silently violate the global invariant).
+    let mut behavior_owners: HashMap<String, PathBuf> = HashMap::new();
     for path in &feature_files {
         validate_feature_file(
             path,
             workspace_root,
             &behaviors,
             &dag_evidence,
+            &mut behavior_owners,
             &mut violations,
         );
     }
@@ -115,6 +122,7 @@ fn validate_feature_file(
     workspace_root: &Path,
     behaviors: &HashMap<String, BehaviorRecord>,
     dag_evidence: &HashMap<String, EvidenceRecord>,
+    behavior_owners: &mut HashMap<String, PathBuf>,
     violations: &mut Vec<String>,
 ) {
     let rel = path.strip_prefix(workspace_root).unwrap_or(path);
@@ -130,6 +138,17 @@ fn validate_feature_file(
         ));
         return;
     };
+
+    if let Some(prior) = behavior_owners.get(&expected_id) {
+        let prior_rel = prior.strip_prefix(workspace_root).unwrap_or(prior);
+        violations.push(format!(
+            "{}: behavior {expected_id} is already proven by {} — F-0002 BDD convention requires exactly one .feature per behavior",
+            rel.display(),
+            prior_rel.display()
+        ));
+    } else {
+        behavior_owners.insert(expected_id.clone(), path.to_path_buf());
+    }
 
     let content = match fs::read_to_string(path).with_context(|| format!("read {}", path.display()))
     {

--- a/xtask/src/bdd_tags/mod.rs
+++ b/xtask/src/bdd_tags/mod.rs
@@ -179,6 +179,12 @@ fn check_forbidden_keywords(rel: &Path, parsed: &ParsedFeature, violations: &mut
             rel.display()
         ));
     }
+    for line in &parsed.stray_tag_lines {
+        violations.push(format!(
+            "{}:{line}: tag block precedes `Background:` / `Rule:`; tags belong at the feature header or immediately above a `Scenario:`",
+            rel.display()
+        ));
+    }
 }
 
 fn check_feature_tags(

--- a/xtask/src/bdd_tags/mod.rs
+++ b/xtask/src/bdd_tags/mod.rs
@@ -1,0 +1,391 @@
+//! BDD tag and coverage validator (`xtask check-bdd-tags`).
+//!
+//! Enforces F-0002's locked BDD convention. The contract is documented in
+//! `docs/architecture/subsystems/behavior-proof.md` (BDD Tagging And File
+//! Convention) and reflected in `tests/bdd/README.md`. Summary:
+//!
+//! - One `.feature` per behavior, named `B-XXXX-<slug>.feature`.
+//! - Feature-level `@B-XXXX` tag matches the filename. No other tags at
+//!   feature level.
+//! - Each `Scenario` carries exactly one of `@positive` / `@falsification`
+//!   and 1–2 interface tags drawn from `@web @api @mcp @cli @tui`.
+//! - Two-interface scenarios require a preceding `# rationale: …` comment.
+//! - `Scenario Outline` and `Examples` are forbidden.
+//! - The behavior file under `docs/behaviors/` must exist and be
+//!   `product_status: accepted`.
+//! - Strict-equality coverage: the union of interface tags across the
+//!   feature's scenarios equals the behavior's frontmatter `interfaces:`.
+//!   For each interface, ≥1 `@positive` scenario is required; when the
+//!   DAG node's `expected_evidence.witnesses` includes `falsification`,
+//!   ≥1 `@falsification` scenario per interface is also required.
+
+mod data;
+mod parser;
+
+use anyhow::{Context, Result, bail};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use data::{BehaviorRecord, EvidenceRecord, load_behaviors, load_dag_evidence};
+use parser::{ParsedFeature, ParsedScenario, parse_feature, parse_filename};
+
+const INTERFACE_TAGS: &[&str] = &["@web", "@api", "@mcp", "@cli", "@tui"];
+const WITNESS_TAGS: &[&str] = &["@positive", "@falsification"];
+
+pub(crate) fn run(workspace_root: &Path) -> Result<()> {
+    let features_dir = workspace_root.join("tests").join("bdd").join("features");
+    let behaviors_dir = workspace_root.join("docs").join("behaviors");
+    let dag_path = workspace_root.join("docs").join("roadmap").join("dag.json");
+
+    let feature_files = collect_feature_files(&features_dir);
+    if feature_files.is_empty() {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let _ = writeln!(
+            handle,
+            "check-bdd-tags: 0 feature files under tests/bdd/features (BDD convention upheld vacuously)"
+        );
+        return Ok(());
+    }
+
+    let behaviors = load_behaviors(&behaviors_dir)?;
+    let dag_evidence = load_dag_evidence(&dag_path)?;
+
+    let mut violations: Vec<String> = Vec::new();
+    for path in &feature_files {
+        validate_feature_file(
+            path,
+            workspace_root,
+            &behaviors,
+            &dag_evidence,
+            &mut violations,
+        );
+    }
+
+    if violations.is_empty() {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let _ = writeln!(
+            handle,
+            "check-bdd-tags: {} feature file(s) validated; convention upheld",
+            feature_files.len()
+        );
+        return Ok(());
+    }
+
+    let stderr = std::io::stderr();
+    let mut handle = stderr.lock();
+    for v in &violations {
+        let _ = writeln!(handle, "{v}");
+    }
+    bail!(
+        "check-bdd-tags: {} violation(s); see docs/architecture/subsystems/behavior-proof.md (BDD Tagging And File Convention)",
+        violations.len()
+    );
+}
+
+fn collect_feature_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return out;
+    }
+    for entry in walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        let path = entry.path();
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("feature"))
+        {
+            out.push(path.to_path_buf());
+        }
+    }
+    out.sort();
+    out
+}
+
+fn validate_feature_file(
+    path: &Path,
+    workspace_root: &Path,
+    behaviors: &HashMap<String, BehaviorRecord>,
+    dag_evidence: &HashMap<String, EvidenceRecord>,
+    violations: &mut Vec<String>,
+) {
+    let rel = path.strip_prefix(workspace_root).unwrap_or(path);
+
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        violations.push(format!("{}: invalid filename", rel.display()));
+        return;
+    };
+    let Some((expected_id, _slug)) = parse_filename(file_name) else {
+        violations.push(format!(
+            "{}: filename must match `B-XXXX-<slug>.feature`",
+            rel.display()
+        ));
+        return;
+    };
+
+    let content = match fs::read_to_string(path).with_context(|| format!("read {}", path.display()))
+    {
+        Ok(c) => c,
+        Err(err) => {
+            violations.push(format!("{}: read failed ({err:#})", rel.display()));
+            return;
+        }
+    };
+    let parsed = parse_feature(&content);
+
+    check_forbidden_keywords(rel, &parsed, violations);
+    check_feature_tags(rel, &parsed, &expected_id, violations);
+    let behavior = check_behavior_catalog(rel, &expected_id, behaviors, violations);
+
+    let coverage = check_scenarios(rel, &parsed, violations);
+
+    if let Some(b) = behavior {
+        check_coverage_against_behavior(rel, &expected_id, b, &coverage, violations);
+        check_coverage_against_dag(
+            rel,
+            &expected_id,
+            &b.interfaces,
+            &coverage,
+            dag_evidence,
+            violations,
+        );
+    }
+}
+
+#[derive(Default)]
+struct ScenarioCoverage {
+    positive_by_iface: BTreeMap<String, usize>,
+    falsification_by_iface: BTreeMap<String, usize>,
+}
+
+fn check_forbidden_keywords(rel: &Path, parsed: &ParsedFeature, violations: &mut Vec<String>) {
+    for line in &parsed.scenario_outline_lines {
+        violations.push(format!(
+            "{}:{line}: `Scenario Outline` is forbidden by F-0002 BDD convention",
+            rel.display()
+        ));
+    }
+    for line in &parsed.examples_lines {
+        violations.push(format!(
+            "{}:{line}: `Examples:` blocks are forbidden by F-0002 BDD convention",
+            rel.display()
+        ));
+    }
+}
+
+fn check_feature_tags(
+    rel: &Path,
+    parsed: &ParsedFeature,
+    expected_id: &str,
+    violations: &mut Vec<String>,
+) {
+    let line = parsed.feature_tag_line.unwrap_or(0);
+    if parsed.feature_tags.len() != 1 || parsed.feature_tags[0] != format!("@{expected_id}") {
+        violations.push(format!(
+            "{}:{line}: feature-level tags must be exactly [@{expected_id}], got {:?}",
+            rel.display(),
+            parsed.feature_tags
+        ));
+    }
+}
+
+fn check_behavior_catalog<'a>(
+    rel: &Path,
+    expected_id: &str,
+    behaviors: &'a HashMap<String, BehaviorRecord>,
+    violations: &mut Vec<String>,
+) -> Option<&'a BehaviorRecord> {
+    match behaviors.get(expected_id) {
+        Some(b) if b.product_status == "accepted" => Some(b),
+        Some(b) => {
+            violations.push(format!(
+                "{}: behavior {expected_id} has product_status={:?}; only `accepted` behaviors may have feature files",
+                rel.display(),
+                b.product_status
+            ));
+            Some(b)
+        }
+        None => {
+            violations.push(format!(
+                "{}: behavior {expected_id} has no docs/behaviors/{expected_id}-*.md catalog entry",
+                rel.display()
+            ));
+            None
+        }
+    }
+}
+
+fn check_scenarios(
+    rel: &Path,
+    parsed: &ParsedFeature,
+    violations: &mut Vec<String>,
+) -> ScenarioCoverage {
+    let mut coverage = ScenarioCoverage::default();
+    let allowed = allowed_tag_set();
+    for scenario in &parsed.scenarios {
+        check_scenario(rel, scenario, &allowed, &mut coverage, violations);
+    }
+    coverage
+}
+
+fn check_scenario(
+    rel: &Path,
+    scenario: &ParsedScenario,
+    allowed: &HashSet<&'static str>,
+    coverage: &mut ScenarioCoverage,
+    violations: &mut Vec<String>,
+) {
+    let line = scenario.keyword_line;
+    let mut witness_count = 0;
+    let mut interface_tags: Vec<String> = Vec::new();
+    let mut is_positive = false;
+    let mut is_falsification = false;
+    for tag in &scenario.tags {
+        if !allowed.contains(tag.as_str()) {
+            violations.push(format!(
+                "{}:{line}: scenario tag {tag} is not in the closed allowlist (\
+                @positive, @falsification, @web, @api, @mcp, @cli, @tui)",
+                rel.display()
+            ));
+            continue;
+        }
+        if tag == "@positive" {
+            witness_count += 1;
+            is_positive = true;
+        } else if tag == "@falsification" {
+            witness_count += 1;
+            is_falsification = true;
+        } else if INTERFACE_TAGS.contains(&tag.as_str()) {
+            interface_tags.push(tag.clone());
+        }
+    }
+    if witness_count != 1 {
+        violations.push(format!(
+            "{}:{line}: scenario must carry exactly one of @positive/@falsification (got {witness_count})",
+            rel.display()
+        ));
+    }
+    if interface_tags.is_empty() {
+        violations.push(format!(
+            "{}:{line}: scenario must carry at least one interface tag (@web/@api/@mcp/@cli/@tui)",
+            rel.display()
+        ));
+    }
+    if interface_tags.len() > 2 {
+        violations.push(format!(
+            "{}:{line}: scenario carries {} interface tags; max 2 allowed",
+            rel.display(),
+            interface_tags.len()
+        ));
+    }
+    if interface_tags.len() == 2 && scenario.rationale.is_none() {
+        violations.push(format!(
+            "{}:{line}: 2-interface scenario requires a preceding `# rationale: <one line>` comment",
+            rel.display()
+        ));
+    }
+
+    if witness_count == 1 {
+        for tag in &interface_tags {
+            let iface = tag.trim_start_matches('@').to_owned();
+            if is_positive {
+                *coverage.positive_by_iface.entry(iface.clone()).or_insert(0) += 1;
+            }
+            if is_falsification {
+                *coverage.falsification_by_iface.entry(iface).or_insert(0) += 1;
+            }
+        }
+    }
+}
+
+fn check_coverage_against_behavior(
+    rel: &Path,
+    expected_id: &str,
+    b: &BehaviorRecord,
+    coverage: &ScenarioCoverage,
+    violations: &mut Vec<String>,
+) {
+    let declared = &b.interfaces;
+    let scenario_iface_union: BTreeSet<String> = coverage
+        .positive_by_iface
+        .keys()
+        .chain(coverage.falsification_by_iface.keys())
+        .cloned()
+        .collect();
+    for iface in scenario_iface_union.difference(declared) {
+        violations.push(format!(
+            "{}: interface tag @{iface} is not in behavior {expected_id} frontmatter `interfaces:` {:?}",
+            rel.display(),
+            declared
+        ));
+    }
+    for iface in declared {
+        if coverage.positive_by_iface.get(iface).copied().unwrap_or(0) == 0 {
+            violations.push(format!(
+                "{}: behavior {expected_id} declares interface @{iface} but no @positive scenario covers it",
+                rel.display()
+            ));
+        }
+    }
+}
+
+fn check_coverage_against_dag(
+    rel: &Path,
+    expected_id: &str,
+    declared: &BTreeSet<String>,
+    coverage: &ScenarioCoverage,
+    dag_evidence: &HashMap<String, EvidenceRecord>,
+    violations: &mut Vec<String>,
+) {
+    let Some(ev) = dag_evidence.get(expected_id) else {
+        violations.push(format!(
+            "{}: behavior {expected_id} has a feature file but no DAG node declares evidence for it",
+            rel.display()
+        ));
+        return;
+    };
+    if ev.witnesses.contains("falsification") {
+        for iface in declared {
+            if coverage
+                .falsification_by_iface
+                .get(iface)
+                .copied()
+                .unwrap_or(0)
+                == 0
+            {
+                violations.push(format!(
+                    "{}: DAG node {} for behavior {expected_id} lists falsification witnesses; interface @{iface} has no @falsification scenario",
+                    rel.display(),
+                    ev.node_id
+                ));
+            }
+        }
+    }
+    if &ev.interfaces != declared {
+        violations.push(format!(
+            "{}: DAG evidence interfaces {:?} disagree with behavior frontmatter {:?}",
+            rel.display(),
+            ev.interfaces,
+            declared
+        ));
+    }
+}
+
+fn allowed_tag_set() -> HashSet<&'static str> {
+    let mut set: HashSet<&'static str> = HashSet::new();
+    for w in WITNESS_TAGS {
+        set.insert(w);
+    }
+    for i in INTERFACE_TAGS {
+        set.insert(i);
+    }
+    set
+}

--- a/xtask/src/bdd_tags/parser.rs
+++ b/xtask/src/bdd_tags/parser.rs
@@ -47,12 +47,23 @@ pub(super) fn parse_feature(content: &str) -> ParsedFeature {
         let trimmed = raw_line.trim_start();
 
         if trimmed.is_empty() {
+            // A blank line breaks rationale-to-tag-block adjacency.
+            // The convention requires `# rationale:` to sit immediately
+            // above the tag block; without this clear, a stray
+            // rationale comment could attach to a later non-adjacent
+            // scenario.
+            pending_rationale = None;
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix('#') {
             let rest = rest.trim();
             if let Some(value) = rest.strip_prefix("rationale:") {
                 pending_rationale = Some(value.trim().to_owned());
+            } else {
+                // Non-rationale comments also break adjacency. Only
+                // contiguous `# rationale:` + tag lines may carry a
+                // rationale forward to the next `Scenario:`.
+                pending_rationale = None;
             }
             continue;
         }
@@ -109,8 +120,14 @@ pub(super) fn parse_feature(content: &str) -> ParsedFeature {
             pending_tags.clear();
             pending_tag_line = None;
             pending_rationale = None;
+            continue;
         }
-        // Steps, doc strings, and tables are passthrough — nothing to do.
+        // Steps, doc strings, tables, and any other unrecognised line
+        // also break rationale adjacency. Pending tags are left alone
+        // here because Gherkin allows stray content only inside step
+        // blocks (which we never reach with active pending_tags), but
+        // a rationale must not float over arbitrary content.
+        pending_rationale = None;
     }
 
     ParsedFeature {

--- a/xtask/src/bdd_tags/parser.rs
+++ b/xtask/src/bdd_tags/parser.rs
@@ -12,6 +12,12 @@ pub(super) struct ParsedFeature {
     pub scenarios: Vec<ParsedScenario>,
     pub scenario_outline_lines: Vec<usize>,
     pub examples_lines: Vec<usize>,
+    /// Lines where tags were observed immediately before a structural
+    /// keyword that does not consume tags (`Background:`, `Rule:`).
+    /// The convention forbids tag-block placement other than feature-
+    /// or scenario-level, so these are reported as violations rather
+    /// than silently floated forward to the next `Scenario:`.
+    pub stray_tag_lines: Vec<usize>,
 }
 
 #[derive(Debug)]
@@ -30,6 +36,7 @@ pub(super) fn parse_feature(content: &str) -> ParsedFeature {
     let mut scenarios: Vec<ParsedScenario> = Vec::new();
     let mut scenario_outline_lines: Vec<usize> = Vec::new();
     let mut examples_lines: Vec<usize> = Vec::new();
+    let mut stray_tag_lines: Vec<usize> = Vec::new();
 
     let mut pending_tags: Vec<String> = Vec::new();
     let mut pending_tag_line: Option<usize> = None;
@@ -87,8 +94,20 @@ pub(super) fn parse_feature(content: &str) -> ParsedFeature {
             continue;
         }
         if trimmed.starts_with("Background:") || trimmed.starts_with("Rule:") {
-            // Tag/rationale must not float past structural keywords other
-            // than `Scenario:`.
+            // Tag/rationale must not float past structural keywords
+            // other than `Scenario:`. Capture the tag-block start line
+            // as a stray-tag violation (a misplaced `@positive @web`
+            // before a `Rule:` header would otherwise silently attach
+            // to the next `Scenario:` and produce confusing pass /
+            // fail reports). Also drop any pending rationale so it
+            // can't bind to a later scenario it didn't precede.
+            if !pending_tags.is_empty()
+                && let Some(line) = pending_tag_line
+            {
+                stray_tag_lines.push(line);
+            }
+            pending_tags.clear();
+            pending_tag_line = None;
             pending_rationale = None;
         }
         // Steps, doc strings, and tables are passthrough — nothing to do.
@@ -100,6 +119,7 @@ pub(super) fn parse_feature(content: &str) -> ParsedFeature {
         scenarios,
         scenario_outline_lines,
         examples_lines,
+        stray_tag_lines,
     }
 }
 

--- a/xtask/src/bdd_tags/parser.rs
+++ b/xtask/src/bdd_tags/parser.rs
@@ -1,0 +1,121 @@
+//! Hand-rolled Gherkin tag scanner for `xtask check-bdd-tags`.
+//!
+//! The cucumber crate validates structure at test-run time; this scanner
+//! only walks `.feature` files for tags, scenario keywords, and filename
+//! shape so the validator can run in seconds without pulling a parser
+//! crate.
+
+#[derive(Debug)]
+pub(super) struct ParsedFeature {
+    pub feature_tags: Vec<String>,
+    pub feature_tag_line: Option<usize>,
+    pub scenarios: Vec<ParsedScenario>,
+    pub scenario_outline_lines: Vec<usize>,
+    pub examples_lines: Vec<usize>,
+}
+
+#[derive(Debug)]
+pub(super) struct ParsedScenario {
+    pub keyword_line: usize,
+    pub tags: Vec<String>,
+    pub rationale: Option<String>,
+}
+
+/// Parse a `.feature` file by line. Tag groups float forward to attach to
+/// the next `Feature:` or `Scenario:` keyword. `# rationale: …` comments
+/// are captured as the next scenario's rationale.
+pub(super) fn parse_feature(content: &str) -> ParsedFeature {
+    let mut feature_tags: Vec<String> = Vec::new();
+    let mut feature_tag_line: Option<usize> = None;
+    let mut scenarios: Vec<ParsedScenario> = Vec::new();
+    let mut scenario_outline_lines: Vec<usize> = Vec::new();
+    let mut examples_lines: Vec<usize> = Vec::new();
+
+    let mut pending_tags: Vec<String> = Vec::new();
+    let mut pending_tag_line: Option<usize> = None;
+    let mut pending_rationale: Option<String> = None;
+
+    for (idx, raw_line) in content.lines().enumerate() {
+        let lineno = idx + 1;
+        let trimmed = raw_line.trim_start();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            let rest = rest.trim();
+            if let Some(value) = rest.strip_prefix("rationale:") {
+                pending_rationale = Some(value.trim().to_owned());
+            }
+            continue;
+        }
+        if trimmed.starts_with('@') {
+            for token in trimmed.split_whitespace() {
+                if token.starts_with('@') {
+                    pending_tags.push(token.to_owned());
+                }
+            }
+            if pending_tag_line.is_none() {
+                pending_tag_line = Some(lineno);
+            }
+            continue;
+        }
+        if trimmed.starts_with("Feature:") {
+            feature_tags = std::mem::take(&mut pending_tags);
+            feature_tag_line = pending_tag_line.take();
+            pending_rationale = None;
+            continue;
+        }
+        if trimmed.starts_with("Scenario Outline:") {
+            scenario_outline_lines.push(lineno);
+            pending_tags.clear();
+            pending_tag_line = None;
+            pending_rationale = None;
+            continue;
+        }
+        if trimmed.starts_with("Examples:") {
+            examples_lines.push(lineno);
+            continue;
+        }
+        if trimmed.starts_with("Scenario:") {
+            scenarios.push(ParsedScenario {
+                keyword_line: lineno,
+                tags: std::mem::take(&mut pending_tags),
+                rationale: pending_rationale.take(),
+            });
+            pending_tag_line = None;
+            continue;
+        }
+        if trimmed.starts_with("Background:") || trimmed.starts_with("Rule:") {
+            // Tag/rationale must not float past structural keywords other
+            // than `Scenario:`.
+            pending_rationale = None;
+        }
+        // Steps, doc strings, and tables are passthrough — nothing to do.
+    }
+
+    ParsedFeature {
+        feature_tags,
+        feature_tag_line,
+        scenarios,
+        scenario_outline_lines,
+        examples_lines,
+    }
+}
+
+/// Parse `B-XXXX-<slug>.feature` filenames. Returns the behavior ID and the
+/// slug if the shape matches; `None` otherwise.
+pub(super) fn parse_filename(name: &str) -> Option<(String, String)> {
+    let stem = name.strip_suffix(".feature")?;
+    let mut parts = stem.splitn(3, '-');
+    let prefix = parts.next()?;
+    let digits = parts.next()?;
+    let slug = parts.next()?;
+    if prefix != "B" || digits.len() != 4 || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    if slug.is_empty() {
+        return None;
+    }
+    Some((format!("B-{digits}"), slug.to_owned()))
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,7 @@
 //! Repo maintenance commands for Tanren.
 
+mod bdd_tags;
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use std::fs;
@@ -22,18 +24,29 @@ struct Cli {
 enum Command {
     /// Reject any `#[test]`, `#[cfg(test)]`, or `mod tests` outside the
     /// `tanren-bdd` crate. Tests live exclusively in BDD scenarios.
-    CheckRustTestSurface,
+    #[command(name = "check-rust-test-surface")]
+    RustTestSurface,
     /// Reject inline `#[allow(...)]` and `#[expect(...)]` anywhere in
     /// workspace Rust source. Lint relaxations belong in a crate's
     /// `[lints.clippy]` section, not at the source-line level.
-    CheckSuppression,
+    #[command(name = "check-suppression")]
+    Suppression,
+    /// Validate `tests/bdd/features/**/*.feature` against the F-0002 BDD
+    /// convention: filename↔feature-tag match, closed tag allowlist,
+    /// strict-equality interface coverage, behavior-catalog cross-check,
+    /// and DAG-evidence coverage. See
+    /// `docs/architecture/subsystems/behavior-proof.md` for the full
+    /// contract.
+    #[command(name = "check-bdd-tags")]
+    BddTags,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::CheckRustTestSurface => check_rust_test_surface(),
-        Command::CheckSuppression => check_suppression(),
+        Command::RustTestSurface => check_rust_test_surface(),
+        Command::Suppression => check_suppression(),
+        Command::BddTags => bdd_tags::run(&workspace_root()?),
     }
 }
 


### PR DESCRIPTION
## Summary

Foundation-correction node that closes four [F-0001](https://github.com/trevorWieland/tanren/pull/118) misalignments with the accepted architecture under [`docs/architecture/`](docs/architecture/) before any `R-*` node lands. Locked plan + decisions in [`docs/roadmap/evidence/F-0002.md`](docs/roadmap/evidence/F-0002.md). Architecture and roadmap stay coherent; every behavior node now transitively depends on F-0002 (which depends on F-0001).

- **MCP transport** — `bin/tanren-mcp` swaps rmcp stdio for an axum-hosted `StreamableHttpService` at `/mcp`, gated by an API-key middleware that emits the shared `auth_required` / `permission_denied` / `unavailable` taxonomy from [`interfaces.md`](docs/architecture/subsystems/interfaces.md). Bootstrap key from `TANREN_MCP_API_KEY`, bind override via `TANREN_MCP_BIND`, public `/health` mirroring `tanren-api`. Workspace flips `rmcp` features from `transport-io` to `transport-streamable-http-server` and adds `tokio-util`.
- **BDD convention enforcement** — new `xtask check-bdd-tags` subcommand (under [`xtask/src/bdd_tags/`](xtask/src/bdd_tags/)) parses `tests/bdd/features/**/*.feature` and enforces filename↔`@B-XXXX`, closed tag allowlist (`@positive | @falsification | @web | @api | @mcp | @cli | @tui`), no `Scenario Outline` / `Examples`, exactly-one witness tag per scenario, 1–2 interface tags, mandatory `# rationale:` for two-interface scenarios, behavior-catalog cross-check, and strict per-interface positive + falsification coverage against the DAG node's `expected_evidence`. Wired into `just check` (and `just ci`). [`scripts/roadmap_check.py`](scripts/roadmap_check.py) gains the inverse check (orphan feature files).
- **BDD convention documented** — [`behavior-proof.md`](docs/architecture/subsystems/behavior-proof.md) gains a "BDD Tagging And File Convention" section. The multi-behavior-feature exception is closed; per-interface falsification is elevated above the original "where meaningful" framing. [`tests/bdd/README.md`](tests/bdd/README.md) becomes a quick-reference pointer; [`CLAUDE.md`](CLAUDE.md) and [`AGENTS.md`](AGENTS.md) pick up one-line pointers.
- **Roadmap** — F-0002 (`kind: foundation`, `depends_on: [F-0001]`, `status: planned`) added to [`docs/roadmap/dag.json`](docs/roadmap/dag.json); `foundation_spec_id` flipped to F-0002; R-0001 and R-0023 repointed from F-0001 → F-0002. Critical path is now 16 nodes. [`docs/roadmap/evidence/F-0002.md`](docs/roadmap/evidence/F-0002.md) drafted.
- **Dependency hygiene** — `just check-deps` gains a positive assertion that `tanren-mcp` depends on `axum` (mechanical guard against accidental reversion to stdio). `cargo machete` clean.

## Manual verification (already run on the branch)

- `just ci` — all stages green including the new `bdd tags` step.
- `python3 scripts/roadmap_check.py` — `OK`.
- `cargo metadata` confirms rmcp resolves with `transport-streamable-http-server` only; `transport-io` is gone from the lockfile.
- Postgres 17 in docker, `tanren-cli migrate up` applied. `tanren-mcp` running:
  - `/health` → 200 + `{"status":"ok",...}`
  - `/mcp` no creds → 401 `auth_required`
  - `/mcp` wrong key → 403 `permission_denied`
  - `/mcp` correct Bearer or X-API-Key → 200 + Streamable HTTP greeting
  - `/mcp` with no key configured → 503 `unavailable` (and a startup WARN log)
  - Full handshake (`initialize` → `notifications/initialized` → `tools/list`) → `{"tools":[]}`.
- BDD validator fixture sweep covers every distinct violation class (forbidden Outline / Examples, extra feature tag, double witness tag, missing interface tag, three interface tags, two interfaces without rationale, disallowed `@http` and `@skip`, unknown behavior, wrong filename, partial per-interface coverage). Vacuous-pass message restored after cleanup.

## Test plan

- [ ] Confirm `just ci` exits 0 in CI.
- [ ] Confirm `python3 scripts/roadmap_check.py` exits 0.
- [ ] Confirm `cargo machete` is clean and `cargo deny check` passes.
- [ ] Spin up postgres + `tanren-cli migrate up`, then `tanren-mcp` with `TANREN_MCP_API_KEY` set and exercise `/health`, `/mcp` (401 / 403 / 200) per the manual steps in the PR thread.
- [ ] Register `tanren-mcp` with Claude Code via `claude mcp add` and confirm the empty tool list is reachable.
- [ ] Drop a partial fixture under `tests/bdd/features/` and confirm `xtask check-bdd-tags` hard-fails with precise messages; remove the fixture and confirm the vacuous-pass message returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)