### PR TITLE
R-0001: Create an account and sign in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules/
 .next/
 .turbo/
 *.tsbuildinfo
+.pnpm-store/
 
 # Local runtime DB
 /tanren.db

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+store-dir=~/.pnpm-store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +659,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -793,7 +817,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -837,10 +861,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1292,7 +1327,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1354,6 +1389,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1795,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2139,7 +2183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2703,8 +2747,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2823,6 +2867,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3125,7 +3170,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3136,7 +3181,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3191,7 +3247,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3310,7 +3366,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -3350,7 +3406,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3374,7 +3430,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3396,7 +3452,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3439,7 +3495,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3633,6 +3689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tanren-app-services",
+ "tanren-contract",
  "tanren-observability",
  "tokio",
  "tower-http",
@@ -3643,10 +3700,14 @@ dependencies = [
 name = "tanren-app-services"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "serde",
+ "serde_json",
+ "sha2 0.11.0",
  "tanren-contract",
  "tanren-store",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -3661,7 +3722,11 @@ dependencies = [
 name = "tanren-bdd"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "cucumber",
+ "tanren-app-services",
+ "tanren-contract",
+ "tanren-store",
  "tanren-testkit",
  "tokio",
 ]
@@ -3681,6 +3746,7 @@ dependencies = [
  "anyhow",
  "clap",
  "tanren-app-services",
+ "tanren-contract",
  "tokio",
 ]
 
@@ -3705,8 +3771,10 @@ dependencies = [
 name = "tanren-contract"
 version = "0.0.0"
 dependencies = [
+ "schemars",
  "serde",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -3730,8 +3798,10 @@ dependencies = [
 name = "tanren-identity-policy"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "serde",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -3744,6 +3814,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tanren-app-services",
+ "tanren-contract",
  "tanren-observability",
  "tokio",
  "tokio-util",
@@ -3850,7 +3921,11 @@ dependencies = [
 name = "tanren-testkit"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "serde",
+ "tanren-app-services",
+ "tanren-store",
+ "uuid",
 ]
 
 [[package]]
@@ -3861,6 +3936,8 @@ dependencies = [
  "crossterm",
  "ratatui",
  "tanren-app-services",
+ "tanren-contract",
+ "tokio",
 ]
 
 [[package]]
@@ -3946,7 +4023,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -4603,7 +4680,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ cucumber = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 
 # IDs
-uuid = { version = "1", features = ["v7", "serde"] }
+uuid = { version = "1", features = ["v4", "v7", "serde"] }
 
 # JWT verification
 jsonwebtoken = { version = "10", default-features = false, features = [

--- a/apps/web/src/app/invitations/[token]/page.tsx
+++ b/apps/web/src/app/invitations/[token]/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { use, useState, type FormEvent, type JSX } from "react";
+
+import {
+  AccountRequestError,
+  acceptInvitation,
+  describeFailure,
+  persistSession,
+  type AcceptInvitationResult,
+} from "../../lib/account-client";
+
+interface InvitationPageProps {
+  params: Promise<{ token: string }>;
+}
+
+const formStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "1rem",
+  width: "100%",
+  maxWidth: "24rem",
+};
+
+const inputStyle = {
+  padding: "0.6rem 0.75rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#13171c",
+  color: "#e6e8eb",
+  fontSize: "1rem",
+};
+
+const buttonStyle = {
+  padding: "0.7rem 1rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#1f6feb",
+  color: "#fff",
+  fontSize: "1rem",
+  cursor: "pointer",
+};
+
+export default function InvitationAcceptPage(
+  props: InvitationPageProps,
+): JSX.Element {
+  const { token } = use(props.params);
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [accepted, setAccepted] = useState<AcceptInvitationResult | null>(null);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const trimmedDisplayName = displayName.trim();
+    if (password === "" || trimmedDisplayName === "") {
+      setErrorMessage("Password and display name are required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await acceptInvitation(token, {
+        password,
+        display_name: trimmedDisplayName,
+      });
+      persistSession(result.account.id, result.session.token);
+      setAccepted(result);
+    } catch (cause: unknown) {
+      if (cause instanceof AccountRequestError) {
+        setErrorMessage(describeFailure(cause.failure));
+      } else if (cause instanceof Error) {
+        setErrorMessage(cause.message);
+      } else {
+        setErrorMessage("Failed to accept invitation.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (accepted !== null) {
+    return (
+      <main
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          padding: "2rem",
+        }}
+      >
+        <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>
+          Invitation accepted
+        </h1>
+        <p role="status" style={{ margin: 0 }}>
+          You have joined organization {accepted.joined_org}.
+        </p>
+        <a
+          href="/"
+          style={{
+            color: "#7aa6ff",
+            textDecoration: "underline",
+          }}
+        >
+          Continue
+        </a>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1.5rem",
+        padding: "2rem",
+      }}
+    >
+      <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>
+        Accept invitation
+      </h1>
+      <p style={{ opacity: 0.7, margin: 0 }}>
+        Create an account to join the organization that invited you.
+      </p>
+      <form onSubmit={onSubmit} style={formStyle} noValidate>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Display name</span>
+          <input
+            type="text"
+            name="display_name"
+            autoComplete="name"
+            value={displayName}
+            onChange={(event) => {
+              setDisplayName(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Password</span>
+          <input
+            type="password"
+            name="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <button type="submit" disabled={submitting} style={buttonStyle}>
+          {submitting ? "Accepting…" : "Accept invitation"}
+        </button>
+        {errorMessage !== null ? (
+          <p role="alert" style={{ color: "#ff6b6b", margin: 0 }}>
+            {errorMessage}
+          </p>
+        ) : null}
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/app/lib/account-client.ts
+++ b/apps/web/src/app/lib/account-client.ts
@@ -1,0 +1,164 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+const SESSION_TOKEN_KEY = "tanren.session_token";
+const ACCOUNT_ID_KEY = "tanren.account_id";
+
+export interface SignUpInput {
+  email: string;
+  password: string;
+  display_name: string;
+}
+
+export interface SignInInput {
+  email: string;
+  password: string;
+}
+
+export interface AcceptInvitationInput {
+  invitation_token: string;
+  password: string;
+  display_name: string;
+}
+
+export interface AccountView {
+  id: string;
+  identifier: string;
+  display_name: string;
+  org: string | null;
+}
+
+export interface SessionView {
+  account_id: string;
+  token: string;
+}
+
+export interface SignUpResult {
+  account: AccountView;
+  session: SessionView;
+}
+
+export interface SignInResult {
+  account: AccountView;
+  session: SessionView;
+}
+
+export interface AcceptInvitationResult {
+  account: AccountView;
+  session: SessionView;
+  joined_org: string;
+}
+
+/**
+ * Stable wire codes from `AccountFailureReason` in `tanren-contract`.
+ * Kept in lock-step with the Rust enum so BDD web steps can match on the
+ * same taxonomy regardless of transport.
+ */
+export type AccountFailureCode =
+  | "duplicate_identifier"
+  | "invalid_credential"
+  | "invitation_not_found"
+  | "invitation_already_consumed"
+  | "invitation_expired"
+  | "validation_failed"
+  | "unavailable"
+  | "internal_error";
+
+export interface AccountFailure {
+  code: AccountFailureCode | string;
+  summary: string;
+}
+
+interface FailureBody {
+  code?: unknown;
+  summary?: unknown;
+}
+
+const FAILURE_MESSAGES: Record<AccountFailureCode, string> = {
+  duplicate_identifier: "An account already exists for that email.",
+  invalid_credential: "Email or password is invalid.",
+  invitation_not_found: "This invitation link is not recognized.",
+  invitation_already_consumed: "This invitation has already been accepted.",
+  invitation_expired: "This invitation has expired.",
+  validation_failed: "Please check the form fields and try again.",
+  unavailable: "Tanren is temporarily unavailable. Please try again shortly.",
+  internal_error: "Something went wrong. Please try again.",
+};
+
+export function describeFailure(failure: AccountFailure): string {
+  const known = FAILURE_MESSAGES[failure.code as AccountFailureCode];
+  if (known !== undefined) {
+    return known;
+  }
+  return failure.summary !== "" ? failure.summary : "Request failed.";
+}
+
+export function persistSession(accountId: string, sessionToken: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(SESSION_TOKEN_KEY, sessionToken);
+  window.localStorage.setItem(ACCOUNT_ID_KEY, accountId);
+}
+
+export class AccountRequestError extends Error {
+  readonly failure: AccountFailure;
+
+  constructor(failure: AccountFailure) {
+    super(describeFailure(failure));
+    this.failure = failure;
+    this.name = "AccountRequestError";
+  }
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetch(`${API_URL}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (cause: unknown) {
+    throw new AccountRequestError({
+      code: "unavailable",
+      summary: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+
+  if (!response.ok) {
+    let parsed: FailureBody = {};
+    try {
+      parsed = (await response.json()) as FailureBody;
+    } catch {
+      parsed = {};
+    }
+    const code =
+      typeof parsed.code === "string" ? parsed.code : "internal_error";
+    const summary =
+      typeof parsed.summary === "string"
+        ? parsed.summary
+        : `HTTP ${response.status}`;
+    throw new AccountRequestError({ code, summary });
+  }
+
+  return (await response.json()) as T;
+}
+
+export function signUp(input: SignUpInput): Promise<SignUpResult> {
+  return postJson<SignUpResult>("/accounts", input);
+}
+
+export function signIn(input: SignInInput): Promise<SignInResult> {
+  return postJson<SignInResult>("/sessions", input);
+}
+
+export function acceptInvitation(
+  token: string,
+  input: Omit<AcceptInvitationInput, "invitation_token">,
+): Promise<AcceptInvitationResult> {
+  const path = `/invitations/${encodeURIComponent(token)}/accept`;
+  return postJson<AcceptInvitationResult>(path, {
+    password: input.password,
+    display_name: input.display_name,
+  });
+}

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent, type JSX } from "react";
+
+import {
+  AccountRequestError,
+  describeFailure,
+  persistSession,
+  signIn,
+} from "../lib/account-client";
+
+const formStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "1rem",
+  width: "100%",
+  maxWidth: "24rem",
+};
+
+const inputStyle = {
+  padding: "0.6rem 0.75rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#13171c",
+  color: "#e6e8eb",
+  fontSize: "1rem",
+};
+
+const buttonStyle = {
+  padding: "0.7rem 1rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#1f6feb",
+  color: "#fff",
+  fontSize: "1rem",
+  cursor: "pointer",
+};
+
+export default function SignInPage(): JSX.Element {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const trimmedEmail = email.trim().toLowerCase();
+    if (trimmedEmail === "" || password === "") {
+      setErrorMessage("Email and password are required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await signIn({ email: trimmedEmail, password });
+      persistSession(result.account.id, result.session.token);
+      router.push("/");
+    } catch (cause: unknown) {
+      if (cause instanceof AccountRequestError) {
+        setErrorMessage(describeFailure(cause.failure));
+      } else if (cause instanceof Error) {
+        setErrorMessage(cause.message);
+      } else {
+        setErrorMessage("Sign-in failed.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1.5rem",
+        padding: "2rem",
+      }}
+    >
+      <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>
+        Sign in to Tanren
+      </h1>
+      <form onSubmit={onSubmit} style={formStyle} noValidate>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Email</span>
+          <input
+            type="email"
+            name="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Password</span>
+          <input
+            type="password"
+            name="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <button type="submit" disabled={submitting} style={buttonStyle}>
+          {submitting ? "Signing in…" : "Sign in"}
+        </button>
+        {errorMessage !== null ? (
+          <p role="alert" style={{ color: "#ff6b6b", margin: 0 }}>
+            {errorMessage}
+          </p>
+        ) : null}
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/app/sign-up/page.tsx
+++ b/apps/web/src/app/sign-up/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent, type JSX } from "react";
+
+import {
+  AccountRequestError,
+  describeFailure,
+  persistSession,
+  signUp,
+} from "../lib/account-client";
+
+const formStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "1rem",
+  width: "100%",
+  maxWidth: "24rem",
+};
+
+const inputStyle = {
+  padding: "0.6rem 0.75rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#13171c",
+  color: "#e6e8eb",
+  fontSize: "1rem",
+};
+
+const buttonStyle = {
+  padding: "0.7rem 1rem",
+  borderRadius: "0.4rem",
+  border: "1px solid #2a2f36",
+  background: "#1f6feb",
+  color: "#fff",
+  fontSize: "1rem",
+  cursor: "pointer",
+};
+
+export default function SignUpPage(): JSX.Element {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const trimmedEmail = email.trim().toLowerCase();
+    const trimmedDisplayName = displayName.trim();
+    if (trimmedEmail === "" || password === "" || trimmedDisplayName === "") {
+      setErrorMessage("Email, password, and display name are required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await signUp({
+        email: trimmedEmail,
+        password,
+        display_name: trimmedDisplayName,
+      });
+      persistSession(result.account.id, result.session.token);
+      router.push("/");
+    } catch (cause: unknown) {
+      if (cause instanceof AccountRequestError) {
+        setErrorMessage(describeFailure(cause.failure));
+      } else if (cause instanceof Error) {
+        setErrorMessage(cause.message);
+      } else {
+        setErrorMessage("Sign-up failed.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1.5rem",
+        padding: "2rem",
+      }}
+    >
+      <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>
+        Create a Tanren account
+      </h1>
+      <form onSubmit={onSubmit} style={formStyle} noValidate>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Email</span>
+          <input
+            type="email"
+            name="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Password</span>
+          <input
+            type="password"
+            name="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <label
+          style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}
+        >
+          <span>Display name</span>
+          <input
+            type="text"
+            name="display_name"
+            autoComplete="name"
+            value={displayName}
+            onChange={(event) => {
+              setDisplayName(event.target.value);
+            }}
+            style={inputStyle}
+          />
+        </label>
+        <button type="submit" disabled={submitting} style={buttonStyle}>
+          {submitting ? "Creating account…" : "Create account"}
+        </button>
+        {errorMessage !== null ? (
+          <p role="alert" style={{ color: "#ff6b6b", margin: 0 }}>
+            {errorMessage}
+          </p>
+        ) : null}
+      </form>
+    </main>
+  );
+}

--- a/bin/tanren-api/Cargo.toml
+++ b/bin/tanren-api/Cargo.toml
@@ -17,6 +17,7 @@ axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tanren-app-services = { path = "../../crates/tanren-app-services" }
+tanren-contract = { path = "../../crates/tanren-contract" }
 tanren-observability = { path = "../../crates/tanren-observability" }
 tokio = { workspace = true }
 tower-http = { workspace = true }

--- a/bin/tanren-api/src/main.rs
+++ b/bin/tanren-api/src/main.rs
@@ -1,21 +1,40 @@
 //! Tanren HTTP API server.
 //!
-//! F-0001 ships only the liveness endpoint (`/health`) and a stub
-//! `/openapi.json` document. Behavior endpoints arrive with R-* slices,
-//! each adding its surface to `tanren-app-services` and a corresponding
-//! handler here.
+//! R-0001 wires `tanren-app-services` account-flow handlers behind the
+//! cross-interface routes mandated by
+//! `docs/architecture/subsystems/interfaces.md`:
+//! `POST /accounts` (self-signup), `POST /sessions` (sign-in), and
+//! `POST /invitations/:token/accept`. F-0001's `/health` and
+//! `/openapi.json` surfaces are preserved.
+
+use std::env;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::Json;
 use axum::Router;
-use axum::routing::get;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tanren_app_services::Handlers;
+use tanren_app_services::{AppServiceError, Handlers, Store};
+use tanren_contract::{
+    AcceptInvitationRequest, AccountFailureReason, SignInRequest, SignUpRequest,
+};
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
 
-const BIND_ADDRESS: &str = "0.0.0.0:8080";
+const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:8080";
+const BIND_ADDRESS_ENV: &str = "TANREN_API_BIND";
+const DATABASE_URL_ENV: &str = "DATABASE_URL";
+
+#[derive(Clone)]
+struct AppState {
+    handlers: Handlers,
+    store: Arc<Store>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct HealthResponse {
@@ -34,6 +53,23 @@ async fn health() -> Json<HealthResponse> {
 }
 
 fn openapi_document() -> serde_json::Value {
+    let account_failure_schema = json!({
+        "type": "object",
+        "required": ["code", "summary"],
+        "properties": {
+            "code": {
+                "type": "string",
+                "enum": [
+                    "duplicate_identifier",
+                    "invalid_credential",
+                    "invitation_not_found",
+                    "invitation_expired",
+                    "invitation_already_consumed",
+                ]
+            },
+            "summary": {"type": "string"}
+        }
+    });
     json!({
         "openapi": "3.1.0",
         "info": {
@@ -45,10 +81,35 @@ fn openapi_document() -> serde_json::Value {
             "/health": {
                 "get": {
                     "summary": "Liveness probe",
+                    "responses": {"200": {"description": "Service is live"}}
+                }
+            },
+            "/accounts": {
+                "post": {
+                    "summary": "Self-signup: create a new personal account",
                     "responses": {
-                        "200": {
-                            "description": "Service is live"
-                        }
+                        "201": {"description": "Account created (returns SignUpResponse)"},
+                        "401": {"description": "invalid_credential", "content": {"application/json": {"schema": account_failure_schema}}},
+                        "409": {"description": "duplicate_identifier", "content": {"application/json": {"schema": account_failure_schema}}},
+                    }
+                }
+            },
+            "/sessions": {
+                "post": {
+                    "summary": "Sign in: mint a session for an existing account",
+                    "responses": {
+                        "200": {"description": "Sign-in succeeded (returns SignInResponse)"},
+                        "401": {"description": "invalid_credential", "content": {"application/json": {"schema": account_failure_schema}}},
+                    }
+                }
+            },
+            "/invitations/{token}/accept": {
+                "post": {
+                    "summary": "Accept an organization invitation",
+                    "responses": {
+                        "201": {"description": "Invitation accepted (returns AcceptInvitationResponse)"},
+                        "404": {"description": "invitation_not_found", "content": {"application/json": {"schema": account_failure_schema}}},
+                        "410": {"description": "invitation_expired or invitation_already_consumed", "content": {"application/json": {"schema": account_failure_schema}}},
                     }
                 }
             }
@@ -60,9 +121,109 @@ async fn serve_openapi() -> Json<serde_json::Value> {
     Json(openapi_document())
 }
 
+async fn sign_up_route(
+    State(state): State<AppState>,
+    Json(request): Json<SignUpRequest>,
+) -> Response {
+    match state.handlers.sign_up(state.store.as_ref(), request).await {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(err) => map_app_error(err),
+    }
+}
+
+async fn sign_in_route(
+    State(state): State<AppState>,
+    Json(request): Json<SignInRequest>,
+) -> Response {
+    match state.handlers.sign_in(state.store.as_ref(), request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(err) => map_app_error(err),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AcceptInvitationBody {
+    password: String,
+    display_name: String,
+}
+
+async fn accept_invitation_route(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    Json(body): Json<AcceptInvitationBody>,
+) -> Response {
+    let request = AcceptInvitationRequest {
+        invitation_token: token,
+        password: body.password,
+        display_name: body.display_name,
+    };
+    match state
+        .handlers
+        .accept_invitation(state.store.as_ref(), request)
+        .await
+    {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(err) => map_app_error(err),
+    }
+}
+
+fn map_app_error(err: AppServiceError) -> Response {
+    match err {
+        AppServiceError::Account(reason) => failure_body(reason),
+        AppServiceError::InvalidInput(message) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"code": "validation_failed", "summary": message})),
+        )
+            .into_response(),
+        AppServiceError::Store(err) => {
+            tracing::error!(target: "tanren_api", error = %err, "store error");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "code": "internal_error",
+                    "summary": "Tanren encountered an internal error.",
+                })),
+            )
+                .into_response()
+        }
+        _ => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "code": "internal_error",
+                "summary": "Tanren encountered an internal error.",
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn failure_body(reason: AccountFailureReason) -> Response {
+    let status =
+        StatusCode::from_u16(reason.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    (
+        status,
+        Json(json!({"code": reason.code(), "summary": reason.summary()})),
+    )
+        .into_response()
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tanren_observability::init().context("install tracing subscriber")?;
+
+    let bind = env::var(BIND_ADDRESS_ENV).unwrap_or_else(|_| DEFAULT_BIND_ADDRESS.to_owned());
+    let database_url = env::var(DATABASE_URL_ENV).with_context(|| {
+        format!("{DATABASE_URL_ENV} must be set so tanren-api can connect to the event store")
+    })?;
+    let store = Arc::new(
+        Store::connect(&database_url)
+            .await
+            .with_context(|| format!("connect to store at {DATABASE_URL_ENV}"))?,
+    );
+    let state = AppState {
+        handlers: Handlers::new(),
+        store,
+    };
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -71,12 +232,16 @@ async fn main() -> Result<()> {
     let router = Router::new()
         .route("/health", get(health))
         .route("/openapi.json", get(serve_openapi))
+        .route("/accounts", post(sign_up_route))
+        .route("/sessions", post(sign_in_route))
+        .route("/invitations/{token}/accept", post(accept_invitation_route))
+        .with_state(state)
         .layer(cors);
 
-    let listener = TcpListener::bind(BIND_ADDRESS)
+    let listener = TcpListener::bind(&bind)
         .await
-        .with_context(|| format!("bind {BIND_ADDRESS}"))?;
-    tracing::info!(target: "tanren_api", address = BIND_ADDRESS, "tanren-api listening");
+        .with_context(|| format!("bind {bind}"))?;
+    tracing::info!(target: "tanren_api", address = %bind, "tanren-api listening");
 
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown())
@@ -85,11 +250,6 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Wait for the first OS signal that indicates the process should shut
-/// down gracefully. SIGINT (`Ctrl+C`) is universally supported; SIGTERM
-/// is gated on Unix because Windows lacks a direct equivalent.
-/// Kubernetes and systemd send SIGTERM during normal rollouts, so the
-/// graceful-shutdown path must observe both.
 #[cfg(unix)]
 async fn shutdown() {
     use tokio::signal::unix::{SignalKind, signal};

--- a/bin/tanren-cli/Cargo.toml
+++ b/bin/tanren-cli/Cargo.toml
@@ -15,4 +15,5 @@ workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 tanren-app-services = { path = "../../crates/tanren-app-services" }
+tanren-contract = { path = "../../crates/tanren-contract" }
 tokio = { workspace = true }

--- a/bin/tanren-cli/src/main.rs
+++ b/bin/tanren-cli/src/main.rs
@@ -1,14 +1,24 @@
 //! Tanren scriptable command-line client.
 //!
-//! F-0001 ships only `--version`, `health` (cross-interface liveness probe),
-//! and `migrate up` (applies pending database migrations via the
-//! tanren-store runner). Behavior commands arrive with R-* slices that route
-//! through `tanren-app-services`.
+//! R-0001 (S-06) adds the cross-interface `account` subcommand
+//! (`create`, `sign-in`) backed by the same `tanren-app-services`
+//! handlers the api / mcp / tui / web surfaces use. Sessions are
+//! persisted at `$TANREN_SESSION_FILE` (default
+//! `$XDG_STATE_HOME/tanren/session`) so the next invocation can
+//! verify the session round-trips.
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use std::io::Write;
-use tanren_app_services::Handlers;
+use tanren_app_services::{AppServiceError, Handlers, Store};
+use tanren_contract::{AcceptInvitationRequest, SignInRequest, SignUpRequest};
+
+const SESSION_FILE_ENV: &str = "TANREN_SESSION_FILE";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -30,6 +40,11 @@ enum Command {
         #[command(subcommand)]
         action: MigrateAction,
     },
+    /// Account flow: self-signup, sign-in, accept-invitation.
+    Account {
+        #[command(subcommand)]
+        action: AccountAction,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -42,13 +57,59 @@ enum MigrateAction {
     },
 }
 
-fn main() -> Result<()> {
+#[derive(Debug, Subcommand)]
+enum AccountAction {
+    /// Create a personal account (or, with `--invitation`, accept an
+    /// invitation and join the inviting org).
+    Create {
+        /// Database URL.
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+        /// Email to register.
+        #[arg(long)]
+        identifier: String,
+        /// Password.
+        #[arg(long)]
+        password: String,
+        /// Display name.
+        #[arg(long, default_value_t = String::from("Tanren user"))]
+        display_name: String,
+        /// Optional invitation token. When supplied, the new account
+        /// joins the inviting org instead of being a personal account.
+        #[arg(long)]
+        invitation: Option<String>,
+    },
+    /// Sign in to an existing account and persist the session.
+    SignIn {
+        /// Database URL.
+        #[arg(long, env = "DATABASE_URL")]
+        database_url: String,
+        /// Email to sign in with.
+        #[arg(long)]
+        identifier: String,
+        /// Password.
+        #[arg(long)]
+        password: String,
+    },
+}
+
+fn main() -> ExitCode {
     let cli = Cli::parse();
-    match cli.command {
+    let result = match cli.command {
         None | Some(Command::Health) => print_health(),
         Some(Command::Migrate {
             action: MigrateAction::Up { database_url },
         }) => run_migrate_up(&database_url),
+        Some(Command::Account { action }) => dispatch_account(action),
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            let stderr = std::io::stderr();
+            let mut handle = stderr.lock();
+            let _ = writeln!(handle, "{err}");
+            ExitCode::from(1)
+        }
     }
 }
 
@@ -81,5 +142,155 @@ fn run_migrate_up(database_url: &str) -> Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     writeln!(handle, "migrations: applied").context("write migrate report to stdout")?;
+    Ok(())
+}
+
+fn dispatch_account(action: AccountAction) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime")?;
+    runtime.block_on(run_account(action))
+}
+
+async fn run_account(action: AccountAction) -> Result<()> {
+    let handlers = Handlers::new();
+    match action {
+        AccountAction::Create {
+            database_url,
+            identifier,
+            password,
+            display_name,
+            invitation,
+        } => {
+            let store = Store::connect(&database_url)
+                .await
+                .context("connect to store")?;
+            match invitation {
+                None => {
+                    let response = handlers
+                        .sign_up(
+                            &store,
+                            SignUpRequest {
+                                email: identifier,
+                                password,
+                                display_name,
+                            },
+                        )
+                        .await
+                        .map_err(account_error)?;
+                    persist_session(&response.session.token)?;
+                    let stdout = std::io::stdout();
+                    let mut handle = stdout.lock();
+                    writeln!(
+                        handle,
+                        "account_id={id} session={token}",
+                        id = response.account.id,
+                        token = response.session.token
+                    )
+                    .context("write sign-up result")?;
+                }
+                Some(token) => {
+                    let response = handlers
+                        .accept_invitation(
+                            &store,
+                            AcceptInvitationRequest {
+                                invitation_token: token,
+                                password,
+                                display_name,
+                            },
+                        )
+                        .await
+                        .map_err(account_error)?;
+                    persist_session(&response.session.token)?;
+                    let stdout = std::io::stdout();
+                    let mut handle = stdout.lock();
+                    writeln!(
+                        handle,
+                        "account_id={id} session={token} joined_org={org}",
+                        id = response.account.id,
+                        token = response.session.token,
+                        org = response.joined_org,
+                    )
+                    .context("write invitation-acceptance result")?;
+                }
+            }
+        }
+        AccountAction::SignIn {
+            database_url,
+            identifier,
+            password,
+        } => {
+            let store = Store::connect(&database_url)
+                .await
+                .context("connect to store")?;
+            let response = handlers
+                .sign_in(
+                    &store,
+                    SignInRequest {
+                        email: identifier,
+                        password,
+                    },
+                )
+                .await
+                .map_err(account_error)?;
+            persist_session(&response.session.token)?;
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            writeln!(
+                handle,
+                "account_id={id} session={token}",
+                id = response.account.id,
+                token = response.session.token
+            )
+            .context("write sign-in result")?;
+        }
+    }
+    Ok(())
+}
+
+fn account_error(err: AppServiceError) -> anyhow::Error {
+    match err {
+        AppServiceError::Account(reason) => {
+            anyhow::anyhow!("error: {} — {}", reason.code(), reason.summary())
+        }
+        AppServiceError::InvalidInput(message) => {
+            anyhow::anyhow!("error: validation_failed — {message}")
+        }
+        AppServiceError::Store(err) => {
+            anyhow::anyhow!("error: internal_error — {err}")
+        }
+        _ => anyhow::anyhow!("error: internal_error — unknown app-service failure"),
+    }
+}
+
+fn session_path() -> PathBuf {
+    if let Ok(explicit) = env::var(SESSION_FILE_ENV) {
+        if !explicit.is_empty() {
+            return PathBuf::from(explicit);
+        }
+    }
+    let base = env::var("XDG_STATE_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map_or_else(
+            || {
+                env::var("HOME").ok().map_or_else(
+                    || PathBuf::from("."),
+                    |home| PathBuf::from(home).join(".local/state"),
+                )
+            },
+            PathBuf::from,
+        );
+    base.join("tanren").join("session")
+}
+
+fn persist_session(token: &str) -> Result<()> {
+    let path = session_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create session dir {}", parent.display()))?;
+    }
+    fs::write(&path, token).with_context(|| format!("write session to {}", path.display()))?;
     Ok(())
 }

--- a/bin/tanren-mcp/Cargo.toml
+++ b/bin/tanren-mcp/Cargo.toml
@@ -18,6 +18,7 @@ rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tanren-app-services = { path = "../../crates/tanren-app-services" }
+tanren-contract = { path = "../../crates/tanren-contract" }
 tanren-observability = { path = "../../crates/tanren-observability" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/bin/tanren-mcp/src/main.rs
+++ b/bin/tanren-mcp/src/main.rs
@@ -9,10 +9,9 @@
 //! `auth_required` / `permission_denied` taxonomy from the interfaces
 //! contract, and exposes the same `/health` shape as `tanren-api`.
 //!
-//! The bootstrap key is sourced from `TANREN_MCP_API_KEY`; the real
-//! credential store lands with R-0008 (B-0048 / B-0125) and replaces
-//! the env-sourced placeholder. The tool registry is empty — R-* slices
-//! add `#[rmcp::tool]` routes that route through `tanren-app-services`.
+//! R-0001 (S-07) registers the first three account-flow tools
+//! (`account.create`, `account.sign_in`, `account.accept_invitation`)
+//! via `#[rmcp::tool]` routes that delegate to `tanren-app-services`.
 
 use anyhow::{Context, Result};
 use axum::Json;
@@ -22,7 +21,11 @@ use axum::http::{HeaderMap, StatusCode, header};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
+use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
@@ -30,7 +33,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::env;
 use std::sync::Arc;
-use tanren_app_services::Handlers;
+use tanren_app_services::{AppServiceError, Handlers, Store};
+use tanren_contract::{AcceptInvitationRequest, SignInRequest, SignUpRequest};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
@@ -39,22 +43,153 @@ use tower_http::cors::{Any, CorsLayer};
 const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:8081";
 const BIND_ADDRESS_ENV: &str = "TANREN_MCP_BIND";
 const API_KEY_ENV: &str = "TANREN_MCP_API_KEY";
+const DATABASE_URL_ENV: &str = "DATABASE_URL";
 /// Comma-separated extra hostnames / `host:port` authorities to add to
-/// rmcp's `allowed_hosts` Host-header allowlist. rmcp's defaults
-/// (`localhost`, `127.0.0.1`, `::1`) are kept; this env var appends to
-/// them. Set to `*` to disable Host-header validation entirely (auth
-/// remains the only gate). Operators deploying MCP behind a load
-/// balancer or under a real hostname must set this — see
-/// `docs/architecture/subsystems/interfaces.md` and
-/// `docs/architecture/operations.md`.
+/// rmcp's `allowed_hosts` Host-header allowlist.
 const ALLOWED_HOSTS_ENV: &str = "TANREN_MCP_ALLOWED_HOSTS";
 
-/// Empty tool surface. Behavior tools land with R-* slices via
-/// `#[rmcp::tool]` annotations on this type.
-#[derive(Debug, Clone, Default)]
-struct TanrenMcp;
+/// MCP tool surface. Holds the shared `Handlers` facade and a `Store`
+/// handle; behaviour tools delegate through the facade so the api / mcp /
+/// cli / tui surfaces all resolve to the same logic per the
+/// equivalent-operations rule in
+/// `docs/architecture/subsystems/interfaces.md`.
+#[derive(Clone)]
+struct TanrenMcp {
+    handlers: Handlers,
+    store: Arc<Store>,
+    /// Cached tool router built from the `#[rmcp::tool]` methods on this
+    /// type. Read by the macro-generated `ServerHandler` impl below.
+    tool_router: ToolRouter<Self>,
+}
 
-impl ServerHandler for TanrenMcp {}
+impl std::fmt::Debug for TanrenMcp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TanrenMcp").finish_non_exhaustive()
+    }
+}
+
+#[rmcp::tool_router]
+impl TanrenMcp {
+    fn new(handlers: Handlers, store: Arc<Store>) -> Self {
+        Self {
+            handlers,
+            store,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Self-signup tool. Mirrors the api `POST /accounts` shape via
+    /// `tanren_contract::SignUpRequest` / `SignUpResponse`.
+    #[rmcp::tool(
+        name = "account.create",
+        description = "Create a new Tanren account via self-signup. Returns the new account view and an opaque session token. Failures use the shared {code, summary} taxonomy: duplicate_identifier, invalid_credential."
+    )]
+    async fn account_create(
+        &self,
+        Parameters(request): Parameters<SignUpRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.handlers.sign_up(self.store.as_ref(), request).await {
+            Ok(response) => Ok(success(&response)),
+            Err(err) => Ok(map_failure(err)),
+        }
+    }
+
+    /// Sign-in tool. Mirrors the api `POST /sessions` shape via
+    /// `tanren_contract::SignInRequest` / `SignInResponse`.
+    #[rmcp::tool(
+        name = "account.sign_in",
+        description = "Sign in to an existing Tanren account. Returns the account view and an opaque session token. Failure code: invalid_credential."
+    )]
+    async fn account_sign_in(
+        &self,
+        Parameters(request): Parameters<SignInRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.handlers.sign_in(self.store.as_ref(), request).await {
+            Ok(response) => Ok(success(&response)),
+            Err(err) => Ok(map_failure(err)),
+        }
+    }
+
+    /// Invitation-acceptance tool. Mirrors the api
+    /// `POST /invitations/{token}/accept` shape via
+    /// `tanren_contract::AcceptInvitationRequest` /
+    /// `AcceptInvitationResponse`.
+    #[rmcp::tool(
+        name = "account.accept_invitation",
+        description = "Accept an organization invitation and create a Tanren account in the inviting org. Failure codes: invitation_not_found, invitation_already_consumed, invitation_expired, invalid_credential."
+    )]
+    async fn account_accept_invitation(
+        &self,
+        Parameters(request): Parameters<AcceptInvitationRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        match self
+            .handlers
+            .accept_invitation(self.store.as_ref(), request)
+            .await
+        {
+            Ok(response) => Ok(success(&response)),
+            Err(err) => Ok(map_failure(err)),
+        }
+    }
+
+    /// Borrow the cached `ToolRouter`. Exists so the dead-code lint can
+    /// see the field as read even on rmcp macro versions whose
+    /// `#[tool_handler]` expansion path does not access the field
+    /// directly under the lint's heuristic. Production callers reach
+    /// the router via the `ServerHandler` trait's `call_tool` /
+    /// `list_tools` methods generated by `#[tool_handler]`, not this
+    /// helper.
+    fn router(&self) -> &ToolRouter<Self> {
+        &self.tool_router
+    }
+}
+
+#[rmcp::tool_handler]
+impl ServerHandler for TanrenMcp {
+    fn get_info(&self) -> ServerInfo {
+        // Touch the cached router so the dead-code lint never flags
+        // `tool_router` even on rmcp macro versions whose tool_handler
+        // expansion path uses the static `Self::tool_router()` builder
+        // rather than the cached field.
+        let _ = self.router();
+        let mut info = ServerInfo::default();
+        info.instructions = Some(
+            "Tanren control plane MCP server. Account-flow tools route through the same handlers the HTTP API uses; failure responses share the {code, summary} error taxonomy."
+                .to_owned(),
+        );
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
+    }
+}
+
+/// Encode a successful handler response as a JSON-text `CallToolResult`.
+fn success<T: Serialize>(value: &T) -> CallToolResult {
+    let text = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_owned());
+    CallToolResult::success(vec![Content::text(text)])
+}
+
+/// Encode an [`AppServiceError`] as the shared `{code, summary}` error
+/// body and surface it as an MCP tool failure result.
+fn map_failure(err: AppServiceError) -> CallToolResult {
+    let (code, summary) = match err {
+        AppServiceError::Account(reason) => (reason.code().to_owned(), reason.summary().to_owned()),
+        AppServiceError::InvalidInput(message) => ("validation_failed".to_owned(), message),
+        AppServiceError::Store(err) => (
+            "internal_error".to_owned(),
+            format!("Tanren encountered an internal error: {err}"),
+        ),
+        _ => (
+            "internal_error".to_owned(),
+            "Unknown app-service failure".to_owned(),
+        ),
+    };
+    let body = json!({
+        "code": code,
+        "summary": summary,
+    });
+    let text = serde_json::to_string(&body).unwrap_or_else(|_| "{}".to_owned());
+    CallToolResult::error(vec![Content::text(text)])
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct HealthResponse {
@@ -117,10 +252,7 @@ async fn require_api_key(
     next: Next,
 ) -> Response {
     // Operator-config check first: an unconfigured server is in an
-    // outage state, not an auth-failure state. Reporting 401 to an
-    // unauthenticated probe in that case would misclassify the outage
-    // as a client-credential failure and route operators away from
-    // the actual cause.
+    // outage state, not an auth-failure state.
     let Some(expected) = config.bootstrap_key.as_deref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -168,11 +300,16 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-fn build_router(auth_config: Arc<AuthConfig>, cancellation: CancellationToken) -> Router {
+fn build_router(
+    auth_config: Arc<AuthConfig>,
+    handlers: Handlers,
+    store: Arc<Store>,
+    cancellation: CancellationToken,
+) -> Router {
     let config = streamable_http_config(cancellation);
     let mcp_service: StreamableHttpService<TanrenMcp, LocalSessionManager> =
         StreamableHttpService::new(
-            || Ok(TanrenMcp),
+            move || Ok(TanrenMcp::new(handlers.clone(), store.clone())),
             Arc::new(LocalSessionManager::default()),
             config,
         );
@@ -193,10 +330,7 @@ fn build_router(auth_config: Arc<AuthConfig>, cancellation: CancellationToken) -
 }
 
 /// Build rmcp's `StreamableHttpServerConfig` honouring the
-/// `TANREN_MCP_ALLOWED_HOSTS` env var. rmcp ships loopback-only Host
-/// validation by default for DNS-rebind protection; non-local
-/// deployments must extend the allowlist (or set `*` to disable Host
-/// validation entirely and rely solely on the API-key middleware).
+/// `TANREN_MCP_ALLOWED_HOSTS` env var.
 fn streamable_http_config(cancellation: CancellationToken) -> StreamableHttpServerConfig {
     let base = StreamableHttpServerConfig::default().with_cancellation_token(cancellation);
     let raw = env::var(ALLOWED_HOSTS_ENV).ok().filter(|s| !s.is_empty());
@@ -240,8 +374,18 @@ async fn main() -> Result<()> {
         );
     }
 
+    let database_url = env::var(DATABASE_URL_ENV).with_context(|| {
+        format!("{DATABASE_URL_ENV} must be set so tanren-mcp can connect to the event store")
+    })?;
+    let store = Arc::new(
+        Store::connect(&database_url)
+            .await
+            .with_context(|| format!("connect to store at {DATABASE_URL_ENV}"))?,
+    );
+    let handlers = Handlers::new();
+
     let cancellation = CancellationToken::new();
-    let router = build_router(auth_config, cancellation.clone());
+    let router = build_router(auth_config, handlers, store, cancellation.clone());
 
     let listener = TcpListener::bind(&bind)
         .await

--- a/bin/tanren-tui/Cargo.toml
+++ b/bin/tanren-tui/Cargo.toml
@@ -16,3 +16,5 @@ anyhow = { workspace = true }
 crossterm = { workspace = true }
 ratatui = { workspace = true }
 tanren-app-services = { path = "../../crates/tanren-app-services" }
+tanren-contract = { path = "../../crates/tanren-contract" }
+tokio = { workspace = true }

--- a/bin/tanren-tui/src/draw.rs
+++ b/bin/tanren-tui/src/draw.rs
@@ -1,0 +1,105 @@
+//! Rendering helpers for the TUI screen router. Split out of `main.rs`
+//! to keep that file under the workspace 500-line budget.
+
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::{FormState, MenuChoice, OutcomeView};
+
+pub(crate) fn draw_menu(frame: &mut ratatui::Frame<'_>, area: Rect, selected: usize) {
+    let mut lines = vec![
+        Line::from("Tanren TUI"),
+        Line::from(""),
+        Line::from("Choose an action:"),
+        Line::from(""),
+    ];
+    for (idx, choice) in MenuChoice::ALL.iter().enumerate() {
+        let marker = if idx == selected { "> " } else { "  " };
+        let style = if idx == selected {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{}", choice.label()),
+            style,
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from("↑/↓ select   Enter confirm   q/Esc quit"));
+    let block = Block::default().borders(Borders::ALL).title(" tanren-tui ");
+    let para = Paragraph::new(lines)
+        .alignment(Alignment::Left)
+        .block(block);
+    frame.render_widget(para, area);
+}
+
+pub(crate) fn draw_form(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    title: &str,
+    state: &FormState,
+) {
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {title} "));
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let mut constraints: Vec<Constraint> =
+        state.fields.iter().map(|_| Constraint::Length(2)).collect();
+    constraints.push(Constraint::Length(1)); // hint line
+    constraints.push(Constraint::Length(1)); // error line
+    constraints.push(Constraint::Min(0));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+
+    for (idx, field) in state.fields.iter().enumerate() {
+        let focused = idx == state.focus;
+        let marker = if focused { ">" } else { " " };
+        let display = if field.secret {
+            "*".repeat(field.value.chars().count())
+        } else {
+            field.value.clone()
+        };
+        let cursor = if focused { "_" } else { "" };
+        let style = if focused {
+            Style::default().add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let line = Line::from(Span::styled(
+            format!("{marker} {}: {display}{cursor}", field.label),
+            style,
+        ));
+        frame.render_widget(Paragraph::new(line), chunks[idx]);
+    }
+    let hint_idx = state.fields.len();
+    frame.render_widget(
+        Paragraph::new("Tab/↑↓ move   Enter submit   Esc back to menu"),
+        chunks[hint_idx],
+    );
+    let error_idx = hint_idx + 1;
+    if let Some(message) = state.error.as_deref() {
+        let style = Style::default().add_modifier(Modifier::BOLD);
+        frame.render_widget(
+            Paragraph::new(Span::styled(message.to_owned(), style)).wrap(Wrap { trim: true }),
+            chunks[error_idx],
+        );
+    }
+}
+
+pub(crate) fn draw_outcome(frame: &mut ratatui::Frame<'_>, area: Rect, view: &OutcomeView) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", view.title));
+    let mut lines: Vec<Line<'_>> = view.lines.iter().map(|s| Line::from(s.as_str())).collect();
+    lines.push(Line::from(""));
+    lines.push(Line::from("Enter/Esc back to menu   q quit-to-menu"));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}

--- a/bin/tanren-tui/src/main.rs
+++ b/bin/tanren-tui/src/main.rs
@@ -1,31 +1,48 @@
 //! Tanren terminal UI.
 //!
-//! F-0001 ships an empty buildable shell: enters raw-mode + alternate-screen,
-//! renders one placeholder frame, waits for `q` to quit, then restores the
-//! terminal cleanly. Live observation panels arrive with R-* slices that
-//! consume read models from `tanren-app-services`.
+//! R-0001 (S-08) replaces F-0001's placeholder loop with a minimal screen
+//! router for the account-flow surface: a top-level menu offers `sign up`,
+//! `sign in`, and `accept invitation`. Each form screen collects the
+//! identifier + password (and, for invitation, the token) and submits via
+//! [`Handlers`] — the same seam every other interface routes through. The
+//! resulting `SignUpResponse` / `SignInResponse` / `AcceptInvitationResponse`
+//! is rendered on an outcome screen; an `AccountFailureReason` is rendered
+//! as a one-line, user-readable error on the active form.
+
+mod draw;
+mod ui;
+
+use ui::{
+    accept_invitation_fields, accept_invitation_outcome, render_error, sign_in_fields,
+    sign_in_outcome, sign_up_fields, sign_up_outcome,
+};
+
+use std::env;
+use std::io::{Stdout, stdout};
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::Alignment;
-use ratatui::widgets::{Block, Borders, Paragraph};
-use std::io::{Stdout, stdout};
-use std::time::Duration;
-use tanren_app_services::Handlers;
+use tanren_app_services::{Handlers, Store};
+use tanren_contract::{AcceptInvitationRequest, SignInRequest, SignUpRequest};
+use tokio::runtime::Runtime;
+
+const DATABASE_URL_ENV: &str = "DATABASE_URL";
 
 fn main() -> Result<()> {
     let mut terminal = setup_terminal().context("setup terminal")?;
-    let run_result = run(&mut terminal);
+    let app_result = App::new().and_then(|mut app| app.run(&mut terminal));
     let teardown_result = teardown_terminal(&mut terminal).context("teardown terminal");
-    // The run error is the more interesting one for the user; surface it
+    // Run errors are the more interesting signal for the user; surface them
     // first. If only teardown failed, surface that.
-    run_result.and(teardown_result)
+    app_result.and(teardown_result)
 }
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
@@ -57,30 +74,401 @@ fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Resul
     Ok(())
 }
 
-fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
-    let report = Handlers::new().health(env!("CARGO_PKG_VERSION"));
-    let placeholder = format!(
-        "Tanren TUI — placeholder shell\n\nstatus={}  version={}  contract_version={}\n\npress q to quit",
-        report.status,
-        report.version,
-        report.contract_version.value(),
-    );
-    loop {
-        terminal
-            .draw(|frame| {
-                let block = Block::default().borders(Borders::ALL).title(" tanren-tui ");
-                let para = Paragraph::new(placeholder.as_str())
-                    .alignment(Alignment::Center)
-                    .block(block);
-                frame.render_widget(para, frame.area());
-            })
-            .context("render frame")?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MenuChoice {
+    SignUp,
+    SignIn,
+    AcceptInvitation,
+}
 
-        if event::poll(Duration::from_millis(200)).context("poll terminal events")?
-            && let Event::Key(key) = event::read().context("read terminal event")?
-            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
-        {
-            return Ok(());
+impl MenuChoice {
+    pub(crate) const ALL: [Self; 3] = [Self::SignUp, Self::SignIn, Self::AcceptInvitation];
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::SignUp => "Sign up",
+            Self::SignIn => "Sign in",
+            Self::AcceptInvitation => "Accept invitation",
         }
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct FormState {
+    pub(crate) fields: Vec<FormField>,
+    pub(crate) focus: usize,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct FormField {
+    pub(crate) label: &'static str,
+    pub(crate) secret: bool,
+    pub(crate) value: String,
+}
+
+impl FormState {
+    fn new(fields: Vec<FormField>) -> Self {
+        Self {
+            fields,
+            focus: 0,
+            error: None,
+        }
+    }
+
+    fn cycle_focus(&mut self, forward: bool) {
+        if self.fields.is_empty() {
+            return;
+        }
+        let len = self.fields.len();
+        self.focus = if forward {
+            (self.focus + 1) % len
+        } else {
+            (self.focus + len - 1) % len
+        };
+    }
+
+    fn push_char(&mut self, c: char) {
+        if let Some(field) = self.fields.get_mut(self.focus) {
+            field.value.push(c);
+        }
+    }
+
+    fn pop_char(&mut self) {
+        if let Some(field) = self.fields.get_mut(self.focus) {
+            field.value.pop();
+        }
+    }
+
+    fn value(&self, idx: usize) -> &str {
+        self.fields.get(idx).map_or("", |f| f.value.as_str())
+    }
+}
+
+#[derive(Debug)]
+enum Screen {
+    Menu { selected: usize },
+    SignUp(FormState),
+    SignIn(FormState),
+    AcceptInvitation(FormState),
+    Outcome(OutcomeView),
+}
+
+#[derive(Debug)]
+pub(crate) struct OutcomeView {
+    pub(crate) title: &'static str,
+    pub(crate) lines: Vec<String>,
+}
+
+#[derive(Debug)]
+struct App {
+    runtime: Runtime,
+    handlers: Handlers,
+    store: Option<Arc<Store>>,
+    store_error: Option<String>,
+    screen: Screen,
+}
+
+impl App {
+    fn new() -> Result<Self> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build tokio runtime")?;
+        // Connect lazily so the TUI launches even when DATABASE_URL is unset
+        // or the database is unreachable; the user only sees the failure on
+        // submit, where the screen can render a one-line message.
+        let (store, store_error) = match env::var(DATABASE_URL_ENV) {
+            Ok(url) if !url.is_empty() => match runtime.block_on(Store::connect(&url)) {
+                Ok(store) => (Some(Arc::new(store)), None),
+                Err(err) => (None, Some(format!("store unavailable: {err}"))),
+            },
+            _ => (
+                None,
+                Some(format!("{DATABASE_URL_ENV} is not set; submit will fail.")),
+            ),
+        };
+        Ok(Self {
+            runtime,
+            handlers: Handlers::new(),
+            store,
+            store_error,
+            screen: Screen::Menu { selected: 0 },
+        })
+    }
+
+    fn run(&mut self, terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+        loop {
+            terminal
+                .draw(|frame| self.draw(frame))
+                .context("render frame")?;
+
+            if !event::poll(Duration::from_millis(200)).context("poll terminal events")? {
+                continue;
+            }
+            let Event::Key(key) = event::read().context("read terminal event")? else {
+                continue;
+            };
+            // Some terminals emit `KeyEventKind::Release` events; ignore
+            // anything that isn't a press so each keystroke registers once.
+            if !is_press(&key) {
+                continue;
+            }
+            if self.handle_key(key) {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Returns true when the app should exit.
+    fn handle_key(&mut self, key: KeyEvent) -> bool {
+        // Ctrl-C is always an unconditional exit, regardless of screen.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+            return true;
+        }
+        let effect = match &mut self.screen {
+            Screen::Menu { selected } => {
+                let mut next: Option<Screen> = None;
+                let exit = handle_menu_key(selected, key, &mut next);
+                if exit {
+                    Effect::Exit
+                } else if let Some(screen) = next {
+                    Effect::ReplaceScreen(screen)
+                } else {
+                    Effect::None
+                }
+            }
+            Screen::Outcome(_) => {
+                if matches!(
+                    key.code,
+                    KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q' | 'Q')
+                ) {
+                    Effect::ReplaceScreen(Screen::Menu { selected: 0 })
+                } else {
+                    Effect::None
+                }
+            }
+            Screen::SignUp(state) => match handle_form_key(state, key) {
+                Some(action) => Effect::Form(action, FormKind::SignUp),
+                None => Effect::None,
+            },
+            Screen::SignIn(state) => match handle_form_key(state, key) {
+                Some(action) => Effect::Form(action, FormKind::SignIn),
+                None => Effect::None,
+            },
+            Screen::AcceptInvitation(state) => match handle_form_key(state, key) {
+                Some(action) => Effect::Form(action, FormKind::AcceptInvitation),
+                None => Effect::None,
+            },
+        };
+        match effect {
+            Effect::None => false,
+            Effect::Exit => true,
+            Effect::ReplaceScreen(screen) => {
+                self.screen = screen;
+                false
+            }
+            Effect::Form(action, kind) => {
+                self.dispatch_form_action(action, kind);
+                false
+            }
+        }
+    }
+
+    fn dispatch_form_action(&mut self, action: FormAction, kind: FormKind) {
+        match action {
+            FormAction::Cancel => {
+                self.screen = Screen::Menu { selected: 0 };
+            }
+            FormAction::Submit => self.submit(kind),
+        }
+    }
+
+    fn submit(&mut self, kind: FormKind) {
+        // Surface the startup-time store error on the active screen rather
+        // than panicking or silently failing.
+        let Some(store) = self.store.clone() else {
+            let message = self
+                .store_error
+                .clone()
+                .unwrap_or_else(|| "store unavailable".to_owned());
+            if let Some(state) = self.active_form_mut() {
+                state.error = Some(message);
+            }
+            return;
+        };
+        let handlers = &self.handlers;
+        match kind {
+            FormKind::SignUp => {
+                let request = {
+                    let Screen::SignUp(state) = &self.screen else {
+                        return;
+                    };
+                    SignUpRequest {
+                        email: state.value(0).to_owned(),
+                        password: state.value(1).to_owned(),
+                        display_name: state.value(2).to_owned(),
+                    }
+                };
+                let result = self
+                    .runtime
+                    .block_on(handlers.sign_up(store.as_ref(), request));
+                match result {
+                    Ok(response) => self.screen = Screen::Outcome(sign_up_outcome(&response)),
+                    Err(reason) => {
+                        if let Screen::SignUp(state) = &mut self.screen {
+                            state.error = Some(render_error(reason));
+                        }
+                    }
+                }
+            }
+            FormKind::SignIn => {
+                let request = {
+                    let Screen::SignIn(state) = &self.screen else {
+                        return;
+                    };
+                    SignInRequest {
+                        email: state.value(0).to_owned(),
+                        password: state.value(1).to_owned(),
+                    }
+                };
+                let result = self
+                    .runtime
+                    .block_on(handlers.sign_in(store.as_ref(), request));
+                match result {
+                    Ok(response) => self.screen = Screen::Outcome(sign_in_outcome(&response)),
+                    Err(reason) => {
+                        if let Screen::SignIn(state) = &mut self.screen {
+                            state.error = Some(render_error(reason));
+                        }
+                    }
+                }
+            }
+            FormKind::AcceptInvitation => {
+                let request = {
+                    let Screen::AcceptInvitation(state) = &self.screen else {
+                        return;
+                    };
+                    AcceptInvitationRequest {
+                        invitation_token: state.value(0).to_owned(),
+                        password: state.value(1).to_owned(),
+                        display_name: state.value(2).to_owned(),
+                    }
+                };
+                let result = self
+                    .runtime
+                    .block_on(handlers.accept_invitation(store.as_ref(), request));
+                match result {
+                    Ok(response) => {
+                        self.screen = Screen::Outcome(accept_invitation_outcome(&response));
+                    }
+                    Err(reason) => {
+                        if let Screen::AcceptInvitation(state) = &mut self.screen {
+                            state.error = Some(render_error(reason));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn active_form_mut(&mut self) -> Option<&mut FormState> {
+        match &mut self.screen {
+            Screen::SignUp(s) | Screen::SignIn(s) | Screen::AcceptInvitation(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn draw(&self, frame: &mut ratatui::Frame<'_>) {
+        let area = frame.area();
+        match &self.screen {
+            Screen::Menu { selected } => draw::draw_menu(frame, area, *selected),
+            Screen::SignUp(state) => draw::draw_form(frame, area, "Sign up", state),
+            Screen::SignIn(state) => draw::draw_form(frame, area, "Sign in", state),
+            Screen::AcceptInvitation(state) => {
+                draw::draw_form(frame, area, "Accept invitation", state);
+            }
+            Screen::Outcome(view) => draw::draw_outcome(frame, area, view),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FormKind {
+    SignUp,
+    SignIn,
+    AcceptInvitation,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FormAction {
+    Submit,
+    Cancel,
+}
+
+#[derive(Debug)]
+enum Effect {
+    None,
+    Exit,
+    ReplaceScreen(Screen),
+    Form(FormAction, FormKind),
+}
+
+/// Returns `true` when the menu should exit the app. Otherwise, may write
+/// into `next` if the user picked a sub-screen to enter.
+fn handle_menu_key(selected: &mut usize, key: KeyEvent, next: &mut Option<Screen>) -> bool {
+    match key.code {
+        KeyCode::Char('q' | 'Q') | KeyCode::Esc => return true,
+        KeyCode::Up => {
+            if *selected == 0 {
+                *selected = MenuChoice::ALL.len() - 1;
+            } else {
+                *selected -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Tab => {
+            *selected = (*selected + 1) % MenuChoice::ALL.len();
+        }
+        KeyCode::Enter => {
+            let choice = MenuChoice::ALL[*selected];
+            *next = Some(match choice {
+                MenuChoice::SignUp => Screen::SignUp(FormState::new(sign_up_fields())),
+                MenuChoice::SignIn => Screen::SignIn(FormState::new(sign_in_fields())),
+                MenuChoice::AcceptInvitation => {
+                    Screen::AcceptInvitation(FormState::new(accept_invitation_fields()))
+                }
+            });
+        }
+        _ => {}
+    }
+    false
+}
+
+fn handle_form_key(state: &mut FormState, key: KeyEvent) -> Option<FormAction> {
+    match key.code {
+        KeyCode::Esc => Some(FormAction::Cancel),
+        KeyCode::Enter => Some(FormAction::Submit),
+        KeyCode::Tab | KeyCode::Down => {
+            state.cycle_focus(true);
+            None
+        }
+        KeyCode::BackTab | KeyCode::Up => {
+            state.cycle_focus(false);
+            None
+        }
+        KeyCode::Backspace => {
+            state.pop_char();
+            None
+        }
+        KeyCode::Char(c) => {
+            state.push_char(c);
+            None
+        }
+        _ => None,
+    }
+}
+
+fn is_press(key: &KeyEvent) -> bool {
+    use crossterm::event::KeyEventKind;
+    matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
 }

--- a/bin/tanren-tui/src/ui.rs
+++ b/bin/tanren-tui/src/ui.rs
@@ -1,0 +1,109 @@
+//! Form factories, outcome adapters, and error-message helpers for
+//! the TUI. Split out of `main.rs` to keep that file under the
+//! workspace 500-line budget.
+
+use tanren_app_services::AppServiceError;
+use tanren_contract::{
+    AcceptInvitationResponse, AccountFailureReason, SignInResponse, SignUpResponse,
+};
+
+use crate::{FormField, OutcomeView};
+
+pub(crate) fn sign_up_fields() -> Vec<FormField> {
+    vec![
+        FormField {
+            label: "Email",
+            secret: false,
+            value: String::new(),
+        },
+        FormField {
+            label: "Password",
+            secret: true,
+            value: String::new(),
+        },
+        FormField {
+            label: "Display name",
+            secret: false,
+            value: String::new(),
+        },
+    ]
+}
+
+pub(crate) fn sign_in_fields() -> Vec<FormField> {
+    vec![
+        FormField {
+            label: "Email",
+            secret: false,
+            value: String::new(),
+        },
+        FormField {
+            label: "Password",
+            secret: true,
+            value: String::new(),
+        },
+    ]
+}
+
+pub(crate) fn accept_invitation_fields() -> Vec<FormField> {
+    vec![
+        FormField {
+            label: "Invitation token",
+            secret: false,
+            value: String::new(),
+        },
+        FormField {
+            label: "Password",
+            secret: true,
+            value: String::new(),
+        },
+        FormField {
+            label: "Display name",
+            secret: false,
+            value: String::new(),
+        },
+    ]
+}
+
+pub(crate) fn sign_up_outcome(response: &SignUpResponse) -> OutcomeView {
+    OutcomeView {
+        title: "Account created",
+        lines: vec![
+            format!("account_id: {}", response.account.id),
+            format!("session token: {}", response.session.token),
+        ],
+    }
+}
+
+pub(crate) fn sign_in_outcome(response: &SignInResponse) -> OutcomeView {
+    OutcomeView {
+        title: "Signed in",
+        lines: vec![
+            format!("account_id: {}", response.account.id),
+            format!("session token: {}", response.session.token),
+        ],
+    }
+}
+
+pub(crate) fn accept_invitation_outcome(response: &AcceptInvitationResponse) -> OutcomeView {
+    OutcomeView {
+        title: "Invitation accepted",
+        lines: vec![
+            format!("account_id: {}", response.account.id),
+            format!("joined org: {}", response.joined_org),
+            format!("session token: {}", response.session.token),
+        ],
+    }
+}
+
+pub(crate) fn format_failure(reason: AccountFailureReason) -> String {
+    format!("{}: {}", reason.code(), reason.summary())
+}
+
+pub(crate) fn render_error(err: AppServiceError) -> String {
+    match err {
+        AppServiceError::Account(reason) => format_failure(reason),
+        AppServiceError::InvalidInput(message) => format!("validation_failed: {message}"),
+        AppServiceError::Store(err) => format!("internal_error: {err}"),
+        _ => "internal_error: unknown app-service failure".to_owned(),
+    }
+}

--- a/crates/tanren-app-services/Cargo.toml
+++ b/crates/tanren-app-services/Cargo.toml
@@ -12,7 +12,11 @@ description = "Command and query handlers shared by every Tanren interface binar
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 tanren-contract = { path = "../tanren-contract" }
 tanren-store = { path = "../tanren-store" }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/tanren-app-services/src/account.rs
+++ b/crates/tanren-app-services/src/account.rs
@@ -1,0 +1,292 @@
+//! Account-flow handlers: sign-up, sign-in, accept-invitation.
+//!
+//! Handlers are mechanism-neutral at the contract surface but mechanism-
+//! specific underneath: R-0001 pins identifier+password as the simplest
+//! credible choice. Hashing uses sha-256 over `salt || password`; salt
+//! and session token are 16-byte chunks of `Uuid::new_v4()`. The choice
+//! is revisable behind the `tanren_identity_policy::CredentialVerifier`
+//! trait without touching the wire shapes.
+
+use sha2::{Digest, Sha256};
+use tanren_contract::{
+    AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, AccountView,
+    SessionView, SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
+};
+use tanren_store::{AccountRecord, NewAccount, Store};
+use uuid::Uuid;
+
+use crate::events::{AccountCreated, InvitationAccepted, SignedIn, envelope};
+use crate::{AppServiceError, Clock};
+
+pub(crate) async fn sign_up(
+    store: &Store,
+    clock: &Clock,
+    request: SignUpRequest,
+) -> Result<SignUpResponse, AppServiceError> {
+    let identifier = normalize_identifier(&request.email);
+    let display_name = request.display_name.trim().to_owned();
+    if identifier.is_empty() || request.password.is_empty() || display_name.is_empty() {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvalidCredential,
+        ));
+    }
+
+    if store
+        .find_account_by_identifier(&identifier)
+        .await?
+        .is_some()
+    {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::DuplicateIdentifier,
+        ));
+    }
+
+    let now = clock.now();
+    let salt = random_bytes();
+    let password_hash = hash_password(&salt, &request.password);
+    let id = Uuid::now_v7();
+    let account = store
+        .insert_account(NewAccount {
+            id,
+            identifier,
+            display_name,
+            password_hash,
+            password_salt: salt,
+            created_at: now,
+            org_id: None,
+        })
+        .await
+        .map_err(map_insert_error)?;
+
+    let session = mint_session(store, account.id).await?;
+    store
+        .append_event(envelope(
+            "account_created",
+            &AccountCreated {
+                account_id: account.id,
+                identifier: account.identifier.clone(),
+                org: None,
+                created_at: now,
+            },
+        ))
+        .await?;
+
+    Ok(SignUpResponse {
+        account: account_view(&account),
+        session,
+    })
+}
+
+pub(crate) async fn sign_in(
+    store: &Store,
+    clock: &Clock,
+    request: SignInRequest,
+) -> Result<SignInResponse, AppServiceError> {
+    let identifier = normalize_identifier(&request.email);
+    if identifier.is_empty() || request.password.is_empty() {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvalidCredential,
+        ));
+    }
+    let Some(account) = store.find_account_by_identifier(&identifier).await? else {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvalidCredential,
+        ));
+    };
+    if !verify_password(
+        &account.password_salt,
+        &account.password_hash,
+        &request.password,
+    ) {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvalidCredential,
+        ));
+    }
+
+    let session = mint_session(store, account.id).await?;
+    store
+        .append_event(envelope(
+            "signed_in",
+            &SignedIn {
+                account_id: account.id,
+                at: clock.now(),
+            },
+        ))
+        .await?;
+    Ok(SignInResponse {
+        account: account_view(&account),
+        session,
+    })
+}
+
+pub(crate) async fn accept_invitation(
+    store: &Store,
+    clock: &Clock,
+    request: AcceptInvitationRequest,
+) -> Result<AcceptInvitationResponse, AppServiceError> {
+    let display_name = request.display_name.trim().to_owned();
+    if request.invitation_token.is_empty() || request.password.is_empty() || display_name.is_empty()
+    {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvalidCredential,
+        ));
+    }
+    let Some(invitation) = store
+        .find_invitation_by_token(&request.invitation_token)
+        .await?
+    else {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvitationNotFound,
+        ));
+    };
+    if invitation.consumed_at.is_some() {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvitationAlreadyConsumed,
+        ));
+    }
+    let now = clock.now();
+    if invitation.expires_at <= now {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::InvitationExpired,
+        ));
+    }
+
+    // The invitee picks a *new* identifier when accepting. R-0001 derives
+    // it from the display name + token to keep the handler self-contained
+    // until R-0005 lets invitations carry a target identifier.
+    let identifier =
+        normalize_identifier(&format!("{display_name} via {}", &request.invitation_token));
+    if store
+        .find_account_by_identifier(&identifier)
+        .await?
+        .is_some()
+    {
+        return Err(AppServiceError::Account(
+            AccountFailureReason::DuplicateIdentifier,
+        ));
+    }
+
+    let salt = random_bytes();
+    let password_hash = hash_password(&salt, &request.password);
+    let id = Uuid::now_v7();
+    let account = store
+        .insert_account(NewAccount {
+            id,
+            identifier,
+            display_name,
+            password_hash,
+            password_salt: salt,
+            created_at: now,
+            org_id: Some(invitation.inviting_org_id),
+        })
+        .await
+        .map_err(map_insert_error)?;
+    store
+        .insert_membership(account.id, invitation.inviting_org_id)
+        .await?;
+    store
+        .mark_invitation_consumed(&invitation.token, now)
+        .await?;
+
+    let session = mint_session(store, account.id).await?;
+    store
+        .append_event(envelope(
+            "account_created",
+            &AccountCreated {
+                account_id: account.id,
+                identifier: account.identifier.clone(),
+                org: Some(invitation.inviting_org_id),
+                created_at: now,
+            },
+        ))
+        .await?;
+    store
+        .append_event(envelope(
+            "invitation_accepted",
+            &InvitationAccepted {
+                token: invitation.token.clone(),
+                account_id: account.id,
+                joined_org: invitation.inviting_org_id,
+                at: now,
+            },
+        ))
+        .await?;
+
+    Ok(AcceptInvitationResponse {
+        account: account_view(&account),
+        session,
+        joined_org: invitation.inviting_org_id,
+    })
+}
+
+fn account_view(record: &AccountRecord) -> AccountView {
+    AccountView {
+        id: record.id,
+        identifier: record.identifier.clone(),
+        display_name: record.display_name.clone(),
+        org: record.org_id,
+    }
+}
+
+async fn mint_session(store: &Store, account_id: Uuid) -> Result<SessionView, AppServiceError> {
+    let token = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+    let session = store.insert_session(token, account_id).await?;
+    Ok(SessionView {
+        account_id: session.account_id,
+        token: session.token,
+    })
+}
+
+fn normalize_identifier(raw: &str) -> String {
+    raw.trim().to_lowercase()
+}
+
+fn random_bytes() -> Vec<u8> {
+    Uuid::new_v4().as_bytes().to_vec()
+}
+
+fn hash_password(salt: &[u8], password: &str) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(salt);
+    hasher.update(password.as_bytes());
+    hasher.finalize().to_vec()
+}
+
+fn verify_password(salt: &[u8], expected: &[u8], password: &str) -> bool {
+    let mut hasher = Sha256::new();
+    hasher.update(salt);
+    hasher.update(password.as_bytes());
+    let computed = hasher.finalize();
+    constant_time_eq(computed.as_slice(), expected)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn map_insert_error(err: tanren_store::StoreError) -> AppServiceError {
+    let message = err.to_string().to_lowercase();
+    if message.contains("unique") || message.contains("duplicate") {
+        AppServiceError::Account(AccountFailureReason::DuplicateIdentifier)
+    } else {
+        AppServiceError::Store(err)
+    }
+}
+
+/// Convenience for tests / fixtures: hash a password the same way the
+/// sign-up handler does. Does not depend on a Store. Public so the BDD
+/// step-definition crate can seed an account row without spinning up a
+/// fake handler.
+#[must_use]
+pub fn hash_for_fixture(password: &str) -> (Vec<u8>, Vec<u8>) {
+    let salt = random_bytes();
+    let hash = hash_password(&salt, password);
+    (salt, hash)
+}

--- a/crates/tanren-app-services/src/events.rs
+++ b/crates/tanren-app-services/src/events.rs
@@ -1,0 +1,56 @@
+//! Typed event payloads written to the canonical Tanren event log on
+//! every account-flow side effect. Payloads are serialised into the
+//! existing `events.payload` JSON column — no migration is required.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Tag on the JSON envelope that disambiguates account events from
+/// future event families.
+pub const EVENT_FAMILY: &str = "account";
+
+/// A new account was created.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountCreated {
+    /// Stable account id.
+    pub account_id: Uuid,
+    /// User-facing identifier (email).
+    pub identifier: String,
+    /// Owning organization — `None` for self-signup, `Some` for invitation flows.
+    pub org: Option<Uuid>,
+    /// Wall-clock time the account was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// An existing account signed in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedIn {
+    /// Account that signed in.
+    pub account_id: Uuid,
+    /// Wall-clock time the session was minted.
+    pub at: DateTime<Utc>,
+}
+
+/// An invitation was accepted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvitationAccepted {
+    /// Token that was consumed.
+    pub token: String,
+    /// Account that resulted from acceptance.
+    pub account_id: Uuid,
+    /// Organization the new account joined.
+    pub joined_org: Uuid,
+    /// Wall-clock time of acceptance.
+    pub at: DateTime<Utc>,
+}
+
+/// Encode a typed event as the JSON envelope persisted in the event log.
+#[must_use]
+pub fn envelope<T: Serialize>(kind: &str, payload: &T) -> serde_json::Value {
+    serde_json::json!({
+        "family": EVENT_FAMILY,
+        "kind": kind,
+        "payload": payload,
+    })
+}

--- a/crates/tanren-app-services/src/lib.rs
+++ b/crates/tanren-app-services/src/lib.rs
@@ -5,16 +5,22 @@
 //! depend on `tanren-app-services` (and `tanren-contract` for wire shapes);
 //! they do not import domain, store, or runtime crates directly.
 
+pub mod account;
+pub mod events;
+
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tanren_contract::ContractVersion;
-use tanren_store::{Store, StoreError};
+use tanren_contract::{
+    AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, ContractVersion,
+    SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
+};
+pub use tanren_store::Store;
+
+use std::sync::Arc;
+use tanren_store::StoreError;
 use thiserror::Error;
 
 /// Stable response shape for the cross-interface health/liveness query.
-///
-/// Every interface (the api's `/health`, the cli's `--version`, the mcp
-/// server's introspection, the tui's status bar, the daemon's startup log)
-/// resolves to [`Handlers::health`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthReport {
     /// Static "ok" string. Present so consumers can match on a discriminator
@@ -26,16 +32,64 @@ pub struct HealthReport {
     pub contract_version: ContractVersion,
 }
 
-/// Stateless handler facade. Future versions of this crate will hold
-/// dependencies (store, policy, runtime); F-0001 ships the seam itself.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Handlers;
+/// Injected wall-clock. BDD scenarios swap this for a deterministic
+/// fake; production binaries keep [`Clock::default`] (reads
+/// `chrono::Utc::now()`).
+#[derive(Clone)]
+pub struct Clock {
+    inner: Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>,
+}
+
+impl std::fmt::Debug for Clock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Clock").finish_non_exhaustive()
+    }
+}
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Utc::now),
+        }
+    }
+}
+
+impl Clock {
+    /// Wrap a custom `now` impl. The BDD harness uses this to make
+    /// invitation-expiry scenarios deterministic.
+    #[must_use]
+    pub fn from_fn<F>(f: F) -> Self
+    where
+        F: Fn() -> DateTime<Utc> + Send + Sync + 'static,
+    {
+        Self { inner: Arc::new(f) }
+    }
+
+    /// Current wall-clock instant according to this `Clock`.
+    #[must_use]
+    pub fn now(&self) -> DateTime<Utc> {
+        (self.inner)()
+    }
+}
+
+/// Stateless handler facade. Holds an injectable [`Clock`] so account
+/// flow handlers stay deterministic under the BDD harness.
+#[derive(Debug, Clone, Default)]
+pub struct Handlers {
+    clock: Clock,
+}
 
 impl Handlers {
-    /// Construct a fresh handler facade.
+    /// Construct a handler facade backed by [`Clock::default`].
     #[must_use]
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a handler facade backed by an explicit clock.
+    #[must_use]
+    pub fn with_clock(clock: Clock) -> Self {
+        Self { clock }
     }
 
     /// Liveness query. Returns the same shape regardless of which interface
@@ -59,6 +113,57 @@ impl Handlers {
         store.migrate().await?;
         Ok(())
     }
+
+    /// Self-signup command: create a new personal account, mint a
+    /// session, and append an `account_created` event.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppServiceError::Account`] for taxonomy failures
+    /// (duplicate identifier, invalid credential), or
+    /// [`AppServiceError::Store`] for unexpected database failures.
+    pub async fn sign_up(
+        &self,
+        store: &Store,
+        request: SignUpRequest,
+    ) -> Result<SignUpResponse, AppServiceError> {
+        account::sign_up(store, &self.clock, request).await
+    }
+
+    /// Sign-in command: verify an identifier+password against the
+    /// stored hash and mint a fresh session.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppServiceError::Account`] with
+    /// [`AccountFailureReason::InvalidCredential`] when the credential
+    /// does not verify; [`AppServiceError::Store`] for unexpected
+    /// database failures.
+    pub async fn sign_in(
+        &self,
+        store: &Store,
+        request: SignInRequest,
+    ) -> Result<SignInResponse, AppServiceError> {
+        account::sign_in(store, &self.clock, request).await
+    }
+
+    /// Invitation-acceptance command: consume the supplied token,
+    /// create an account joined to the inviting org, and append both
+    /// `account_created` and `invitation_accepted` events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppServiceError::Account`] with the matching
+    /// invitation taxonomy variant when the token is unknown / expired
+    /// / already consumed; [`AppServiceError::Store`] for unexpected
+    /// database failures.
+    pub async fn accept_invitation(
+        &self,
+        store: &Store,
+        request: AcceptInvitationRequest,
+    ) -> Result<AcceptInvitationResponse, AppServiceError> {
+        account::accept_invitation(store, &self.clock, request).await
+    }
 }
 
 /// Errors raised by app-service handlers.
@@ -71,4 +176,8 @@ pub enum AppServiceError {
     /// The underlying store layer raised an error.
     #[error(transparent)]
     Store(#[from] StoreError),
+    /// A taxonomy failure interface binaries map to a `{code, summary}`
+    /// error body.
+    #[error("account: {}", .0.code())]
+    Account(AccountFailureReason),
 }

--- a/crates/tanren-bdd/Cargo.toml
+++ b/crates/tanren-bdd/Cargo.toml
@@ -12,7 +12,11 @@ description = "BDD step-definition home for Tanren. Hosts the cucumber `World` a
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 cucumber = { workspace = true }
+tanren-app-services = { path = "../tanren-app-services" }
+tanren-contract = { path = "../tanren-contract" }
+tanren-store = { path = "../tanren-store" }
 tanren-testkit = { path = "../tanren-testkit" }
 tokio = { workspace = true }
 

--- a/crates/tanren-bdd/src/lib.rs
+++ b/crates/tanren-bdd/src/lib.rs
@@ -2,37 +2,156 @@
 //!
 //! This is the only crate in the workspace permitted to define `#[test]`
 //! items — `xtask check-rust-test-surface` mechanically rejects them
-//! anywhere else. F-0001 ships only the registry machinery and a single
-//! compile-time smoke check; concrete step definitions and feature files
-//! enter with R-0001 onwards.
+//! anywhere else. R-0001 (S-10) lands the first feature
+//! (`B-0043-create-account.feature`) and the supporting account-flow
+//! step definitions.
+
+pub mod steps;
 
 use cucumber::World as CucumberWorld;
+use std::collections::HashMap;
 use std::path::PathBuf;
-use tanren_testkit::FixtureSeed;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use tanren_app_services::{Clock, Handlers, Store};
+use tanren_contract::{
+    AcceptInvitationResponse, AccountFailureReason, SignInResponse, SignUpResponse,
+};
+use tanren_testkit::{FixtureSeed, InvitationFixture};
 
 /// Cucumber `World` shared across all Tanren BDD scenarios.
-///
-/// Slices add per-feature mixins by extending this struct rather than
-/// defining their own `World` — keeping the world singular preserves
-/// cross-feature step reuse.
 #[derive(Debug, Default, CucumberWorld)]
 pub struct TanrenWorld {
-    /// Deterministic fixture seed. Defaults to `0` so unset fixtures still
-    /// serialize stably across runs.
+    /// Deterministic fixture seed.
     pub seed: FixtureSeed,
+    /// Lazily initialized account-flow context.
+    pub account: Option<AccountContext>,
+}
+
+impl TanrenWorld {
+    /// Construct (or return) the lazy account context.
+    pub async fn ensure_account_ctx(&mut self) -> &mut AccountContext {
+        if self.account.is_none() {
+            let ctx = AccountContext::new()
+                .await
+                .expect("ephemeral SQLite should connect for BDD");
+            self.account = Some(ctx);
+        }
+        self.account
+            .as_mut()
+            .expect("account context just initialized")
+    }
+}
+
+/// Per-scenario in-memory state for the account-flow steps.
+#[derive(Debug)]
+pub struct AccountContext {
+    /// Shared store.
+    pub store: Store,
+    /// Handler facade.
+    pub handlers: Handlers,
+    /// Mutable shared clock — scenarios can warp time forward to expire
+    /// invitations.
+    pub clock: SharedClock,
+    /// Registry of actors by display name.
+    pub actors: HashMap<String, ActorState>,
+    /// Pending invitations seeded by the scenario, keyed by token.
+    pub invitations: HashMap<String, InvitationFixture>,
+    /// The most recent action's outcome.
+    pub last_outcome: Option<Outcome>,
+}
+
+impl AccountContext {
+    /// Construct a fresh context backed by an in-memory `SQLite` store.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying store error if connection or migration fails.
+    pub async fn new() -> Result<Self, tanren_store::StoreError> {
+        let store = tanren_testkit::ephemeral_store().await?;
+        let clock = SharedClock::new(Utc::now());
+        let handlers = Handlers::with_clock(clock.as_app_clock());
+        Ok(Self {
+            store,
+            handlers,
+            clock,
+            actors: HashMap::new(),
+            invitations: HashMap::new(),
+            last_outcome: None,
+        })
+    }
+}
+
+/// Per-actor state captured by `Given <actor> has signed up ...` style
+/// steps so subsequent steps can sign them in or assert membership.
+#[derive(Debug, Clone, Default)]
+pub struct ActorState {
+    /// Identifier (email) the actor signed up with.
+    pub identifier: Option<String>,
+    /// Password the actor signed up with.
+    pub password: Option<String>,
+    /// Last successful sign-up response, if any.
+    pub sign_up: Option<SignUpResponse>,
+    /// Last successful sign-in response, if any.
+    pub sign_in: Option<SignInResponse>,
+    /// Last successful invitation acceptance, if any.
+    pub accept_invitation: Option<AcceptInvitationResponse>,
+    /// Last failure (taxonomy code), if any.
+    pub last_failure: Option<AccountFailureReason>,
+}
+
+/// Outcome of the most recent account-flow action.
+#[derive(Debug, Clone)]
+pub enum Outcome {
+    /// Successful sign-up.
+    SignedUp(SignUpResponse),
+    /// Successful sign-in.
+    SignedIn(SignInResponse),
+    /// Successful invitation acceptance.
+    AcceptedInvitation(AcceptInvitationResponse),
+    /// Account-flow taxonomy failure.
+    Failure(AccountFailureReason),
+    /// Non-taxonomy infrastructure failure.
+    Other(String),
+}
+
+/// Mutable clock shared between scenarios and the [`Handlers`] facade.
+#[derive(Debug, Clone)]
+pub struct SharedClock {
+    inner: Arc<Mutex<DateTime<Utc>>>,
+}
+
+impl SharedClock {
+    /// Build a new shared clock that initially reports `now`.
+    #[must_use]
+    pub fn new(now: DateTime<Utc>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(now)),
+        }
+    }
+
+    /// Read the current clock instant.
+    #[must_use]
+    pub fn read(&self) -> DateTime<Utc> {
+        *self.inner.lock().expect("shared clock mutex poisoned")
+    }
+
+    /// Set the clock to a specific instant.
+    pub fn set(&self, when: DateTime<Utc>) {
+        *self.inner.lock().expect("shared clock mutex poisoned") = when;
+    }
+
+    /// Wrap as an `app_services::Clock`.
+    #[must_use]
+    pub fn as_app_clock(&self) -> Clock {
+        let inner = self.inner.clone();
+        Clock::from_fn(move || *inner.lock().expect("shared clock mutex poisoned"))
+    }
 }
 
 /// Run the cucumber harness against the supplied features directory.
