### PR TITLE
feat(R-0001): sub-12 — regression fixtures + check-openapi-handcraft + final cleanup

### DIFF
--- a/docs/architecture/subsystems/behavior-proof.md
+++ b/docs/architecture/subsystems/behavior-proof.md
@@ -395,7 +395,7 @@ the same behavior.
   `crates/tanren-bdd/src/steps/**/*.rs` (AST via `syn`) and rejects any
   step body that calls `tanren_app_services::Handlers::` directly.
   Steps must dispatch through `*Harness` traits.
-- `xtask check-deps` rejects `tanren-app-services` from
+- `just check-deps` rejects `tanren-app-services` from
   `tanren-bdd/Cargo.toml`. The BDD crate depends on `tanren-testkit`
   and `tanren-contract` only; `Handlers` is reachable only via
   harnesses.

--- a/docs/architecture/technology.md
+++ b/docs/architecture/technology.md
@@ -51,7 +51,7 @@ Library crates use `thiserror`; binaries may use `anyhow`. Production code
 avoids `unsafe`, `unwrap`, `panic!`, `todo!`, `unimplemented!`, `println!`,
 `eprintln!`, and `dbg!`.
 
-Crate dependency rules (mechanically enforced by `xtask check-deps`):
+Crate dependency rules (mechanically enforced by `just check-deps`):
 
 1. `tanren-domain` does not depend on any other workspace crate. It is the
    leaf canonical-entity layer.

--- a/justfile
+++ b/justfile
@@ -345,6 +345,8 @@ check:
     run_stage "tracing init" just check-tracing-init
     run_stage "bdd wire coverage" just check-bdd-wire-coverage
     run_stage "tsconfig" just check-tsconfig
+    run_stage "openapi handcraft" just check-openapi-handcraft
+    run_stage "enforcement regressions" just check-enforcement-regressions
     run_stage "cargo check" bash -c 'CARGO_INCREMENTAL=0 {{ cargo }} check --workspace --all-targets --locked --quiet'
     run_stage "clippy" bash -c 'CARGO_INCREMENTAL=0 {{ cargo }} clippy --workspace --all-targets --locked --quiet -- -D warnings'
     total_elapsed="$(( $(now_ms) - total_start ))"
@@ -721,10 +723,21 @@ check-profiles:
 check-orphan-traits:
     @{{ cargo }} run -q -p tanren-xtask -- check-orphan-traits
 
+# Reject hand-rolled `serde_json::json!({"openapi": ..., "paths": ...,
+# "components": ...})` documents in api crates. The api stack derives
+# its OpenAPI document via `utoipa`; raw JSON literals would silently
+# drift from the running server. Wired into `check` by PR 12.
+check-openapi-handcraft:
+    @{{ cargo }} run -q -p tanren-xtask -- check-openapi-handcraft
+
 # Run the regression-fixture test suite that proves each guard rejects
-# its synthetic regression. Fixtures land in PR 12; until then this
-# recipe runs `cargo test -p tanren-xtask --tests`, which exits 0 with
-# no tests, so branch protection can require it now.
+# its synthetic regression. Each fixture under
+# `xtask/tests/fixtures/<guard>/` is a synthetic minimal source tree
+# that violates exactly one rule; the matching `#[test]` in
+# `xtask/tests/regressions.rs` invokes `xtask <subcommand> --root
+# <fixture>` and asserts the guard fails with the expected error
+# substring. If any fixture stops failing, the corresponding guard has
+# been weakened — investigate before merging.
 check-enforcement-regressions:
     @{{ cargo }} test -p tanren-xtask --tests
 

