### PR TITLE
fix(R-0001): sub-15 — CI follow-up + atomic invitation + parallel race scenario

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,6 +12,11 @@ env:
   RUSTFLAGS: "-D warnings"
   RUST_TOOLCHAIN: "1.94.1"
 
+# Restrict GITHUB_TOKEN to read-only by default. CodeQL flagged the
+# missing permissions block; this job only checks out + builds + tests.
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: just ci

--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -16,6 +16,8 @@ permissions:
 
 env:
   CI: "true"
+  # Match rust-ci.yml so cargo runs use the pinned toolchain.
+  RUST_TOOLCHAIN: "1.94.1"
 
 jobs:
   web:
@@ -68,9 +70,12 @@ jobs:
         run: just check-tsconfig
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # SHA-pinned to match rust-ci.yml; the repo's action policy
+        # rejects tag refs (`@stable`), which surfaces as a workflow
+        # startup_failure rather than a step error.
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache cargo build
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57

--- a/crates/tanren-app-services/src/account.rs
+++ b/crates/tanren-app-services/src/account.rs
@@ -13,10 +13,13 @@
 //!
 //! Handlers consume `&dyn AccountStore` (the port defined in
 //! `tanren_store::traits`); the SeaORM-backed `Store` is the adapter
-//! injected by interface binaries. The atomic `consume_invitation` call
-//! replaces the previous find-then-check-then-update sequence — no two
-//! callers can both successfully accept the same token even under
-//! concurrent load.
+//! injected by interface binaries. The atomic `accept_invitation_atomic`
+//! call wraps the consume + insert account + insert membership + insert
+//! session + append events sequence in one DB transaction, so a
+//! transient failure mid-flow leaves the invitation pending and the
+//! user can retry. Concurrent acceptances of the same token still
+//! serialise to exactly one success — the rest receive
+//! `InvitationAlreadyConsumed`.
 
 use chrono::{DateTime, Duration, Utc};
 use secrecy::ExposeSecret;
@@ -24,8 +27,13 @@ use tanren_contract::{
     AcceptInvitationRequest, AcceptInvitationResponse, AccountFailureReason, AccountView,
     SessionView, SignInRequest, SignInResponse, SignUpRequest, SignUpResponse,
 };
-use tanren_identity_policy::{AccountId, CredentialVerifier, Identifier, SessionToken};
-use tanren_store::{AccountRecord, AccountStore, ConsumeInvitationError, NewAccount};
+use tanren_identity_policy::{
+    AccountId, CredentialVerifier, Identifier, MembershipId, SessionToken,
+};
+use tanren_store::{
+    AcceptInvitationAtomicRequest, AcceptInvitationError, AcceptInvitationEventContext,
+    AccountRecord, AccountStore, NewAccount,
+};
 
 use crate::events::{
     AccountCreated, AccountEventKind, InvitationAcceptFailed, InvitationAccepted, SignInFailed,
@@ -223,6 +231,12 @@ where
     // (subsequent specs will reconcile against the invitation row's
     // target_identifier when R-0005's invite flow lands).
     let identifier = Identifier::from_email(&request.email);
+    // Pre-flight duplicate check: lets us fail fast for the common
+    // "this email is already an account" case without paying the
+    // password-hash cost. The atomic call below ALSO catches a
+    // duplicate under race (unique index inside the transaction), so
+    // skipping this read would still be correct — it just costs one
+    // hash on the reject path.
     if store
         .find_account_by_identifier(&identifier)
         .await?
@@ -240,80 +254,111 @@ where
         ));
     }
 
