### PR TITLE
fix(R-0001): sub-14 — just ci doc + machete + Playwright env-load fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,19 +3620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,12 +4484,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "proc-macro2",
  "quote",
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
  "syn 2.0.117",
  "toml",
  "walkdir",
@@ -5132,12 +5117,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -21,8 +21,8 @@ const webBaseUrl = process.env["WEB_BASE_URL"] ?? `http://127.0.0.1:${webPort}`;
 // config-load. globalSetup (./tests/bdd/global-setup.ts) chooses the API
 // port at runtime — possibly falling back to a kernel-picked port when
 // 8081 is busy — and writes the resolved URL to BOTH process.env and
-// `apps/web/.env.test.local`. The webServer block below relies on
-// inheritance: `pnpm dev` reads .env.test.local automatically (Next.js
+// `apps/web/.env.local`. The webServer block below relies on
+// inheritance: `pnpm dev` reads .env.local automatically (Next.js
 // loads it ahead of .env), and any explicit `env:` here would override
 // that with a stale value. Keeping the block absent fixes the
 // nondeterministic-port bug Codex flagged on PR #133.
@@ -45,7 +45,7 @@ export default defineConfig({
   ],
   // The `tanren-api` Rust binary is spawned by globalSetup against an
   // ephemeral SQLite DB; the Next.js dev server below picks up the API
-  // URL from .env.test.local (written by globalSetup). PLAYWRIGHT_NO_SERVER
+  // URL from .env.local (written by globalSetup). PLAYWRIGHT_NO_SERVER
   // skips the Next.js spin-up when the developer has already booted the
   // dev server in another tab.
   ...(process.env["PLAYWRIGHT_NO_SERVER"]
@@ -53,7 +53,7 @@ export default defineConfig({
     : {
         webServer: {
           // `next dev` is used over `next start` so `NEXT_PUBLIC_API_URL`
-          // resolves at runtime from .env.test.local (production builds
+          // resolves at runtime from .env.local (production builds
           // bake the value at build time, which is incompatible with
           // globalSetup picking an ephemeral API port).
           command: "pnpm dev",
@@ -61,7 +61,7 @@ export default defineConfig({
           reuseExistingServer: process.env["CI"] !== "true",
           timeout: 240_000,
           // No `env` block — see comment above. NEXT_PUBLIC_API_URL is
-          // sourced from .env.test.local, which globalSetup writes after
+          // sourced from .env.local, which globalSetup writes after
           // it has bound to the actual port.
         },
       }),

--- a/apps/web/tests/bdd/global-setup.ts
+++ b/apps/web/tests/bdd/global-setup.ts
@@ -104,10 +104,10 @@ export default async function globalSetup(): Promise<void> {
         "TANREN_BDD_EXTERNAL_API=true but NEXT_PUBLIC_API_URL is unset",
       );
     }
-    // Mirror to .env.test.local so the Next.js dev server (a child
+    // Mirror to .env.local so the Next.js dev server (a child
     // process spawned by Playwright's webServer) picks it up.
     writeFileSync(
-      join(process.cwd(), ".env.test.local"),
+      join(process.cwd(), ".env.local"),
       `NEXT_PUBLIC_API_URL=${process.env["NEXT_PUBLIC_API_URL"]}\n`,
     );
     return;
@@ -177,7 +177,7 @@ export default async function globalSetup(): Promise<void> {
 
   process.env["NEXT_PUBLIC_API_URL"] = apiUrl;
   writeFileSync(
-    join(process.cwd(), ".env.test.local"),
+    join(process.cwd(), ".env.local"),
     `NEXT_PUBLIC_API_URL=${apiUrl}\n`,
   );
 

--- a/apps/web/tests/bdd/global-teardown.ts
+++ b/apps/web/tests/bdd/global-teardown.ts
@@ -17,7 +17,7 @@ declare global {
 export default async function globalTeardown(): Promise<void> {
   const state = globalThis.__tanrenBddState;
   try {
-    unlinkSync(join(process.cwd(), ".env.test.local"));
+    unlinkSync(join(process.cwd(), ".env.local"));
   } catch {
     /* file may not exist */
   }

--- a/apps/web/tests/bdd/steps/account.steps.ts
+++ b/apps/web/tests/bdd/steps/account.steps.ts
@@ -260,12 +260,7 @@ Given(
 
 When(
   /^(\w+) accepts invitation "([^"]+)" with password "([^"]+)"$/,
-  async (
-    { page, world },
-    name: string,
-    token: string,
-    password: string,
-  ) => {
+  async ({ page, world }, name: string, token: string, password: string) => {
     const a = actor(world, name);
     // Mirror the Rust step's email-synthesis convention so the @web
     // slice creates accounts that don't collide with @api ones (the

--- a/crates/tanren-app-services/src/account.rs
+++ b/crates/tanren-app-services/src/account.rs
@@ -2,11 +2,11 @@
 //!
 //! Handlers are mechanism-neutral at the contract surface but mechanism-
 //! specific underneath: R-0001 pins identifier+password as the simplest
-//! credible choice, with hashing delegated to a
-//! [`CredentialVerifier`](tanren_identity_policy::CredentialVerifier)
-//! trait object. Production binaries inject the
-//! [`Argon2idVerifier`](tanren_identity_policy::Argon2idVerifier);
+//! credible choice, with hashing delegated to a [`CredentialVerifier`]
+//! trait object. Production binaries inject the [`Argon2idVerifier`];
 //! BDD scenarios inject the cheap-parameter `fast_for_tests` preset.
+//!
+//! [`Argon2idVerifier`]: tanren_identity_policy::Argon2idVerifier
 //!
 //! Session tokens are 256 bits of CSPRNG randomness wrapped in
 //! `SessionToken` (URL-safe base64, no padding).

--- a/crates/tanren-identity-policy/src/lib.rs
+++ b/crates/tanren-identity-policy/src/lib.rs
@@ -267,7 +267,8 @@ impl InvitationToken {
     /// Returns [`ValidationError::InvitationTokenEmpty`] if the input
     /// is empty after trimming, or
     /// [`ValidationError::InvitationTokenTooShort`] if the trimmed
-    /// token is shorter than [`INVITATION_TOKEN_MIN_LEN`] bytes.
+    /// token is shorter than 16 bytes (the canonical minimum, kept as
+    /// a private `INVITATION_TOKEN_MIN_LEN` constant in this module).
     pub fn parse(raw: &str) -> Result<Self, ValidationError> {
         let trimmed = raw.trim();
         if trimmed.is_empty() {

--- a/crates/tanren-store/src/records.rs
+++ b/crates/tanren-store/src/records.rs
@@ -136,7 +136,7 @@ impl From<entity::account_sessions::Model> for SessionRecord {
     }
 }
 
-/// Input shape for [`crate::Store::insert_account`].
+/// Input shape for [`crate::AccountStore::insert_account`].
 #[derive(Debug, Clone)]
 pub struct NewAccount {
     /// Stable id allocated by the caller (`UUIDv7`).

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,10 +20,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 toml = { workspace = true }
 walkdir = "2"
 syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 quote = "1"
-proc-macro2 = "1"
 regex = "1"


### PR DESCRIPTION
Sub-PR 14 unblocks `just ci` on PR #133.

`just ci` runs strict-warnings rustdoc + machete + the full web suite (which sub-13's quicker `just check` skips). Five issues surfaced after #133 went up:

- **rustdoc::redundant-explicit-links** in `tanren-app-services/src/account.rs` — drop the explicit `(tanren_identity_policy::CredentialVerifier)` target since the label resolves via the existing `use` import; for `Argon2idVerifier` (not imported in code) use a reference-style link footer
- **rustdoc::private-intra-doc-links** in `tanren-identity-policy/src/lib.rs` — `InvitationToken::parse` doc linked to the private `INVITATION_TOKEN_MIN_LEN` const. Inline the literal value and mention the const by name in prose
- **rustdoc::broken-intra-doc-links** in `tanren-store/src/records.rs` — `NewAccount` doc still pointed at `crate::Store::insert_account`; PR 4 moved the method to the `AccountStore` trait. Repoint to `crate::AccountStore::insert_account`
- **cargo machete** flagged `serde_yaml` and `proc-macro2` as unused in xtask. Removed; xtask reads markdown frontmatter via regex/walkdir, not serde, and uses `syn` directly without proc-macro2 span types
- **Playwright env-load regression** from sub-13: globalSetup wrote to `.env.test.local`, which Next.js only loads when `NODE_ENV=test`. `pnpm dev` runs with `NODE_ENV=development`. Switched to `.env.local` (loaded in all non-test environments). All 7 @web Playwright scenarios pass

## Test plan

- [x] `just ci` green end-to-end (29s)
- [x] `just doc` green
- [x] `pnpm e2e` green (7/7)
- [x] `cargo machete` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)