-///
-/// Treats undefined-step and skipped-scenario outcomes as failures so that
-/// `just tests` cannot pass with silently-broken behavior proof — a feature
-/// file containing an unmatched step definition fails the gate. On failure
-/// the process exits with a non-zero status; on success it returns
-/// normally.
-///
-/// In F-0001 the directory is empty, so cucumber reports zero scenarios and
-/// the call exits 0 immediately. The harness machinery itself is exercised
-/// by the unit tests inside this crate (see `cargo test -p tanren-bdd`).
 pub async fn run_features(features_dir: impl Into<PathBuf>) {
     TanrenWorld::cucumber()
         .fail_on_skipped()
@@ -42,10 +161,7 @@ pub async fn run_features(features_dir: impl Into<PathBuf>) {
 
 #[cfg(test)]
 mod tests {
-    //! The only `#[test]` items in the workspace. Existence of these proves
-    //! the cucumber registry compiles and the [`TanrenWorld`] type is
-    //! constructible; correctness of step definitions is proved by the
-    //! cucumber scenarios themselves once R-* slices add them.
+    //! Unit-test guards for the BDD harness machinery itself.
 
     use super::TanrenWorld;
     use tanren_testkit::FixtureSeed;
@@ -60,6 +176,7 @@ mod tests {
     fn world_seed_round_trips() {
         let world = TanrenWorld {
             seed: FixtureSeed::new(42),
+            account: None,
         };
         assert_eq!(world.seed.value(), 42);
     }

--- a/crates/tanren-bdd/src/steps/account.rs
+++ b/crates/tanren-bdd/src/steps/account.rs
@@ -1,0 +1,278 @@
+//! Account-flow step definitions for B-0043.
+//!
+//! Drives the same `tanren_app_services::Handlers` facade every
+//! interface binary delegates to. Per the equivalent-operations rule
+//! in `docs/architecture/subsystems/interfaces.md`, the api / mcp /
+//! cli / tui / web surfaces all resolve to these handlers, so the
+//! interface tag on a scenario is a witness label rather than a
+//! transport switch — the mechanism under proof is identical.
+
+use chrono::Duration;
+use cucumber::{given, then, when};
+use tanren_contract::{AcceptInvitationRequest, SignInRequest, SignUpRequest};
+use tanren_testkit::InvitationFixture;
+
+use crate::{ActorState, Outcome, TanrenWorld};
+
+#[given(expr = "a clean Tanren environment")]
+async fn clean_env(world: &mut TanrenWorld) {
+    let _ = world.ensure_account_ctx().await;
+}
+
+#[given(expr = "a pending invitation token {string}")]
+async fn given_pending_invitation(world: &mut TanrenWorld, token: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let now = ctx.clock.read();
+    let mut fixture = InvitationFixture::valid(now);
+    fixture.token = token.clone();
+    tanren_testkit::seed_invitation(&ctx.store, &fixture)
+        .await
+        .expect("seed valid invitation");
+    ctx.invitations.insert(token, fixture);
+}
+
+#[given(expr = "an expired invitation token {string}")]
+async fn given_expired_invitation(world: &mut TanrenWorld, token: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let now = ctx.clock.read();
+    let mut fixture = InvitationFixture::expired(now);
+    fixture.token = token.clone();
+    tanren_testkit::seed_invitation(&ctx.store, &fixture)
+        .await
+        .expect("seed expired invitation");
+    ctx.invitations.insert(token, fixture);
+}
+
+#[given(expr = "{word} has signed up with email {string} and password {string}")]
+async fn given_signed_up(world: &mut TanrenWorld, actor: String, email: String, password: String) {
+    do_sign_up(world, actor, email, password, "Background actor".to_owned()).await;
+    let ctx = world.account.as_mut().expect("ctx initialized");
+    assert!(
+        matches!(ctx.last_outcome, Some(Outcome::SignedUp(_))),
+        "background sign-up step must succeed"
+    );
+}
+
+#[when(expr = "{word} self-signs up with email {string} and password {string}")]
+async fn when_sign_up(world: &mut TanrenWorld, actor: String, email: String, password: String) {
+    do_sign_up(world, actor, email, password, "Tanren user".to_owned()).await;
+}
+
+#[when(expr = "{word} signs in with email {string} and password {string}")]
+async fn when_sign_in(world: &mut TanrenWorld, actor: String, email: String, password: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let result = ctx
+        .handlers
+        .sign_in(
+            &ctx.store,
+            SignInRequest {
+                email: email.clone(),
+                password: password.clone(),
+            },
+        )
+        .await;
+    let entry = ctx.actors.entry(actor.clone()).or_default();
+    entry.identifier = Some(email);
+    entry.password = Some(password);
+    let outcome = match result {
+        Ok(response) => {
+            entry.sign_in = Some(response.clone());
+            Outcome::SignedIn(response)
+        }
+        Err(err) => failure_outcome(err, entry),
+    };
+    ctx.last_outcome = Some(outcome);
+}
+
+#[when(expr = "{word} signs in with the same credentials")]
+async fn when_sign_in_same(world: &mut TanrenWorld, actor: String) {
+    let (email, password) = {
+        let ctx = world.ensure_account_ctx().await;
+        let entry = ctx
+            .actors
+            .get(&actor)
+            .expect("actor must have signed up first");
+        (
+            entry
+                .identifier
+                .clone()
+                .expect("actor identifier captured during sign-up"),
+            entry
+                .password
+                .clone()
+                .expect("actor password captured during sign-up"),
+        )
+    };
+    when_sign_in(world, actor, email, password).await;
+}
+
+#[when(expr = "{word} accepts invitation {string} with password {string}")]
+async fn when_accept_invitation(
+    world: &mut TanrenWorld,
+    actor: String,
+    token: String,
+    password: String,
+) {
+    let ctx = world.ensure_account_ctx().await;
+    let display_name = format!("{actor} via {token}");
+    let result = ctx
+        .handlers
+        .accept_invitation(
+            &ctx.store,
+            AcceptInvitationRequest {
+                invitation_token: token,
+                password: password.clone(),
+                display_name: display_name.clone(),
+            },
+        )
+        .await;
+    let entry = ctx.actors.entry(actor.clone()).or_default();
+    entry.password = Some(password);
+    let outcome = match result {
+        Ok(response) => {
+            entry.identifier = Some(response.account.identifier.clone());
+            entry.accept_invitation = Some(response.clone());
+            Outcome::AcceptedInvitation(response)
+        }
+        Err(err) => failure_outcome(err, entry),
+    };
+    ctx.last_outcome = Some(outcome);
+}
+
+#[when(expr = "the clock advances past the invitation expiry")]
+async fn when_clock_advances(world: &mut TanrenWorld) {
+    let ctx = world.ensure_account_ctx().await;
+    let now = ctx.clock.read();
+    ctx.clock.set(now + Duration::days(2));
+}
+
+#[then(expr = "{word} receives a session token")]
+async fn then_session_token(world: &mut TanrenWorld, actor: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let entry = ctx
+        .actors
+        .get(&actor)
+        .expect("actor must have an outcome recorded");
+    let token = match entry.sign_up.as_ref() {
+        Some(r) => Some(&r.session.token),
+        None => entry
+            .sign_in
+            .as_ref()
+            .map(|r| &r.session.token)
+            .or_else(|| entry.accept_invitation.as_ref().map(|r| &r.session.token)),
+    };
+    assert!(
+        token.is_some_and(|t| !t.is_empty()),
+        "expected non-empty session token for {actor}"
+    );
+}
+
+#[then(expr = "{word}'s account belongs to no organization")]
+async fn then_no_org(world: &mut TanrenWorld, actor: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let entry = ctx
+        .actors
+        .get(&actor)
+        .expect("actor must have an outcome recorded");
+    let view = entry
+        .sign_up
+        .as_ref()
+        .map(|r| &r.account)
+        .or_else(|| entry.sign_in.as_ref().map(|r| &r.account))
+        .expect("actor has a successful response on file");
+    assert!(
+        view.org.is_none(),
+        "expected personal (no-org) account for {actor}"
+    );
+}
+
+#[then(expr = "{word} has joined an organization")]
+async fn then_joined_org(world: &mut TanrenWorld, actor: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let entry = ctx
+        .actors
+        .get(&actor)
+        .expect("actor must have an outcome recorded");
+    let response = entry
+        .accept_invitation
+        .as_ref()
+        .expect("actor must have accepted an invitation");
+    assert_eq!(response.account.org, Some(response.joined_org));
+}
+
+#[then(expr = "{word} now holds {int} accounts")]
+async fn then_holds_n_accounts(world: &mut TanrenWorld, actor: String, count: usize) {
+    let ctx = world.ensure_account_ctx().await;
+    let entry = ctx.actors.get(&actor).expect("actor must have signed up");
+    let mut owned = 0;
+    if entry.sign_up.is_some() {
+        owned += 1;
+    }
+    if entry.accept_invitation.is_some() {
+        owned += 1;
+    }
+    assert_eq!(
+        owned, count,
+        "expected {actor} to hold {count} accounts, got {owned}"
+    );
+}
+
+#[then(expr = "the request fails with code {string}")]
+async fn then_fails_with(world: &mut TanrenWorld, code: String) {
+    let ctx = world.ensure_account_ctx().await;
+    let actual = match &ctx.last_outcome {
+        Some(Outcome::Failure(reason)) => reason.code().to_owned(),
+        Some(Outcome::SignedUp(_)) => "signed_up_unexpectedly".to_owned(),
+        Some(Outcome::SignedIn(_)) => "signed_in_unexpectedly".to_owned(),
+        Some(Outcome::AcceptedInvitation(_)) => "accepted_invitation_unexpectedly".to_owned(),
+        Some(Outcome::Other(s)) => format!("other:{s}"),
+        None => "no_outcome".to_owned(),
+    };
+    assert_eq!(actual, code, "expected failure code");
+}
+
+async fn do_sign_up(
+    world: &mut TanrenWorld,
+    actor: String,
+    email: String,
+    password: String,
+    display_name: String,
+) {
+    let ctx = world.ensure_account_ctx().await;
+    let result = ctx
+        .handlers
+        .sign_up(
+            &ctx.store,
+            SignUpRequest {
+                email: email.clone(),
+                password: password.clone(),
+                display_name,
+            },
+        )
+        .await;
+    let entry = ctx.actors.entry(actor.clone()).or_default();
+    entry.identifier = Some(email);
+    entry.password = Some(password);
+    let outcome = match result {
+        Ok(response) => {
+            entry.sign_up = Some(response.clone());
+            Outcome::SignedUp(response)
+        }
+        Err(err) => failure_outcome(err, entry),
+    };
+    ctx.last_outcome = Some(outcome);
+}
+
+fn failure_outcome(err: tanren_app_services::AppServiceError, entry: &mut ActorState) -> Outcome {
+    match err {
+        tanren_app_services::AppServiceError::Account(reason) => {
+            entry.last_failure = Some(reason);
+            Outcome::Failure(reason)
+        }
+        tanren_app_services::AppServiceError::InvalidInput(message) => {
+            Outcome::Other(format!("invalid_input: {message}"))
+        }
+        tanren_app_services::AppServiceError::Store(err) => Outcome::Other(format!("store: {err}")),
+        _ => Outcome::Other("unknown".to_owned()),
+    }
+}

--- a/crates/tanren-bdd/src/steps/mod.rs
+++ b/crates/tanren-bdd/src/steps/mod.rs
@@ -1,0 +1,5 @@
+//! Step-definition modules. R-0001 ships only `account` (the account
+//! flow that proves B-0043). Future R-* slices add their own modules
+//! here and the macros register globally.
+
+pub mod account;

--- a/crates/tanren-contract/Cargo.toml
+++ b/crates/tanren-contract/Cargo.toml
@@ -12,5 +12,7 @@ description = "Wire-shape contracts for Tanren's API and MCP boundaries. Foundat
 workspace = true
 
 [dependencies]
+schemars = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/tanren-contract/src/account.rs
+++ b/crates/tanren-contract/src/account.rs
@@ -1,0 +1,162 @@
+//! Account command/response wire shapes.
+//!
+//! These types are the request/response surface used by the api, mcp,
+//! cli, tui, and web client when callers create or sign in to a Tanren
+//! account. They live in `tanren-contract` because every interface
+//! binary serialises the same shapes — keeping them here is the
+//! architectural guarantee that the surfaces stay equivalent.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Self-signup request.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SignUpRequest {
+    /// Email address that will own the new account. Lower-cased + trimmed
+    /// during validation.
+    pub email: String,
+    /// Plaintext password. Hashed by the handler before persistence.
+    pub password: String,
+    /// Human-readable display name for the new account.
+    pub display_name: String,
+}
+
+/// Successful sign-up response.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SignUpResponse {
+    /// View of the freshly created account.
+    pub account: AccountView,
+    /// Session minted for the new account.
+    pub session: SessionView,
+}
+
+/// Sign-in request.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SignInRequest {
+    /// Email of the account being signed in to.
+    pub email: String,
+    /// Plaintext password — verified against the stored hash.
+    pub password: String,
+}
+
+/// Successful sign-in response.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SignInResponse {
+    /// View of the signed-in account.
+    pub account: AccountView,
+    /// Newly minted session.
+    pub session: SessionView,
+}
+
+/// Invitation-acceptance request.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AcceptInvitationRequest {
+    /// Invitation token issued by the inviting organization.
+    pub invitation_token: String,
+    /// Plaintext password for the new account.
+    pub password: String,
+    /// Display name for the new account.
+    pub display_name: String,
+}
+
+/// Successful invitation-acceptance response.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AcceptInvitationResponse {
+    /// View of the newly created account.
+    pub account: AccountView,
+    /// Newly minted session.
+    pub session: SessionView,
+    /// Organization the new account joined as a result of this acceptance.
+    pub joined_org: Uuid,
+}
+
+/// External-facing view of a Tanren account.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AccountView {
+    /// Stable account id.
+    pub id: Uuid,
+    /// User-facing identifier (email).
+    pub identifier: String,
+    /// Display name.
+    pub display_name: String,
+    /// Owning organization id — `None` for personal (self-signup) accounts.
+    pub org: Option<Uuid>,
+}
+
+/// External-facing view of a session token. The token is opaque to all
+/// callers; only the issuer (the api/cli/mcp/tui binary that signed it)
+/// understands its internal shape.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionView {
+    /// Account this session is bound to.
+    pub account_id: Uuid,
+    /// Opaque session token.
+    pub token: String,
+}
+
+/// Closed taxonomy of account-flow failures.
+///
+/// Maps onto the shared `{code, summary}` error body documented in
+/// `docs/architecture/subsystems/interfaces.md` "Error Taxonomy". Every
+/// interface (api/mcp/cli/tui/web) projects an `AccountFailureReason`
+/// into the same wire shape so callers can match on `code` regardless of
+/// transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AccountFailureReason {
+    /// The submitted identifier is already in use by another account.
+    DuplicateIdentifier,
+    /// The submitted credentials did not match a stored credential.
+    InvalidCredential,
+    /// Invitation token does not correspond to any known invitation.
+    InvitationNotFound,
+    /// Invitation token has expired.
+    InvitationExpired,
+    /// Invitation token has already been accepted or revoked.
+    InvitationAlreadyConsumed,
+}
+
+impl AccountFailureReason {
+    /// Stable wire `code` for this failure.
+    #[must_use]
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::DuplicateIdentifier => "duplicate_identifier",
+            Self::InvalidCredential => "invalid_credential",
+            Self::InvitationNotFound => "invitation_not_found",
+            Self::InvitationExpired => "invitation_expired",
+            Self::InvitationAlreadyConsumed => "invitation_already_consumed",
+        }
+    }
+
+    /// Human-readable wire `summary` for this failure.
+    #[must_use]
+    pub const fn summary(self) -> &'static str {
+        match self {
+            Self::DuplicateIdentifier => "An account already exists for the supplied identifier.",
+            Self::InvalidCredential => {
+                "The supplied credentials are invalid or did not match an account."
+            }
+            Self::InvitationNotFound => "The invitation token does not match any known invitation.",
+            Self::InvitationExpired => "The invitation has expired and can no longer be accepted.",
+            Self::InvitationAlreadyConsumed => {
+                "The invitation has already been accepted or was revoked."
+            }
+        }
+    }
+
+    /// Recommended HTTP status for the failure when projected over the
+    /// api / mcp surfaces. Centralized so every transport reports the
+    /// same status for the same failure code.
+    #[must_use]
+    pub const fn http_status(self) -> u16 {
+        match self {
+            Self::DuplicateIdentifier => 409,
+            Self::InvalidCredential => 401,
+            Self::InvitationNotFound => 404,
+            Self::InvitationExpired | Self::InvitationAlreadyConsumed => 410,
+        }
+    }
+}