-    // Atomic consume: a single conditional UPDATE on the store
-    // transitions the invitation from pending → consumed. Concurrent
-    // callers serialise to exactly one success; the rest receive
-    // `AlreadyConsumed`.
-    let consumed = match store.consume_invitation(&token, now).await {
-        Ok(consumed) => consumed,
-        Err(consume_err) => {
-            let reason = match consume_err {
-                ConsumeInvitationError::NotFound => AccountFailureReason::InvitationNotFound,
-                ConsumeInvitationError::AlreadyConsumed => {
-                    AccountFailureReason::InvitationAlreadyConsumed
-                }
-                ConsumeInvitationError::Expired => AccountFailureReason::InvitationExpired,
-                ConsumeInvitationError::Store(err) => return Err(AppServiceError::Store(err)),
+    let password_phc = verifier
+        .hash(&request.password)
+        .map_err(|err| AppServiceError::InvalidInput(err.to_string()))?;
+    let id = AccountId::fresh();
+    let session_token = SessionToken::generate();
+    let session_expires_at = now + Duration::days(SESSION_LIFETIME_DAYS);
+
+    // Atomic accept: consume + insert account + insert membership +
+    // insert session + append both success events run in one DB
+    // transaction. A failure on any step rolls the whole flow back so
+    // the invitation row stays pending and the user can retry —
+    // closing the previous gap where a transient failure after the
+    // consume burned the token without producing an account.
+    let outcome = match store
+        .accept_invitation_atomic(AcceptInvitationAtomicRequest {
+            token: token.clone(),
+            now,
+            account: NewAccount {
+                id,
+                identifier,
+                display_name,
+                password_phc,
+                created_at: now,
+                // `org_id` is overridden inside the atomic call from
+                // the consumed invitation row; the value here is
+                // irrelevant.
+                org_id: None,
+            },
+            membership_id: MembershipId::fresh(),
+            session_token,
+            session_expires_at,
+            events_builder: build_accept_invitation_events_builder(),
+        })
+        .await
+    {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            let reason = match map_accept_invitation_error(err) {
+                Ok(reason) => reason,
+                Err(app_err) => return Err(app_err),
             };
             emit_invitation_accept_failed(store, reason, &token, now).await?;
             return Err(AppServiceError::Account(reason));
         }
     };
 
-    let password_phc = verifier
-        .hash(&request.password)
-        .map_err(|err| AppServiceError::InvalidInput(err.to_string()))?;
-    let id = AccountId::fresh();
-    let account = store
-        .insert_account(NewAccount {
-            id,
-            identifier,
-            display_name,
-            password_phc,
-            created_at: now,
-            org_id: Some(consumed.inviting_org_id),
-        })
-        .await
-        .map_err(map_insert_error)?;
-    store
-        .insert_membership(account.id, consumed.inviting_org_id, now)
-        .await?;
-
-    let session = mint_session(store, account.id, now).await?;
-    store
-        .append_event(
-            envelope(
-                AccountEventKind::AccountCreated,
-                &AccountCreated {
-                    account_id: account.id,
-                    identifier: account.identifier.as_str().to_owned(),
-                    org: Some(consumed.inviting_org_id),
-                    created_at: now,
-                },
-            ),
-            now,
-        )
-        .await?;
-    store
-        .append_event(
-            envelope(
-                AccountEventKind::InvitationAccepted,
-                &InvitationAccepted {
-                    token,
-                    account_id: account.id,
-                    joined_org: consumed.inviting_org_id,
-                    at: now,
-                },
-            ),
-            now,
-        )
-        .await?;
-
     Ok(AcceptInvitationResponse {
-        account: account_view(&account),
-        session,
-        joined_org: consumed.inviting_org_id,
+        account: account_view(&outcome.account),
+        session: SessionView {
+            account_id: outcome.session.account_id,
+            token: outcome.session.token,
+            expires_at: outcome.session.expires_at,
+        },
+        joined_org: outcome.joined_org,
     })
+}
+
+/// Build the `Box<dyn FnOnce>` the store invokes inside its transaction
+/// to stamp the success-path event envelopes. The store crate does not
+/// know the typed event payload shapes — they live in this crate — so
+/// the closure builds the wire envelopes once the store has determined
+/// the inviting-org id from the consumed invitation row.
+fn build_accept_invitation_events_builder() -> tanren_store::AcceptInvitationEventsBuilder {
+    Box::new(
+        |ctx: &AcceptInvitationEventContext| -> Vec<serde_json::Value> {
+            vec![
+                envelope(
+                    AccountEventKind::AccountCreated,
+                    &AccountCreated {
+                        account_id: ctx.account_id,
+                        identifier: ctx.identifier.as_str().to_owned(),
+                        org: Some(ctx.joined_org),
+                        created_at: ctx.now,
+                    },
+                ),
+                envelope(
+                    AccountEventKind::InvitationAccepted,
+                    &InvitationAccepted {
+                        token: ctx.token.clone(),
+                        account_id: ctx.account_id,
+                        joined_org: ctx.joined_org,
+                        at: ctx.now,
+                    },
+                ),
+            ]
+        },
+    )
+}
+
+/// Translate the store-layer taxonomy error into either an
+/// [`AccountFailureReason`] (for emit-then-fail flows) or a non-taxonomy
+/// [`AppServiceError`] that should bypass the failure-event emit and
+/// propagate directly.
+fn map_accept_invitation_error(
+    err: AcceptInvitationError,
+) -> Result<AccountFailureReason, AppServiceError> {
+    match err {
+        AcceptInvitationError::InvitationNotFound => Ok(AccountFailureReason::InvitationNotFound),
+        AcceptInvitationError::InvitationAlreadyConsumed => {
+            Ok(AccountFailureReason::InvitationAlreadyConsumed)
+        }
+        AcceptInvitationError::InvitationExpired => Ok(AccountFailureReason::InvitationExpired),
+        AcceptInvitationError::DuplicateIdentifier => Ok(AccountFailureReason::DuplicateIdentifier),
+        AcceptInvitationError::Store(store_err) => Err(AppServiceError::Store(store_err)),
+    }
 }
 
 async fn emit_signup_rejected<S>(

--- a/crates/tanren-bdd/src/steps/account.rs
+++ b/crates/tanren-bdd/src/steps/account.rs
@@ -8,8 +8,6 @@
 //! `xtask check-bdd-wire-coverage` mechanically rejects any future
 //! step that bypasses this seam.
 
-use std::future::Future;
-use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{Duration as ChronoDuration, Utc};
@@ -20,7 +18,6 @@ use tanren_identity_policy::{Email, InvitationToken, OrgId};
 use tanren_testkit::{
     ConcurrentAcceptanceTally, HarnessInvitation, HarnessOutcome, record_failure,
 };
-use tokio::sync::Mutex;
 
 use crate::TanrenWorld;
 
@@ -167,11 +164,15 @@ async fn when_concurrent_accept(world: &mut TanrenWorld, count: usize, token: St
     let ctx = world.ensure_account_ctx().await;
     let invitation_token =
         InvitationToken::parse(&token).expect("scenario invitation tokens must parse");
-    let harness_ref = Arc::new(Mutex::new(&mut ctx.harness));
-    let mut tally = ConcurrentAcceptanceTally::default();
-    let mut handles = Vec::with_capacity(count);
+    // Build N independent acceptance requests, then dispatch them
+    // through the harness's parallel fan-out (default impl is serial;
+    // ApiHarness overrides to spawn each request as its own
+    // `tokio::spawn` against the live api server). Without the
+    // override, the previous mutex-around-harness design serialized
+    // every request and could not catch real `consume_invitation` race
+    // regressions — Codex P2 review on PR #133.
+    let mut requests = Vec::with_capacity(count);
     for i in 0..count {
-        let harness = harness_ref.clone();
         let token = invitation_token.clone();
         let email_raw = format!(
             "racer-{i}-{token}@invitation.tanren",
@@ -179,18 +180,15 @@ async fn when_concurrent_accept(world: &mut TanrenWorld, count: usize, token: St
         );
         let parsed_email = Email::parse(&email_raw).expect("synthesised email must parse");
         let display = format!("Racer {i}");
-        let req = AcceptInvitationRequest {
+        requests.push(AcceptInvitationRequest {
             invitation_token: token,
             email: parsed_email,
             password: SecretString::from("race-password".to_owned()),
             display_name: display,
-        };
-        handles.push(async move {
-            let mut h = harness.lock().await;
-            h.accept_invitation(req).await
         });
     }
-    let outcomes = futures_join_all(handles).await;
+    let outcomes = ctx.harness.accept_invitations_concurrent(requests).await;
+    let mut tally = ConcurrentAcceptanceTally::default();
     for outcome in outcomes {
         tally.record(outcome);
     }
@@ -413,26 +411,4 @@ async fn read_concurrent_tally(world: &mut TanrenWorld) -> ConcurrentAcceptanceT
         failures_by_code: parsed.failures,
         other: Vec::new(),
     }
-}
-
-/// Local thin wrapper around `futures::future::join_all` to avoid
-/// pulling the `futures` crate in as a workspace dep just for this
-/// single call. Awaits each future sequentially — fine for the
-/// concurrent-race test because the outer `tokio::spawn` model isn't
-/// strictly required: the race window is the harness's own
-/// `accept_invitation` round-trip, and serializing the spawn calls
-/// still proves the store-level atomicity (the DB constraint plus
-/// `consume_invitation` rejects all but one). To get true parallelism
-/// we'd need each task on its own runtime task; switching to
-/// `tokio::spawn` is a follow-up once the harness is `Send + Sync +
-/// Clone` (currently `Send` only, hence the local mutex).
-async fn futures_join_all<F, T>(futures: Vec<F>) -> Vec<T>
-where
-    F: Future<Output = T>,
-{
-    let mut results = Vec::with_capacity(futures.len());
-    for f in futures {
-        results.push(f.await);
-    }
-    results
 }

--- a/crates/tanren-store/src/accept_invitation.rs
+++ b/crates/tanren-store/src/accept_invitation.rs
@@ -1,0 +1,233 @@
+//! `SeaORM`-backed implementation of the atomic invitation-acceptance
+//! flow. Lives in its own module so the lib.rs core file stays under
+//! the workspace per-file line budget.
+//!
+//! Wraps the consume + insert account + insert membership + insert
+//! session + append events sequence in one DB transaction. Failure on
+//! any step rolls the whole flow back so the invitation row stays
+//! pending and the user can retry — closing the previous gap where a
+//! transient failure after the consume burned the token without
+//! producing an account.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    QueryFilter, Set, TransactionTrait,
+};
+use tanren_identity_policy::{MembershipId, OrgId, SessionToken, ValidationError};
+use uuid::Uuid;
+
+use crate::entity;
+use crate::traits::{
+    AcceptInvitationAtomicOutput, AcceptInvitationAtomicRequest, AcceptInvitationError,
+    AcceptInvitationEventContext, AcceptInvitationEventsBuilder,
+};
+use crate::{AccountRecord, NewAccount, SessionRecord, StoreError};
+
+pub(crate) async fn run(
+    conn: &DatabaseConnection,
+    request: AcceptInvitationAtomicRequest,
+) -> Result<AcceptInvitationAtomicOutput, AcceptInvitationError> {
+    conn.transaction::<_, AcceptInvitationAtomicOutput, AcceptInvitationError>(|txn| {
+        Box::pin(async move { run_in_txn(txn, request).await })
+    })
+    .await
+    .map_err(map_transaction_error)
+}
+
+async fn run_in_txn(
+    txn: &DatabaseTransaction,
+    request: AcceptInvitationAtomicRequest,
+) -> Result<AcceptInvitationAtomicOutput, AcceptInvitationError> {
+    let AcceptInvitationAtomicRequest {
+        token,
+        now,
+        account,
+        membership_id,
+        session_token,
+        session_expires_at,
+        events_builder,
+    } = request;
+
+    let inviting_org_id = consume_invitation_in_txn(txn, token.as_str(), now).await?;
+    let account_record = insert_account_in_txn(txn, &account, inviting_org_id).await?;
+    insert_membership_in_txn(
+        txn,
+        membership_id,
+        account_record.id.as_uuid(),
+        inviting_org_id,
+        now,
+    )
+    .await?;
+    let session_record = insert_session_in_txn(
+        txn,
+        session_token,
+        account_record.id.as_uuid(),
+        now,
+        session_expires_at,
+    )
+    .await?;
+    append_success_events_in_txn(
+        txn,
+        events_builder,
+        &AcceptInvitationEventContext {
+            account_id: account_record.id,
+            identifier: account_record.identifier.clone(),
+            token,
+            joined_org: inviting_org_id,
+            now,
+        },
+    )
+    .await?;
+
+    Ok(AcceptInvitationAtomicOutput {
+        account: account_record,
+        session: session_record,
+        joined_org: inviting_org_id,
+    })
+}
+
+/// Conditional UPDATE on the invitation row + disambiguation read.
+/// Mirrors `Store::consume_invitation` exactly; running inside a
+/// transaction means the disambiguation `find_by_id` sees a consistent
+/// view even under concurrent acceptance.
+async fn consume_invitation_in_txn(
+    txn: &DatabaseTransaction,
+    token: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<OrgId, AcceptInvitationError> {
+    let token_owned = token.to_owned();
+    let result = entity::invitations::Entity::update_many()
+        .col_expr(
+            entity::invitations::Column::ConsumedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entity::invitations::Column::Token.eq(token_owned.clone()))
+        .filter(entity::invitations::Column::ConsumedAt.is_null())
+        .filter(entity::invitations::Column::ExpiresAt.gt(now))
+        .exec(txn)
+        .await
+        .map_err(StoreError::from)?;
+
+    if result.rows_affected == 1 {
+        let row = entity::invitations::Entity::find_by_id(token_owned)
+            .one(txn)
+            .await
+            .map_err(StoreError::from)?
+            .ok_or_else(|| StoreError::DataInvariant {
+                column: "invitation_token",
+                cause: ValidationError::InvitationTokenEmpty,
+            })?;
+        return Ok(OrgId::new(row.inviting_org_id));
+    }
+
+    let existing = entity::invitations::Entity::find_by_id(token_owned)
+        .one(txn)
+        .await
+        .map_err(StoreError::from)?;
+    Err(match existing {
+        None => AcceptInvitationError::InvitationNotFound,
+        Some(row) if row.consumed_at.is_some() => AcceptInvitationError::InvitationAlreadyConsumed,
+        Some(row) if row.expires_at <= now => AcceptInvitationError::InvitationExpired,
+        Some(_) => AcceptInvitationError::InvitationAlreadyConsumed,
+    })
+}
+
+/// Insert the new account row. Caller's `account.org_id` is ignored —
+/// the inviting-org id read from the consumed invitation row is the
+/// source of truth.
+async fn insert_account_in_txn(
+    txn: &DatabaseTransaction,
+    account: &NewAccount,
+    inviting_org_id: OrgId,
+) -> Result<AccountRecord, AcceptInvitationError> {
+    let account_model = entity::accounts::ActiveModel {
+        id: Set(account.id.as_uuid()),
+        identifier: Set(account.identifier.as_str().to_owned()),
+        display_name: Set(account.display_name.clone()),
+        password_phc: Set(account.password_phc.clone()),
+        created_at: Set(account.created_at),
+        org_id: Set(Some(inviting_org_id.as_uuid())),
+    };
+    let inserted = match account_model.insert(txn).await {
+        Ok(a) => a,
+        Err(err) => {
+            let lower = err.to_string().to_lowercase();
+            if lower.contains("unique") || lower.contains("duplicate") {
+                return Err(AcceptInvitationError::DuplicateIdentifier);
+            }
+            return Err(StoreError::from(err).into());
+        }
+    };
+    AccountRecord::try_from(inserted).map_err(AcceptInvitationError::Store)
+}
+
+async fn insert_membership_in_txn(
+    txn: &DatabaseTransaction,
+    membership_id: MembershipId,
+    account_uuid: Uuid,
+    inviting_org_id: OrgId,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), AcceptInvitationError> {
+    let model = entity::memberships::ActiveModel {
+        id: Set(membership_id.as_uuid()),
+        account_id: Set(account_uuid),
+        org_id: Set(inviting_org_id.as_uuid()),
+        created_at: Set(now),
+    };
+    model.insert(txn).await.map_err(StoreError::from)?;
+    Ok(())
+}
+
+async fn insert_session_in_txn(
+    txn: &DatabaseTransaction,
+    session_token: SessionToken,
+    account_uuid: Uuid,
+    now: chrono::DateTime<chrono::Utc>,
+    expires_at: chrono::DateTime<chrono::Utc>,
+) -> Result<SessionRecord, AcceptInvitationError> {
+    let model = entity::account_sessions::ActiveModel {
+        token: Set(session_token.expose_secret().to_owned()),
+        account_id: Set(account_uuid),
+        created_at: Set(now),
+        expires_at: Set(expires_at),
+    };
+    model.insert(txn).await.map_err(StoreError::from)?;
+    Ok(SessionRecord {
+        token: session_token,
+        account_id: tanren_identity_policy::AccountId::new(account_uuid),
+        created_at: now,
+        expires_at,
+    })
+}
+
+async fn append_success_events_in_txn(
+    txn: &DatabaseTransaction,
+    events_builder: AcceptInvitationEventsBuilder,
+    ctx: &AcceptInvitationEventContext,
+) -> Result<(), AcceptInvitationError> {
+    for payload in (events_builder)(ctx) {
+        let model = entity::events::ActiveModel {
+            id: Set(Uuid::now_v7()),
+            occurred_at: Set(ctx.now),
+            payload: Set(payload),
+        };
+        model.insert(txn).await.map_err(StoreError::from)?;
+    }
+    Ok(())
+}
+
+/// Translate the `SeaORM` [`sea_orm::TransactionError`] envelope back
+/// into the domain-shaped [`AcceptInvitationError`]. The `Connection`
+/// arm only fires for the begin/commit/rollback steps themselves; it
+/// surfaces as a `Store` variant so callers can distinguish it from
+/// in-flight taxonomy failures.
+fn map_transaction_error(
+    err: sea_orm::TransactionError<AcceptInvitationError>,
+) -> AcceptInvitationError {
+    match err {
+        sea_orm::TransactionError::Connection(db_err) => {
+            AcceptInvitationError::Store(StoreError::from(db_err))
+        }
+        sea_orm::TransactionError::Transaction(inner) => inner,
+    }
+}

--- a/crates/tanren-store/src/lib.rs
+++ b/crates/tanren-store/src/lib.rs
@@ -7,6 +7,7 @@
 //! (`entity/` is a private module) so that row shape changes never leak
 //! across the dependency boundary.
 
+mod accept_invitation;
 mod entity;
 mod migration;
 mod records;
@@ -16,7 +17,11 @@ pub use migration::Migrator;
 pub use records::{
     AccountRecord, InvitationRecord, MembershipRecord, NewAccount, NewInvitation, SessionRecord,
 };
-pub use traits::{AccountStore, ConsumeInvitationError, ConsumedInvitation};
+pub use traits::{
+    AcceptInvitationAtomicOutput, AcceptInvitationAtomicRequest, AcceptInvitationError,
+    AcceptInvitationEventContext, AcceptInvitationEventsBuilder, AccountStore,
+    ConsumeInvitationError, ConsumedInvitation,
+};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -240,6 +245,13 @@ impl AccountStore for Store {
             // already-locked invitation.
             Some(_) => Err(ConsumeInvitationError::AlreadyConsumed),
         }
+    }
+
+    async fn accept_invitation_atomic(
+        &self,
+        request: AcceptInvitationAtomicRequest,
+    ) -> Result<AcceptInvitationAtomicOutput, AcceptInvitationError> {
+        accept_invitation::run(&self.conn, request).await
     }
 
     async fn insert_session(

--- a/crates/tanren-store/src/traits.rs
+++ b/crates/tanren-store/src/traits.rs
@@ -35,6 +35,120 @@ use crate::{
     AccountRecord, EventEnvelope, InvitationRecord, NewAccount, SessionRecord, StoreError,
 };
 
+/// Context the store passes back to the caller's event-builder so
+/// the caller can stamp the inviting org id (only known after the
+/// in-transaction `consume_invitation` step) into the success-path
+/// event payloads it owns.
+#[derive(Debug, Clone)]
+pub struct AcceptInvitationEventContext {
+    /// The id of the freshly inserted account row.
+    pub account_id: AccountId,
+    /// The user-facing identifier on the new account.
+    pub identifier: Identifier,
+    /// The invitation token that was consumed.
+    pub token: InvitationToken,
+    /// The organization the new account joined (read from the
+    /// consumed invitation row inside the transaction).
+    pub joined_org: OrgId,
+    /// `now` from the request, threaded through so event payloads
+    /// can carry the same instant as the row writes.
+    pub now: DateTime<Utc>,
+}
+
+/// Closure the store invokes inside the transaction to build the
+/// success-path event envelopes. The store crate does not know the
+/// concrete event payload shape — that lives in `tanren-app-services`
+/// — so the caller hands in an event-builder closure and the store
+/// invokes it once it has computed the inviting-org id.
+pub type AcceptInvitationEventsBuilder =
+    Box<dyn FnOnce(&AcceptInvitationEventContext) -> Vec<serde_json::Value> + Send>;
+
+/// Input shape for [`AccountStore::accept_invitation_atomic`]. Bundles
+/// every input the atomic flow needs so the trait method runs as a
+/// single unit. The caller pre-derives the password PHC and the
+/// session token because the verifier and the CSPRNG live in the
+/// app-service layer, not in the store.
+pub struct AcceptInvitationAtomicRequest {
+    /// The invitation token the caller is trying to consume.
+    pub token: InvitationToken,
+    /// Wall-clock instant the flow runs at. Used for the consume
+    /// predicate, the membership row, the session row, and every
+    /// emitted event envelope.
+    pub now: DateTime<Utc>,
+    /// New account row to insert. The caller has already derived the
+    /// password PHC and validated the identifier. The `org_id` field
+    /// is ignored by the atomic call — the inviting org id from the
+    /// consumed invitation row is the source of truth.
+    pub account: NewAccount,
+    /// Stable membership id the caller pre-allocates so the success
+    /// path of the atomic call does not need to thread an id back
+    /// out for any subsequent step.
+    pub membership_id: MembershipId,
+    /// Session token the caller pre-generated.
+    pub session_token: SessionToken,
+    /// Wall-clock time the session expires (`now + lifetime`).
+    pub session_expires_at: DateTime<Utc>,
+    /// Closure the store invokes inside the transaction to build the
+    /// success-path event envelopes. See
+    /// [`AcceptInvitationEventsBuilder`].
+    pub events_builder: AcceptInvitationEventsBuilder,
+}
+
+impl std::fmt::Debug for AcceptInvitationAtomicRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcceptInvitationAtomicRequest")
+            .field("token", &self.token)
+            .field("now", &self.now)
+            .field("account", &self.account)
+            .field("membership_id", &self.membership_id)
+            .field("session_expires_at", &self.session_expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Successful return from [`AccountStore::accept_invitation_atomic`].
+/// The store layer builds and appends the success-path events itself
+/// (it is the only layer that knows the inviting org id at envelope-
+/// build time inside the transaction); the caller only needs the
+/// row-shaped output to render the response.
+#[derive(Debug, Clone)]
+pub struct AcceptInvitationAtomicOutput {
+    /// The freshly inserted account row.
+    pub account: AccountRecord,
+    /// The freshly inserted session row.
+    pub session: SessionRecord,
+    /// Organization the new account joined.
+    pub joined_org: OrgId,
+}
+
+/// Failure taxonomy for [`AccountStore::accept_invitation_atomic`]. The
+/// app-service layer maps each variant to the matching
+/// `AccountFailureReason`; the `Store` variant carries non-taxonomy DB
+/// errors through unchanged. Mirrors [`ConsumeInvitationError`] but
+/// adds [`AcceptInvitationError::DuplicateIdentifier`] for the
+/// race-safe duplicate-account check that runs inside the
+/// transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum AcceptInvitationError {
+    /// No invitation matches the supplied token.
+    #[error("invitation not found")]
+    InvitationNotFound,
+    /// The invitation exists but `consumed_at` was already set.
+    #[error("invitation already consumed")]
+    InvitationAlreadyConsumed,
+    /// The invitation exists but `expires_at <= now`.
+    #[error("invitation expired")]
+    InvitationExpired,
+    /// The supplied identifier collides with an existing account
+    /// (caught either by a pre-flight read or by the unique-index
+    /// constraint inside the transaction).
+    #[error("duplicate identifier")]
+    DuplicateIdentifier,
+    /// Unexpected database failure.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
 /// Port the account-flow handlers consume. The SeaORM-backed adapter is
 /// `impl AccountStore for Store` (see `lib.rs`).
 #[async_trait]
@@ -78,6 +192,14 @@ pub trait AccountStore: Send + Sync + std::fmt::Debug {
     /// > now` and use a follow-up read to populate the return shape and
     /// disambiguate the failure taxonomy.
     ///
+    /// **For the typical invitation-acceptance flow prefer
+    /// [`AccountStore::accept_invitation_atomic`]** — it consumes the
+    /// invitation, creates the account, links the membership, mints the
+    /// session, and appends the success events in one transaction so a
+    /// failure mid-flow leaves the invitation pending. This bare
+    /// `consume_invitation` is retained for any future flow that wants
+    /// to consume-without-creating.
+    ///
     /// Returns:
     /// - `Ok(ConsumedInvitation { .. })` when exactly one row was
     ///   transitioned.
@@ -94,6 +216,22 @@ pub trait AccountStore: Send + Sync + std::fmt::Debug {
         token: &InvitationToken,
         now: DateTime<Utc>,
     ) -> Result<ConsumedInvitation, ConsumeInvitationError>;
+
+    /// Run the full invitation-acceptance flow as a single transaction:
+    /// consume the invitation, insert the account, link the membership,
+    /// insert the session, and append the success-path
+    /// `account_created` and `invitation_accepted` events. If any step
+    /// fails the transaction rolls back — the invitation row stays
+    /// pending so the user can retry.
+    ///
+    /// The caller pre-derives the password PHC, the session token, the
+    /// membership id and `now`. The implementation owns the inviting-
+    /// org id (it reads it from the consumed row) and stamps it onto
+    /// the inserted account, the membership, and the emitted events.
+    async fn accept_invitation_atomic(
+        &self,
+        request: AcceptInvitationAtomicRequest,
+    ) -> Result<AcceptInvitationAtomicOutput, AcceptInvitationError>;
 
     /// Issue a session for the supplied account.
     async fn insert_session(

--- a/crates/tanren-testkit/src/harness/api.rs
+++ b/crates/tanren-testkit/src/harness/api.rs
@@ -263,6 +263,96 @@ impl AccountHarness for ApiHarness {
         })
     }
 
+    async fn accept_invitations_concurrent(
+        &mut self,
+        requests: Vec<AcceptInvitationRequest>,
+    ) -> Vec<HarnessResult<HarnessAcceptance>> {
+        // Fan out via `tokio::spawn` so each acceptance issues its own
+        // POST against the live api server in parallel. Each task gets
+        // its own `reqwest::Client` (built fresh from a default
+        // configuration) so cookie state from one task doesn't bleed
+        // into another. The shared base URL is cheap to clone.
+        //
+        // Without this override, the trait's default impl would await
+        // each request serially — defeating the @falsification @api
+        // race scenario which is supposed to prove that
+        // `consume_invitation` serializes concurrent acceptances at
+        // the store layer (Codex P2 review on PR #133).
+        let base_url = self.base_url.clone();
+        let mut handles = Vec::with_capacity(requests.len());
+        for req in requests {
+            let url = format!(
+                "{}/invitations/{}/accept",
+                base_url,
+                req.invitation_token.as_str()
+            );
+            let body = accept_invitation_body(&req);
+            // Each task builds its own client. cookie_store is irrelevant
+            // here — the race scenario doesn't reuse the session.
+            let client = match Client::builder().build() {
+                Ok(c) => c,
+                Err(e) => {
+                    handles.push(tokio::spawn(async move {
+                        Err::<HarnessAcceptance, HarnessError>(HarnessError::Transport(format!(
+                            "build client: {e}"
+                        )))
+                    }));
+                    continue;
+                }
+            };
+            handles.push(tokio::spawn(async move {
+                let response = client.post(&url).json(&body).send().await.map_err(|e| {
+                    HarnessError::Transport(format!("POST /invitations/{{token}}/accept: {e}"))
+                })?;
+                let status = response.status();
+                let cookies_set = response
+                    .headers()
+                    .get_all(reqwest::header::SET_COOKIE)
+                    .iter()
+                    .any(|v| {
+                        v.to_str()
+                            .ok()
+                            .is_some_and(|s| s.starts_with("tanren_session="))
+                    });
+                let json: Value = response
+                    .json()
+                    .await
+                    .map_err(|e| HarnessError::Transport(format!("decode body: {e}")))?;
+                if !status.is_success() {
+                    return Err(failure_from_body(&json));
+                }
+                let account: AccountView = serde_json::from_value(json["account"].clone())
+                    .map_err(|e| HarnessError::Transport(format!("decode account: {e}")))?;
+                let expires_at = json["session"]["expires_at"]
+                    .as_str()
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|d| d.with_timezone(&chrono::Utc))
+                    .ok_or_else(|| {
+                        HarnessError::Transport("missing session.expires_at".to_owned())
+                    })?;
+                let joined_org = serde_json::from_value(json["joined_org"].clone())
+                    .map_err(|e| HarnessError::Transport(format!("decode joined_org: {e}")))?;
+                Ok(HarnessAcceptance {
+                    session: HarnessSession {
+                        account_id: account.id,
+                        account,
+                        expires_at,
+                        has_token: cookies_set,
+                    },
+                    joined_org,
+                })
+            }));
+        }
+        let mut out = Vec::with_capacity(handles.len());
+        for h in handles {
+            out.push(match h.await {
+                Ok(r) => r,
+                Err(e) => Err(HarnessError::Transport(format!("join: {e}"))),
+            });
+        }
+        out
+    }
+
     async fn seed_invitation(&mut self, fixture: HarnessInvitation) -> HarnessResult<()> {
         self.store
             .seed_invitation(NewInvitation {

--- a/crates/tanren-testkit/src/harness/mod.rs
+++ b/crates/tanren-testkit/src/harness/mod.rs
@@ -211,6 +211,28 @@ pub trait AccountHarness: Send + std::fmt::Debug {
         req: AcceptInvitationRequest,
     ) -> HarnessResult<HarnessAcceptance>;
 
+    /// Fan out N invitation-acceptance requests in parallel against the
+    /// underlying surface. Used by the `@falsification @api` race
+    /// scenario to prove `consume_invitation`'s atomicity. The default
+    /// implementation runs the requests serially via [`accept_invitation`];
+    /// `ApiHarness` overrides this to dispatch each request as an
+    /// independent `tokio::spawn` so the race actually happens.
+    ///
+    /// Returns one `HarnessResult<HarnessAcceptance>` per input request
+    /// in the order submitted.
+    ///
+    /// [`accept_invitation`]: AccountHarness::accept_invitation
+    async fn accept_invitations_concurrent(
+        &mut self,
+        requests: Vec<AcceptInvitationRequest>,
+    ) -> Vec<HarnessResult<HarnessAcceptance>> {
+        let mut out = Vec::with_capacity(requests.len());
+        for r in requests {
+            out.push(self.accept_invitation(r).await);
+        }
+        out
+    }
+
     /// Seed a fresh invitation into the harness's backing store.
     async fn seed_invitation(&mut self, fixture: HarnessInvitation) -> HarnessResult<()>;
 

--- a/justfile
+++ b/justfile
@@ -365,6 +365,12 @@ check:
 tests:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Pre-build binaries that the wire harnesses spawn as subprocesses.
+    # CliHarness::spawn locates `tanren-cli` next to the test executable
+    # in `target/debug/`; without an explicit build, CI runs (which only
+    # `cargo check` earlier) hit "binary tanren-cli not found alongside
+    # test executable". Locally the binaries are warm from `just install`.
+    {{ cargo }} build -p tanren-cli -p tanren-tui --locked --quiet
     {{ cargo }} test -p tanren-bdd --locked --quiet
     {{ cargo }} run -q -p tanren-bdd --bin tanren-bdd-runner --locked
 

--- a/tests/bdd/features/B-0043-create-account.feature
+++ b/tests/bdd/features/B-0043-create-account.feature
@@ -71,9 +71,9 @@ Feature: Create an account
     @falsification @api
     Scenario: API serializes concurrent acceptances of one invitation
       Given a pending invitation token "api-race-token-padpad"
-      When 5 actors concurrently accept invitation "api-race-token-padpad"
+      When 20 actors concurrently accept invitation "api-race-token-padpad"
       Then exactly 1 acceptance succeeds
-      And 4 fail with code "invitation_already_consumed"
+      And 19 fail with code "invitation_already_consumed"
 
   Rule: Web surface
 


### PR DESCRIPTION
Sub-PR 15. Closes the remaining CI failures and the two new Codex findings on PR #133.

## CI fixes (1st commit)

- `just tests` now pre-builds `tanren-cli` and `tanren-tui` so the wire harnesses can spawn them. Previously CI's `cargo check`-only path left the binaries missing → 7 hook errors.
- `web-checks.yml` switched `dtolnay/rust-toolchain@stable` → SHA-pinned (matches `rust-ci.yml`); fixes the `startup_failure` from the action-pinning policy.
- `rust-ci.yml` gained the `permissions: contents: read` block CodeQL flagged on the original review (sub-13 polish missed this one workflow).

## Codex P1 — atomic invitation acceptance (2nd commit)

Previous handler consumed the invitation BEFORE the account/membership/session/event writes, so any later failure permanently burned the token. Fix lifts the entire success path into a single SeaORM transaction:
- New `AccountStore::accept_invitation_atomic` method takes a request struct + an event-builder closure that runs *inside* the transaction once the inviting org id is known.
- `SeaOrmStore` impl in new `crates/tanren-store/src/accept_invitation.rs` runs the conditional UPDATE filter, insert_account, insert_membership, insert_session, and the two events on one `DatabaseTransaction`. Any failure rolls back; the invitation stays pending so users can retry.
- Standalone `consume_invitation` method stays on the trait for future consume-without-create flows; doc points callers at the atomic method.

## Codex P2 — truly-parallel concurrent race (2nd commit)

Previous step Arc-Mutex'd the harness across 20 spawned futures, serializing every request and defeating the race-detection intent. Fix:
- New `AccountHarness::accept_invitations_concurrent` fan-out method on the trait (sequential default for cli/mcp/tui/in-process; `ApiHarness` overrides).
- `ApiHarness` override spawns each request as its own `tokio::spawn` with a fresh `reqwest::Client` against the live api server.
- Bumped scenario from N=5 sequential to **N=20 truly-parallel**: exactly 1 succeeds, 19 fail with `invitation_already_consumed`. The atomic SeaORM transaction + DB partial-unique constraint serialize the race correctly.

## Test plan

- [x] `just ci` green end-to-end (55s including web)
- [x] 36/36 BDD scenarios, 171/171 steps
- [x] N=20 parallel race scenario passes — Codex P2 properly exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)