--- a/profiles/rust-cargo/testing/bdd-wire-harness.md
+++ b/profiles/rust-cargo/testing/bdd-wire-harness.md
@@ -101,7 +101,7 @@ async fn sign_up(world: &mut TanrenWorld, email: String) {
 - `xtask check-bdd-wire-coverage` (AST walker) rejects any direct
   `Handlers::` call inside `crates/tanren-bdd/src/steps/**`. The witness
   earned by an interface tag must be earned over its real wire.
-- `xtask check-deps` rejects `tanren-app-services` in
+- `just check-deps` rejects `tanren-app-services` in
   `crates/tanren-bdd/Cargo.toml`. The crate cannot reach the in-process
   handlers even by accident — the dep edge is closed.
 

--- a/profiles/rust-cargo/testing/mock-boundaries.md
+++ b/profiles/rust-cargo/testing/mock-boundaries.md
@@ -69,7 +69,7 @@ Mechanical enforcement:
 
 - `xtask check-bdd-wire-coverage` (AST walker) rejects any direct
   `Handlers::` call inside `crates/tanren-bdd/src/steps/**`.
-- `xtask check-deps` rejects `tanren-app-services` as a dependency of
+- `just check-deps` rejects `tanren-app-services` as a dependency of
   the `tanren-bdd` crate. The crate cannot reach the in-process surface
   even by accident.
 

--- a/xtask/check-profiles-pending.toml
+++ b/xtask/check-profiles-pending.toml
@@ -5,20 +5,24 @@
 #
 # Source of references: `profiles/rust-cargo/global/just-ci-gate.md` and the
 # enforcement matrix in PR 1's architecture/profile updates.
+#
+# As of R-0001 sub-12 (regression-fixture coverage) every previously-pending
+# recipe and subcommand has landed:
+#   - `check-thin-binary`            — sub-8 (thin-binary line-budget recipe)
+#   - `check-tsconfig`               — sub-10 (apps/web TS-strict gate)
+#   - `check-enforcement-regressions` — sub-12 (this PR; fixtures)
+#   - `check-lines`                  — sub-2 (max-lines-per-file gate)
+#   - `check-deps`                   — sub-2 (workspace dependency-boundary
+#                                      gate; remained as a `just` recipe
+#                                      rather than an `xtask` subcommand)
+#   - `check-openapi-handcraft`      — sub-12 (this PR; AST guard against
+#                                      hand-rolled `json!({...})` OpenAPI
+#                                      documents in api crates)
+#
+# Both lists are intentionally empty so the file fails noisily the next time
+# someone references a non-existent recipe / subcommand without first
+# wiring it in.
 
-# `just <recipe>` references that are not yet present in `justfile`.
-pending_recipes = [
-  "check-thin-binary",          # PR (system thin-binary work) wires this in.
-  "check-tsconfig",             # apps/web TS strictness gate; arrives later.
-  "check-enforcement-regressions", # falsification-fixture meta-gate.
-  "check-lines",                # max-lines-per-file gate; lands later.
-]
+pending_recipes = []
 
-# `xtask <subcommand>` references for subcommands that PR 2 does not ship.
-pending_subcommands = [
-  "check-openapi-handcraft",    # planned guard from openapi-generation.md.
-  "check-deps",                 # exists today as a `just` recipe; arch docs
-                                # still describe it as `xtask check-deps`.
-                                # PR fixing the docs (or porting the recipe
-                                # into xtask) removes this entry.
-]
+pending_subcommands = []

--- a/xtask/src/check_openapi_handcraft/mod.rs
+++ b/xtask/src/check_openapi_handcraft/mod.rs
@@ -1,0 +1,148 @@
+//! `xtask check-openapi-handcraft` — hand-rolled `OpenAPI` documents are
+//! forbidden in api crates.
+//!
+//! The api stack generates its `OpenAPI` document from `utoipa` derives at
+//! compile time so the schema, the types, and the running handlers stay
+//! in lockstep. Hand-rolled `serde_json::json!({"openapi": ..., "paths":
+//! ..., "components": ...})` literals would silently drift from the
+//! types they purport to describe within a release or two and become a
+//! second source of truth nobody trusts.
+//!
+//! This guard scans every `.rs` file under
+//! `bin/tanren-api/src/**` and `crates/tanren-{api,*-api,*-api-app}/src/**`
+//! (matched lexically so a future api crate falls under the rule
+//! automatically) and rejects any `json!` / `serde_json::json!` macro
+//! invocation whose body mentions one of the well-known top-level
+//! `OpenAPI` keys (`"openapi"`, `"paths"`, `"components"`). The substring
+//! match is intentionally lenient — formatting is not load-bearing;
+//! presence of the keys anywhere inside the macro body is sufficient
+//! evidence that someone is hand-rolling a document.
+//!
+//! See `profiles/rust-cargo/architecture/openapi-generation.md`.
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+const FORBIDDEN_KEYS: &[&str] = &["\"openapi\"", "\"paths\"", "\"components\""];
+
+pub(crate) fn run(root: &Path) -> Result<()> {
+    // `(?s)` so `.` matches newlines; `?` so the body capture stops at
+    // the first `}` to keep the scan from swallowing the rest of the
+    // file. The check then re-scans the captured slice for forbidden
+    // keys; a second `json!` block in the same file is matched on the
+    // next iteration of the captures.
+    let macro_re = Regex::new(r"(?s)\bjson!\s*\(\s*\{(?P<body>.*?)\}\s*\)")
+        .context("compile json!() regex")?;
+    let macro_re_brace =
+        Regex::new(r"(?s)\bjson!\s*\{(?P<body>.*?)\}").context("compile json!{} regex")?;
+
+    let mut violations: Vec<String> = Vec::new();
+    let bin_api = root.join("bin").join("tanren-api").join("src");
+    if bin_api.exists() {
+        scan_dir(root, &bin_api, &macro_re, &macro_re_brace, &mut violations)?;
+    }
+    let crates_dir = root.join("crates");
+    if crates_dir.exists() {
+        for entry in fs::read_dir(&crates_dir)
+            .with_context(|| format!("read_dir {}", crates_dir.display()))?
+        {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // Match every `tanren-*-app` whose name carries `api`, plus
+            // any `tanren-*-api*` crate, so the guard keeps biting as
+            // the api surface grows.
+            let is_target =
+                name == "tanren-api-app" || (name.starts_with("tanren-") && name.contains("-api"));
+            if !is_target {
+                continue;
+            }
+            let crate_src = entry.path().join("src");
+            if crate_src.exists() {
+                scan_dir(
+                    root,
+                    &crate_src,
+                    &macro_re,
+                    &macro_re_brace,
+                    &mut violations,
+                )?;
+            }
+        }
+    }
+
+    if violations.is_empty() {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let _ = writeln!(
+            handle,
+            "check-openapi-handcraft: 0 violations (api crates use utoipa-generated documents)"
+        );
+        return Ok(());
+    }
+    let stderr = std::io::stderr();
+    let mut handle = stderr.lock();
+    for v in &violations {
+        let _ = writeln!(handle, "{v}");
+    }
+    bail!(
+        "check-openapi-handcraft: {} violation(s); use utoipa derives, see profiles/rust-cargo/architecture/openapi-generation.md",
+        violations.len()
+    );
+}
+
+fn scan_dir(
+    root: &Path,
+    dir: &Path,
+    paren_re: &Regex,
+    brace_re: &Regex,
+    violations: &mut Vec<String>,
+) -> Result<()> {
+    for entry in walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        scan_file(root, path, paren_re, brace_re, violations)?;
+    }
+    Ok(())
+}
+
+fn scan_file(
+    root: &Path,
+    path: &Path,
+    paren_re: &Regex,
+    brace_re: &Regex,
+    violations: &mut Vec<String>,
+) -> Result<()> {
+    let src = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    for re in [paren_re, brace_re] {
+        for cap in re.captures_iter(&src) {
+            let Some(m) = cap.get(0) else { continue };
+            let body = match cap.name("body") {
+                Some(b) => b.as_str(),
+                None => continue,
+            };
+            if FORBIDDEN_KEYS.iter().any(|k| body.contains(k)) {
+                let line = src[..m.start()].lines().count().max(1);
+                violations.push(format!(
+                    "{}:{}: hand-rolled `OpenAPI` document — `json!{{...}}` body contains an `OpenAPI` top-level key; generate via utoipa derives instead",
+                    path.strip_prefix(root).unwrap_or(path).display(),
+                    line
+                ));
+            }
+        }
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,6 +4,7 @@ mod bdd_tags;
 mod check_bdd_wire_coverage;
 mod check_event_coverage;
 mod check_newtype_ids;
+mod check_openapi_handcraft;
 mod check_orphan_traits;
 mod check_profiles;
 mod check_secrets;
@@ -11,7 +12,7 @@ mod check_test_hooks;
 mod check_tracing_init;
 
 use anyhow::{Context, Result, bail};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -28,17 +29,42 @@ struct Cli {
     command: Command,
 }
 
+/// Shared options exposed by every subcommand. `--root` lets the
+/// regression-fixture suite (under `xtask/tests/`) point each guard at a
+/// synthetic minimal source tree without rebuilding the workspace; in
+/// normal CI runs the flag is absent and the guard scans the real
+/// workspace root inferred from `CARGO_MANIFEST_DIR`.
+#[derive(Debug, Args, Clone, Default)]
+struct RootArg {
+    /// Workspace root the check should walk. Defaults to the parent of
+    /// the xtask manifest directory.
+    #[arg(long, value_name = "PATH", global = false)]
+    root: Option<PathBuf>,
+}
+
+impl RootArg {
+    fn resolve(&self) -> Result<PathBuf> {
+        match &self.root {
+            Some(p) => Ok(p.clone()),
+            None => workspace_root(),
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Reject any `#[test]`, `#[cfg(test)]`, or `mod tests` outside the
-    /// `tanren-bdd` crate. Tests live exclusively in BDD scenarios.
+    /// `tanren-bdd` crate (and the xtask integration-test tree, which
+    /// hosts the regression-fixture suite). Tests live exclusively in
+    /// BDD scenarios; xtask's `tests/` is a closed-loop self-test of the
+    /// guards themselves.
     #[command(name = "check-rust-test-surface")]
-    RustTestSurface,
+    RustTestSurface(RootArg),
     /// Reject inline `#[allow(...)]` and `#[expect(...)]` anywhere in
     /// workspace Rust source. Lint relaxations belong in a crate's
     /// `[lints.clippy]` section, not at the source-line level.
     #[command(name = "check-suppression")]
-    Suppression,
+    Suppression(RootArg),
     /// Validate `tests/bdd/features/**/*.feature` against the F-0002 BDD
     /// convention: filename↔feature-tag match, closed tag allowlist,
     /// strict-equality interface coverage, behavior-catalog cross-check,
@@ -46,67 +72,74 @@ enum Command {
     /// `docs/architecture/subsystems/behavior-proof.md` for the full
     /// contract.
     #[command(name = "check-bdd-tags")]
-    BddTags,
+    BddTags(RootArg),
     /// Reject struct fields whose name implies a secret but whose type is
     /// not a `secrecy` wrapper or workspace newtype listed in
     /// `xtask/secret-newtypes.toml`. See
     /// `profiles/rust-cargo/architecture/secrets-handling.md`.
     #[command(name = "check-secrets")]
-    Secrets,
+    Secrets(RootArg),
     /// Reject BDD step definitions that dispatch directly through
     /// `tanren_app_services::Handlers::*` rather than the
     /// per-interface `*Harness` traits. See
     /// `profiles/rust-cargo/testing/bdd-wire-harness.md`.
     #[command(name = "check-bdd-wire-coverage")]
-    BddWireCoverage,
+    BddWireCoverage(RootArg),
     /// Reject `pub fn`s whose doc-comment hints at test/fixture/seed use
     /// but lack a `#[cfg(test)]` / `#[cfg(feature = "test-hooks")]`
     /// gate. See `docs/architecture/subsystems/state.md`.
     #[command(name = "check-test-hooks")]
-    TestHooks,
+    TestHooks(RootArg),
     /// Reject struct/enum field types that use bare `uuid::Uuid`
     /// outside the newtype declaration sites listed in
     /// `xtask/uuid-allowlist.toml`. See
     /// `profiles/rust-cargo/architecture/id-formats.md`.
     #[command(name = "check-newtype-ids")]
-    NewtypeIds,
+    NewtypeIds(RootArg),
     /// Reject `bin/*/src/main.rs` files that do not initialize tracing
     /// via `tanren_observability::init`. See
     /// `docs/architecture/subsystems/observation.md`.
     #[command(name = "check-tracing-init")]
-    TracingInit,
+    TracingInit(RootArg),
     /// Reject event variants (enums whose name ends in `Event` /
     /// `EventKind`) without a corresponding BDD scenario asserting the
     /// variant fires. See
     /// `profiles/rust-cargo/global/just-ci-gate.md`.
     #[command(name = "check-event-coverage")]
-    EventCoverage,
+    EventCoverage(RootArg),
     /// Validate that profile/architecture markdown links resolve and
     /// every referenced `just <recipe>` / `xtask <subcommand>` exists
     /// (or is listed in `xtask/check-profiles-pending.toml`).
     #[command(name = "check-profiles")]
-    Profiles,
+    Profiles(RootArg),
     /// Reject `pub trait` definitions that have no implementor in the
     /// workspace. See `profiles/rust-cargo/global/just-ci-gate.md`.
     #[command(name = "check-orphan-traits")]
-    OrphanTraits,
+    OrphanTraits(RootArg),
+    /// Reject hand-rolled `serde_json::json!({"openapi": ..., "paths":
+    /// ..., "components": ...})` literals in api crates. The api stack
+    /// generates its `OpenAPI` document via `utoipa` derives; raw JSON
+    /// literals would silently drift from the running server. See
+    /// `profiles/rust-cargo/architecture/openapi-generation.md`.
+    #[command(name = "check-openapi-handcraft")]
+    OpenapiHandcraft(RootArg),
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let root = workspace_root()?;
     match cli.command {
-        Command::RustTestSurface => check_rust_test_surface(),
-        Command::Suppression => check_suppression(),
-        Command::BddTags => bdd_tags::run(&root),
-        Command::Secrets => check_secrets::run(&root),
-        Command::BddWireCoverage => check_bdd_wire_coverage::run(&root),
-        Command::TestHooks => check_test_hooks::run(&root),
-        Command::NewtypeIds => check_newtype_ids::run(&root),
-        Command::TracingInit => check_tracing_init::run(&root),
-        Command::EventCoverage => check_event_coverage::run(&root),
-        Command::Profiles => check_profiles::run(&root),
-        Command::OrphanTraits => check_orphan_traits::run(&root),
+        Command::RustTestSurface(r) => check_rust_test_surface(&r.resolve()?),
+        Command::Suppression(r) => check_suppression(&r.resolve()?),
+        Command::BddTags(r) => bdd_tags::run(&r.resolve()?),
+        Command::Secrets(r) => check_secrets::run(&r.resolve()?),
+        Command::BddWireCoverage(r) => check_bdd_wire_coverage::run(&r.resolve()?),
+        Command::TestHooks(r) => check_test_hooks::run(&r.resolve()?),
+        Command::NewtypeIds(r) => check_newtype_ids::run(&r.resolve()?),
+        Command::TracingInit(r) => check_tracing_init::run(&r.resolve()?),
+        Command::EventCoverage(r) => check_event_coverage::run(&r.resolve()?),
+        Command::Profiles(r) => check_profiles::run(&r.resolve()?),
+        Command::OrphanTraits(r) => check_orphan_traits::run(&r.resolve()?),
+        Command::OpenapiHandcraft(r) => check_openapi_handcraft::run(&r.resolve()?),
     }
 }
 
@@ -133,12 +166,42 @@ fn rust_source_files(root: &Path) -> impl Iterator<Item = PathBuf> + use<> {
                 .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "rs"))
                 .map(walkdir::DirEntry::into_path)
         })
+        // The xtask crate's own integration-test tree (`xtask/tests/`)
+        // hosts:
+        //   - the regression-fixture suite (`xtask/tests/regressions.rs`),
+        //     the only `#[test]` items the workspace allows outside
+        //     `tanren-bdd`. Each fixture proves that a guard rejects a
+        //     synthetic violation.
+        //   - the synthetic source fixtures themselves
+        //     (`xtask/tests/fixtures/<guard>/...`), which are
+        //     intentionally invalid Rust by the workspace's own rules
+        //     (raw `String` password fields, bare `Uuid` ids, ungated
+        //     `pub fn seed_*`, etc.).
+        // Sweeping either of these into the workspace-wide guards would
+        // either falsely fail `check-rust-test-surface` /
+        // `check-suppression`, or make the regression suite have to
+        // tiptoe around its own checks. Skipping the tree at the source
+        // level is the cleanest fix.
+        .filter(|p| !is_under_xtask_tests(p))
 }
 
-fn check_rust_test_surface() -> Result<()> {
-    let root = workspace_root()?;
+fn is_under_xtask_tests(path: &Path) -> bool {
+    let mut comps = path.components().peekable();
+    while let Some(c) = comps.next() {
+        if c.as_os_str() == "xtask" {
+            if let Some(next) = comps.peek() {
+                if next.as_os_str() == "tests" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn check_rust_test_surface(root: &Path) -> Result<()> {
     let mut violations = Vec::<String>::new();
-    for path in rust_source_files(&root) {
+    for path in rust_source_files(root) {
         if path.components().any(|c| c.as_os_str() == "tanren-bdd") {
             continue;
         }
@@ -153,7 +216,7 @@ fn check_rust_test_surface() -> Result<()> {
             if hit {
                 violations.push(format!(
                     "{}:{}: forbidden test surface — `{}`",
-                    path.strip_prefix(&root).unwrap_or(&path).display(),
+                    path.strip_prefix(root).unwrap_or(&path).display(),
                     lineno + 1,
                     trimmed
                 ));
@@ -180,10 +243,9 @@ fn check_rust_test_surface() -> Result<()> {
     );
 }
 
-fn check_suppression() -> Result<()> {
-    let root = workspace_root()?;
+fn check_suppression(root: &Path) -> Result<()> {
     let mut violations = Vec::<String>::new();
-    for path in rust_source_files(&root) {
+    for path in rust_source_files(root) {
         let content =
             fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
         for (lineno, line) in content.lines().enumerate() {
@@ -191,7 +253,7 @@ fn check_suppression() -> Result<()> {
             if trimmed.starts_with("#[allow(") || trimmed.starts_with("#[expect(") {
                 violations.push(format!(
                     "{}:{}: inline lint suppression — `{}`",
-                    path.strip_prefix(&root).unwrap_or(&path).display(),
+                    path.strip_prefix(root).unwrap_or(&path).display(),
                     lineno + 1,
                     trimmed
                 ));

--- a/xtask/tests/fixtures/regression-bare-uuid/crates/tanren-contract/src/lib.rs
+++ b/xtask/tests/fixtures/regression-bare-uuid/crates/tanren-contract/src/lib.rs
@@ -1,0 +1,13 @@
+//! Regression fixture for `xtask check-newtype-ids`.
+//!
+//! Mirrors `tanren-contract/src/` and contains exactly one violation:
+//! a struct field typed as bare `Uuid` instead of a workspace newtype.
+//! `check-newtype-ids` must reject this fixture; if it stops doing so
+//! the guard has been weakened.
+
+use uuid::Uuid;
+
+pub struct AccountRecord {
+    pub id: Uuid,
+    pub display_name: String,
+}

--- a/xtask/tests/fixtures/regression-bdd-direct-handler/crates/tanren-bdd/src/steps/account.rs
+++ b/xtask/tests/fixtures/regression-bdd-direct-handler/crates/tanren-bdd/src/steps/account.rs
@@ -1,0 +1,16 @@
+//! Regression fixture for `xtask check-bdd-wire-coverage`.
+//!
+//! Mirrors `tanren-bdd/src/steps/` and contains exactly one violation: a
+//! step body that dispatches directly through
+//! `tanren_app_services::Handlers::*` instead of routing through a
+//! per-interface `*Harness` trait. `check-bdd-wire-coverage` must
+//! reject this fixture; if it stops doing so the guard has been
+//! weakened.
+
+use tanren_app_services::Handlers;
+
+#[when(expr = "alice signs in")]
+async fn alice_signs_in() {
+    let handlers = Handlers::new();
+    handlers.sign_in().await;
+}

--- a/xtask/tests/fixtures/regression-no-tracing-init/bin/silent/src/main.rs
+++ b/xtask/tests/fixtures/regression-no-tracing-init/bin/silent/src/main.rs
@@ -1,0 +1,15 @@
+// Regression fixture for the tracing-init guard. The guard rejects any
+// `bin/*/src/main.rs` whose body does not call into the observability
+// crate's init function. This fixture's main does no such thing —
+// reject it.
+//
+// NOTE: doc-comments on this file deliberately use `//`, NOT `//!`. The
+// guard scans the AST token stream of each main.rs, and inner doc
+// attributes become `#[doc = "..."]` items in the token stream. If we
+// named the observability init path inside an inner-doc, the guard
+// would see the substring inside the doc text and falsely conclude
+// the binary initialised tracing.
+
+fn main() {
+    println!("hi");
+}

--- a/xtask/tests/fixtures/regression-openapi-handcraft/crates/tanren-api-app/src/lib.rs
+++ b/xtask/tests/fixtures/regression-openapi-handcraft/crates/tanren-api-app/src/lib.rs
@@ -1,0 +1,18 @@
+//! Regression fixture for `xtask check-openapi-handcraft`.
+//!
+//! Mirrors `tanren-api-app/src/` and contains exactly one violation: a
+//! hand-rolled OpenAPI document built from a `serde_json::json!` macro
+//! literal whose body carries the well-known top-level OpenAPI keys.
+//! `check-openapi-handcraft` must reject this fixture; if it stops
+//! doing so the guard has been weakened.
+
+pub fn openapi_doc() -> serde_json::Value {
+    serde_json::json!({
+        "openapi": "3.1.0",
+        "info": { "title": "tanren", "version": "0.0.0" },
+        "paths": {
+            "/v1/sign-in": { "post": {} }
+        },
+        "components": {}
+    })
+}

--- a/xtask/tests/fixtures/regression-orphan-trait/crates/tanren-orphan/src/lib.rs
+++ b/xtask/tests/fixtures/regression-orphan-trait/crates/tanren-orphan/src/lib.rs
@@ -1,0 +1,9 @@
+//! Regression fixture for `xtask check-orphan-traits`.
+//!
+//! Declares a `pub trait` and provides no `impl` for it anywhere in
+//! the synthetic workspace. `check-orphan-traits` must reject this
+//! fixture; if it stops doing so the guard has been weakened.
+
+pub trait DanglingTrait {
+    fn do_thing(&self);
+}

--- a/xtask/tests/fixtures/regression-pub-test-fn/crates/tanren-store/src/lib.rs
+++ b/xtask/tests/fixtures/regression-pub-test-fn/crates/tanren-store/src/lib.rs
@@ -1,0 +1,11 @@
+//! Regression fixture for `xtask check-test-hooks`.
+//!
+//! Mirrors a workspace crate's `src/` layout and contains exactly one
+//! violation: a `pub fn` whose doc-comment mentions "test" but which
+//! is not gated on `#[cfg(test)]` or `#[cfg(feature = "test-hooks")]`.
+//! `check-test-hooks` must reject this fixture; if it stops doing so
+//! the guard has been weakened.
+
+/// Test-only seed helper. Used by integration tests to populate the
+/// store with a known fixture row.
+pub fn seed_test_data() {}

--- a/xtask/tests/fixtures/regression-string-password/crates/tanren-contract/src/lib.rs
+++ b/xtask/tests/fixtures/regression-string-password/crates/tanren-contract/src/lib.rs
@@ -1,0 +1,13 @@
+//! Regression fixture for `xtask check-secrets`.
+//!
+//! Mirrors the `tanren-contract` crate's path layout and contains
+//! exactly one violation: a `password` field whose type is bare
+//! `String` instead of a `secrecy` wrapper or workspace newtype.
+//! `check-secrets` must reject this fixture; if it stops doing so the
+//! guard has been weakened.
+
+pub struct SignUpRequest {
+    pub email: String,
+    pub password: String,
+    pub display_name: String,
+}

--- a/xtask/tests/regressions.rs
+++ b/xtask/tests/regressions.rs
@@ -1,0 +1,119 @@
+//! Regression-fixture suite for the xtask enforcement guards.
+//!
+//! Each `#[test]` below points one xtask subcommand at the matching
+//! synthetic source tree under `xtask/tests/fixtures/<guard>/` and
+//! asserts the guard exits non-zero with the expected error message
+//! substring. The fixtures are intentionally minimal Rust trees that
+//! violate exactly one rule — they do not have to compile or be valid
+//! Cargo packages, only valid input for the AST/text walkers each
+//! guard runs.
+//!
+//! If a fixture stops failing its guard, the guard has been weakened —
+//! investigate before merging the change. This file is the only
+//! `#[test]`-bearing module the workspace permits outside `tanren-bdd`;
+//! `check-rust-test-surface` skips `xtask/tests/` for that reason.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn xtask_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tanren-xtask"))
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[track_caller]
+fn assert_check_fails(subcommand: &str, fixture: &str, expected_substring: &str) {
+    let dir = fixture_dir(fixture);
+    assert!(
+        dir.exists(),
+        "fixture `{fixture}` does not exist at {}",
+        dir.display()
+    );
+    let output = Command::new(xtask_bin())
+        .arg(subcommand)
+        .arg("--root")
+        .arg(&dir)
+        .output()
+        .expect("xtask binary spawns and produces output");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected `xtask {subcommand} --root {}` to fail but it succeeded.\n\
+         stdout: {stdout}\n\
+         stderr: {stderr}",
+        dir.display()
+    );
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains(expected_substring),
+        "expected output of `xtask {subcommand} --root {}` to contain {expected_substring:?}.\n\
+         stdout: {stdout}\n\
+         stderr: {stderr}",
+        dir.display()
+    );
+}
+
+#[test]
+fn check_secrets_rejects_string_password() {
+    assert_check_fails("check-secrets", "regression-string-password", "password");
+}
+
+#[test]
+fn check_bdd_wire_coverage_rejects_direct_handler_dispatch() {
+    // `quote::ToTokens` lowercases the receiver (the local `handlers`
+    // binding) and inserts spaces around `.`; assert on the rendered
+    // form the guard actually emits.
+    assert_check_fails(
+        "check-bdd-wire-coverage",
+        "regression-bdd-direct-handler",
+        "handlers . sign_in",
+    );
+}
+
+#[test]
+fn check_test_hooks_rejects_ungated_pub_seed_fn() {
+    assert_check_fails(
+        "check-test-hooks",
+        "regression-pub-test-fn",
+        "seed_test_data",
+    );
+}
+
+#[test]
+fn check_newtype_ids_rejects_bare_uuid_field() {
+    assert_check_fails("check-newtype-ids", "regression-bare-uuid", "bare uuid");
+}
+
+#[test]
+fn check_tracing_init_rejects_main_without_init() {
+    assert_check_fails(
+        "check-tracing-init",
+        "regression-no-tracing-init",
+        "tanren_observability::init",
+    );
+}
+
+#[test]
+fn check_orphan_traits_rejects_unimplemented_trait() {
+    assert_check_fails(
+        "check-orphan-traits",
+        "regression-orphan-trait",
+        "DanglingTrait",
+    );
+}
+
+#[test]
+fn check_openapi_handcraft_rejects_json_literal_document() {
+    assert_check_fails(
+        "check-openapi-handcraft",
+        "regression-openapi-handcraft",
+        "hand-rolled",
+    );
+}


### PR DESCRIPTION
Sub-PR 12 of 12 — final coverage. After this lands, the entire R-0001 stack is ready for merge to main.

- 7 regression fixtures under xtask/tests/fixtures/, each a synthetic source tree that violates exactly one guard. xtask/tests/regressions.rs runs each guard against its fixture and asserts non-zero exit + expected error message:
  - check-secrets / regression-string-password
  - check-bdd-wire-coverage / regression-bdd-direct-handler
  - check-test-hooks / regression-pub-test-fn
  - check-newtype-ids / regression-bare-uuid
  - check-tracing-init / regression-no-tracing-init
  - check-orphan-traits / regression-orphan-trait
  - check-openapi-handcraft / regression-openapi-handcraft (new guard)
- New xtask check-openapi-handcraft: regex-scans bin/tanren-api/** and the api-app crate for serde_json::json!({"openapi":...}) literals. Wired into `just check`.
- Each xtask subcommand now accepts --root <path> for fixture-targeted runs.
- xtask/check-profiles-pending.toml drained (all entries landed in earlier PRs).
- xtask/tests/ added to the path-scoped allowlist for #[test] (the only #[test]-permitting location in the workspace besides tanren-bdd).
- 4 doc cross-references corrected ("xtask check-deps" → "just check-deps"; check-deps is a justfile recipe, not an xtask subcommand).

After this PR, `just check-enforcement-regressions` proves on every CI run that every guard rejects its target regression. If a guard ever weakens, the matching fixture stops failing → CI catches it.

## Test plan
- [x] cargo test -p tanren-xtask --tests: 7/7 pass
- [x] just check: all 21 stages green
- [x] just tests: 36 BDD scenarios pass
- [x] just web-test: 12 Storybook + 4 Playwright (3 deferred scenarios stay skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)