### PR TITLE
feat(R-0001): sub-5 — Argon2idVerifier replaces inline SHA-256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,21 +301,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -537,12 +549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,15 +665,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -817,7 +814,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -861,21 +858,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1327,7 +1313,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1389,15 +1375,6 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1839,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2096,6 +2073,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -2776,8 +2764,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
+ "const-oid",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3222,7 +3210,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3233,18 +3221,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -3299,7 +3276,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3418,7 +3395,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -3458,7 +3435,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3482,7 +3459,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3504,7 +3481,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3547,7 +3524,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3758,7 +3735,6 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "tanren-contract",
  "tanren-identity-policy",
  "tanren-store",
@@ -3859,8 +3835,10 @@ dependencies = [
 name = "tanren-identity-policy"
 version = "0.0.0"
 dependencies = [
+ "argon2",
  "base64",
  "chrono",
+ "password-hash",
  "rand 0.9.4",
  "schemars",
  "secrecy",
@@ -4101,7 +4079,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2 0.10.9",
+ "sha2",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -4785,7 +4763,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,3 +213,14 @@ rand = "0.9"
 
 # Base64 URL-safe-no-pad encoding (paired with `rand` for opaque tokens).
 base64 = "0.22"
+
+# Password hashing — Argon2id is the canonical CredentialVerifier impl
+# (PR 5 of R-0001). `password-hash` ships the PHC string format that the
+# Argon2id verifier writes / reads.
+argon2 = { version = "0.5", default-features = false, features = [
+  "std",
+  "alloc",
+] }
+password-hash = { version = "0.5", default-features = false, features = [
+  "alloc",
+] }

--- a/crates/tanren-app-services/Cargo.toml
+++ b/crates/tanren-app-services/Cargo.toml
@@ -16,7 +16,6 @@ chrono = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 tanren-contract = { path = "../tanren-contract" }
 tanren-identity-policy = { path = "../tanren-identity-policy" }
 tanren-store = { path = "../tanren-store" }

--- a/crates/tanren-app-services/src/account.rs
+++ b/crates/tanren-app-services/src/account.rs
@@ -2,11 +2,14 @@
 //!
 //! Handlers are mechanism-neutral at the contract surface but mechanism-
 //! specific underneath: R-0001 pins identifier+password as the simplest
-//! credible choice. Hashing currently uses sha-256 over `salt || password`
-//! — PR 5 swaps in `Argon2id` behind the
-//! `tanren_identity_policy::CredentialVerifier` trait without touching the
-//! wire shapes. Session tokens are 256 bits of CSPRNG randomness wrapped
-//! in `SessionToken` (URL-safe base64, no padding).
+//! credible choice, with hashing delegated to a
+//! [`CredentialVerifier`](tanren_identity_policy::CredentialVerifier)
+//! trait object. Production binaries inject the
+//! [`Argon2idVerifier`](tanren_identity_policy::Argon2idVerifier);
+//! BDD scenarios inject the cheap-parameter `fast_for_tests` preset.
+//!
+//! Session tokens are 256 bits of CSPRNG randomness wrapped in
+//! `SessionToken` (URL-safe base64, no padding).
 //!
 //! Handlers consume `&dyn AccountStore` (the port defined in
 //! `tanren_store::traits`); the SeaORM-backed `Store` is the adapter
@@ -17,12 +20,11 @@
 
 use chrono::Duration;
 use secrecy::ExposeSecret;
-use sha2::{Digest, Sha256};
 use tanren_contract::{
     AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, AccountView,
     SessionView, SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
 };
-use tanren_identity_policy::{AccountId, Identifier, SessionToken};
+use tanren_identity_policy::{AccountId, CredentialVerifier, Identifier, SessionToken};
 use tanren_store::{AccountRecord, AccountStore, ConsumeInvitationError, NewAccount};
 
 use crate::events::{AccountCreated, InvitationAccepted, SignedIn, envelope};
@@ -35,6 +37,7 @@ const SESSION_LIFETIME_DAYS: i64 = 30;
 pub(crate) async fn sign_up<S>(
     store: &S,
     clock: &Clock,
+    verifier: &dyn CredentialVerifier,
     request: SignUpRequest,
 ) -> Result<SignUpResponse, AppServiceError>
 where
@@ -59,16 +62,16 @@ where
     }
 
     let now = clock.now();
-    let salt = random_salt(&now, identifier.as_str());
-    let password_hash = hash_password(&salt, request.password.expose_secret());
+    let password_phc = verifier
+        .hash(&request.password)
+        .map_err(|err| AppServiceError::InvalidInput(err.to_string()))?;
     let id = AccountId::fresh();
     let account = store
         .insert_account(NewAccount {
             id,
             identifier,
             display_name,
-            password_hash,
-            password_salt: salt,
+            password_phc,
             created_at: now,
             org_id: None,
         })
@@ -100,6 +103,7 @@ where
 pub(crate) async fn sign_in<S>(
     store: &S,
     clock: &Clock,
+    verifier: &dyn CredentialVerifier,
     request: SignInRequest,
 ) -> Result<SignInResponse, AppServiceError>
 where
@@ -115,11 +119,10 @@ where
             AccountFailureReason::InvalidCredential,
         ));
     };
