### PR TITLE
fix(R-0001): sub-20 — validating Deserialize + RFC 5322 + ValidatedJson + tighter test-surface guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-validator-rfc5322"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff8b1bffee2940db7f16e2521a1544d118d990f40e17e35d41b029fcd566e84"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,6 +4304,7 @@ dependencies = [
  "argon2",
  "base64",
  "chrono",
+ "email-validator-rfc5322",
  "password-hash",
  "rand 0.9.4",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,14 @@ jsonwebtoken = { version = "10", default-features = false, features = [
 # Secrets
 secrecy = { version = "0.10", features = ["serde"] }
 
+# RFC 5322-compliant email validator. Used by
+# `tanren_identity_policy::Email::parse` so wire-input and CLI/TUI
+# user-input go through the same canonicalisation rules. The previous
+# hand-rolled "single @ + dot in domain" check accepted malformed
+# addresses (Codex P1 review on PR #133); RFC 5322 closes that gap and
+# the crate exposes detailed error variants we can surface.
+email-validator-rfc5322 = "0.1"
+
 # CSPRNG (for opaque session/credential tokens; never used as a record id).
 rand = "0.9"
 

--- a/crates/tanren-api-app/src/errors.rs
+++ b/crates/tanren-api-app/src/errors.rs
@@ -6,8 +6,10 @@
 //! API's HTTP transport.
 
 use axum::Json;
+use axum::extract::{FromRequest, Request, rejection::JsonRejection};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tanren_app_services::AppServiceError;
@@ -74,6 +76,53 @@ fn failure_body(reason: AccountFailureReason) -> Response {
     (
         status,
         Json(json!({"code": reason.code(), "summary": reason.summary()})),
+    )
+        .into_response()
+}
+
+/// Custom `Json` extractor that maps any deserialize-time failure
+/// (malformed JSON, missing required field, OR a validating-newtype
+/// `Deserialize` impl returning an error — e.g. `Email::parse` rejecting
+/// an RFC-malformed address) to the shared `{code, summary}` taxonomy:
+/// `400 Bad Request` with `code = "validation_failed"`. Without this
+/// wrapper, axum's default behaviour returns 422 with a plain-text body
+/// that bypasses the wire taxonomy clients depend on, and the new
+/// validating-`Deserialize` impls on `Email` / `Identifier` /
+/// `InvitationToken` (Codex P1 review on PR #133) would surface as
+/// untyped 422s.
+#[derive(Debug)]
+pub(crate) struct ValidatedJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for ValidatedJson<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(Self(value)),
+            Err(rejection) => Err(map_json_rejection(&rejection)),
+        }
+    }
+}
+
+fn map_json_rejection(rejection: &JsonRejection) -> Response {
+    let summary = match rejection {
+        JsonRejection::JsonDataError(e) => e.body_text(),
+        JsonRejection::JsonSyntaxError(e) => e.body_text(),
+        JsonRejection::MissingJsonContentType(_) => {
+            "request body must be application/json".to_owned()
+        }
+        other => other.body_text(),
+    };
+    (
+        StatusCode::BAD_REQUEST,
+        Json(AccountFailureBody {
+            code: "validation_failed".to_owned(),
+            summary,
+        }),
     )
         .into_response()
 }

--- a/crates/tanren-api-app/src/routes.rs
+++ b/crates/tanren-api-app/src/routes.rs
@@ -23,7 +23,7 @@ use utoipa_axum::routes;
 
 use crate::AppState;
 use crate::cookies::{SessionWrite, install_cookie_session};
