### PR TITLE
fix(R-0001): sub-19 — cfg-gate alignment + .env.local restore + TUI email field

### DIFF
--- a/apps/web/tests/bdd/global-setup.ts
+++ b/apps/web/tests/bdd/global-setup.ts
@@ -6,7 +6,7 @@
 // `@api` BDD harness in `crates/tanren-testkit/src/harness/api.rs`.
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -23,6 +23,13 @@ interface TanrenBddState {
   databaseUrl: string;
   databasePath: string;
   tmpRoot: string;
+  /**
+   * Pre-existing `.env.local` content captured at setup time so
+   * `globalTeardown` can restore the developer's file rather than
+   * unlinking it. `null` when no `.env.local` existed before our run.
+   * Codex P2 review on PR #133.
+   */
+  preExistingEnvLocal: string | null;
 }
 
 async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
@@ -96,6 +103,15 @@ async function pickFreePort(): Promise<number> {
 }
 
 export default async function globalSetup(): Promise<void> {
+  // Capture any pre-existing .env.local so globalTeardown can restore
+  // the developer's file. Without this, running `pnpm e2e` locally
+  // wipes whatever the developer had configured for unrelated
+  // local-dev workflows. Codex P2 review on PR #133.
+  const envLocalPath = join(process.cwd(), ".env.local");
+  const preExistingEnvLocal = existsSync(envLocalPath)
+    ? readFileSync(envLocalPath, "utf-8")
+    : null;
+
   // If the caller already booted an API (e.g. `cargo run -p tanren-api`
   // in another shell), respect that and skip our own spawn.
   if (process.env["TANREN_BDD_EXTERNAL_API"] === "true") {
@@ -107,9 +123,20 @@ export default async function globalSetup(): Promise<void> {
     // Mirror to .env.local so the Next.js dev server (a child
     // process spawned by Playwright's webServer) picks it up.
     writeFileSync(
-      join(process.cwd(), ".env.local"),
+      envLocalPath,
       `NEXT_PUBLIC_API_URL=${process.env["NEXT_PUBLIC_API_URL"]}\n`,
     );
+    // Stash the pre-existing content for teardown even on the
+    // external-API path; teardown reads __tanrenBddState first and
+    // falls back to the unconditional behavior if it's missing, so
+    // we always set it.
+    globalThis.__tanrenBddState = {
+      apiProcess: null,
+      databaseUrl: "",
+      databasePath: "",
+      tmpRoot: "",
+      preExistingEnvLocal,
+    };
     return;
   }
 
@@ -176,15 +203,13 @@ export default async function globalSetup(): Promise<void> {
   await waitForHealth(`${apiUrl}/health`, 180_000);
 
   process.env["NEXT_PUBLIC_API_URL"] = apiUrl;
-  writeFileSync(
-    join(process.cwd(), ".env.local"),
-    `NEXT_PUBLIC_API_URL=${apiUrl}\n`,
-  );
+  writeFileSync(envLocalPath, `NEXT_PUBLIC_API_URL=${apiUrl}\n`);
 
   globalThis.__tanrenBddState = {
     apiProcess,
     databaseUrl,
     databasePath,
     tmpRoot,
+    preExistingEnvLocal,
   };
 }

--- a/apps/web/tests/bdd/global-teardown.ts
+++ b/apps/web/tests/bdd/global-teardown.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { rmSync, unlinkSync } from "node:fs";
+import { rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 declare global {
@@ -10,17 +10,42 @@ declare global {
         databaseUrl: string;
         databasePath: string;
         tmpRoot: string;
+        /**
+         * Pre-existing `.env.local` content snapshotted in globalSetup.
+         * Restored on teardown so we don't clobber a developer's local
+         * env file. Codex P2 review on PR #133.
+         */
+        preExistingEnvLocal: string | null;
       }
     | undefined;
 }
 
 export default async function globalTeardown(): Promise<void> {
   const state = globalThis.__tanrenBddState;
-  try {
-    unlinkSync(join(process.cwd(), ".env.local"));
-  } catch {
-    /* file may not exist */
+  const envLocalPath = join(process.cwd(), ".env.local");
+
+  // Restore the pre-existing .env.local if the developer had one;
+  // otherwise unlink the file we wrote. Falls back to unconditional
+  // unlink if globalSetup didn't run (defensive — should not happen
+  // under playwright-bdd's lifecycle).
+  if (state?.preExistingEnvLocal !== undefined) {
+    if (state.preExistingEnvLocal === null) {
+      try {
+        unlinkSync(envLocalPath);
+      } catch {
+        /* file may not exist */
+      }
+    } else {
+      writeFileSync(envLocalPath, state.preExistingEnvLocal);
+    }
+  } else {
+    try {
+      unlinkSync(envLocalPath);
+    } catch {
+      /* file may not exist */
+    }
   }
+
   if (!state) return;
   if (state.apiProcess && !state.apiProcess.killed) {
     state.apiProcess.kill("SIGTERM");
@@ -31,10 +56,12 @@ export default async function globalTeardown(): Promise<void> {
       state.apiProcess.kill("SIGKILL");
     }
   }
-  try {
-    rmSync(state.tmpRoot, { recursive: true, force: true });
-  } catch {
-    /* best-effort cleanup */
+  if (state.tmpRoot) {
+    try {
+      rmSync(state.tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
   }
   globalThis.__tanrenBddState = undefined;
 }

--- a/crates/tanren-api-app/src/lib.rs
+++ b/crates/tanren-api-app/src/lib.rs
@@ -39,7 +39,11 @@
 mod cookies;
 mod errors;
 mod routes;
-#[cfg(feature = "test-hooks")]
+// test_hooks must be visible in any compilation that exposes
+// `build_app_with_store` (i.e. `cargo test -p tanren-api-app` in addition
+// to feature-on builds), otherwise the call site at the bottom of
+// `build_app_with_store` references an undefined module. Codex P1 review.
+#[cfg(any(test, feature = "test-hooks"))]
 mod test_hooks;
 
 use std::env;

--- a/crates/tanren-tui-app/src/ui.rs
+++ b/crates/tanren-tui-app/src/ui.rs
@@ -55,6 +55,11 @@ pub(crate) fn accept_invitation_fields() -> Vec<FormField> {
             value: String::new(),
         },
         FormField {
+            label: "Email",
+            secret: false,
+            value: String::new(),
+        },
+        FormField {
             label: "Password",
             secret: true,
             value: String::new(),
@@ -137,16 +142,14 @@ pub(crate) fn parse_accept_invitation(
 ) -> Result<AcceptInvitationRequest, String> {
     let invitation_token =
         InvitationToken::parse(state.value(0)).map_err(|e| validation_message(&e))?;
-    let password = SecretString::from(state.value(1).to_owned());
-    let display_name = state.value(2).to_owned();
-    // PR 7 sources the email from the invitation row; for PR 3 the TUI
-    // lacks an email field on the accept-invitation form, so we synthesise
-    // a placeholder derived from the invitation token. The synthesised
-    // email is unique per invitation token (the token must be ≥ 16 bytes
-    // so the resulting local-part is non-empty).
-    let token_str = invitation_token.as_str().to_owned();
-    let synthesised = format!("{token_str}@invitation.tanren");
-    let email = Email::parse(&synthesised).map_err(|e| validation_message(&e))?;
+    // The user supplies the email directly; the previous implementation
+    // synthesised it from the invitation token, which broke any token
+    // containing `@` (the resulting "<token>@invitation.tanren" had two
+    // `@` characters and Email::parse rejected it before the request
+    // ever reached `accept_invitation`). Codex P2 review on PR #133.
+    let email = Email::parse(state.value(1)).map_err(|e| validation_message(&e))?;
+    let password = SecretString::from(state.value(2).to_owned());
+    let display_name = state.value(3).to_owned();
     Ok(AcceptInvitationRequest {
         invitation_token,
         email,


### PR DESCRIPTION
Three Codex findings on PR #133:

- **P1** `tanren-api-app/src/lib.rs:229` — `build_app_with_store` was gated `cfg(any(test, feature = "test-hooks"))` but `mod test_hooks` was `cfg(feature = "test-hooks")`. `cargo test -p tanren-api-app` failed to compile. Aligned to the same gate.
- **P2** `apps/web/tests/bdd/global-teardown.ts` — destroyed developer's pre-existing `.env.local`. globalSetup now snapshots; globalTeardown restores or unlinks based on what was there before.
- **P2** `tanren-tui-app/src/ui.rs:149` — synthesized email from invitation token broke when token contained `@`. Added an Email field to the TUI accept-invitation form.

`just ci` green (63s); 36/36 BDD; 7/7 @web Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)