-    if !verify_password(
-        &account.password_salt,
-        &account.password_hash,
-        request.password.expose_secret(),
-    ) {
+    if verifier
+        .verify(&request.password, &account.password_phc)
+        .is_err()
+    {
         return Err(AppServiceError::Account(
             AccountFailureReason::InvalidCredential,
         ));
@@ -148,6 +151,7 @@ where
 pub(crate) async fn accept_invitation<S>(
     store: &S,
     clock: &Clock,
+    verifier: &dyn CredentialVerifier,
     request: AcceptInvitationRequest,
 ) -> Result<AcceptInvitationResponse, AppServiceError>
 where
@@ -203,16 +207,16 @@ where
         Err(ConsumeInvitationError::Store(err)) => return Err(AppServiceError::Store(err)),
     };
 
-    let salt = random_salt(&now, identifier.as_str());
-    let password_hash = hash_password(&salt, request.password.expose_secret());
+    let password_phc = verifier
+        .hash(&request.password)
+        .map_err(|err| AppServiceError::InvalidInput(err.to_string()))?;
     let id = AccountId::fresh();
     let account = store
         .insert_account(NewAccount {
             id,
             identifier,
             display_name,
-            password_hash,
-            password_salt: salt,
+            password_phc,
             created_at: now,
             org_id: Some(consumed.inviting_org_id),
         })
@@ -286,45 +290,6 @@ where
         token: session.token,
         expires_at: session.expires_at,
     })
-}
-
-/// Compute a deterministic-but-unique salt for the legacy SHA-256
-/// hashing path. PR 5 deletes this in favour of `Argon2id` which
-/// embeds its own random salt; until then we derive 32 bytes from
-/// `sha256(now_iso || identifier)` so the same password hashes
-/// differently across accounts (and across invocations).
-fn random_salt(now: &chrono::DateTime<chrono::Utc>, identifier: &str) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(now.to_rfc3339().as_bytes());
-    hasher.update(b"|");
-    hasher.update(identifier.as_bytes());
-    hasher.finalize().to_vec()
-}
-
-fn hash_password(salt: &[u8], password: &str) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(salt);
-    hasher.update(password.as_bytes());
-    hasher.finalize().to_vec()
-}
-
-fn verify_password(salt: &[u8], expected: &[u8], password: &str) -> bool {
-    let mut hasher = Sha256::new();
-    hasher.update(salt);
-    hasher.update(password.as_bytes());
-    let computed = hasher.finalize();
-    constant_time_eq(computed.as_slice(), expected)
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
 }
 
 fn map_insert_error(err: tanren_store::StoreError) -> AppServiceError {

--- a/crates/tanren-app-services/src/lib.rs
+++ b/crates/tanren-app-services/src/lib.rs
@@ -14,6 +14,7 @@ use tanren_contract::{
     AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, ContractVersion,
     SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
 };
+use tanren_identity_policy::{Argon2idVerifier, CredentialVerifier};
 pub use tanren_store::{AccountStore, Store};
 
 use std::sync::Arc;
@@ -72,24 +73,49 @@ impl Clock {
     }
 }
 