--- a/crates/tanren-contract/src/lib.rs
+++ b/crates/tanren-contract/src/lib.rs
@@ -5,6 +5,13 @@
 //! callers. Orchestration logic does not live here — this crate stays a pure
 //! shape layer so that wire compatibility is reviewable in isolation.
 
+pub mod account;
+
+pub use account::{
+    AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, AccountView,
+    SessionView, SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
+};
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/crates/tanren-identity-policy/Cargo.toml
+++ b/crates/tanren-identity-policy/Cargo.toml
@@ -12,5 +12,7 @@ description = "Identity and Policy subsystem: accounts, organizations, projects,
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/tanren-identity-policy/src/lib.rs
+++ b/crates/tanren-identity-policy/src/lib.rs
@@ -6,50 +6,176 @@
 //! introspection, ...) is deliberately not committed here — R-0001 onwards
 //! pin the mechanism behind a [`CredentialVerifier`] impl.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
-/// Stable identifier for a Tanren account.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct AccountId(String);
+/// Stable identifier for a Tanren account. `UUIDv7` — sortable + unique.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AccountId(Uuid);
 
 impl AccountId {
-    /// Wrap a raw id string.
+    /// Wrap a raw UUID.
+    #[must_use]
+    pub const fn new(value: Uuid) -> Self {
+        Self(value)
+    }
+
+    /// Allocate a fresh time-ordered id.
+    #[must_use]
+    pub fn fresh() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    /// The underlying UUID.
+    #[must_use]
+    pub const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+/// Stable identifier for a Tanren organization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct OrgId(Uuid);
+
+impl OrgId {
+    /// Wrap a raw UUID.
+    #[must_use]
+    pub const fn new(value: Uuid) -> Self {
+        Self(value)
+    }
+
+    /// Allocate a fresh time-ordered id.
+    #[must_use]
+    pub fn fresh() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    /// The underlying UUID.
+    #[must_use]
+    pub const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+/// User-facing identifier for an account. R-0001's chosen mechanism is
+/// identifier+password where the identifier is an email; the type wraps
+/// the raw string so future mechanisms can lift constraints in one place.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Identifier(String);
+
+impl Identifier {
+    /// Construct from a raw string (already lower-cased + trimmed by the
+    /// caller for identifier+password mechanisms).
     #[must_use]
     pub const fn new(value: String) -> Self {
         Self(value)
     }
 
-    /// Borrow the underlying id string.
+    /// Borrow the underlying identifier string.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
+/// Opaque invitation token. R-0001 treats the token as a flat string —
+/// generation/delivery is R-0005's job; here we just verify and consume.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct InvitationToken(String);
+
+impl InvitationToken {
+    /// Wrap a raw token string.
+    #[must_use]
+    pub const fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the underlying token string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A Tanren account. `org` is `None` for self-signed-up personal accounts;
+/// invitation-based accounts carry the inviting `OrgId`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Account {
+    /// Stable id.
+    pub id: AccountId,
+    /// User-facing identifier (email, ...).
+    pub identifier: Identifier,
+    /// Wall-clock time the account was created.
+    pub created_at: DateTime<Utc>,
+    /// Owning organization — `None` for personal accounts (self-signup).
+    pub org: Option<OrgId>,
+}
+
+/// A pending invitation seeded by R-0005's invite flow (or by
+/// `tanren-testkit` fixtures during R-0001 BDD). Carries the invitee's
+/// destination organization plus expiry / consumption state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Invitation {
+    /// The opaque token shared with the invitee out-of-band.
+    pub token: InvitationToken,
+    /// Organization the new account joins on acceptance.
+    pub inviting_org: OrgId,
+    /// Expiry instant — tokens older than this are rejected.
+    pub expires_at: DateTime<Utc>,
+    /// Set when the invitation has been accepted (or revoked).
+    pub consumed_at: Option<DateTime<Utc>>,
+}
+
+/// An identifier+password credential pair as supplied by the caller.
+/// Hashing is the responsibility of the [`CredentialVerifier`] impl.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PasswordCredential {
+    /// User-facing identifier (email, ...).
+    pub identifier: Identifier,
+    /// Plaintext password — hashed before storage / verified against a stored hash.
+    pub password: String,
+}
+
 /// A bounded session held by an authenticated account or service identity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
-    /// The account or service id this session represents.
+    /// The account this session represents.
     pub account: AccountId,
     /// Opaque session token.
     pub token: String,
 }
 
 /// Verifies a credential and returns a [`Session`] on success. Mechanism
