### PR TITLE
ci(R-0001): sub-17 — prettier ignore inlang autogen + bddgen before playwright

### DIFF
--- a/apps/web/.prettierignore
+++ b/apps/web/.prettierignore
@@ -1,0 +1,22 @@
+# Generated artefacts that prettier shouldn't reformat:
+#
+# - paraglide compiler output (typed message functions; gitignored, but
+#   the i18n:compile step runs before format:check on CI so the files
+#   are present at lint time)
+# - inlang project state (cache + README + .meta.json — only
+#   settings.json is human-curated; ignored by inlang's own
+#   src/i18n/project.inlang/.gitignore but prettier doesn't read that
+#   nested gitignore by default)
+src/i18n/paraglide/
+src/i18n/project.inlang/cache/
+src/i18n/project.inlang/README.md
+src/i18n/project.inlang/.meta.json
+
+# Playwright + Storybook artefacts
+tests/bdd/.bdd-gen/
+playwright-report/
+test-results/
+storybook-static/
+
+# Next.js build cache
+.next/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "storybook:test": "vitest run --project=storybook",
-    "e2e": "playwright test",
+    "bddgen": "bddgen",
+    "e2e": "bddgen && playwright test",
     "e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes the two remaining CI failures on PR #133. Local just ci 54s green. Also dismissed 4 stale CodeQL alerts (used-in-tests) for loopback HTTP test traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)