-use crate::errors::{AccountFailureBody, map_app_error, session_install_error};
+use crate::errors::{AccountFailureBody, ValidatedJson, map_app_error, session_install_error};
 
 /// Liveness response.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -152,7 +152,7 @@ pub(crate) async fn health_route() -> Json<HealthResponse> {
 pub(crate) async fn sign_up_route(
     State(state): State<AppState>,
     session: Session,
-    Json(request): Json<SignUpRequest>,
+    ValidatedJson(request): ValidatedJson<SignUpRequest>,
 ) -> Response {
     match state.handlers.sign_up(state.store.as_ref(), request).await {
         Ok(response) => {
@@ -191,7 +191,7 @@ pub(crate) async fn sign_up_route(
 pub(crate) async fn sign_in_route(
     State(state): State<AppState>,
     session: Session,
-    Json(request): Json<SignInRequest>,
+    ValidatedJson(request): ValidatedJson<SignInRequest>,
 ) -> Response {
     match state.handlers.sign_in(state.store.as_ref(), request).await {
         Ok(response) => {
@@ -235,7 +235,7 @@ pub(crate) async fn accept_invitation_route(
     State(state): State<AppState>,
     session: Session,
     Path(token): Path<String>,
-    Json(body): Json<AcceptInvitationBody>,
+    ValidatedJson(body): ValidatedJson<AcceptInvitationBody>,
 ) -> Response {
     let invitation_token = match InvitationToken::parse(&token) {
         Ok(t) => t,

--- a/crates/tanren-identity-policy/Cargo.toml
+++ b/crates/tanren-identity-policy/Cargo.toml
@@ -23,6 +23,7 @@ test-hooks = []
 argon2 = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+email-validator-rfc5322 = { workspace = true }
 password-hash = { workspace = true }
 rand = { workspace = true }
 schemars = { workspace = true }

--- a/crates/tanren-identity-policy/src/lib.rs
+++ b/crates/tanren-identity-policy/src/lib.rs
@@ -154,37 +154,62 @@ impl std::fmt::Display for MembershipId {
     }
 }
 
-/// Validated email address. Constructed via [`Email::parse`] which
-/// trims surrounding whitespace and lower-cases the string. R-0001
-/// keeps the validation deliberately lightweight (presence + single
-/// `@`) — full RFC 5322 verification is the responsibility of an
-/// out-of-band confirmation flow that lands later.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
+/// Validated email address. Constructed via [`Email::parse`] which:
+/// trims surrounding whitespace, validates against RFC 5322 syntax via
+/// the [`email_validator_rfc5322`] crate (RFC 5321 length limits +
+/// quoted local parts), additionally requires a TLD-style domain (no
+/// dotless or IP-literal domains), and canonicalises to lower-case so
+/// case variants of the same address compare equal.
+///
+/// # Wire-input contract
+///
+/// `Email` does NOT derive `Deserialize` — the custom impl below routes
+/// every wire input through [`parse`](Self::parse). Without this,
+/// `#[serde(transparent)]` would let HTTP/MCP/CLI requests carry
+/// untrimmed/un-lowercased/RFC-invalid addresses, which would persist
+/// verbatim via `Identifier::from_email` and let two case variants of
+/// the same logical email register as separate accounts. Codex P1
+/// review on PR #133.
+///
+/// Validation invariants are exercised end-to-end by the @api / @web
+/// scenarios in `tests/bdd/features/B-0043-create-account.feature` —
+/// case-variant rejection and malformed-email rejection both run
+/// through the live wire surface, not through Rust unit tests.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, JsonSchema, ToSchema)]
 #[serde(transparent)]
 #[schema(value_type = String, format = "email")]
 pub struct Email(String);
 
 impl Email {
-    /// Parse a raw user-supplied email. Trims and lower-cases.
+    /// Parse a raw user-supplied email. Trims, validates against RFC
+    /// 5322 + RFC 5321 length limits, and canonicalises to lower-case.
     ///
     /// # Errors
     ///
-    /// Returns [`ValidationError::EmptyEmail`] if the input is empty
-    /// after trimming, or [`ValidationError::InvalidEmail`] if the
-    /// input does not contain exactly one `@` separating non-empty
-    /// local and domain parts.
+    /// Returns [`ValidationError::EmptyEmail`] when the input is empty
+    /// after trimming. Returns [`ValidationError::InvalidEmail`] when
+    /// the input fails RFC 5322 syntax or RFC 5321 length limits.
     pub fn parse(raw: &str) -> Result<Self, ValidationError> {
         let trimmed = raw.trim();
         if trimmed.is_empty() {
             return Err(ValidationError::EmptyEmail);
         }
-        let mut parts = trimmed.split('@');
-        let local = parts.next().unwrap_or("");
-        let domain = parts.next().unwrap_or("");
-        if local.is_empty() || domain.is_empty() || parts.next().is_some() {
-            return Err(ValidationError::InvalidEmail);
-        }
-        if !domain.contains('.') {
+        email_validator_rfc5322::validate_email(trimmed)
+            .map_err(|_| ValidationError::InvalidEmail)?;
+        // RFC 5322 permits dotless domains (`user@host`), but the
+        // public-internet account flow this type backs always uses a
+        // TLD-style domain. Reject dotless and IP-literal domains
+        // (`[10.0.0.1]`, `[IPv6:...]`) so identifier collisions and
+        // typos are caught at the boundary instead of at the duplicate-
+        // identifier error code path. If a future feature needs the
+        // permissive RFC 5322 surface, add a sibling
+        // `Email::parse_permissive` rather than relaxing here.
+        let domain_start = trimmed
+            .rfind('@')
+            .ok_or(ValidationError::InvalidEmail)?
+            .saturating_add(1);
+        let domain = &trimmed[domain_start..];
+        if domain.starts_with('[') || !domain.contains('.') {
             return Err(ValidationError::InvalidEmail);
         }
         Ok(Self(trimmed.to_lowercase()))
@@ -194,6 +219,13 @@ impl Email {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Email {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
     }
 }
 
@@ -207,7 +239,16 @@ impl std::fmt::Display for Email {
 /// identifier+password where the identifier is the canonical email; the
 /// type wraps the raw string so future mechanisms can lift constraints
 /// in one place.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
+///
+/// `Identifier` does NOT derive `Deserialize` — the custom impl below
+/// routes every wire input through [`parse`](Self::parse) so untrimmed
+/// or differently-cased identifiers cannot bypass canonicalisation.
+/// Validation invariants are exercised end-to-end by the @api / @web
+/// scenarios in `tests/bdd/features/B-0043-create-account.feature`
+/// (case-variant rejection, malformed-input rejection); per the
+/// BDD-only test surface policy there are no Rust unit or doc-tests
+/// for these rules.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, JsonSchema, ToSchema)]
 #[serde(transparent)]
 #[schema(value_type = String)]
 pub struct Identifier(String);
@@ -243,6 +284,13 @@ impl Identifier {
     }
 }
 
+impl<'de> Deserialize<'de> for Identifier {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
 impl std::fmt::Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
@@ -254,7 +302,17 @@ const INVITATION_TOKEN_MIN_LEN: usize = 16;
 
 /// Opaque invitation token. R-0001 treats the token as a flat string —
 /// generation/delivery is R-0005's job; here we just verify and consume.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, ToSchema)]
+///
+/// `InvitationToken` does NOT derive `Deserialize` — the custom impl
+/// below routes every wire input through [`parse`](Self::parse) so
+/// short-on-wire tokens are rejected at the contract boundary instead
+/// of reaching the handler. Validation invariants are exercised
+/// end-to-end by the @api / @web scenarios in
+/// `tests/bdd/features/B-0043-create-account.feature` (expired-token
+/// rejection, missing-token rejection, etc.); per the BDD-only test
+/// surface policy there are no Rust unit or doc-tests for these
+/// rules.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, JsonSchema, ToSchema)]
 #[serde(transparent)]
 #[schema(value_type = String)]
 pub struct InvitationToken(String);
@@ -284,6 +342,13 @@ impl InvitationToken {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for InvitationToken {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
     }
 }
 

--- a/tests/bdd/features/B-0043-create-account.feature
+++ b/tests/bdd/features/B-0043-create-account.feature
@@ -55,6 +55,13 @@ Feature: Create an account
       And a "sign_up_rejected" event is recorded
 
     @falsification @api
+    Scenario: API rejects sign-up with a case variant of an existing identifier
+      Given alice has signed up with email "alice-api-case@example.com" and password "p4ssw0rd"
+      When mallory self-signs up with email "ALICE-API-CASE@Example.COM" and password "different-pw"
+      Then the request fails with code "duplicate_identifier"
+      And a "sign_up_rejected" event is recorded
+
+    @falsification @api
     Scenario: API rejects sign-in with a wrong credential
       Given alice has signed up with email "alice-api-wrong@example.com" and password "p4ssw0rd"
       When alice signs in with email "alice-api-wrong@example.com" and password "wrong-pw"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -207,6 +207,9 @@ fn check_rust_test_surface(root: &Path) -> Result<()> {
         }
         let content =
             fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let mut in_doc_block = false;
+        let mut doc_block_runnable = false;
+        let mut doc_block_start = 0usize;
         for (lineno, line) in content.lines().enumerate() {
             let trimmed = line.trim_start();
             let hit = trimmed.starts_with("#[test]")
@@ -220,6 +223,48 @@ fn check_rust_test_surface(root: &Path) -> Result<()> {
                     lineno + 1,
                     trimmed
                 ));
+            }
+            // Reject runnable doc-tests (``` rust code blocks inside
+            // `///` or `//!` comments without `ignore`/`no_run`/`text`
+            // markers). Doc-tests are tests by `cargo test` semantics
+            // and the BDD-only policy admits zero exceptions: any
+            // executable test must live in `tanren-bdd` as a `.feature`
+            // scenario. Allowed annotations: `text`, `ignore`,
+            // `no_run`, `compile_fail` — all non-runnable.
+            if trimmed.starts_with("///") || trimmed.starts_with("//!") {
+                let body = trimmed
+                    .trim_start_matches("///")
+                    .trim_start_matches("//!")
+                    .trim_start();
+                if let Some(rest) = body.strip_prefix("```") {
+                    if in_doc_block {
+                        if doc_block_runnable {
+                            violations.push(format!(
+                                "{}:{}: runnable doc-test — annotate with `text`/`ignore`/`no_run`/`compile_fail` or move to a BDD scenario",
+                                path.strip_prefix(root).unwrap_or(&path).display(),
+                                doc_block_start + 1,
+                            ));
+                        }
+                        in_doc_block = false;
+                        doc_block_runnable = false;
+                    } else {
+                        in_doc_block = true;
+                        doc_block_start = lineno;
+                        let lang = rest.trim();
+                        let runnable_lang = lang.is_empty()
+                            || lang == "rust"
+                            || lang.starts_with("rust,")
+                            || lang.starts_with("rust ");
+                        let opts: Vec<&str> = lang
+                            .split(|c: char| c == ',' || c.is_whitespace())
+                            .filter(|s| !s.is_empty())
+                            .collect();
+                        let suppressed = opts.iter().any(|o| {
+                            *o == "text" || *o == "ignore" || *o == "no_run" || *o == "compile_fail"
+                        });
+                        doc_block_runnable = runnable_lang && !suppressed;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Codex P1: Email/Identifier/InvitationToken derived Deserialize transparently, bypassing the canonicalisation contract. Real fix at the type-system level — custom Deserialize impls route wire input through ::parse(); RFC 5322 email validation; ValidatedJson axum extractor maps deserialize failures to validation_failed; xtask check-rust-test-surface now rejects runnable doc-tests anywhere outside tanren-bdd (zero exceptions to the BDD-only policy). New @api case-variant duplicate-identifier scenario proves the fix end-to-end.

just ci green (62s). 38/38 BDD scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)