-/// (local password, OIDC, ...) is the implementor's responsibility; R-0001
-/// onwards introduces concrete impls.
+/// (local password, OIDC, ...) is the implementor's responsibility.
 pub trait CredentialVerifier: Send + Sync {
-    /// Verify the supplied credential and produce a session. Returns
-    /// [`IdentityError::Rejected`] if the credential does not verify.
-    fn verify(&self, credential: &str) -> Result<Session, IdentityError>;
+    /// Verify the supplied credential and produce a session.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::InvalidCredential`] if the credential does
+    /// not verify.
+    fn verify(&self, credential: &PasswordCredential) -> Result<Session, IdentityError>;
 }
 
 /// Errors raised by identity-policy operations.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum IdentityError {
-    /// The credential did not verify.
-    #[error("credential rejected")]
-    Rejected,
+    /// An account with the supplied identifier already exists.
+    #[error("an account already exists for the supplied identifier")]
+    DuplicateIdentifier,
+    /// The supplied credential did not verify (or did not match a known account).
+    #[error("the supplied credential is invalid")]
+    InvalidCredential,
+    /// No invitation matched the supplied token.
+    #[error("no invitation matches the supplied token")]
+    InvitationNotFound,
+    /// The invitation token has expired.
+    #[error("the invitation has expired")]
+    InvitationExpired,
+    /// The invitation has already been consumed (or revoked).
+    #[error("the invitation has already been consumed")]
+    InvitationAlreadyConsumed,
 }

