### PR TITLE
ci(R-0001): sub-16 — web-checks installs mold + clang

### DIFF
--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -77,6 +77,14 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
+      - name: Install mold + clang
+        # `.cargo/config.toml` pins `linker = "clang"` +
+        # `-C link-arg=-fuse-ld=mold` for Linux targets so dev/CI builds
+        # match. `just bootstrap` installs these on the rust-ci runner;
+        # this workflow doesn't run bootstrap, so install them directly
+        # before the cargo build.
+        run: sudo apt-get update -qq && sudo apt-get install -y mold clang
+
       - name: Cache cargo build
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:


### PR DESCRIPTION
Fixes the lingering Web Checks failure on PR #133. `.cargo/config.toml` pins clang+mold for Linux targets; web-checks.yml needs to install them since it doesn't run `just bootstrap` (rust-ci.yml does).

Also resolved 4 stale github-advanced-security[bot] PR review threads via GraphQL — underlying findings were fixed by sub-13's SecretString wrap + the codeql-config.yml path-ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)