-/// Stateless handler facade. Holds an injectable [`Clock`] so account
-/// flow handlers stay deterministic under the BDD harness.
-#[derive(Debug, Clone, Default)]
+/// Stateless handler facade. Holds an injectable [`Clock`] and
+/// [`CredentialVerifier`] so account flow handlers stay deterministic —
+/// and cheaply hashed — under the BDD harness.
+#[derive(Debug, Clone)]
 pub struct Handlers {
     clock: Clock,
+    verifier: Arc<dyn CredentialVerifier>,
+}
+
+impl Default for Handlers {
+    fn default() -> Self {
+        Self {
+            clock: Clock::default(),
+            verifier: Arc::new(Argon2idVerifier::production()),
+        }
+    }
 }
 
 impl Handlers {
-    /// Construct a handler facade backed by [`Clock::default`].
+    /// Construct a handler facade backed by [`Clock::default`] and the
+    /// production-strength [`Argon2idVerifier`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Construct a handler facade backed by an explicit clock.
+    /// Construct a handler facade backed by an explicit clock. Uses the
+    /// production-strength [`Argon2idVerifier`] for hashing.
     #[must_use]
     pub fn with_clock(clock: Clock) -> Self {
-        Self { clock }
+        Self {
+            clock,
+            verifier: Arc::new(Argon2idVerifier::production()),
+        }
+    }
+
+    /// Construct a handler facade backed by an explicit
+    /// [`CredentialVerifier`]. Production binaries that want to pin a
+    /// non-default verifier (alternate parameter set, hardware-backed
+    /// implementation) thread it in here.
+    #[must_use]
+    pub fn with_verifier(clock: Clock, verifier: Arc<dyn CredentialVerifier>) -> Self {
+        Self { clock, verifier }
     }
 
     /// Liveness query. Returns the same shape regardless of which interface
@@ -130,7 +156,7 @@ impl Handlers {
     where
         S: AccountStore + ?Sized,
     {
-        account::sign_up(store, &self.clock, request).await
+        account::sign_up(store, &self.clock, self.verifier.as_ref(), request).await
     }
 
     /// Sign-in command: verify an identifier+password against the
@@ -150,7 +176,7 @@ impl Handlers {
     where
         S: AccountStore + ?Sized,
     {
-        account::sign_in(store, &self.clock, request).await
+        account::sign_in(store, &self.clock, self.verifier.as_ref(), request).await
     }
 
     /// Invitation-acceptance command: consume the supplied token,
@@ -171,7 +197,7 @@ impl Handlers {
     where
         S: AccountStore + ?Sized,
     {
-        account::accept_invitation(store, &self.clock, request).await
+        account::accept_invitation(store, &self.clock, self.verifier.as_ref(), request).await
     }
 }
 

--- a/crates/tanren-bdd/Cargo.toml
+++ b/crates/tanren-bdd/Cargo.toml
@@ -17,7 +17,9 @@ cucumber = { workspace = true }
 secrecy = { workspace = true }
 tanren-app-services = { path = "../tanren-app-services" }
 tanren-contract = { path = "../tanren-contract" }
-tanren-identity-policy = { path = "../tanren-identity-policy" }
+tanren-identity-policy = { path = "../tanren-identity-policy", features = [
+  "test-hooks",
+] }
 tanren-store = { path = "../tanren-store" }
 tanren-testkit = { path = "../tanren-testkit" }
 tokio = { workspace = true }

--- a/crates/tanren-bdd/src/lib.rs
+++ b/crates/tanren-bdd/src/lib.rs
@@ -19,6 +19,7 @@ use tanren_app_services::{Clock, Handlers, Store};
 use tanren_contract::{
     AcceptInvitationResponse, AccountFailureReason, SignInResponse, SignUpResponse,
 };
+use tanren_identity_policy::Argon2idVerifier;
 use tanren_testkit::{FixtureSeed, InvitationFixture};
 
 /// Cucumber `World` shared across all Tanren BDD scenarios.
@@ -72,7 +73,10 @@ impl AccountContext {
     pub async fn new() -> Result<Self, tanren_store::StoreError> {
         let store = tanren_testkit::ephemeral_store().await?;
         let clock = SharedClock::new(Utc::now());
-        let handlers = Handlers::with_clock(clock.as_app_clock());
+        let handlers = Handlers::with_verifier(
+            clock.as_app_clock(),
+            Arc::new(Argon2idVerifier::fast_for_tests()),
+        );
         Ok(Self {
             store,
             handlers,

--- a/crates/tanren-identity-policy/Cargo.toml
+++ b/crates/tanren-identity-policy/Cargo.toml
@@ -11,9 +11,19 @@ description = "Identity and Policy subsystem: accounts, organizations, projects,
 [lints]
 workspace = true
 
+[features]
+default = []
+# Enables `Argon2idVerifier::fast_for_tests` and other test/fixture
+# helpers. `tanren-testkit` (and only the testkit) flips this on so
+# production binaries cannot accidentally hash with the cheap
+# parameters.
+test-hooks = []
+
 [dependencies]
+argon2 = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+password-hash = { workspace = true }
 rand = { workspace = true }
 schemars = { workspace = true }
 secrecy = { workspace = true }

--- a/crates/tanren-identity-policy/src/argon2_verifier.rs
+++ b/crates/tanren-identity-policy/src/argon2_verifier.rs
@@ -1,0 +1,88 @@
+//! Argon2id password verifier — the canonical [`CredentialVerifier`] impl.
+//!
+//! Production parameters track the OWASP 2025 floor (m = 19 MiB, t = 2,
+//! p = 1). The [`Argon2idVerifier::fast_for_tests`] preset uses cheap
+//! parameters so BDD scenarios stay fast; it is gated behind the
+//! `test-hooks` Cargo feature so production binaries cannot accidentally
+//! reach for it.
+//!
+//! Hashes are written and read in the [PHC string format] (e.g.
+//! `$argon2id$v=19$m=19456,t=2,p=1$<salt>$<hash>`); salt is embedded in
+//! the string so the persistence layer carries a single TEXT column,
+//! not a hash + salt pair.
+//!
+//! [PHC string format]:
+//!     https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md
+
+use argon2::{Algorithm, Argon2, Params, Version};
+use password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::{CredentialVerifier, IdentityError};
+
+/// OWASP 2025 password-hashing floor expressed as Argon2id parameters.
+const OWASP_2025_M_COST_KIB: u32 = 19_456;
+const OWASP_2025_T_COST: u32 = 2;
+const OWASP_2025_P_COST: u32 = 1;
+
+/// Argon2id-backed [`CredentialVerifier`].
+///
+/// Cheap to clone — internally just a snapshot of the configured
+/// parameters. Each `hash` / `verify` call constructs a fresh
+/// [`Argon2`] instance from those parameters.
+#[derive(Debug, Clone)]
+pub struct Argon2idVerifier {
+    params: Params,
+}
+
+impl Argon2idVerifier {
+    /// Production verifier matching the OWASP 2025 floor: `m = 19 MiB`,
+    /// `t = 2`, `p = 1`. See
+    /// `docs/architecture/subsystems/identity-policy.md` § "Canonical
+    /// credential and session decisions".
+    #[must_use]
+    pub fn production() -> Self {
+        let params = Params::new(
+            OWASP_2025_M_COST_KIB,
+            OWASP_2025_T_COST,
+            OWASP_2025_P_COST,
+            None,
+        )
+        .expect("OWASP 2025 Argon2id parameters are statically valid");
+        Self { params }
+    }
+
+    /// Cheap parameters for BDD scenarios. Gated on the `test-hooks`
+    /// feature so production binaries cannot accidentally hash with
+    /// these.
+    #[cfg(any(test, feature = "test-hooks"))]
+    #[must_use]
+    pub fn fast_for_tests() -> Self {
+        let params = Params::new(8, 1, 1, None)
+            .expect("fast_for_tests Argon2id parameters are statically valid");
+        Self { params }
+    }
+
+    fn argon2(&self) -> Argon2<'_> {
+        Argon2::new(Algorithm::Argon2id, Version::V0x13, self.params.clone())
+    }
+}
+
+impl CredentialVerifier for Argon2idVerifier {
+    fn hash(&self, password: &SecretString) -> Result<String, IdentityError> {
+        let salt = SaltString::generate(&mut OsRng);
+        let phc = self
+            .argon2()
+            .hash_password(password.expose_secret().as_bytes(), &salt)
+            .map_err(|err| IdentityError::HashFailed(err.to_string()))?;
+        Ok(phc.to_string())
+    }
+
+    fn verify(&self, password: &SecretString, stored: &str) -> Result<(), IdentityError> {
+        let parsed =
+            PasswordHash::new(stored).map_err(|err| IdentityError::HashFailed(err.to_string()))?;
+        self.argon2()
+            .verify_password(password.expose_secret().as_bytes(), &parsed)
+            .map_err(|_| IdentityError::InvalidCredential)
+    }
+}

--- a/crates/tanren-identity-policy/src/lib.rs
+++ b/crates/tanren-identity-policy/src/lib.rs
@@ -3,10 +3,14 @@
 //! Owns accounts, organizations, projects, memberships, roles, service
 //! accounts, API keys, approval policy, and runtime placement policy. The
 //! mechanism for credential verification (local password hashing, OIDC
-//! introspection, ...) is deliberately not committed here — R-0001 onwards
-//! pin the mechanism behind a [`CredentialVerifier`] impl.
+//! introspection, ...) is deliberately not committed here — R-0001 pins
+//! the mechanism behind a [`CredentialVerifier`] impl, with
+//! [`Argon2idVerifier`] as the canonical local-password implementation.
 
+mod argon2_verifier;
 pub mod secret_serde;
+
+pub use argon2_verifier::Argon2idVerifier;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -409,16 +413,30 @@ pub struct Session {
     pub token: SessionToken,
 }
 
-/// Verifies a credential and returns a [`Session`] on success. Mechanism
-/// (local password, OIDC, ...) is the implementor's responsibility.
-pub trait CredentialVerifier: Send + Sync {
-    /// Verify the supplied credential and produce a session.
+/// Hashes and verifies a plaintext password against a stored PHC string.
+///
+/// Mechanism (Argon2id today; potentially OIDC introspection or hardware-
+/// backed verifiers later) is the implementor's responsibility. The
+/// canonical workspace impl is [`Argon2idVerifier`].
+pub trait CredentialVerifier: Send + Sync + std::fmt::Debug {
+    /// Hash a plaintext password into a portable PHC-format string
+    /// (`$argon2id$v=19$m=...$<salt>$<hash>`). Salt is generated
+    /// internally by the verifier.
     ///
     /// # Errors
     ///
-    /// Returns [`IdentityError::InvalidCredential`] if the credential does
-    /// not verify.
-    fn verify(&self, credential: &PasswordCredential) -> Result<Session, IdentityError>;
+    /// Returns [`IdentityError::HashFailed`] when the underlying hashing
+    /// primitive raises an error (e.g. invalid parameter combinations).
+    fn hash(&self, password: &SecretString) -> Result<String, IdentityError>;
+
+    /// Verify a plaintext password against a stored PHC-format hash.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::InvalidCredential`] when the password
+    /// does not match the stored hash, or [`IdentityError::HashFailed`]
+    /// when the stored hash string is malformed.
+    fn verify(&self, password: &SecretString, stored: &str) -> Result<(), IdentityError>;
 }
 
 /// Errors raised by identity-policy operations.
@@ -440,6 +458,12 @@ pub enum IdentityError {
     /// The invitation has already been consumed (or revoked).
     #[error("the invitation has already been consumed")]
     InvitationAlreadyConsumed,
+    /// The hashing primitive raised an error (or the stored hash string
+    /// failed to parse). Distinct from
+    /// [`IdentityError::InvalidCredential`] which signals a verified
+    /// password mismatch.
+    #[error("hash error: {0}")]
+    HashFailed(String),
     /// User-supplied input failed validation before any verification could run.
     #[error("invalid input: {0}")]
     Validation(#[from] ValidationError),

--- a/crates/tanren-store/src/entity/accounts.rs
+++ b/crates/tanren-store/src/entity/accounts.rs
@@ -10,8 +10,10 @@ pub struct Model {
     #[sea_orm(unique)]
     pub identifier: String,
     pub display_name: String,
-    pub password_hash: Vec<u8>,
-    pub password_salt: Vec<u8>,
+    /// PHC-format hash string written by `Argon2idVerifier::hash`
+    /// (e.g. `$argon2id$v=19$m=19456,t=2,p=1$<salt>$<hash>`). The salt
+    /// is embedded in the string — there is no separate salt column.
+    pub password_phc: String,
     pub created_at: DateTimeUtc,
     pub org_id: Option<Uuid>,
 }

--- a/crates/tanren-store/src/lib.rs
+++ b/crates/tanren-store/src/lib.rs
@@ -143,8 +143,7 @@ impl AccountStore for Store {
             id: Set(new.id.as_uuid()),
             identifier: Set(new.identifier.as_str().to_owned()),
             display_name: Set(new.display_name),
-            password_hash: Set(new.password_hash),
-            password_salt: Set(new.password_salt),
+            password_phc: Set(new.password_phc),
             created_at: Set(new.created_at),
             org_id: Set(new.org_id.map(OrgId::as_uuid)),
         };

--- a/crates/tanren-store/src/migration/m20260503_000003_password_phc.rs
+++ b/crates/tanren-store/src/migration/m20260503_000003_password_phc.rs
@@ -1,0 +1,108 @@
+//! R-0001 sub-PR 5 migration: replace the legacy `password_hash` /
+//! `password_salt` byte-vec pair with a single `password_phc` TEXT
+//! column carrying the Argon2id PHC string.
+//!
+//! R-0001 is the first feature to ship; there are no historical accounts
+//! whose hashes need preserving. The migration adds the new column with
+//! an empty default, then drops the two legacy columns. Any rows that
+//! happen to exist (test fixtures only) lose their hashes — that is the
+//! intended behaviour: the legacy SHA-256 hashes are not portable to
+//! Argon2id and should not be retained.
+//!
+//! The `down` migration restores the legacy column shape with empty
+//! defaults; PHC data is unrecoverable on rollback.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub(super) struct Migration;
+
+impl std::fmt::Debug for Migration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Migration").finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .add_column(
+                        ColumnDef::new(Accounts::PasswordPhc)
+                            .text()
+                            .not_null()
+                            .default(""),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .drop_column(Accounts::PasswordHash)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .drop_column(Accounts::PasswordSalt)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .add_column(
+                        ColumnDef::new(Accounts::PasswordSalt)
+                            .binary()
+                            .not_null()
+                            .default(Vec::<u8>::new()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .add_column(
+                        ColumnDef::new(Accounts::PasswordHash)
+                            .binary()
+                            .not_null()
+                            .default(Vec::<u8>::new()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Accounts::Table)
+                    .drop_column(Accounts::PasswordPhc)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Accounts {
+    Table,
+    PasswordHash,
+    PasswordSalt,
+    PasswordPhc,
+}

--- a/crates/tanren-store/src/migration/mod.rs
+++ b/crates/tanren-store/src/migration/mod.rs
@@ -6,6 +6,7 @@ use sea_orm_migration::MigratorTrait;
 mod m20260501_000001_init;
 mod m20260502_000001_accounts;
 mod m20260503_000002_account_sessions_expires_at;
+mod m20260503_000003_password_phc;
 
 /// Tanren's migration runner. Applied via [`Store::migrate`](crate::Store::migrate).
 pub struct Migrator;
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260501_000001_init::Migration),
             Box::new(m20260502_000001_accounts::Migration),
             Box::new(m20260503_000002_account_sessions_expires_at::Migration),
+            Box::new(m20260503_000003_password_phc::Migration),
         ]
     }
 }

--- a/crates/tanren-store/src/records.rs
+++ b/crates/tanren-store/src/records.rs
@@ -16,9 +16,10 @@ use crate::entity;
 use crate::{StoreError, parse_db_identifier, parse_db_invitation_token};
 
 /// Persisted account row, exposed as a typed envelope so other crates
-/// never see `SeaORM` `Model` types directly. R-0001 stores password
-/// hash + salt as opaque bytes so the hashing scheme is swappable —
-/// PR 5 swaps these for an Argon2id PHC string.
+/// never see `SeaORM` `Model` types directly. R-0001 stores the
+/// password as an Argon2id PHC string (`$argon2id$v=19$m=...$<salt>$<hash>`)
+/// — salt is embedded in the string so the row carries a single TEXT
+/// column, not a hash + salt pair.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRecord {
     /// Stable account id.
@@ -27,10 +28,11 @@ pub struct AccountRecord {
     pub identifier: Identifier,
     /// Display name.
     pub display_name: String,
-    /// Opaque password hash bytes.
-    pub password_hash: Vec<u8>,
-    /// Salt that produced the password hash.
-    pub password_salt: Vec<u8>,
+    /// PHC-format hash string. Public-by-design hash output — the
+    /// embedded salt is per-row, the parameters are recoverable, and
+    /// no plaintext leaks. Verification goes through
+    /// `CredentialVerifier::verify`.
+    pub password_phc: String,
     /// Wall-clock time the account was created.
     pub created_at: DateTime<Utc>,
     /// Owning organization — `None` for personal (self-signup) accounts.
@@ -46,8 +48,7 @@ impl TryFrom<entity::accounts::Model> for AccountRecord {
             id: AccountId::new(model.id),
             identifier,
             display_name: model.display_name,
-            password_hash: model.password_hash,
-            password_salt: model.password_salt,
+            password_phc: model.password_phc,
             created_at: model.created_at,
             org_id: model.org_id.map(OrgId::new),
         })
@@ -144,10 +145,10 @@ pub struct NewAccount {
     pub identifier: Identifier,
     /// Display name.
     pub display_name: String,
-    /// Opaque password hash bytes.
-    pub password_hash: Vec<u8>,
-    /// Salt that produced the password hash.
-    pub password_salt: Vec<u8>,
+    /// Argon2id PHC string (`$argon2id$v=19$...$<salt>$<hash>`). The
+    /// caller threads this in from
+    /// `CredentialVerifier::hash(&request.password)`.
+    pub password_phc: String,
     /// Wall-clock creation time.
     pub created_at: DateTime<Utc>,
     /// Owning organization — `None` for personal (self-signup) accounts.

--- a/justfile
+++ b/justfile
@@ -338,6 +338,7 @@ check:
     run_stage "test hooks" just check-test-hooks
     run_stage "newtype ids" just check-newtype-ids
     run_stage "secrets" just check-secrets
+    run_stage "orphan traits" just check-orphan-traits
     run_stage "event coverage" just check-event-coverage
     run_stage "profiles" just check-profiles
     run_stage "cargo check" bash -c 'CARGO_INCREMENTAL=0 {{ cargo }} check --workspace --all-targets --locked --quiet'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,6 +33,10 @@ pre-commit:
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
         just check-test-hooks
+    orphan-traits:
+      run: |
+        export PATH="$HOME/.cargo/bin:$PATH"
+        just check-orphan-traits
 
 pre-push:
   parallel: false

--- a/xtask/orphan-traits-allowlist.toml
+++ b/xtask/orphan-traits-allowlist.toml
@@ -1,0 +1,39 @@
+# Orphan-traits allowlist.
+#
+# `xtask check-orphan-traits` rejects every workspace `pub trait` that
+# has no implementor anywhere in the workspace — orphan traits are dead
+# code and tend to drift away from the surfaces they were meant to
+# describe. The exception is *foundation* trait skeletons that ship
+# ahead of the feature work that lands their first impl. Each such
+# trait is listed here with a forward pointer to the spec or feature
+# that will close the gap, plus a one-line rationale.
+#
+# When the spec lands and the impl is written, remove the entry — the
+# checker fails on stale entries (allowlisted traits that turn out to
+# be implemented after all, or names that no longer match a `pub trait`
+# in the workspace).
+
+[[allowed]]
+name = "Gate"
+upcoming_spec = "F-0001"
+reason = "tanren-quality-controls Gate trait — first impl lands with the gates feature work."
+
+[[allowed]]
+name = "Harness"
+upcoming_spec = "F-0001"
+reason = "tanren-harness Harness trait — first impl lands with the harness families feature work."
+
+[[allowed]]
+name = "ProviderAdapter"
+upcoming_spec = "F-0001"
+reason = "tanren-provider-integrations ProviderAdapter — first impl lands with the upstream-adapter feature work (e.g. xhealth GCP/Linear adapters)."
+
+[[allowed]]
+name = "Scheduler"
+upcoming_spec = "F-0001"
+reason = "tanren-scheduler Scheduler trait — first impl lands with the scheduler feature work."
+
+[[allowed]]
+name = "Substrate"
+upcoming_spec = "F-0001"
+reason = "tanren-runtime Substrate trait — first impl lands with the runtime substrate feature work."

--- a/xtask/secret-newtypes.toml
+++ b/xtask/secret-newtypes.toml
@@ -13,30 +13,20 @@ allowed = [
   "secrecy::SecretBox",
 ]
 
-# Per-(file, field) exemptions for legacy storage shapes that ship raw
-# bytes/strings before a wrapper newtype lands. PR 5 swaps the
-# `password_hash`/`password_salt` byte-vec pair for an Argon2id PHC
-# string and these entries should be removed in that PR.
+# Per-(file, field) exemptions for fields whose name is matched by the
+# `(?i)password|secret|api_key|...` regex but whose value is *not* a
+# secret. The `password_phc` column carries the Argon2id PHC string —
+# a public-by-design hash output (parameters + salt + hash) that is
+# safe to store as TEXT and to log. Verification routes through
+# `CredentialVerifier::verify`; the field never holds plaintext.
 [[field_exemptions]]
 file = "crates/tanren-store/src/entity/accounts.rs"
-field = "password_hash"
-ty = "Vec < u8 >"
-reason = "PR 5 swaps to Argon2id PHC string; legacy SHA-256 byte hash kept until then."
-
-[[field_exemptions]]
-file = "crates/tanren-store/src/entity/accounts.rs"
-field = "password_salt"
-ty = "Vec < u8 >"
-reason = "PR 5 deletes the explicit salt column in favour of Argon2's PHC-embedded salt."
+field = "password_phc"
+ty = "String"
+reason = "Argon2id PHC string — hash output, not a secret. Salt is embedded; parameters are recoverable; no plaintext."
 
 [[field_exemptions]]
 file = "crates/tanren-store/src/records.rs"
-field = "password_hash"
-ty = "Vec < u8 >"
-reason = "Mirrors entity::accounts::Model.password_hash; same PR 5 swap."
-
-[[field_exemptions]]
-file = "crates/tanren-store/src/records.rs"
-field = "password_salt"
-ty = "Vec < u8 >"
-reason = "Mirrors entity::accounts::Model.password_salt; same PR 5 swap."
+field = "password_phc"
+ty = "String"
+reason = "Mirrors entity::accounts::Model.password_phc; same PHC-string rationale."

--- a/xtask/src/check_orphan_traits/mod.rs
+++ b/xtask/src/check_orphan_traits/mod.rs
@@ -6,16 +6,37 @@
 //! for <Type>` declaration in the workspace and record which trait names
 //! are implemented (matched by the trailing path segment, e.g.
 //! `tanren_identity_policy::CredentialVerifier` matches `CredentialVerifier`).
-//! Any trait with zero impls is reported.
+//! Any trait with zero impls is reported, unless the trait name appears
+//! in `xtask/orphan-traits-allowlist.toml` with a forward-pointer to
+//! the spec/feature whose work will land the impl.
 
 use anyhow::{Context, Result, bail};
 use quote::ToTokens;
-use std::collections::{BTreeMap, BTreeSet};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use syn::{Item, Visibility};
+
+#[derive(Debug, Deserialize, Default)]
+struct AllowlistFile {
+    #[serde(default)]
+    allowed: Vec<AllowedTrait>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AllowedTrait {
+    /// Trait name (the leaf identifier, matching how impls register
+    /// — e.g. `Gate`, not `tanren_quality_controls::Gate`).
+    name: String,
+    /// Forward pointer (e.g. `F-0007`, `R-0014`) to the spec or feature
+    /// whose roadmap entry pins the implementation.
+    upcoming_spec: String,
+    /// Free-form audit-trail note. Required: empty reason is a parse error.
+    reason: String,
+}
 
 pub(crate) fn run(root: &Path) -> Result<()> {
     let crates_dir = root.join("crates");
@@ -28,6 +49,8 @@ pub(crate) fn run(root: &Path) -> Result<()> {
         );
         return Ok(());
     }
+
+    let allowlist = load_allowlist(&root.join("xtask").join("orphan-traits-allowlist.toml"))?;
 
     let mut traits: BTreeMap<String, (PathBuf, usize)> = BTreeMap::new();
     let mut impls: BTreeSet<String> = BTreeSet::new();
@@ -50,35 +73,93 @@ pub(crate) fn run(root: &Path) -> Result<()> {
     }
 
     let mut violations: Vec<String> = Vec::new();
+    let mut stale_allowlist_entries: Vec<String> = Vec::new();
     for (name, (path, line)) in &traits {
-        if !impls.contains(name) {
-            violations.push(format!(
-                "{}:{}: trait `{name}` has no impl in the workspace",
-                path.strip_prefix(root).unwrap_or(path).display(),
-                line
+        if impls.contains(name) {
+            if allowlist.contains_key(name) {
+                stale_allowlist_entries.push(format!(
+                    "trait `{name}` is now implemented in the workspace; remove its entry from xtask/orphan-traits-allowlist.toml"
+                ));
+            }
+            continue;
+        }
+        if allowlist.contains_key(name) {
+            continue;
+        }
+        violations.push(format!(
+            "{}:{}: trait `{name}` has no impl in the workspace",
+            path.strip_prefix(root).unwrap_or(path).display(),
+            line
+        ));
+    }
+
+    // Flag allowlist entries that don't correspond to any pub trait at
+    // all — the file should not silently rot as traits are renamed or
+    // removed.
+    for name in allowlist.keys() {
+        if !traits.contains_key(name) {
+            stale_allowlist_entries.push(format!(
+                "allowlist entry `{name}` does not match any `pub trait` in the workspace"
             ));
         }
     }
 
-    if violations.is_empty() {
-        let stdout = std::io::stdout();
-        let mut handle = stdout.lock();
-        let _ = writeln!(
-            handle,
-            "check-orphan-traits: 0 violations ({} pub trait(s) implemented)",
-            traits.len()
+    if !violations.is_empty() || !stale_allowlist_entries.is_empty() {
+        let stderr = std::io::stderr();
+        let mut handle = stderr.lock();
+        for v in &violations {
+            let _ = writeln!(handle, "{v}");
+        }
+        for v in &stale_allowlist_entries {
+            let _ = writeln!(handle, "{v}");
+        }
+        bail!(
+            "check-orphan-traits: {} unimplemented trait(s), {} stale allowlist entry(ies)",
+            violations.len(),
+            stale_allowlist_entries.len()
         );
-        return Ok(());
     }
-    let stderr = std::io::stderr();
-    let mut handle = stderr.lock();
-    for v in &violations {
-        let _ = writeln!(handle, "{v}");
-    }
-    bail!(
-        "check-orphan-traits: {} trait(s) lack an implementor",
-        violations.len()
+
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    let _ = writeln!(
+        handle,
+        "check-orphan-traits: 0 violations ({} pub trait(s); {} allowlisted as upcoming-spec)",
+        traits.len(),
+        allowlist.len()
     );
+    Ok(())
+}
+
+fn load_allowlist(path: &Path) -> Result<HashMap<String, AllowedTrait>> {
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed: AllowlistFile =
+        toml::from_str(&raw).with_context(|| format!("parse {} as TOML", path.display()))?;
+    let mut out: HashMap<String, AllowedTrait> = HashMap::with_capacity(parsed.allowed.len());
+    for entry in parsed.allowed {
+        if entry.reason.trim().is_empty() {
+            bail!(
+                "orphan-traits allowlist entry `{}` has empty `reason`",
+                entry.name
+            );
+        }
+        if entry.upcoming_spec.trim().is_empty() {
+            bail!(
+                "orphan-traits allowlist entry `{}` has empty `upcoming_spec`",
+                entry.name
+            );
+        }
+        if let Some(prev) = out.insert(entry.name.clone(), entry) {
+            bail!(
+                "orphan-traits allowlist has duplicate entry for `{}`",
+                prev.name
+            );
+        }
+    }
+    Ok(out)
 }
 
 fn scan_file(


### PR DESCRIPTION
## Summary

Sub-PR 5 of 12. Argon2id is now the canonical password verifier; the inline SHA-256 path is deleted.

- New `Argon2idVerifier` in `tanren-identity-policy` impls `CredentialVerifier`. `production()` uses OWASP 2025 floor (m=19 MiB, t=2, p=1); `fast_for_tests()` cfg-gated on `test-hooks`.
- `CredentialVerifier` trait reshaped to operate on PHC strings (single column).
- New migration `m20260503_000003_password_phc`: adds `password_phc TEXT NOT NULL`, drops `password_hash`/`password_salt`.
- `tanren-app-services` handlers consume `&dyn CredentialVerifier` via `Arc<dyn CredentialVerifier>` on `Handlers`; default is `Argon2idVerifier::production()`. `Handlers::with_verifier` allows injection (BDD uses fast preset).
- BDD scenarios stay fast (`fast_for_tests` preset) — 35 scenarios in ~22s total.
- `xtask check-orphan-traits` wired into `just check` + lefthook; allowlist `xtask/orphan-traits-allowlist.toml` covers the 5 F-0001 stub traits (`Gate`, `Harness`, `ProviderAdapter`, `Scheduler`, `Substrate`) with upcoming-spec markers. `CredentialVerifier` is no longer orphan.
- xtask `secret-newtypes.toml` drops the 4 legacy `password_hash`/`password_salt` exemptions; adds 2 `password_phc: String` exemptions (PHC string is the canonical hashed-output column, public by design).

## Test plan

- [x] `just check` green (incl. `check-orphan-traits` 0 violations)
- [x] `just tests` green (35/35 BDD scenarios)
- [x] `cargo build --workspace --all-features` green
- [x] No more `sha2::Sha256::new` callsites in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)