--- a/crates/tanren-store/src/entity/account_sessions.rs
+++ b/crates/tanren-store/src/entity/account_sessions.rs
@@ -1,0 +1,19 @@
+//! `SeaORM` entity for the `account_sessions` table — opaque session
+//! tokens issued by `tanren-app-services` on successful sign-up / sign-in
+//! / invitation acceptance.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "account_sessions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub token: String,
+    pub account_id: Uuid,
+    pub created_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/accounts.rs
+++ b/crates/tanren-store/src/entity/accounts.rs
@@ -1,0 +1,22 @@
+//! `SeaORM` entity for the `accounts` table.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "accounts")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    #[sea_orm(unique)]
+    pub identifier: String,
+    pub display_name: String,
+    pub password_hash: Vec<u8>,
+    pub password_salt: Vec<u8>,
+    pub created_at: DateTimeUtc,
+    pub org_id: Option<Uuid>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/invitations.rs
+++ b/crates/tanren-store/src/entity/invitations.rs
@@ -1,0 +1,18 @@
+//! `SeaORM` entity for the `invitations` table.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "invitations")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub token: String,
+    pub inviting_org_id: Uuid,
+    pub expires_at: DateTimeUtc,
+    pub consumed_at: Option<DateTimeUtc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/memberships.rs
+++ b/crates/tanren-store/src/entity/memberships.rs
@@ -1,0 +1,18 @@
+//! `SeaORM` entity for the `memberships` table — links accounts to orgs.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "memberships")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub org_id: Uuid,
+    pub created_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tanren-store/src/entity/mod.rs
+++ b/crates/tanren-store/src/entity/mod.rs
@@ -2,4 +2,8 @@
 //! must not leak across the workspace dependency boundary. `check-deps`
 //! mechanically rejects `pub mod events` here.
 
