### PR TITLE
feat(R-0001): sub-7 — failure events + ValidationFailed taxonomy + AccountEventKind enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "chrono",
  "cucumber",
  "secrecy",
+ "serde_json",
  "tanren-app-services",
  "tanren-contract",
  "tanren-identity-policy",

--- a/crates/tanren-app-services/src/account.rs
+++ b/crates/tanren-app-services/src/account.rs
@@ -18,7 +18,7 @@
 //! callers can both successfully accept the same token even under
 //! concurrent load.
 
-use chrono::Duration;
+use chrono::{DateTime, Duration, Utc};
 use secrecy::ExposeSecret;
 use tanren_contract::{
     AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, AccountView,
@@ -27,7 +27,10 @@ use tanren_contract::{
 use tanren_identity_policy::{AccountId, CredentialVerifier, Identifier, SessionToken};
 use tanren_store::{AccountRecord, AccountStore, ConsumeInvitationError, NewAccount};
 
-use crate::events::{AccountCreated, InvitationAccepted, SignedIn, envelope};
+use crate::events::{
+    AccountCreated, AccountEventKind, InvitationAcceptFailed, InvitationAccepted, SignInFailed,
+    SignUpRejected, SignedIn, envelope,
+};
 use crate::{AppServiceError, Clock};
 
 /// Default session lifetime. Held centrally so the cookie-session policy
@@ -45,9 +48,18 @@ where
 {
     let identifier = Identifier::from_email(&request.email);
     let display_name = request.display_name.trim().to_owned();
+    let now = clock.now();
+
     if request.password.expose_secret().is_empty() || display_name.is_empty() {
+        emit_signup_rejected(
+            store,
+            AccountFailureReason::ValidationFailed,
+            &identifier,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
-            AccountFailureReason::InvalidCredential,
+            AccountFailureReason::ValidationFailed,
         ));
     }
 
@@ -56,33 +68,47 @@ where
         .await?
         .is_some()
     {
+        emit_signup_rejected(
+            store,
+            AccountFailureReason::DuplicateIdentifier,
+            &identifier,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
             AccountFailureReason::DuplicateIdentifier,
         ));
     }
 
-    let now = clock.now();
     let password_phc = verifier
         .hash(&request.password)
         .map_err(|err| AppServiceError::InvalidInput(err.to_string()))?;
     let id = AccountId::fresh();
-    let account = store
+    let account = match store
         .insert_account(NewAccount {
             id,
-            identifier,
+            identifier: identifier.clone(),
             display_name,
             password_phc,
             created_at: now,
             org_id: None,
         })
         .await
-        .map_err(map_insert_error)?;
+        .map_err(map_insert_error)
+    {
+        Ok(a) => a,
+        Err(AppServiceError::Account(reason)) => {
+            emit_signup_rejected(store, reason, &identifier, now).await?;
+            return Err(AppServiceError::Account(reason));
+        }
+        Err(other) => return Err(other),
+    };
 
     let session = mint_session(store, account.id, now).await?;
     store
         .append_event(
             envelope(
-                "account_created",
+                AccountEventKind::AccountCreated,
                 &AccountCreated {
                     account_id: account.id,
                     identifier: account.identifier.as_str().to_owned(),
@@ -109,12 +135,29 @@ pub(crate) async fn sign_in<S>(
 where
     S: AccountStore + ?Sized,
 {
+    let now = clock.now();
+    let identifier = Identifier::from_email(&request.email);
+
     if request.password.expose_secret().is_empty() {
+        emit_signin_failed(
+            store,
+            AccountFailureReason::ValidationFailed,
+            &identifier,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
-            AccountFailureReason::InvalidCredential,
+            AccountFailureReason::ValidationFailed,
         ));
     }
     let Some(account) = store.find_account_by_email(&request.email).await? else {
+        emit_signin_failed(
+            store,
+            AccountFailureReason::InvalidCredential,
+            &identifier,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
             AccountFailureReason::InvalidCredential,
         ));
@@ -123,17 +166,23 @@ where
         .verify(&request.password, &account.password_phc)
         .is_err()
     {
+        emit_signin_failed(
+            store,
+            AccountFailureReason::InvalidCredential,
+            &identifier,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
             AccountFailureReason::InvalidCredential,
         ));
     }
 
-    let now = clock.now();
     let session = mint_session(store, account.id, now).await?;
     store
         .append_event(
             envelope(
-                "signed_in",
+                AccountEventKind::SignedIn,
                 &SignedIn {
                     account_id: account.id,
                     at: now,
@@ -158,53 +207,57 @@ where
     S: AccountStore + ?Sized,
 {
     let display_name = request.display_name.trim().to_owned();
+    let now = clock.now();
+    let token = request.invitation_token.clone();
+
     if request.password.expose_secret().is_empty() || display_name.is_empty() {
+        emit_invitation_accept_failed(store, AccountFailureReason::ValidationFailed, &token, now)
+            .await?;
         return Err(AppServiceError::Account(
-            AccountFailureReason::InvalidCredential,
+            AccountFailureReason::ValidationFailed,
         ));
     }
 
-    // The invitee picks the email/identifier pair when accepting. PR 7
-    // will source the identifier from the invitation row instead — for
-    // now the contract carries `request.email` as a first-class field
-    // and the handler trusts it.
+    // The invitee supplies the email when accepting. The contract carries
+    // `request.email` as a first-class field; the handler trusts it
+    // (subsequent specs will reconcile against the invitation row's
+    // target_identifier when R-0005's invite flow lands).
     let identifier = Identifier::from_email(&request.email);
     if store
         .find_account_by_identifier(&identifier)
         .await?
         .is_some()
     {
+        emit_invitation_accept_failed(
+            store,
+            AccountFailureReason::DuplicateIdentifier,
+            &token,
+            now,
+        )
+        .await?;
         return Err(AppServiceError::Account(
             AccountFailureReason::DuplicateIdentifier,
         ));
     }
 
-    let now = clock.now();
     // Atomic consume: a single conditional UPDATE on the store
     // transitions the invitation from pending → consumed. Concurrent
     // callers serialise to exactly one success; the rest receive
     // `AlreadyConsumed`.
-    let consumed = match store
-        .consume_invitation(&request.invitation_token, now)
-        .await
-    {
+    let consumed = match store.consume_invitation(&token, now).await {
         Ok(consumed) => consumed,
-        Err(ConsumeInvitationError::NotFound) => {
-            return Err(AppServiceError::Account(
-                AccountFailureReason::InvitationNotFound,
-            ));
+        Err(consume_err) => {
+            let reason = match consume_err {
+                ConsumeInvitationError::NotFound => AccountFailureReason::InvitationNotFound,
+                ConsumeInvitationError::AlreadyConsumed => {
+                    AccountFailureReason::InvitationAlreadyConsumed
+                }
+                ConsumeInvitationError::Expired => AccountFailureReason::InvitationExpired,
+                ConsumeInvitationError::Store(err) => return Err(AppServiceError::Store(err)),
+            };
+            emit_invitation_accept_failed(store, reason, &token, now).await?;
+            return Err(AppServiceError::Account(reason));
         }
-        Err(ConsumeInvitationError::AlreadyConsumed) => {
-            return Err(AppServiceError::Account(
-                AccountFailureReason::InvitationAlreadyConsumed,
-            ));
-        }
-        Err(ConsumeInvitationError::Expired) => {
-            return Err(AppServiceError::Account(
-                AccountFailureReason::InvitationExpired,
-            ));
-        }
-        Err(ConsumeInvitationError::Store(err)) => return Err(AppServiceError::Store(err)),
     };
 
     let password_phc = verifier
@@ -230,7 +283,7 @@ where
     store
         .append_event(
             envelope(
-                "account_created",
+                AccountEventKind::AccountCreated,
                 &AccountCreated {
                     account_id: account.id,
                     identifier: account.identifier.as_str().to_owned(),
@@ -244,9 +297,9 @@ where
     store
         .append_event(
             envelope(
-                "invitation_accepted",
+                AccountEventKind::InvitationAccepted,
                 &InvitationAccepted {
-                    token: request.invitation_token.clone(),
+                    token,
                     account_id: account.id,
                     joined_org: consumed.inviting_org_id,
                     at: now,
@@ -263,6 +316,81 @@ where
     })
 }
 
+async fn emit_signup_rejected<S>(
+    store: &S,
+    reason: AccountFailureReason,
+    identifier: &Identifier,
+    now: DateTime<Utc>,
+) -> Result<(), AppServiceError>
+where
+    S: AccountStore + ?Sized,
+{
+    store
+        .append_event(
+            envelope(
+                AccountEventKind::SignUpRejected,
+                &SignUpRejected {
+                    reason,
+                    identifier: identifier.as_str().to_owned(),
+                    at: now,
+                },
+            ),
+            now,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn emit_signin_failed<S>(
+    store: &S,
+    reason: AccountFailureReason,
+    identifier: &Identifier,
+    now: DateTime<Utc>,
+) -> Result<(), AppServiceError>
+where
+    S: AccountStore + ?Sized,
+{
+    store
+        .append_event(
+            envelope(
+                AccountEventKind::SignInFailed,
+                &SignInFailed {
+                    reason,
+                    identifier: identifier.as_str().to_owned(),
+                    at: now,
+                },
+            ),
+            now,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn emit_invitation_accept_failed<S>(
+    store: &S,
+    reason: AccountFailureReason,
+    token: &tanren_identity_policy::InvitationToken,
+    now: DateTime<Utc>,
+) -> Result<(), AppServiceError>
+where
+    S: AccountStore + ?Sized,
+{
+    store
+        .append_event(
+            envelope(
+                AccountEventKind::InvitationAcceptFailed,
+                &InvitationAcceptFailed {
+                    reason,
+                    token: token.clone(),
+                    at: now,
+                },
+            ),
+            now,
+        )
+        .await?;
+    Ok(())
+}
+
 fn account_view(record: &AccountRecord) -> AccountView {
     AccountView {
         id: record.id,
@@ -275,7 +403,7 @@ fn account_view(record: &AccountRecord) -> AccountView {
 async fn mint_session<S>(
     store: &S,
     account_id: AccountId,
-    now: chrono::DateTime<chrono::Utc>,
+    now: DateTime<Utc>,
 ) -> Result<SessionView, AppServiceError>
 where
     S: AccountStore + ?Sized,

--- a/crates/tanren-app-services/src/events.rs
+++ b/crates/tanren-app-services/src/events.rs
@@ -9,11 +9,54 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tanren_contract::AccountFailureReason;
 use tanren_identity_policy::{AccountId, InvitationToken, OrgId};
 
 /// Tag on the JSON envelope that disambiguates account events from
 /// future event families.
 pub const EVENT_FAMILY: &str = "account";
+
+/// Closed taxonomy of account-flow event kinds.
+///
+/// `xtask check-event-coverage` cross-references every variant against
+/// BDD feature steps to ensure each kind has at least one assertion. The
+/// kind also serialises to the JSON envelope's `kind` field so log
+/// consumers can filter without parsing the payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AccountEventKind {
+    /// A new account was created (self-signup or invitation acceptance).
+    AccountCreated,
+    /// An existing account signed in.
+    SignedIn,
+    /// An invitation was accepted (paired with `AccountCreated` for the
+    /// new invitee account).
+    InvitationAccepted,
+    /// A sign-up was rejected — duplicate identifier, validation failure,
+    /// or other taxonomy reason.
+    SignUpRejected,
+    /// A sign-in was rejected — invalid credential or validation failure.
+    SignInFailed,
+    /// An invitation acceptance was rejected — not found / expired /
+    /// already consumed / validation failure.
+    InvitationAcceptFailed,
+}
+
+impl AccountEventKind {
+    /// Stable wire `kind` string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AccountCreated => "account_created",
+            Self::SignedIn => "signed_in",
+            Self::InvitationAccepted => "invitation_accepted",
+            Self::SignUpRejected => "sign_up_rejected",
+            Self::SignInFailed => "sign_in_failed",
+            Self::InvitationAcceptFailed => "invitation_accept_failed",
+        }
+    }
+}
 
 /// A new account was created.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,12 +93,47 @@ pub struct InvitationAccepted {
     pub at: DateTime<Utc>,
 }
 
+/// A sign-up attempt was rejected. Carries the [`AccountFailureReason`]
+/// so audit consumers can distinguish duplicate identifiers from
+/// validation failures.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignUpRejected {
+    /// Why the attempt was rejected.
+    pub reason: AccountFailureReason,
+    /// Email the caller submitted (case-folded; safe to log).
+    pub identifier: String,
+    /// Wall-clock time the rejection was emitted.
+    pub at: DateTime<Utc>,
+}
+
+/// A sign-in attempt was rejected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignInFailed {
+    /// Why the attempt failed.
+    pub reason: AccountFailureReason,
+    /// Email the caller submitted (case-folded; safe to log).
+    pub identifier: String,
+    /// Wall-clock time the rejection was emitted.
+    pub at: DateTime<Utc>,
+}
+
+/// An invitation-acceptance attempt was rejected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvitationAcceptFailed {
+    /// Why the attempt was rejected.
+    pub reason: AccountFailureReason,
+    /// Token the caller submitted.
+    pub token: InvitationToken,
+    /// Wall-clock time the rejection was emitted.
+    pub at: DateTime<Utc>,
+}
+
 /// Encode a typed event as the JSON envelope persisted in the event log.
 #[must_use]
-pub fn envelope<T: Serialize>(kind: &str, payload: &T) -> serde_json::Value {
+pub fn envelope<T: Serialize>(kind: AccountEventKind, payload: &T) -> serde_json::Value {
     serde_json::json!({
         "family": EVENT_FAMILY,
-        "kind": kind,
+        "kind": kind.as_str(),
         "payload": payload,
     })
 }

--- a/crates/tanren-bdd/Cargo.toml
+++ b/crates/tanren-bdd/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 chrono = { workspace = true }
 cucumber = { workspace = true }
 secrecy = { workspace = true }
+serde_json = { workspace = true }
 tanren-app-services = { path = "../tanren-app-services" }
 tanren-contract = { path = "../tanren-contract" }
 tanren-identity-policy = { path = "../tanren-identity-policy", features = [

--- a/crates/tanren-bdd/src/steps/account.rs
+++ b/crates/tanren-bdd/src/steps/account.rs
@@ -249,6 +249,30 @@ async fn then_fails_with(world: &mut TanrenWorld, code: String) {
     assert_eq!(actual, code, "expected failure code");
 }
 
+#[then(expr = "a {string} event is recorded")]
+async fn then_event_recorded(world: &mut TanrenWorld, kind: String) {
+    use tanren_store::AccountStore;
+    let ctx = world.ensure_account_ctx().await;
+    let recent: Vec<tanren_store::EventEnvelope> = AccountStore::recent_events(&ctx.store, 20)
+        .await
+        .expect("recent_events should succeed under BDD");
+    let found = recent.iter().any(|envelope| {
+        envelope
+            .payload
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|k| k == kind)
+    });
+    assert!(
+        found,
+        "expected a '{kind}' event in the recent log; got {kinds:?}",
+        kinds = recent
+            .iter()
+            .filter_map(|e| e.payload.get("kind").and_then(serde_json::Value::as_str))
+            .collect::<Vec<_>>()
+    );
+}
+
 async fn do_sign_up(
     world: &mut TanrenWorld,
     actor: String,

--- a/tests/bdd/features/B-0043-create-account.feature
+++ b/tests/bdd/features/B-0043-create-account.feature
@@ -20,8 +20,10 @@ Feature: Create an account
     Scenario: Self-signup over the API creates an account that can sign in
       When alice self-signs up with email "alice-api@example.com" and password "p4ssw0rd"
       Then alice receives a session token
+      And a "account_created" event is recorded
       When alice signs in with the same credentials
       Then alice receives a session token
+      And a "signed_in" event is recorded
 
     @positive @api
     Scenario: Invitation acceptance over the API joins the inviting org
@@ -29,6 +31,7 @@ Feature: Create an account
       When bob accepts invitation "api-token-1-padpad" with password "team-pw"
       Then bob receives a session token
       And bob has joined an organization
+      And a "invitation_accepted" event is recorded
 
     @positive @api
     Scenario: One person holds two accounts via the API
@@ -49,18 +52,21 @@ Feature: Create an account
       Given alice has signed up with email "alice-api-dup@example.com" and password "p4ssw0rd"
       When mallory self-signs up with email "alice-api-dup@example.com" and password "different-pw"
       Then the request fails with code "duplicate_identifier"
+      And a "sign_up_rejected" event is recorded
 
     @falsification @api
     Scenario: API rejects sign-in with a wrong credential
       Given alice has signed up with email "alice-api-wrong@example.com" and password "p4ssw0rd"
       When alice signs in with email "alice-api-wrong@example.com" and password "wrong-pw"
       Then the request fails with code "invalid_credential"
+      And a "sign_in_failed" event is recorded
 
     @falsification @api
     Scenario: API rejects accepting an expired invitation
       Given an expired invitation token "api-token-expired-padpad"
       When erin accepts invitation "api-token-expired-padpad" with password "any-pw"
       Then the request fails with code "invitation_expired"
+      And a "invitation_accept_failed" event is recorded
 
   Rule: Web surface
 


### PR DESCRIPTION
Sub-PR 7 of 12. Empty-input → ValidationFailed (HTTP 400, was 401); sign_up_rejected/sign_in_failed/invitation_accept_failed events emitted on every rejection path; AccountEventKind enum makes envelope() typo-proof; xtask check-event-coverage now enforces 6-variant BDD coverage. All gates green; 166 BDD steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)