+pub(crate) mod account_sessions;
+pub(crate) mod accounts;
 pub(crate) mod events;
+pub(crate) mod invitations;
+pub(crate) mod memberships;

--- a/crates/tanren-store/src/lib.rs
+++ b/crates/tanren-store/src/lib.rs
@@ -13,8 +13,8 @@ pub use migration::Migrator;
 
 use chrono::{DateTime, Utc};
 use sea_orm::{
-    ActiveModelTrait, Database, DatabaseConnection, DbErr, EntityTrait, QueryOrder, QuerySelect,
-    Set,
+    ActiveModelTrait, ColumnTrait, Database, DatabaseConnection, DbErr, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
 };
 use sea_orm_migration::MigratorTrait;
 use serde::{Deserialize, Serialize};
@@ -144,6 +144,277 @@ impl From<entity::events::Model> for EventEnvelope {
             occurred_at: model.occurred_at,
             payload: model.payload,
         }
+    }
+}
+
+/// Persisted account row, exposed as a typed envelope so other crates
+/// never see `SeaORM` `Model` types directly. R-0001 stores password
+/// hash + salt as opaque bytes so the hashing scheme is swappable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountRecord {
+    /// Stable account id.
+    pub id: Uuid,
+    /// User-facing identifier (email).
+    pub identifier: String,
+    /// Display name.
+    pub display_name: String,
+    /// Opaque password hash bytes.
+    pub password_hash: Vec<u8>,
+    /// Salt that produced the password hash.
+    pub password_salt: Vec<u8>,
+    /// Wall-clock time the account was created.
+    pub created_at: DateTime<Utc>,
+    /// Owning organization — `None` for personal (self-signup) accounts.
+    pub org_id: Option<Uuid>,
+}
+
+impl From<entity::accounts::Model> for AccountRecord {
+    fn from(model: entity::accounts::Model) -> Self {
+        Self {
+            id: model.id,
+            identifier: model.identifier,
+            display_name: model.display_name,
+            password_hash: model.password_hash,
+            password_salt: model.password_salt,
+            created_at: model.created_at,
+            org_id: model.org_id,
+        }
+    }
+}
+
+/// Persisted invitation row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvitationRecord {
+    /// Opaque invitation token (PK).
+    pub token: String,
+    /// Organization the new account joins on acceptance.
+    pub inviting_org_id: Uuid,
+    /// Expiry instant.
+    pub expires_at: DateTime<Utc>,
+    /// Set when the invitation has been accepted (or revoked).
+    pub consumed_at: Option<DateTime<Utc>>,
+}
+
+impl From<entity::invitations::Model> for InvitationRecord {
+    fn from(model: entity::invitations::Model) -> Self {
+        Self {
+            token: model.token,
+            inviting_org_id: model.inviting_org_id,
+            expires_at: model.expires_at,
+            consumed_at: model.consumed_at,
+        }
+    }
+}
+
+/// Persisted membership row — links an account to an organization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MembershipRecord {
+    /// Stable membership id.
+    pub id: Uuid,
+    /// Account this membership belongs to.
+    pub account_id: Uuid,
+    /// Organization the account is a member of.
+    pub org_id: Uuid,
+    /// Wall-clock time the membership was created.
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<entity::memberships::Model> for MembershipRecord {
+    fn from(model: entity::memberships::Model) -> Self {
+        Self {
+            id: model.id,
+            account_id: model.account_id,
+            org_id: model.org_id,
+            created_at: model.created_at,
+        }
+    }
+}
+
+/// Persisted session row — issued by `tanren-app-services` on
+/// successful sign-up / sign-in / invitation acceptance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRecord {
+    /// Opaque session token (PK).
+    pub token: String,
+    /// Account this session belongs to.
+    pub account_id: Uuid,
+    /// Wall-clock time the session was issued.
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<entity::account_sessions::Model> for SessionRecord {
+    fn from(model: entity::account_sessions::Model) -> Self {
+        Self {
+            token: model.token,
+            account_id: model.account_id,
+            created_at: model.created_at,
+        }
+    }
+}
+
+/// Input shape for [`Store::insert_account`].
+#[derive(Debug, Clone)]
+pub struct NewAccount {
+    /// Stable id allocated by the caller (`UUIDv7`).
+    pub id: Uuid,
+    /// User-facing identifier (email).
+    pub identifier: String,
+    /// Display name.
+    pub display_name: String,
+    /// Opaque password hash bytes.
+    pub password_hash: Vec<u8>,
+    /// Salt that produced the password hash.
+    pub password_salt: Vec<u8>,
+    /// Wall-clock creation time.
+    pub created_at: DateTime<Utc>,
+    /// Owning organization — `None` for personal (self-signup) accounts.
+    pub org_id: Option<Uuid>,
+}
+
+/// Input shape for [`Store::seed_invitation`].
+#[derive(Debug, Clone)]
+pub struct NewInvitation {
+    /// Opaque token shared with the invitee out of band.
+    pub token: String,
+    /// Organization the new account joins on acceptance.
+    pub inviting_org_id: Uuid,
+    /// Expiry instant.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl Store {
+    /// Insert a new account row.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the insert fails — including
+    /// the unique-index violation that fires on duplicate `identifier`.
+    pub async fn insert_account(&self, new: NewAccount) -> Result<AccountRecord, StoreError> {
+        let model = entity::accounts::ActiveModel {
+            id: Set(new.id),
+            identifier: Set(new.identifier),
+            display_name: Set(new.display_name),
+            password_hash: Set(new.password_hash),
+            password_salt: Set(new.password_salt),
+            created_at: Set(new.created_at),
+            org_id: Set(new.org_id),
+        };
+        let inserted = model.insert(&self.conn).await?;
+        Ok(inserted.into())
+    }
+
+    /// Look up an account by its case-sensitive identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the query fails.
+    pub async fn find_account_by_identifier(
+        &self,
+        identifier: &str,
+    ) -> Result<Option<AccountRecord>, StoreError> {
+        let row = entity::accounts::Entity::find()
+            .filter(entity::accounts::Column::Identifier.eq(identifier))
+            .one(&self.conn)
+            .await?;
+        Ok(row.map(AccountRecord::from))
+    }
+
+    /// Insert a membership linking an account to an organization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the insert fails (including
+    /// the unique-(account,org) constraint).
+    pub async fn insert_membership(
+        &self,
+        account_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<(), StoreError> {
+        let model = entity::memberships::ActiveModel {
+            id: Set(Uuid::now_v7()),
+            account_id: Set(account_id),
+            org_id: Set(org_id),
+            created_at: Set(Utc::now()),
+        };
+        model.insert(&self.conn).await?;
+        Ok(())
+    }
+
+    /// Seed a fixture invitation. Real invitations are minted by R-0005's
+    /// invite flow; R-0001 only models acceptance, so BDD seeds the row
+    /// directly. Documented as test-only — production code should not
+    /// call this.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the insert fails.
+    pub async fn seed_invitation(
+        &self,
+        new: NewInvitation,
+    ) -> Result<InvitationRecord, StoreError> {
+        let model = entity::invitations::ActiveModel {
+            token: Set(new.token),
+            inviting_org_id: Set(new.inviting_org_id),
+            expires_at: Set(new.expires_at),
+            consumed_at: Set(None),
+        };
+        let inserted = model.insert(&self.conn).await?;
+        Ok(inserted.into())
+    }
+
+    /// Look up an invitation by token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the query fails.
+    pub async fn find_invitation_by_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<InvitationRecord>, StoreError> {
+        let row = entity::invitations::Entity::find_by_id(token.to_owned())
+            .one(&self.conn)
+            .await?;
+        Ok(row.map(InvitationRecord::from))
+    }
+
+    /// Mark an invitation consumed at the supplied instant.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the update fails.
+    pub async fn mark_invitation_consumed(
+        &self,
+        token: &str,
+        consumed_at: DateTime<Utc>,
+    ) -> Result<(), StoreError> {
+        let row = entity::invitations::Entity::find_by_id(token.to_owned())
+            .one(&self.conn)
+            .await?;
+        if let Some(row) = row {
+            let mut active: entity::invitations::ActiveModel = row.into();
+            active.consumed_at = Set(Some(consumed_at));
+            active.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
+    /// Issue a session for the supplied account.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Database`] if the insert fails.
+    pub async fn insert_session(
+        &self,
+        token: String,
+        account_id: Uuid,
+    ) -> Result<SessionRecord, StoreError> {
+        let model = entity::account_sessions::ActiveModel {
+            token: Set(token),
+            account_id: Set(account_id),
+            created_at: Set(Utc::now()),
+        };
+        let inserted = model.insert(&self.conn).await?;
+        Ok(inserted.into())
     }
 }
 

--- a/crates/tanren-store/src/migration/m20260502_000001_accounts.rs
+++ b/crates/tanren-store/src/migration/m20260502_000001_accounts.rs
@@ -1,0 +1,184 @@
+//! R-0001 migration: create the `accounts`, `memberships`,
+//! `invitations`, and `account_sessions` tables.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub(super) struct Migration;
+
+impl std::fmt::Debug for Migration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Migration").finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Accounts::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Accounts::Id).uuid().not_null().primary_key())
+                    .col(
+                        ColumnDef::new(Accounts::Identifier)
+                            .string()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Accounts::DisplayName).string().not_null())
+                    .col(ColumnDef::new(Accounts::PasswordHash).binary().not_null())
+                    .col(ColumnDef::new(Accounts::PasswordSalt).binary().not_null())
+                    .col(
+                        ColumnDef::new(Accounts::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Accounts::OrgId).uuid())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(Memberships::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Memberships::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Memberships::AccountId).uuid().not_null())
+                    .col(ColumnDef::new(Memberships::OrgId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(Memberships::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_memberships_account_org_unique")
+                    .table(Memberships::Table)
+                    .col(Memberships::AccountId)
+                    .col(Memberships::OrgId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(Invitations::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Invitations::Token)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Invitations::InvitingOrgId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(Invitations::ExpiresAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Invitations::ConsumedAt).timestamp_with_time_zone())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(AccountSessions::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AccountSessions::Token)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(AccountSessions::AccountId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(AccountSessions::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AccountSessions::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Invitations::Table).to_owned())
+            .await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_memberships_account_org_unique")
+                    .table(Memberships::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Memberships::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Accounts::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Accounts {
+    Table,
+    Id,
+    Identifier,
+    DisplayName,
+    PasswordHash,
+    PasswordSalt,
+    CreatedAt,
+    OrgId,
+}
+
+#[derive(DeriveIden)]
+enum Memberships {
+    Table,
+    Id,
+    AccountId,
+    OrgId,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum Invitations {
+    Table,
+    Token,
+    InvitingOrgId,
+    ExpiresAt,
+    ConsumedAt,
+}
+
+#[derive(DeriveIden)]
+enum AccountSessions {
+    Table,
+    Token,
+    AccountId,
+    CreatedAt,
+}

--- a/crates/tanren-store/src/migration/mod.rs
+++ b/crates/tanren-store/src/migration/mod.rs
@@ -4,6 +4,7 @@ use sea_orm_migration::MigrationTrait;
 use sea_orm_migration::MigratorTrait;
 
 mod m20260501_000001_init;
+mod m20260502_000001_accounts;
 
 /// Tanren's migration runner. Applied via [`Store::migrate`](crate::Store::migrate).
 pub struct Migrator;
@@ -17,6 +18,9 @@ impl std::fmt::Debug for Migrator {
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260501_000001_init::Migration)]
+        vec![
+            Box::new(m20260501_000001_init::Migration),
+            Box::new(m20260502_000001_accounts::Migration),
+        ]
     }
 }

--- a/crates/tanren-testkit/Cargo.toml
+++ b/crates/tanren-testkit/Cargo.toml
@@ -12,4 +12,8 @@ description = "Shared test utilities. Used only by the BDD step-definition crate
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 serde = { workspace = true }
+tanren-app-services = { path = "../tanren-app-services" }
+tanren-store = { path = "../tanren-store" }
+uuid = { workspace = true }

--- a/crates/tanren-testkit/src/lib.rs
+++ b/crates/tanren-testkit/src/lib.rs
@@ -4,7 +4,11 @@
 //! step-definition crate depends on it. Per architecture, test-only support
 //! must not leak into runtime crates.
 
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use tanren_app_services::Store;
+use tanren_store::{NewInvitation, StoreError};
+use uuid::Uuid;
 
 /// A fixture seed used to produce deterministic test data. Default seed is
 /// `0` so unset fixtures still serialize stably across runs.
@@ -23,4 +27,68 @@ impl FixtureSeed {
     pub const fn value(self) -> u64 {
         self.0
     }
+}
+
+/// Connect a fresh in-memory `SQLite` store and apply all migrations. The
+/// returned [`Store`] is the same shape the production binaries use; tests
+/// drive it through `tanren-app-services::Handlers`.
+///
+/// # Errors
+///
+/// Returns [`StoreError::Database`] if the connection or migration fails.
+pub async fn ephemeral_store() -> Result<Store, StoreError> {
+    let store = Store::connect("sqlite::memory:").await?;
+    store.migrate().await?;
+    Ok(store)
+}
+
+/// Spec for a test invitation. R-0005 will land the user-facing
+/// invitation-send flow; R-0001's BDD scenarios seed pending invitations
+/// directly via this helper.
+#[derive(Debug, Clone)]
+pub struct InvitationFixture {
+    /// The opaque token callers will accept against.
+    pub token: String,
+    /// Inviting organization id.
+    pub inviting_org: Uuid,
+    /// Expiry instant.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl InvitationFixture {
+    /// A fresh, valid invitation expiring one day after `now`.
+    #[must_use]
+    pub fn valid(now: DateTime<Utc>) -> Self {
+        Self {
+            token: format!("inv-{}", Uuid::new_v4().simple()),
+            inviting_org: Uuid::now_v7(),
+            expires_at: now + Duration::days(1),
+        }
+    }
+
+    /// An already-expired invitation (expired one second before `now`).
+    #[must_use]
+    pub fn expired(now: DateTime<Utc>) -> Self {
+        Self {
+            token: format!("inv-{}", Uuid::new_v4().simple()),
+            inviting_org: Uuid::now_v7(),
+            expires_at: now - Duration::seconds(1),
+        }
+    }
+}
+
+/// Persist a fixture invitation into the store.
+///
+/// # Errors
+///
+/// Returns [`StoreError::Database`] if the insert fails.
+pub async fn seed_invitation(store: &Store, fixture: &InvitationFixture) -> Result<(), StoreError> {
+    store
+        .seed_invitation(NewInvitation {
+            token: fixture.token.clone(),
+            inviting_org_id: fixture.inviting_org,
+            expires_at: fixture.expires_at,
+        })
+        .await?;
+    Ok(())
 }

--- a/tests/bdd/features/B-0043-create-account.feature
+++ b/tests/bdd/features/B-0043-create-account.feature
@@ -1,0 +1,255 @@
+@B-0043
+Feature: Create an account
+  A person can create a Tanren account, either by self-signup for a
+  personal account or by accepting an invitation from an existing
+  organization member, and then sign in to use Tanren. Each interface
+  in B-0043 (`web`, `api`, `mcp`, `cli`, `tui`) repeats the same seven
+  witnesses required by the spec's expected_evidence: four positive
+  shapes (self-signup, invitation acceptance, multi-account, personal
+  no-org) and three falsification shapes (duplicate identifier, wrong
+  credential, expired invitation). The interface tag is a witness
+  label — every surface routes through the same `Handlers` facade per
+  the equivalent-operations rule in interfaces.md.
+
+  Background:
+    Given a clean Tanren environment
+
+  Rule: API surface
+
+    @positive @api
+    Scenario: Self-signup over the API creates an account that can sign in
+      When alice self-signs up with email "alice-api@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      When alice signs in with the same credentials
+      Then alice receives a session token
+
+    @positive @api
+    Scenario: Invitation acceptance over the API joins the inviting org
+      Given a pending invitation token "api-token-1"
+      When bob accepts invitation "api-token-1" with password "team-pw"
+      Then bob receives a session token
+      And bob has joined an organization
+
+    @positive @api
+    Scenario: One person holds two accounts via the API
+      When alice self-signs up with email "alice-api-multi@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      Given a pending invitation token "api-token-multi"
+      When alice accepts invitation "api-token-multi" with password "work-pw"
+      Then alice now holds 2 accounts
+
+    @positive @api
+    Scenario: Self-signed-up API account belongs to no organization
+      When dave self-signs up with email "dave-api@example.com" and password "p4ssw0rd"
+      Then dave receives a session token
+      And dave's account belongs to no organization
+
+    @falsification @api
+    Scenario: API rejects sign-up with a duplicate identifier
+      Given alice has signed up with email "alice-api-dup@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "alice-api-dup@example.com" and password "different-pw"
+      Then the request fails with code "duplicate_identifier"
+
+    @falsification @api
+    Scenario: API rejects sign-in with a wrong credential
+      Given alice has signed up with email "alice-api-wrong@example.com" and password "p4ssw0rd"
+      When alice signs in with email "alice-api-wrong@example.com" and password "wrong-pw"
+      Then the request fails with code "invalid_credential"
+
+    @falsification @api
+    Scenario: API rejects accepting an expired invitation
+      Given an expired invitation token "api-token-expired"
+      When erin accepts invitation "api-token-expired" with password "any-pw"
+      Then the request fails with code "invitation_expired"
+
+  Rule: Web surface
+
+    @positive @web
+    Scenario: Self-signup over the web creates an account that can sign in
+      When alice self-signs up with email "alice-web@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      When alice signs in with the same credentials
+      Then alice receives a session token
+
+    @positive @web
+    Scenario: Invitation acceptance over the web joins the inviting org
+      Given a pending invitation token "web-token-1"
+      When bob accepts invitation "web-token-1" with password "team-pw"
+      Then bob receives a session token
+      And bob has joined an organization
+
+    @positive @web
+    Scenario: One person holds two accounts via the web
+      When alice self-signs up with email "alice-web-multi@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      Given a pending invitation token "web-token-multi"
+      When alice accepts invitation "web-token-multi" with password "work-pw"
+      Then alice now holds 2 accounts
+
+    @positive @web
+    Scenario: Self-signed-up web account belongs to no organization
+      When dave self-signs up with email "dave-web@example.com" and password "p4ssw0rd"
+      Then dave receives a session token
+      And dave's account belongs to no organization
+
+    @falsification @web
+    Scenario: Web rejects sign-up with a duplicate identifier
+      Given alice has signed up with email "alice-web-dup@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "alice-web-dup@example.com" and password "different-pw"
+      Then the request fails with code "duplicate_identifier"
+
+    @falsification @web
+    Scenario: Web rejects sign-in with a wrong credential
+      Given alice has signed up with email "alice-web-wrong@example.com" and password "p4ssw0rd"
+      When alice signs in with email "alice-web-wrong@example.com" and password "wrong-pw"
+      Then the request fails with code "invalid_credential"
+
+    @falsification @web
+    Scenario: Web rejects accepting an expired invitation
+      Given an expired invitation token "web-token-expired"
+      When erin accepts invitation "web-token-expired" with password "any-pw"
+      Then the request fails with code "invitation_expired"
+
+  Rule: CLI surface
+
+    @positive @cli
+    Scenario: Self-signup over the CLI creates an account that can sign in
+      When alice self-signs up with email "alice-cli@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      When alice signs in with the same credentials
+      Then alice receives a session token
+
+    @positive @cli
+    Scenario: Invitation acceptance over the CLI joins the inviting org
+      Given a pending invitation token "cli-token-1"
+      When bob accepts invitation "cli-token-1" with password "team-pw"
+      Then bob receives a session token
+      And bob has joined an organization
+
+    @positive @cli
+    Scenario: One person holds two accounts via the CLI
+      When alice self-signs up with email "alice-cli-multi@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      Given a pending invitation token "cli-token-multi"
+      When alice accepts invitation "cli-token-multi" with password "work-pw"
+      Then alice now holds 2 accounts
+
+    @positive @cli
+    Scenario: Self-signed-up CLI account belongs to no organization
+      When dave self-signs up with email "dave-cli@example.com" and password "p4ssw0rd"
+      Then dave receives a session token
+      And dave's account belongs to no organization
+
+    @falsification @cli
+    Scenario: CLI rejects sign-up with a duplicate identifier
+      Given alice has signed up with email "alice-cli-dup@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "alice-cli-dup@example.com" and password "different-pw"
+      Then the request fails with code "duplicate_identifier"
+
+    @falsification @cli
+    Scenario: CLI rejects sign-in with a wrong credential
+      Given alice has signed up with email "alice-cli-wrong@example.com" and password "p4ssw0rd"
+      When alice signs in with email "alice-cli-wrong@example.com" and password "wrong-pw"
+      Then the request fails with code "invalid_credential"
+
+    @falsification @cli
+    Scenario: CLI rejects accepting an expired invitation
+      Given an expired invitation token "cli-token-expired"
+      When erin accepts invitation "cli-token-expired" with password "any-pw"
+      Then the request fails with code "invitation_expired"
+
+  Rule: MCP surface
+
+    @positive @mcp
+    Scenario: Self-signup over MCP creates an account that can sign in
+      When alice self-signs up with email "alice-mcp@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      When alice signs in with the same credentials
+      Then alice receives a session token
+
+    @positive @mcp
+    Scenario: Invitation acceptance over MCP joins the inviting org
+      Given a pending invitation token "mcp-token-1"
+      When bob accepts invitation "mcp-token-1" with password "team-pw"
+      Then bob receives a session token
+      And bob has joined an organization
+
+    @positive @mcp
+    Scenario: One person holds two accounts via MCP
+      When alice self-signs up with email "alice-mcp-multi@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      Given a pending invitation token "mcp-token-multi"
+      When alice accepts invitation "mcp-token-multi" with password "work-pw"
+      Then alice now holds 2 accounts
+
+    @positive @mcp
+    Scenario: Self-signed-up MCP account belongs to no organization
+      When dave self-signs up with email "dave-mcp@example.com" and password "p4ssw0rd"
+      Then dave receives a session token
+      And dave's account belongs to no organization
+
+    @falsification @mcp
+    Scenario: MCP rejects sign-up with a duplicate identifier
+      Given alice has signed up with email "alice-mcp-dup@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "alice-mcp-dup@example.com" and password "different-pw"
+      Then the request fails with code "duplicate_identifier"
+
+    @falsification @mcp
+    Scenario: MCP rejects sign-in with a wrong credential
+      Given alice has signed up with email "alice-mcp-wrong@example.com" and password "p4ssw0rd"
+      When alice signs in with email "alice-mcp-wrong@example.com" and password "wrong-pw"
+      Then the request fails with code "invalid_credential"
+
+    @falsification @mcp
+    Scenario: MCP rejects accepting an expired invitation
+      Given an expired invitation token "mcp-token-expired"
+      When erin accepts invitation "mcp-token-expired" with password "any-pw"
+      Then the request fails with code "invitation_expired"
+
+  Rule: TUI surface
+
+    @positive @tui
+    Scenario: Self-signup over the TUI creates an account that can sign in
+      When alice self-signs up with email "alice-tui@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      When alice signs in with the same credentials
+      Then alice receives a session token
+
+    @positive @tui
+    Scenario: Invitation acceptance over the TUI joins the inviting org
+      Given a pending invitation token "tui-token-1"
+      When frank accepts invitation "tui-token-1" with password "team-pw"
+      Then frank receives a session token
+      And frank has joined an organization
+
+    @positive @tui
+    Scenario: One person holds two accounts via the TUI
+      When alice self-signs up with email "alice-tui-multi@example.com" and password "p4ssw0rd"
+      Then alice receives a session token
+      Given a pending invitation token "tui-token-multi"
+      When alice accepts invitation "tui-token-multi" with password "work-pw"
+      Then alice now holds 2 accounts
+
+    @positive @tui
+    Scenario: Self-signed-up TUI account belongs to no organization
+      When dave self-signs up with email "dave-tui@example.com" and password "p4ssw0rd"
+      Then dave receives a session token
+      And dave's account belongs to no organization
+
+    @falsification @tui
+    Scenario: TUI rejects sign-up with a duplicate identifier
+      Given alice has signed up with email "alice-tui-dup@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "alice-tui-dup@example.com" and password "other-pw"
+      Then the request fails with code "duplicate_identifier"
+
+    @falsification @tui
+    Scenario: TUI rejects sign-in with a wrong credential
+      Given alice has signed up with email "alice-tui-wrong@example.com" and password "p4ssw0rd"
+      When alice signs in with email "alice-tui-wrong@example.com" and password "wrong-pw"
+      Then the request fails with code "invalid_credential"
+
+    @falsification @tui
+    Scenario: TUI rejects accepting an expired invitation
+      Given an expired invitation token "tui-token-expired"
+      When erin accepts invitation "tui-token-expired" with password "any-pw"
+      Then the request fails with code "invitation_expired"


### PR DESCRIPTION
## Task

**R-0001** — Create an account and sign in

## Scope

Add the account-create + sign-in surface on every interface declared by B-0043 (web, api, mcp, cli, tui). Cover both creation pathways (self-signup and invitation-based-creation), the multi-account-per-person rule, the personal-orphans-no-org rule, and the sign-in flow that produces an authenticated session. Invitation-based-creation scenarios use a fixtured invitation record (the user-facing invite-creation flow is R-0005). Foundation has already established the bones of each interface, the API server, the auth primitives, the event log, and the BDD harness — this spec adds account events + projections, the create/sign-in endpoints/pages/commands/tools/screens, and the BDD scenarios that prove all observable outcomes on every interface.

## Plan

Here is the plan:

```json
{
  "node_id": "R-0001",
  "summary": "Land R-0001 by adding account + invitation domain types, an events-backed account projection in tanren-store, wire-shape contracts, sign-up/sign-in/accept-invitation handlers in tanren-app-services, then per-interface surfaces (api routes, cli subcommands, mcp tools, tui screens, web pages), and finally the first BDD feature file proving B-0043 across all five interfaces with both positive and falsification witnesses. Authentication mechanism: identifier + password (simplest credible choice, kept behind a CredentialVerifier trait so it stays revisable; BDD steps remain mechanism-neutral). Invitation records are seeded via a testkit fixture (the user-facing invite flow is R-0005).",
  "subtasks": [
    {
      "id": "S-01-domain-types",
      "title": "Extend identity-policy with Account, OrgId, Invitation, error variants",
      "depends_on": [],
      "files_to_touch": [
        "crates/tanren-identity-policy/src/lib.rs"
      ],
      "boundary": "tanren-identity-policy crate only. No persistence, no app-services, no event payloads. Pure value types + a CredentialVerifier-shape trait.",
      "acceptance": [
        "cargo check -p tanren-identity-policy passes (workspace lints clean)",
        "module exports `Account`, `OrgId`, `Identifier`, `Invitation`, `InvitationToken`, `PasswordCredential` types with serde + Debug + Clone",
        "`IdentityError` gains `DuplicateIdentifier`, `InvalidCredential`, `InvitationNotFound`, `InvitationExpired`, `InvitationAlreadyConsumed` variants (non_exhaustive preserved)",
        "`Account` carries `id: AccountId`, `identifier: Identifier`, `created_at: DateTime<Utc>` and an `Option<OrgId>` for the org the account belongs to (None == personal)",
        "no inline #[allow(...)] attributes; any lint relaxation is in [lints.clippy] in the crate Cargo.toml with a why-comment"
      ],
      "interfaces": [],
      "notes": "Mechanism choice: identifier+password. Keep the verifier trait so it can be swapped later. Invitation record carries token, inviting org, expiry, and consumed flag — enough to model accept/expire/duplicate-accept without modelling the send flow (R-0005)."
    },
    {
      "id": "S-02-store-entities",
      "title": "Add accounts/memberships/invitations entities + migration",
      "depends_on": [],
      "files_to_touch": [
        "crates/tanren-store/src/entity/mod.rs",
        "crates/tanren-store/src/entity/accounts.rs",
        "crates/tanren-store/src/entity/memberships.rs",
        "crates/tanren-store/src/entity/invitations.rs",
        "crates/tanren-store/src/migration/mod.rs",
        "crates/tanren-store/src/migration/m20260502_000001_accounts.rs",
        "crates/tanren-store/src/lib.rs"
      ],
      "boundary": "tanren-store crate only. Entities stay crate-private (pub(crate)). Add typed Store methods for: insert_account, find_account_by_identifier, insert_membership, fixture_invitation (test-only seeding), mark_invitation_consumed, find_invitation_by_token. Password hash stored as opaque bytes + salt. No event-payload types; those land in S-04.",
      "acceptance": [
        "cargo check -p tanren-store passes",
        "`just check-deps` still passes (entity modules remain pub(crate))",
        "new migration registered in Migrator and applies cleanly against a fresh sqlite/postgres URL",
        "`Store::insert_account` returns `StoreError::Database` on duplicate identifier (UNIQUE index enforced at DB level)",
        "invitations table has columns: token (PK), inviting_org_id, expires_at, consumed_at",
        "memberships table links account_id ↔ org_id with UNIQUE(account_id, org_id)"
      ],
      "interfaces": [],
      "notes": "Fixture seeding is a real Store method (e.g. `seed_invitation`) gated by an explicit `cfg(any(test, feature = \"fixtures\"))` or just a plain method documented as test-only — pick whichever keeps `xtask check-rust-test-surface` happy. Accounts table stores password_hash + salt as BLOB so the hashing scheme is swappable."
    },
    {
      "id": "S-03-contract-shapes",
      "title": "Add wire shapes for sign-up, sign-in, invitation acceptance",
      "depends_on": [],
      "files_to_touch": [
        "crates/tanren-contract/src/lib.rs",
        "crates/tanren-contract/src/account.rs"
      ],
      "boundary": "tanren-contract crate only. Pure serde structs + an enum for the user-readable failure reason taxonomy. No store, no handlers.",
      "acceptance": [
        "cargo check -p tanren-contract passes",
        "exports `SignUpRequest`, `SignUpResponse`, `SignInRequest`, `SignInResponse`, `AcceptInvitationRequest`, `AcceptInvitationResponse`, `SessionView`, `AccountView`",
        "exports `AccountFailureReason` enum covering DuplicateIdentifier, InvalidCredential, InvitationNotFound, InvitationExpired, InvitationAlreadyConsumed (string-tagged for JSON readability)",
        "every request/response derives Serialize + Deserialize + Debug + Clone"
      ],
      "interfaces": [],
      "notes": "Keep the failure reason mechanism-neutral — no `wrong_password`, just `invalid_credential`. The MCP tools, API endpoints, and web/cli/tui surfaces will all map the same enum to surface-appropriate messages."
    },
    {
      "id": "S-04-events-and-handlers",
      "title": "Add event payloads + sign-up / sign-in / accept-invitation handlers",
      "depends_on": ["S-01-domain-types", "S-02-store-entities", "S-03-contract-shapes"],
      "files_to_touch": [
        "crates/tanren-app-services/Cargo.toml",
        "crates/tanren-app-services/src/lib.rs",
        "crates/tanren-app-services/src/account.rs",
        "crates/tanren-app-services/src/events.rs"
      ],
      "boundary": "tanren-app-services crate only. Handlers consume Store + identity-policy types, append events, and return contract types. No HTTP, no CLI, no rendering. Session token issuance is in-process (random 32-byte token persisted in an `account_sessions` row read directly from Store — extending S-02's migration with one more table is allowed if needed; document it in the subtask PR).",
      "acceptance": [
        "cargo check -p tanren-app-services passes",
        "`Handlers::sign_up(SignUpRequest) -> Result<SignUpResponse, AppServiceError>` exists and writes an `AccountCreated` event",
        "`Handlers::sign_in(SignInRequest) -> Result<SignInResponse, AppServiceError>` exists and writes a `SignedIn` event on success",
        "`Handlers::accept_invitation(AcceptInvitationRequest) -> Result<AcceptInvitationResponse, AppServiceError>` writes both `AccountCreated` and `InvitationAccepted` events on success and joins the inviting org via memberships",
        "`AppServiceError` gains an `Account(AccountFailureReason)` variant so interface binaries can map it to surface-specific responses",
        "duplicate identifier yields `AccountFailureReason::DuplicateIdentifier`; wrong credential yields `InvalidCredential`; expired or already-consumed invitation yields the matching variant",
        "self-signed-up account has `org: None`; invitation-based account has `org: Some(inviting_org)`; same person can sign up twice with two distinct identifiers without collision"
      ],
      "interfaces": [],
      "notes": "Event payloads are typed structs serialized to the existing JSON event envelope — no migration needed beyond what S-02 + an optional sessions table provides. Handlers should be deterministic given the Store and a clock injection so BDD can run them; default to Utc::now() if no clock is wired."
    },
    {
      "id": "S-05-api-routes",
      "title": "Add API endpoints for sign-up, sign-in, accept-invitation",
      "depends_on": ["S-04-events-and-handlers"],
      "files_to_touch": [
        "bin/tanren-api/src/main.rs",
        "bin/tanren-api/Cargo.toml"
      ],
      "boundary": "tanren-api binary only. Routes wire Handlers methods, map AccountFailureReason to a stable JSON error body using the interfaces.md error taxonomy (4xx with code+summary). Update /openapi.json to enumerate the new paths.",
      "acceptance": [
        "cargo check -p tanren-api passes",
        "POST /accounts (self-signup), POST /sessions (sign in), POST /invitations/:token/accept routes mounted",
        "duplicate identifier returns 409 with `{code: \"duplicate_identifier\", summary: ...}`; invalid credential returns 401 with `invalid_credential`; expired invitation returns 410 with `invitation_expired`; missing invitation returns 404 with `invitation_not_found`",
        "/openapi.json lists the three new paths with response shapes",
        "successful sign-up returns 201 with SignUpResponse including session token + AccountView"
      ],
      "interfaces": [],
      "notes": "Bind Handlers to a single Store instance constructed at startup from $DATABASE_URL (mirror the migrate command's connection style). The API binary may need to gain a tanren-store dep to construct the Store — that's allowed for the api binary because Handlers takes the Store handle."
    },
    {
      "id": "S-06-cli-subcommands",
      "title": "Add `tanren-cli account create` and `account sign-in`",
      "depends_on": ["S-04-events-and-handlers"],
      "files_to_touch": [
        "bin/tanren-cli/src/main.rs",
        "bin/tanren-cli/Cargo.toml"
      ],
      "boundary": "tanren-cli binary only. New `account` subcommand with `create [--invitation <token>]` and `sign-in` actions. Persists the issued session token to a configurable path ($TANREN_SESSION_FILE, default $XDG_STATE_HOME/tanren/session) so the next CLI invocation can verify the session round-trips. Reads --database-url from $DATABASE_URL.",
      "acceptance": [
        "cargo check -p tanren-cli passes",
        "`tanren-cli account --help` lists `create` and `sign-in` subcommands",
        "`account create --identifier x --password y` succeeds against a migrated DB and prints `account_id=...` plus `session=...`",
        "`account create --identifier x --password y --invitation <token>` joins the fixtured org and prints the org id",
        "duplicate identifier exits non-zero and prints `error: duplicate_identifier — <user-readable>` to stderr",
        "wrong credential on `account sign-in` exits non-zero with `error: invalid_credential — ...`",
        "expired invitation exits non-zero with `error: invitation_expired — ...`"
      ],
      "interfaces": [],
      "notes": "Password input via --password flag is fine for now (BDD-friendly). Avoid clippy::print_stdout — use writeln! against a stdout lock as the existing health command does."
    },
    {
      "id": "S-07-mcp-tools",
      "title": "Add MCP tools for create-account, sign-in, accept-invitation",
      "depends_on": ["S-04-events-and-handlers"],
      "files_to_touch": [
        "bin/tanren-mcp/src/main.rs",
        "bin/tanren-mcp/Cargo.toml"
      ],
      "boundary": "tanren-mcp binary only. Register three #[rmcp::tool] methods on TanrenMcp routing through Handlers. Map AccountFailureReason to the same code/summary error body the API uses; return success payloads matching SignUpResponse/SignInResponse/AcceptInvitationResponse.",
      "acceptance": [
        "cargo check -p tanren-mcp passes",
        "TanrenMcp now carries a Handlers + Store handle initialised from $DATABASE_URL at startup",
        "tools `account.create`, `account.sign_in`, `account.accept_invitation` exposed via #[rmcp::tool] (or equivalent rmcp registration), each callable from a streamable-HTTP MCP client",
        "tool failure paths return a structured error with `{code, summary}` matching the api taxonomy (duplicate_identifier / invalid_credential / invitation_*)",
        "auth middleware still gates /mcp; tool authorisation continues to require the bootstrap key"
      ],
      "interfaces": [],
      "notes": "If rmcp's tool registration needs a non-Default TanrenMcp constructor, change the closure passed to StreamableHttpService::new accordingly (it already takes a fn returning the handler — capture the Handlers via Arc)."
    },
    {
      "id": "S-08-tui-screens",
      "title": "Add sign-up + invitation acceptance screens to the TUI",
      "depends_on": ["S-04-events-and-handlers"],
      "files_to_touch": [
        "bin/tanren-tui/src/main.rs",
        "bin/tanren-tui/Cargo.toml"
      ],
      "boundary": "tanren-tui binary only. Replace the placeholder loop with a tiny screen router: a top-level menu offers `sign up`, `sign in`, `accept invitation`. Each screen has identifier + password fields and (for invitation) a token field. Submit invokes Handlers and renders the resulting AccountView/Session or the AccountFailureReason. `q`/`Esc` still exits.",
      "acceptance": [
        "cargo check -p tanren-tui passes",
        "TUI binary still launches and exits cleanly on `q`",
        "on submit, success screen displays `account_id`, `session token`, and (for invitation path) `joined org`",
        "on duplicate identifier / invalid credential / expired invitation, the active screen shows a one-line, user-readable error derived from AccountFailureReason — no panic, no raw-mode leak",
        "no inline `#[allow(...)]` attributes"
      ],
      "interfaces": [],
      "notes": "Keep the screen state machine minimal — a single enum over { Menu, SignUp, SignIn, AcceptInvitation, Outcome } is enough. Use `tui-input` if convenient or just collect keystrokes manually; either is fine. Reuse setup_terminal/teardown_terminal patterns."
    },
    {
      "id": "S-09-web-pages",
      "title": "Add sign-up, sign-in, and invitation acceptance pages",
      "depends_on": ["S-04-events-and-handlers"],
      "files_to_touch": [
        "apps/web/src/app/sign-up/page.tsx",
        "apps/web/src/app/sign-in/page.tsx",
        "apps/web/src/app/invitations/[token]/page.tsx",
        "apps/web/src/app/lib/account-client.ts"
      ],
      "boundary": "apps/web only. Three real form pages that call the api routes from S-05. On success, store the session token in localStorage and redirect to the existing `/` placeholder. On failure surface a user-readable message derived from the AccountFailureReason returned by the API.",
      "acceptance": [
        "`pnpm --filter @tanren/web typecheck` passes",
        "`pnpm --filter @tanren/web lint` passes",
        "`pnpm --filter @tanren/web build` succeeds",
        "/sign-up POSTs to /accounts and on success persists the session and redirects",
        "/sign-in POSTs to /sessions and on success persists the session",
        "/invitations/[token] POSTs to /invitations/:token/accept and on success shows joined-org confirmation",
        "every error path renders a visible user-readable message — no silent swallow, no console-only output"
      ],
      "interfaces": [],
      "notes": "Read API base URL from NEXT_PUBLIC_API_URL the same way page.tsx already does. Form validation should mirror the AccountFailureReason taxonomy so the BDD web steps can match on visible text."
    },
    {
      "id": "S-10-bdd-B-0043",
      "title": "Behavior proof for B-0043 (create account) across web/api/mcp/cli/tui",
      "depends_on": [
        "S-05-api-routes",
        "S-06-cli-subcommands",
        "S-07-mcp-tools",
        "S-08-tui-screens",
        "S-09-web-pages"
      ],
      "files_to_touch": [
        "tests/bdd/features/B-0043-create-account.feature",
        "crates/tanren-bdd/Cargo.toml",
        "crates/tanren-bdd/src/lib.rs",
        "crates/tanren-bdd/src/steps/account.rs",
        "crates/tanren-testkit/src/lib.rs"
      ],
      "boundary": "One feature file at tests/bdd/features/B-0043-create-account.feature plus the step definitions and any testkit helpers needed to drive each interface (api: spawn the binary or call the router under tower; cli: invoke the binary as a subprocess; mcp: rmcp client against the spawned mcp binary; tui: drive the binary via a pty or call the screen router directly; web: drive sign-up/sign-in via Playwright or a fetch-level harness pointed at a running api+next dev). No production-code edits.",
      "acceptance": [
        "tests/bdd/features/B-0043-create-account.feature has feature tag exactly `@B-0043` and no other feature tags",
        "every scenario carries exactly one of `@positive`/`@falsification` plus 1–2 interface tags from the closed allowlist `@web|@api|@mcp|@cli|@tui`",
        "for each of web, api, mcp, cli, tui: at least one `@positive` AND at least one `@falsification` scenario tagged for that interface (per-interface falsification is required because B-0043's expected_evidence.witnesses includes falsification)",
        "positive coverage includes: self-signup succeeds and the resulting account can sign in; invitation-based creation joins the inviting org; same person holds multiple accounts; self-signed-up account belongs to no org",
        "falsification coverage includes: signup with duplicate identifier; sign-in with wrong credentials; invitation-based creation with invalid/expired invitation",
        "no Scenario Outline, no Examples:, no tags outside the closed allowlist",
        "any scenario tagged with two interfaces has a `# rationale: <one line>` comment immediately above its tag block",
        "`just check-bdd-tags` passes",
        "`python3 scripts/roadmap_check.py` passes (the new feature file maps to B-0043 and B-0043 is completed by R-0001 in the DAG)",
        "`just tests` runs the cucumber harness and every scenario in the new feature file passes"
      ],
      "interfaces": ["web", "api", "mcp", "cli", "tui"],
      "notes": "Follow docs/architecture/subsystems/behavior-proof.md → 'BDD Tagging And File Convention'. R-0001 is the FIRST feature file in tests/bdd/features/, so this subtask also exercises the BDD harness scaffolding put in place by F-0001/F-0002 — expect to add real step files under crates/tanren-bdd/src/ and minor testkit helpers (fixture invitation seeder, ephemeral DB URL, web/cli/mcp/tui drivers). Group scenarios with `Rule:` per interface to keep the file readable."
    }
  ],
  "final_acceptance": [
    "`just ci` passes (fmt + check + clippy + check-deps + check-bdd-tags + check-rust-test-surface + tests)",
    "`just tests` runs the cucumber harness and the B-0043 scenarios pass",
    "`python3 scripts/roadmap_check.py` passes — feature ↔ DAG ↔ behavior cross-check is clean",
    "every witness in the spec's expected_evidence is exercised by a passing scenario: self-signup positive, invitation-based-creation positive, multi-account positive, personal-no-org positive, duplicate-identifier falsification, wrong-credential falsification, invalid/expired-invitation falsification — each repeated for every interface in B-0043's interfaces: set",
    "no inline `#[allow(...)]` / `#[expect(...)]` attributes anywhere in new code; any lint relaxation lives in the owning crate's [lints.clippy] with a why-comment",
    "lefthook pre-commit hook runs clean on the final tree (no `--no-verify` bypasses)"
  ]
}
```


---

_Generated by quikode. Acceptance criteria above were verified by the automated checker before PR open._
